### PR TITLE
feat: restrict avatar upload to 500x500 dimensions

### DIFF
--- a/src/components/ui/avatarCropModal.tsx
+++ b/src/components/ui/avatarCropModal.tsx
@@ -46,10 +46,10 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
             <AvatarEditor
               ref={editorRef}
               image={file}
-              width={200}
-              height={200}
+              width={512}
+              height={512}
               border={50}
-              borderRadius={100}
+              borderRadius={300}
               scale={zoomScale}
             />
           )}


### PR DESCRIPTION
## What Does This PR Do?

- Fixes the upload image feature to set the height and width to 500x500.

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

![image](https://github.com/user-attachments/assets/fa6e780f-530b-4330-960a-ba311b401481)

## Anything to Note?

N/A
