### PR TITLE
feat: integrate backend api for profile avatar update

### DIFF
--- a/src/app/auth/(sign)/onboarding/page.tsx
+++ b/src/app/auth/(sign)/onboarding/page.tsx
@@ -19,6 +19,7 @@ import { useMultiStepForm } from '@/hooks/useMultiStepForm';
 import useLocationOptions from '@/hooks/user/country/useLocationOptions';
 import useIndustry from '@/hooks/user/industry/useIndustry';
 import useInterests from '@/hooks/user/interests/useInterests';
+import { updateAvatar } from '@/services/auth/updateAvatar';
 import { updateProfile } from '@/services/auth/updateProfile';
 
 const STEP_TITLE = [
@@ -37,6 +38,7 @@ export default function Page() {
     defaultValues: {
       name: '',
       avatar: '',
+      avatarFile: undefined,
       location: 'TWN',
       years_of_experience: '',
       industry: '',
@@ -86,12 +88,24 @@ export default function Page() {
     goToPrev();
   };
 
-  const onSubmit = (values: z.infer<typeof formSchema>) => {
-    handleGoToNext();
+  const onSubmit = async (values: z.infer<typeof formSchema>) => {
+    try {
+      handleGoToNext();
 
-    if (isLastStep) {
-      updateProfile(values);
-      router.push('/profile/card');
+      if (isLastStep) {
+        if (values.avatarFile) {
+          values.avatar = await updateAvatar(values.avatarFile);
+          values.avatarFile = undefined;
+        }
+
+        await updateProfile(values);
+        router.push('/profile/card');
+      }
+    } catch (error) {
+      console.error(
+        '提交失敗:',
+        error instanceof Error ? error.message : error,
+      );
     }
   };
 

--- a/src/components/onboarding/Steps/WhoAreYou.tsx
+++ b/src/components/onboarding/Steps/WhoAreYou.tsx
@@ -25,7 +25,7 @@ export const WhoAreYou: FC<Props> = ({ form }) => {
     <>
       <AvatarUpload
         control={form.control}
-        name="avatar"
+        name="avatarFile"
         maxSize={2 * 1024 * 1024}
       />
 

--- a/src/components/onboarding/Steps/index.ts
+++ b/src/components/onboarding/Steps/index.ts
@@ -6,6 +6,7 @@ const linkedinProfileUrlRegex =
 export const formSchema = z.object({
   name: z.string().min(1, '請輸入姓名').max(20, '最多不可超過 20 字'),
   avatar: z.string().optional(),
+  avatarFile: z.instanceof(File).optional(),
   location: z.string({ required_error: '請選擇地區' }),
   years_of_experience: z.string({ required_error: '請選擇您的年資區間' }),
   industry: z.string({ required_error: '請選擇您的產業類別' }),

--- a/src/services/auth/updateAvatar.ts
+++ b/src/services/auth/updateAvatar.ts
@@ -1,0 +1,67 @@
+import { getSession } from 'next-auth/react';
+
+interface UpdateAvatarResponse {
+  code: string;
+  msg: string;
+  data?: {
+    file_info_vo_list: {
+      file_id: string;
+      file_name: string;
+      file_size: number;
+      content_type: string;
+      url: string;
+      create_time: string;
+      update_time: string;
+      create_user_id: number;
+      is_deleted: boolean;
+    }[];
+  };
+}
+
+export async function updateAvatar(
+  avatarFile: File,
+): Promise<string | undefined> {
+  try {
+    const session = await getSession();
+    const token = session?.accessToken;
+    const userId = session?.user?.id;
+
+    if (!token || !userId) {
+      throw new Error('未獲取到有效的身份驗證信息，請重新登入。');
+    }
+
+    const formData = new FormData();
+    formData.append('file', avatarFile, avatarFile.name);
+
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/storage/?user_id=${userId}`,
+      {
+        method: 'POST',
+        body: formData,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      },
+    );
+
+    if (!response.ok) {
+      const result: UpdateAvatarResponse = await response.json();
+      throw new Error(result.msg || '上傳頭像失敗');
+    }
+
+    const result: UpdateAvatarResponse = await response.json();
+
+    const uploadedFile = result.data?.file_info_vo_list?.[1];
+    if (!uploadedFile) {
+      throw new Error('未找到原本尺寸的檔案');
+    }
+
+    return uploadedFile.url;
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網絡連接。');
+    }
+
+    throw new Error(error instanceof Error ? error.message : '未知的錯誤發生');
+  }
+}


### PR DESCRIPTION
## What Does This PR Do?

- Calls the backend API to upload the avatar file to cloud storage.
- Sends the `avatarUrl` to the backend when calling `updateProfile`.

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

![image](https://github.com/user-attachments/assets/675b15ac-1021-4761-94b1-29cf7c5f1a17)


## Anything to Note?

N/A
