### PR TITLE
feat: integrate google authentication with backend signup

### DIFF
--- a/src/app/auth/(sign)/signin/page.tsx
+++ b/src/app/auth/(sign)/signin/page.tsx
@@ -18,6 +18,7 @@ export default function AuthPage() {
         <GoogleSignUpButton
           isSubmitting={signInFormProps.isSubmitting}
           label="使用 Google 帳號登入"
+          isSignIn={true}
         />
       </div>
     </div>

--- a/src/app/auth/(sign)/signup/page.tsx
+++ b/src/app/auth/(sign)/signup/page.tsx
@@ -17,6 +17,7 @@ export default function AuthPage() {
         <GoogleSignUpButton
           isSubmitting={signUpFormProps.isSubmitting}
           label="使用 Google 帳號註冊"
+          isSignIn={false}
         />
       </div>
     </div>

--- a/src/app/auth/google/callback/signin/page.tsx
+++ b/src/app/auth/google/callback/signin/page.tsx
@@ -1,0 +1,74 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { getSession } from 'next-auth/react';
+import { signIn } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { handleSignUpError } from '@/services/auth/signUpErrorHandler';
+import { AuthResponse } from '@/services/types';
+
+export default function Page() {
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const [message, setMessage] = useState('');
+  const router = useRouter();
+
+  useEffect(() => {
+    const doSignIn = async () => {
+      const session = await getSession();
+
+      const user = session?.user;
+      const googleAccessToken = session?.googleAccessToken;
+
+      if (!user?.oauthId || !googleAccessToken) {
+        if (!session?.accessToken || session?.accessToken.length === 0) {
+          toast({
+            variant: 'destructive',
+            description: 'Login failed: User data is missing',
+            duration: 1000,
+          });
+          return;
+        }
+
+        if (session?.user.onBoarding === false) {
+          router.push('/auth/onboarding');
+        } else {
+          router.push('/mentorlist');
+        }
+
+        return;
+      }
+
+      try {
+        await signIn('credentials-google-oauth', {
+          access_token: googleAccessToken,
+          oauth_id: user.oauthId,
+          language: 'zh_TW',
+        });
+      } catch (err) {
+        const error = err as AuthResponse;
+
+        if (error?.message) {
+          setMessage(error.message);
+        } else {
+          setMessage('Unknown error occurred');
+        }
+
+        handleSignUpError(error as AuthResponse, toast);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    doSignIn();
+  }, []);
+
+  if (isLoading) {
+    return <div className="text-center">驗證中，請稍候...</div>;
+  }
+
+  if (message) {
+    return <div className="text-center">{message}</div>;
+  }
+}

--- a/src/app/auth/google/callback/signup/page.tsx
+++ b/src/app/auth/google/callback/signup/page.tsx
@@ -1,0 +1,73 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { googleSignUp, GoogleSignUpType } from '@/services/auth/googleSignUp';
+import { handleSignUpError } from '@/services/auth/signUpErrorHandler';
+import { AuthResponse } from '@/services/types';
+
+export default function Page() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isLoading, setIsLoading] = useState(true);
+  const [message, setMessage] = useState('');
+
+  useEffect(() => {
+    if (status === 'loading') return;
+
+    if (status === 'unauthenticated') {
+      router.push('/auth/signup');
+      return;
+    }
+
+    const doSignUp = async () => {
+      const user = session?.user;
+      const googleAccessToken = session?.googleAccessToken;
+
+      if (!user?.email || !user?.oauthId || !googleAccessToken) {
+        router.push('/auth/signup');
+        return;
+      }
+
+      const googleSignUpBody: GoogleSignUpType = {
+        email: user.email,
+        oauth_id: user.oauthId as string,
+        access_token: googleAccessToken,
+      };
+
+      try {
+        const result = await googleSignUp(googleSignUpBody);
+
+        if (result.status === 'success') {
+          sessionStorage.setItem('email', googleSignUpBody.email);
+          router.push('/auth/emailVerify');
+        }
+      } catch (err) {
+        const error = err as AuthResponse;
+
+        if (error?.message) {
+          setMessage(error.message);
+        } else {
+          setMessage('Unknown error occurred');
+        }
+
+        handleSignUpError(error as AuthResponse, toast);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    doSignUp();
+  }, [status]);
+
+  if (isLoading) {
+    return <div className="text-center">驗證中，請稍候...</div>;
+  }
+
+  if (message) {
+    return <div className="text-center">{message}</div>;
+  }
+}

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,6 +1,5 @@
 import type { NextAuthConfig } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
-// import Google from 'next-auth/providers/google';
 import GoogleProvider from 'next-auth/providers/google';
 
 import { SignInSchema } from '@/schemas/auth';
@@ -40,29 +39,71 @@ export default {
         return null;
       },
     }),
+    CredentialsProvider({
+      id: 'credentials-google-oauth',
+      credentials: {
+        access_token: { label: 'Google Access Token', type: 'text' },
+        oauth_id: { label: 'OAuth Id', type: 'text' },
+        language: { label: 'Language', type: 'text' },
+      },
+      async authorize(credentials) {
+        const { access_token, oauth_id, language } = credentials ?? {};
+        if (!access_token || !oauth_id) return null;
+
+        const res = await fetch(
+          `${process.env.NEXT_PUBLIC_API_URL}/oauth/login/GOOGLE?language=${language}`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ access_token, oauth_id }),
+          },
+        );
+
+        const response = await res.json();
+
+        if (res.ok && response.data) {
+          return {
+            id: response.data.auth.user_id,
+            token: response.data.auth.token,
+            onBoarding: response.data.user.onboarding,
+          };
+        }
+        return null;
+      },
+    }),
   ],
-  // callbacks: {
-  //   async jwt({ account }) {
-  //     console.log('Account Data:', account);
-  //   },
-  // },
-  // callbacks: {
-  //   async jwt({ token, user }) {
-  //     if (user && 'id' in user) {
-  //       token.id = user.id as string;
-  //       token.token = user.token as string;
-  //       token.onBoarding = user.onBoarding as boolean;
-  //     }
-  //     return token;
-  //   },
-  //   async session({ session, token }) {
-  //     session.user = {
-  //       id: token.id as string,
-  //       onBoarding: token.onBoarding as boolean,
-  //     };
-  //     session.accessToken = token.token as string;
-  //     return session;
-  //   },
-  // },
+  callbacks: {
+    async jwt({ token, user, account, profile }) {
+      if (account) {
+        if (
+          account.provider === 'google' &&
+          profile &&
+          user.onBoarding === undefined
+        ) {
+          token.access_token = account.access_token;
+          token.email = profile.email;
+          token.oauthId = profile.sub;
+        } else if (user) {
+          token.id = user.id as string;
+          token.token = user.token as string;
+          token.onBoarding = user.onBoarding as boolean;
+        }
+      }
+
+      return token;
+    },
+    async session({ session, token }) {
+      session.user = {
+        id: token.id as string,
+        onBoarding: token.onBoarding as boolean | undefined,
+        email: token.email as string | undefined,
+        oauthId: token.oauthId as string | undefined,
+      };
+      session.accessToken = token.token as string | undefined;
+      session.googleAccessToken = token.access_token as string | undefined;
+
+      return session;
+    },
+  },
   secret: process.env.NEXTAUTH_SECRET,
 } satisfies NextAuthConfig;

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -28,7 +28,7 @@ export const Header: FC = async () => {
           >
             關於 X-Talent
           </Link>
-          {session ? (
+          {session?.user.id ? (
             <form
               action={async () => {
                 'use server';

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -6,18 +6,24 @@ import { useToast } from '@/components/ui/use-toast';
 
 interface GoogleSignUpButtonProps {
   isSubmitting: boolean;
+  isSignIn: boolean;
   label: string;
 }
 
 export default function GoogleSignUpButton({
   isSubmitting,
   label,
+  isSignIn,
 }: GoogleSignUpButtonProps) {
   const { toast } = useToast();
 
   const handleGoogleSignUp = async () => {
     try {
-      await signIn('google');
+      await signIn('google', {
+        callbackUrl: isSignIn
+          ? '/auth/google/callback/signin'
+          : '/auth/google/callback/signup',
+      });
     } catch (error) {
       toast({
         variant: 'destructive',

--- a/src/hooks/auth/useSignInForm.ts
+++ b/src/hooks/auth/useSignInForm.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
 import { getSession } from 'next-auth/react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -14,6 +15,7 @@ type SignInValues = z.infer<typeof SignInSchema>;
 export default function useSignInForm(): AuthFormProps<SignInValues> {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
+  const router = useRouter();
 
   const form = useForm<z.infer<typeof SignInSchema>>({
     resolver: zodResolver(SignInSchema),
@@ -40,9 +42,9 @@ export default function useSignInForm(): AuthFormProps<SignInValues> {
       }
 
       if (session?.user.onBoarding === false) {
-        window.location.href = '/auth/onboarding';
+        router.push('/auth/onboarding');
       } else {
-        window.location.href = '/mentorlist';
+        router.push('/mentorlist');
       }
     } catch (error) {
       console.error(error);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,10 +6,6 @@ export default auth((req) => {
   const { nextUrl } = req;
   const isLoggedIn = !!req.auth;
 
-  if (req.auth) {
-    console.log('Google Auth Data:', req.auth);
-  }
-
   const isApiAuthRoute = nextUrl.pathname.startsWith(apiAuthPrefix);
   const isPublicRoute = publicRoutes.includes(nextUrl.pathname);
 

--- a/src/services/auth/googleSignUp.ts
+++ b/src/services/auth/googleSignUp.ts
@@ -1,0 +1,63 @@
+import { AuthResponse, createGeneralErrorResponse } from '../types';
+import {
+  createEmailAlreadyRegisteredResponse,
+  createRateLimitResponse,
+  createSignUpSuccessResponse,
+  createValidationErrorResponse,
+} from './signupResponseHandlers';
+
+export interface GoogleSignUpType {
+  email: string;
+  access_token: string;
+  oauth_id: string;
+}
+
+export async function googleSignUp(
+  values: GoogleSignUpType,
+): Promise<AuthResponse> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/oauth/signup/GOOGLE`,
+      {
+        method: 'POST',
+        body: JSON.stringify(values),
+        headers: { 'Content-Type': 'application/json' },
+      },
+    );
+
+    const result = await response.json();
+    if (response.status === 201 && result.code === '0') {
+      return createSignUpSuccessResponse();
+    }
+
+    if (response.status === 422) {
+      throw createValidationErrorResponse();
+    }
+
+    if (response.status === 406) {
+      throw createEmailAlreadyRegisteredResponse();
+    }
+
+    if (response.status === 429 && result.code === '42900') {
+      throw createRateLimitResponse();
+    }
+
+    throw createGeneralErrorResponse(
+      response.status,
+      result.message || '註冊失敗',
+    );
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw createGeneralErrorResponse(
+        0,
+        '無法連接到伺服器。請檢查您的網絡連接。',
+      );
+    }
+
+    if (error instanceof Error || (error as AuthResponse)?.status === 'error') {
+      throw error;
+    }
+
+    throw createGeneralErrorResponse(500, '系統錯誤，請稍後再試');
+  }
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -6,9 +6,10 @@ declare module 'next-auth' {
    * Extending the User object returned by `authorize`, `getUser`, etc.
    */
   interface User {
-    id: string;
+    id?: string;
     token?: string;
     onBoarding?: boolean;
+    oauthId?: string;
   }
 
   /**
@@ -16,10 +17,13 @@ declare module 'next-auth' {
    */
   interface Session {
     user: {
-      id: string;
+      id?: string;
+      token?: string;
       onBoarding?: boolean;
+      oauthId?: string;
     } & DefaultSession['user'];
     accessToken?: string;
+    googleAccessToken?: string;
   }
 
   /**


### PR DESCRIPTION
## What Does This PR Do?

- Implements Google OAuth for signup and signin processes (using a callback page to handle different logic).
- During signup, passes the Google Access token, email, and OAuth ID to the backend.
- During signin, passes the Google Access token and OAuth ID to the backend.


## Demo

http://localhost:3000/auth/signup
http://localhost:3000/auth/signin

## Screenshot

![image](https://github.com/user-attachments/assets/cd55558d-0358-4b8e-92bc-0ff2b4d583db)

## Anything to Note?

N/A
