### PR TITLE
feat: display user avatar and name after google oauth signin

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,10 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    domains: ['x-career-multimedia.s3.ap-northeast-1.amazonaws.com'],
+    domains: [
+      'x-career-multimedia.s3.ap-northeast-1.amazonaws.com',
+      'lh3.googleusercontent.com',
+    ],
   },
 };
 

--- a/src/app/auth/(sign)/onboarding/page.tsx
+++ b/src/app/auth/(sign)/onboarding/page.tsx
@@ -2,7 +2,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import ArrowBackIcon from '@mui/icons-material/ArrowBackIosNew';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -45,6 +45,22 @@ export default function Page() {
 
   const [currentStep, setCurrentStep] = useState(1);
 
+  useEffect(() => {
+    const name = sessionStorage.getItem('name');
+    let avatar = sessionStorage.getItem('avatar');
+
+    if (avatar) {
+      avatar = avatar.slice(0, avatar.lastIndexOf('='));
+    }
+
+    step1Form.reset({
+      name: name || '',
+      avatar: avatar || '',
+      avatarFile: undefined,
+      language: 'zh_TW',
+    });
+  }, []);
+
   const [tempData, setTempData] = useState<{
     step1?: z.infer<typeof step1Schema>;
     step2?: z.infer<typeof step2Schema>;
@@ -58,6 +74,7 @@ export default function Page() {
     defaultValues: {
       name: '',
       avatarFile: undefined,
+      avatar: '',
       language: 'zh_TW',
     },
   });
@@ -160,7 +177,10 @@ export default function Page() {
               </div>
 
               <div>
-                <WhoAreYou form={step1Form} />
+                <WhoAreYou
+                  form={step1Form}
+                  avatarUrl={step1Form.getValues().avatar || ''}
+                />
               </div>
 
               <div>

--- a/src/app/auth/google/callback/signin/page.tsx
+++ b/src/app/auth/google/callback/signin/page.tsx
@@ -5,8 +5,6 @@ import { signIn } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 import { useToast } from '@/components/ui/use-toast';
-import { handleSignUpError } from '@/services/auth/signUpErrorHandler';
-import { AuthResponse } from '@/services/types';
 
 export default function Page() {
   const { toast } = useToast();
@@ -28,6 +26,11 @@ export default function Page() {
             description: 'Login failed: User data is missing',
             duration: 1000,
           });
+          if (user?.msg) {
+            setMessage(user.msg);
+          } else {
+            setMessage('Unknown error occurred');
+          }
           return;
         }
 
@@ -36,8 +39,15 @@ export default function Page() {
         } else {
           router.push('/mentorlist');
         }
-
         return;
+      }
+
+      if (user?.name) {
+        sessionStorage.setItem('name', user.name);
+      }
+
+      if (user?.avatar) {
+        sessionStorage.setItem('avatar', user.avatar);
       }
 
       try {
@@ -47,15 +57,14 @@ export default function Page() {
           language: 'zh_TW',
         });
       } catch (err) {
-        const error = err as AuthResponse;
+        const error = err as Error;
+        console.error(error);
 
-        if (error?.message) {
+        if (error) {
           setMessage(error.message);
         } else {
           setMessage('Unknown error occurred');
         }
-
-        handleSignUpError(error as AuthResponse, toast);
       } finally {
         setIsLoading(false);
       }
@@ -64,11 +73,11 @@ export default function Page() {
     doSignIn();
   }, []);
 
-  if (isLoading) {
-    return <div className="text-center">驗證中，請稍候...</div>;
-  }
-
   if (message) {
     return <div className="text-center">{message}</div>;
+  }
+
+  if (isLoading) {
+    return <div className="text-center">驗證中，請稍候...</div>;
   }
 }

--- a/src/app/auth/google/callback/signup/page.tsx
+++ b/src/app/auth/google/callback/signup/page.tsx
@@ -63,11 +63,11 @@ export default function Page() {
     doSignUp();
   }, [status]);
 
-  if (isLoading) {
-    return <div className="text-center">驗證中，請稍候...</div>;
-  }
-
   if (message) {
     return <div className="text-center">{message}</div>;
+  }
+
+  if (isLoading) {
+    return <div className="text-center">驗證中，請稍候...</div>;
   }
 }

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -68,7 +68,7 @@ export default {
             onBoarding: response.data.user.onboarding,
           };
         }
-        return null;
+        return { id: response.code, msg: response.msg };
       },
     }),
   ],
@@ -83,10 +83,13 @@ export default {
           token.access_token = account.access_token;
           token.email = profile.email;
           token.oauthId = profile.sub;
+          token.avatar = profile.picture;
+          token.name = profile.name;
         } else if (user) {
           token.id = user.id as string;
           token.token = user.token as string;
           token.onBoarding = user.onBoarding as boolean;
+          token.msg = user.msg;
         }
       }
 
@@ -98,6 +101,9 @@ export default {
         onBoarding: token.onBoarding as boolean | undefined,
         email: token.email as string | undefined,
         oauthId: token.oauthId as string | undefined,
+        name: token.name as string | undefined,
+        avatar: token.avatar as string | undefined,
+        msg: token.msg as string | undefined,
       };
       session.accessToken = token.token as string | undefined;
       session.googleAccessToken = token.access_token as string | undefined;

--- a/src/components/onboarding/Steps/WhoAreYou.tsx
+++ b/src/components/onboarding/Steps/WhoAreYou.tsx
@@ -18,15 +18,17 @@ import { step1Schema } from './index';
 
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step1Schema>>>;
+  avatarUrl: string;
 }
 
-export const WhoAreYou: FC<Props> = ({ form }) => {
+export const WhoAreYou: FC<Props> = ({ form, avatarUrl }) => {
   return (
     <>
       <AvatarUpload
         control={form.control}
         name="avatarFile"
         maxSize={2 * 1024 * 1024}
+        avatarUrl={avatarUrl}
       />
 
       <FormField

--- a/src/components/ui/avatarUpload.tsx
+++ b/src/components/ui/avatarUpload.tsx
@@ -10,16 +10,20 @@ interface AvatarUploadProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
   maxSize?: number;
+  avatarUrl: string;
 }
 
 const AvatarUpload = <T extends FieldValues>({
   control,
   name,
   maxSize = 2 * 1024 * 1024,
+  avatarUrl,
 }: AvatarUploadProps<T>) => {
   const { field } = useController({ control, name });
 
-  const imagePreviewUrl = field.value ? URL.createObjectURL(field.value) : null;
+  const imagePreviewUrl = field.value
+    ? URL.createObjectURL(field.value)
+    : avatarUrl;
 
   const [selectedImage, setSelectedImage] = useState<File | null>(null);
   const [open, setOpen] = useState(false);

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -10,6 +10,9 @@ declare module 'next-auth' {
     token?: string;
     onBoarding?: boolean;
     oauthId?: string;
+    name?: string;
+    avatar?: string;
+    msg?: string;
   }
 
   /**
@@ -21,6 +24,7 @@ declare module 'next-auth' {
       token?: string;
       onBoarding?: boolean;
       oauthId?: string;
+      msg?: string;
     } & DefaultSession['user'];
     accessToken?: string;
     googleAccessToken?: string;
@@ -47,5 +51,6 @@ declare module 'next-auth/jwt' {
     id: string;
     token: string;
     onBoarding?: boolean;
+    msg?: string;
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- Saves the Google avatar and name in the session after signing in with a Google account. After signing in with credentials, the onboarding page will display the avatar and name.
- Handles error messages when signing in fails.

## Demo

http://localhost:3000/auth/signin
http://localhost:3000/auth/onboarding

## Screenshot

![image](https://github.com/user-attachments/assets/a88bc7e4-b082-4d4d-b33e-25162c3d4310)


## Anything to Note?

N/A
