### PR TITLE
feat: implement linkedin sigin/signup button and authentication flow

### DIFF
--- a/src/app/auth/(sign)/signin/page.tsx
+++ b/src/app/auth/(sign)/signin/page.tsx
@@ -2,6 +2,7 @@
 import AuthTitle from '@/components/auth/AuthTitle';
 import Divider from '@/components/auth/Divider';
 import GoogleSignUpButton from '@/components/auth/GoogleButton';
+import LinkedInSignInButton from '@/components/auth/LinedinButton';
 import SignInForm from '@/components/auth/signin/SignInForm';
 import useSignInForm from '@/hooks/auth/useSignInForm';
 
@@ -15,6 +16,10 @@ export default function AuthPage() {
         <SignInForm {...signInFormProps} />
         <Divider>或</Divider>
         <GoogleSignUpButton isSubmitting={signInFormProps.isSubmitting} />
+        <LinkedInSignInButton
+          isSubmitting={signInFormProps.isSubmitting}
+          label="使用 LinkedIn 帳號登入"
+        />
       </div>
     </div>
   );

--- a/src/app/auth/(sign)/signup/page.tsx
+++ b/src/app/auth/(sign)/signup/page.tsx
@@ -2,6 +2,7 @@
 import AuthTitle from '@/components/auth/AuthTitle';
 import Divider from '@/components/auth/Divider';
 import GoogleSignUpButton from '@/components/auth/GoogleButton';
+import LinkedInSignUpButton from '@/components/auth/LinedinButton';
 import SignUpForm from '@/components/auth/signup/SignUpForm';
 import useSignUpForm from '@/hooks/auth/useSignUpForm';
 
@@ -15,6 +16,10 @@ export default function AuthPage() {
         <SignUpForm {...signUpFormProps} />
         <Divider>或</Divider>
         <GoogleSignUpButton isSubmitting={signUpFormProps.isSubmitting} />
+        <LinkedInSignUpButton
+          isSubmitting={signUpFormProps.isSubmitting}
+          label="使用 LinkedIn 帳號註冊"
+        />
       </div>
     </div>
   );

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,6 +1,7 @@
 import type { NextAuthConfig } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 import GoogleProvider from 'next-auth/providers/google';
+import LinkedInProvider from 'next-auth/providers/linkedin';
 
 import { SignInSchema } from './schemas/auth';
 
@@ -35,6 +36,10 @@ export default {
     GoogleProvider({
       clientId: process.env.GOOGLE_CLIENT_ID,
       clientSecret: process.env.GOOGLE_CLIENT_SECRET,
+    }),
+    LinkedInProvider({
+      clientId: process.env.LINKEDIN_CLIENT_ID,
+      clientSecret: process.env.LINKEDIN_CLIENT_SECRET,
     }),
   ],
 } satisfies NextAuthConfig;

--- a/src/components/auth/LinedinButton.tsx
+++ b/src/components/auth/LinedinButton.tsx
@@ -1,0 +1,42 @@
+import { signIn } from 'next-auth/react';
+
+import { LinkedinColor } from '@/components/Icon';
+import { Button } from '@/components/ui/button';
+import { useToast } from '@/components/ui/use-toast';
+
+interface LinkedInSignUpButtonProps {
+  isSubmitting: boolean;
+  label: string;
+}
+
+export default function LinkedInSignUpButton({
+  isSubmitting,
+  label,
+}: LinkedInSignUpButtonProps) {
+  const { toast } = useToast();
+
+  const handleLinkedInSignUp = async () => {
+    try {
+      await signIn('linkedin');
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '無法完成 LinkedIn 註冊，請稍後再試。',
+      });
+      return;
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      className="h-12 w-full rounded-full"
+      disabled={isSubmitting}
+      onClick={handleLinkedInSignUp}
+    >
+      <LinkedinColor className="mr-3 text-xl" />
+      <span className="text-base">{label}</span>
+    </Button>
+  );
+}


### PR DESCRIPTION
## 這個 PR 做了什麼

- Add Linkedin sign-in/sign-up OAuth
- Redirect to auth/emailVerify upon signup, and redirect to auth/onboarding upon signin

## Demo

localhost:3000/auth/signup
localhost:3000/auth/signin

## Screenshot
![image](https://github.com/user-attachments/assets/dd522304-0fd4-450e-a94d-b2ad316c6368)

## 有什麼需特別註記的

N/A
