### PR TITLE
feat: implement resend verification email functionality

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,1 +1,0 @@
-NEXT_PUBLIC_API_URL=https://szm7ap94u8.execute-api.ap-northeast-1.amazonaws.com/dev/api/v1

--- a/src/app/auth/emailVerify/container.tsx
+++ b/src/app/auth/emailVerify/container.tsx
@@ -1,0 +1,60 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { resendVerificationEmail } from '@/services/resend/resend';
+
+const EmailVerificationPage = dynamic(() => import('./ui'));
+
+export default function EmailVerificationContainer() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [email, setEmail] = useState<string | null>(null);
+
+  useEffect(() => {
+    const storedEmail = sessionStorage.getItem('email');
+    if (!storedEmail) {
+      router.push('/');
+    } else {
+      setEmail(storedEmail);
+    }
+  }, [router]);
+
+  const handleResendEmail = async () => {
+    if (!email) return;
+
+    try {
+      await resendVerificationEmail(email);
+      toast({
+        variant: 'default',
+        title: '已重新寄送',
+        description: '驗證信已重新寄送！',
+      });
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        title: '寄送失敗',
+        description:
+          error instanceof Error ? error.message : '重新寄送失敗，請稍後再試。',
+      });
+    }
+  };
+
+  const handleNavigateHome = () => {
+    router.push('/');
+  };
+
+  if (!email) {
+    return null;
+  }
+
+  return (
+    <EmailVerificationPage
+      onResendEmail={handleResendEmail}
+      onNavigateHome={handleNavigateHome}
+    />
+  );
+}

--- a/src/app/auth/emailVerify/page.tsx
+++ b/src/app/auth/emailVerify/page.tsx
@@ -1,53 +1,5 @@
-'use client';
-
-import Image from 'next/image';
-import { useRouter } from 'next/navigation';
-
-import EmailVerifyIconUrl from '@/assets/auth/email-verify-icon.svg';
-import { Button } from '@/components/ui/button';
+import EmailVerificationContainer from './container';
 
 export default function Page() {
-  const router = useRouter();
-
-  const handleResendEmail = () => {
-    alert('Resend email');
-  };
-
-  return (
-    <div className="mx-auto my-40 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:max-w-[630px]">
-      <div className="relative h-[108px] bg-[#EBFBFB]">
-        <Image
-          className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-2/3 transform"
-          src={EmailVerifyIconUrl.src}
-          alt="Verify Email"
-          width={80}
-          height={80}
-        />
-      </div>
-      <div className="flex flex-col items-center gap-6 p-20 text-center">
-        <h1 className="text-[32px] font-bold leading-10">驗證信箱</h1>
-
-        <p className="text-neutral-600">
-          已傳送一封驗證信，點選連結以完成帳號註冊。
-        </p>
-
-        <Button
-          className="max-w-60 rounded-full"
-          onClick={() => router.push('/')}
-        >
-          回首頁
-        </Button>
-
-        <p className="text-xs text-text-tertiary">
-          沒有收到信嗎？{' '}
-          <span
-            className="cursor-pointer underline decoration-1"
-            onClick={handleResendEmail}
-          >
-            點此重新寄送
-          </span>
-        </p>
-      </div>
-    </div>
-  );
+  return <EmailVerificationContainer />;
 }

--- a/src/app/auth/emailVerify/ui.tsx
+++ b/src/app/auth/emailVerify/ui.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image';
+
+import EmailVerifyIconUrl from '@/assets/auth/email-verify-icon.svg';
+import { Button } from '@/components/ui/button';
+
+interface EmailVerificationPageProps {
+  onResendEmail: () => void;
+  onNavigateHome: () => void;
+}
+
+export default function EmailVerificationPage({
+  onResendEmail,
+  onNavigateHome,
+}: EmailVerificationPageProps) {
+  return (
+    <div className="mx-auto my-40 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:max-w-[630px]">
+      <div className="relative h-[108px] bg-[#EBFBFB]">
+        <Image
+          className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-2/3 transform"
+          src={EmailVerifyIconUrl.src}
+          alt="Verify Email"
+          width={80}
+          height={80}
+        />
+      </div>
+      <div className="flex flex-col items-center gap-6 p-20 text-center">
+        <h1 className="text-[32px] font-bold leading-10">驗證信箱</h1>
+
+        <p className="text-neutral-600">
+          已傳送一封驗證信，點選連結以完成帳號註冊。
+        </p>
+
+        <Button className="max-w-60 rounded-full" onClick={onNavigateHome}>
+          回首頁
+        </Button>
+
+        <p className="text-xs text-text-tertiary">
+          沒有收到信嗎？{' '}
+          <span
+            className="cursor-pointer underline decoration-1"
+            onClick={onResendEmail}
+          >
+            點此重新寄送
+          </span>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/auth/useSignUpForm.ts
+++ b/src/hooks/auth/useSignUpForm.ts
@@ -8,7 +8,7 @@ import { AuthFormProps } from '@/components/auth/types';
 import { useToast } from '@/components/ui/use-toast';
 import { SignUpSchema } from '@/schemas/auth';
 import { signUp } from '@/services/auth/signUp';
-import { AuthResponse } from '@/services/auth/types';
+import { AuthResponse } from '@/services/types';
 
 import { handleSignUpError } from '../../services/auth/signUpErrorHandler';
 type SignUpValues = z.infer<typeof SignUpSchema>;
@@ -34,6 +34,7 @@ export default function useSignUpForm(): AuthFormProps<SignUpValues> {
       const result = await signUp(values);
 
       if (result.status === 'success') {
+        sessionStorage.setItem('email', values.email);
         router.push('/auth/emailVerify');
         return;
       }

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -9,8 +9,7 @@ import { auth } from './auth';
 
 export default auth((req) => {
   const { nextUrl } = req;
-  // const isLoggedIn = !!req.auth;
-  const isLoggedIn = false;
+  const isLoggedIn = !!req.auth;
 
   const isApiAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
   const isAuthRoute = authRoutes.includes(nextUrl.pathname);

--- a/src/services/auth/signUp.ts
+++ b/src/services/auth/signUp.ts
@@ -2,14 +2,13 @@ import { z } from 'zod';
 
 import { SignUpSchema } from '@/schemas/auth';
 
+import { AuthResponse, createGeneralErrorResponse } from '../types';
 import {
   createEmailAlreadyRegisteredResponse,
-  createGeneralErrorResponse,
   createRateLimitResponse,
   createSignUpSuccessResponse,
   createValidationErrorResponse,
 } from './signupResponseHandlers';
-import { AuthResponse } from './types';
 
 export async function signUp(
   values: z.infer<typeof SignUpSchema>,

--- a/src/services/auth/signUpErrorHandler.ts
+++ b/src/services/auth/signUpErrorHandler.ts
@@ -1,4 +1,4 @@
-import { AuthResponse } from '@/services/auth/types';
+import { AuthResponse } from '@/services/types';
 
 export const handleSignUpError = (
   result: AuthResponse,

--- a/src/services/auth/signupResponseHandlers.ts
+++ b/src/services/auth/signupResponseHandlers.ts
@@ -1,4 +1,4 @@
-import { AuthResponse } from './types';
+import { AuthResponse } from '../types';
 
 export const createSignUpSuccessResponse = (): AuthResponse => ({
   status: 'success',
@@ -25,14 +25,4 @@ export const createRateLimitResponse = (): AuthResponse => ({
   code: 429,
   httpStatus: 429,
   message: '您已超出最大註冊嘗試次數。請稍後再試。',
-});
-
-export const createGeneralErrorResponse = (
-  httpStatus: number,
-  message: string,
-): AuthResponse => ({
-  status: 'error',
-  code: httpStatus,
-  httpStatus,
-  message,
 });

--- a/src/services/auth/types.ts
+++ b/src/services/auth/types.ts
@@ -1,6 +1,0 @@
-export type AuthResponse = {
-  status: string;
-  code: number;
-  httpStatus: number;
-  message?: string;
-};

--- a/src/services/resend/resend.ts
+++ b/src/services/resend/resend.ts
@@ -1,0 +1,30 @@
+interface ResendEmailResponse {
+  msg?: string;
+}
+
+export async function resendVerificationEmail(email: string): Promise<void> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/auth/email/resend`,
+      {
+        method: 'POST',
+        body: JSON.stringify({ email }),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+
+    if (response.status === 201) {
+      return;
+    }
+
+    const result: ResendEmailResponse = await response.json();
+
+    throw new Error(result.msg || '重新寄送失敗');
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網絡連接。');
+    }
+
+    throw new Error(error instanceof Error ? error.message : '未知的錯誤發生');
+  }
+}

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -1,0 +1,16 @@
+export type AuthResponse = {
+  status: string;
+  code: number;
+  httpStatus?: number;
+  message?: string;
+};
+
+export const createGeneralErrorResponse = (
+  httpStatus: number,
+  message: string,
+): AuthResponse => ({
+  status: 'error',
+  code: httpStatus,
+  httpStatus,
+  message,
+});


### PR DESCRIPTION
## What does this PR do?

- Implements **resend email functionality** and integrates with the backend API `v1/auth/signup/confirm`  
- Adds **lazy loading** to the `emailVerify` page  
- Redirects users to the homepage if navigated from the signup page without an `email` parameter  

---

## Demo

http://localhost:3000/auth/emailVerify  

---

## Screenshot

![image](https://github.com/user-attachments/assets/008206e5-2bde-486f-9ba1-3fb5b39b9f08)

---

## Notes

- The **response status** should be discussed further in the future  
