### PR TITLE
feat: add Google OAuth and redirect logic

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_URL=https://szm7ap94u8.execute-api.ap-northeast-1.amazonaws.com/dev/api/v1

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,5 +1,6 @@
 import type { NextAuthConfig } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
+import GoogleProvider from 'next-auth/providers/google';
 
 import { SignInSchema } from './schemas/auth';
 
@@ -30,6 +31,10 @@ export default {
         }
         return null;
       },
+    }),
+    GoogleProvider({
+      clientId: process.env.GOOGLE_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_CLIENT_SECRET,
     }),
   ],
 } satisfies NextAuthConfig;

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -1,3 +1,5 @@
+import { signIn } from 'next-auth/react';
+
 import { GoogleColor } from '@/components/Icon';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
@@ -11,12 +13,17 @@ export default function GoogleSignUpButton({
 }: GoogleSignUpButtonProps) {
   const { toast } = useToast();
 
-  const handleGoogleSignUp = () => {
-    toast({
-      variant: 'default',
-      title: '註冊成功',
-      description: '請前往您的電子郵件信箱驗證您的帳號',
-    });
+  const handleGoogleSignUp = async () => {
+    try {
+      await signIn('google');
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '無法完成 Google 註冊，請稍後再試。',
+      });
+      return;
+    }
   };
 
   return (

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,8 +9,7 @@ import { auth } from './auth';
 
 export default auth((req) => {
   const { nextUrl } = req;
-  // const isLoggedIn = !!req.auth;
-  const isLoggedIn = false;
+  const isLoggedIn = !!req.auth;
 
   const isApiAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);
@@ -21,6 +20,11 @@ export default auth((req) => {
   }
 
   if (isAuthRoute && isLoggedIn) {
+    if (nextUrl.pathname === '/auth/signin') {
+      return Response.redirect(new URL('/auth/onboarding', nextUrl));
+    } else if (nextUrl.pathname === '/auth/signup') {
+      return Response.redirect(new URL('/auth/emailVerify', nextUrl));
+    }
     return Response.redirect(new URL(DEFAULT_LOGIN_REDIRECT, nextUrl));
   }
 

--- a/src/types/process.d.ts
+++ b/src/types/process.d.ts
@@ -4,6 +4,8 @@ declare namespace NodeJS {
     NEXTAUTH_SECRET: string;
     GITHUB_ID: string;
     GITHUB_SECRET: string;
+    GOOGLE_CLIENT_ID: string;
+    GOOGLE_CLIENT_SECRET: string;
     LINKEDIN_CLIENT_ID: string;
     LINKEDIN_CLIENT_SECRET: string;
   }


### PR DESCRIPTION
## 這個 PR 做了什麼

- Add Google sign-in/sign-up OAuth
- Redirect to auth/emailVerify upon signup, and redirect to auth/onboarding upon signin

## Demo
localhost:3000/auth/signup
localhost:3000/auth/signin


## Screenshot

![image](https://github.com/user-attachments/assets/ecc75dd8-bb34-4346-829d-308ebac778b7)

- After signup, redirect to emailVerify page
![image](https://github.com/user-attachments/assets/8b05bec9-e587-44d0-92c4-fb6c08e8cdcf)

- After signin, redirect to onboarding page
![image](https://github.com/user-attachments/assets/8f7bb018-cca2-4a0a-a5f1-b3b0c08fd47a)


## 有什麼需特別註記的

N/A
