### PR TITLE
feat: display failure page for expired token on email verification

### DIFF
--- a/src/app/auth/emailVerified/container.tsx
+++ b/src/app/auth/emailVerified/container.tsx
@@ -4,6 +4,8 @@ import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
+import EmailVerifiedFailuredIconUrl from '@/assets/auth/email-verified-failed-icon.svg';
+import EmailVerifiedIconUrl from '@/assets/auth/email-verified-icon.svg';
 import { useToast } from '@/components/ui/use-toast';
 import { confirmRegister } from '@/services/auth/confirmRegister';
 
@@ -15,6 +17,13 @@ export default function EmailVerifiedContainer() {
   const token = searchParams.get('token');
   const { toast } = useToast();
   const [isLoading, setIsLoading] = useState(true);
+  const [icon, setIcon] = useState(EmailVerifiedIconUrl.src);
+  const [title, setTitle] = useState('驗證成功');
+  const [content, setContent] = useState(
+    '你的帳號已完成註冊。現在可以開始建立你的個人頁面和尋找 Mentors 了！',
+  );
+  const [btnContent, setBtnContent] = useState('設定個人資訊');
+  const [redirectUrl, setRedirectUrl] = useState('/auth/signin');
 
   useEffect(() => {
     if (!token) {
@@ -32,7 +41,12 @@ export default function EmailVerifiedContainer() {
           description:
             error instanceof Error ? error.message : '註冊失敗，請稍後再試。',
         });
-        router.push('/auth/signup');
+
+        setIcon(EmailVerifiedFailuredIconUrl.src);
+        setTitle('驗證失敗');
+        setContent('您的驗證連結已失效，請重新輸入Email再次驗證');
+        setBtnContent('返回重試');
+        setRedirectUrl('/auth/signup');
       } finally {
         setIsLoading(false);
       }
@@ -47,7 +61,11 @@ export default function EmailVerifiedContainer() {
 
   return (
     <EmailVerifiedPresentation
-      onSetProfile={() => router.push('/auth/signin')}
+      icon={icon}
+      onSetProfile={() => router.push(redirectUrl)}
+      title={title}
+      content={content}
+      btnContent={btnContent}
     />
   );
 }

--- a/src/app/auth/emailVerified/ui.tsx
+++ b/src/app/auth/emailVerified/ui.tsx
@@ -1,13 +1,20 @@
 import Image from 'next/image';
 
-import EmailVerifiedIconUrl from '@/assets/auth/email-verified-icon.svg';
 import { Button } from '@/components/ui/button';
 
 interface EmailVerifiedPresentationProps {
+  icon: string;
+  title: string;
+  content: string;
+  btnContent: string;
   onSetProfile: () => void;
 }
 
 export default function EmailVerifiedPresentation({
+  icon,
+  title,
+  content,
+  btnContent,
   onSetProfile,
 }: EmailVerifiedPresentationProps) {
   return (
@@ -15,21 +22,19 @@ export default function EmailVerifiedPresentation({
       <div className="relative h-[108px] bg-[#EBFBFB]">
         <Image
           className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-2/3 transform"
-          src={EmailVerifiedIconUrl.src}
+          src={icon}
           alt="Verify Email"
           width={80}
           height={80}
         />
       </div>
       <div className="flex flex-col items-center gap-6 p-20 text-center">
-        <h1 className="text-[32px] font-bold leading-10">驗證成功</h1>
+        <h1 className="text-[32px] font-bold leading-10">{title}</h1>
 
-        <p className="text-neutral-600">
-          你的帳號已完成註冊。現在可以開始建立你的個人頁面和尋找 Mentors 了！
-        </p>
+        <p className="text-neutral-600">{content}</p>
 
         <Button className="max-w-60 rounded-full" onClick={onSetProfile}>
-          設定個人資訊
+          {btnContent}
         </Button>
       </div>
     </div>

--- a/src/assets/auth/email-verified-failed-icon.svg
+++ b/src/assets/auth/email-verified-failed-icon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80">
+  <circle cx="40" cy="40" r="40" fill="#E5F9F9" />
+  <circle cx="40" cy="40" r="39.5" fill="#FFFFFF" stroke="#D3D3D3" stroke-width="1" />
+  <circle cx="40" cy="40" r="20" fill="#FF4B4B" />
+  <rect x="37" y="25" width="6" height="20" fill="#FFFFFF" />
+  <circle cx="40" cy="55" r="3" fill="#FFFFFF" />
+</svg>


### PR DESCRIPTION
## What Does This PR Do?

- Adds a failure page to the emailVerified page.

## Demo

http://localhost:3000/auth/emailVerified?token=12345

## Screenshot

![image](https://github.com/user-attachments/assets/27e45b4d-83f3-4d4e-b7d3-121c6a3ac45d)

## Anything to Note?

N/A
