### PR TITLE
feat: add display role based profile button mentor/mentee

### DIFF
--- a/src/app/profile/[userId]/page.tsx
+++ b/src/app/profile/[userId]/page.tsx
@@ -2,6 +2,8 @@
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { getSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.jpeg';
 import { LinkedinColor } from '@/components/Icon';
@@ -30,8 +32,22 @@ export default function Page({
 }) {
   const router = useRouter();
 
-  // TODO: 待處理依據 userId 取資料邏輯
-  console.info('userId', userId);
+  const [isLogging, setIsLogging] = useState(false);
+  const [isMentee, setIsMentee] = useState(false);
+  const [isMentor, setIsMentor] = useState(false);
+
+  useEffect(() => {
+    const fetchSession = async () => {
+      const session = await getSession();
+      const user = session?.user;
+
+      setIsLogging(!!user?.id);
+      setIsMentee(user?.isMentor !== true);
+      setIsMentor(user?.isMentor === true);
+    };
+
+    fetchSession();
+  }, []);
 
   const { name, avatarImgUrl, jobTitle, companyName } = PROFILE_DATA;
 
@@ -68,19 +84,33 @@ export default function Page({
           </div>
 
           <div className="static mt-4 flex items-center justify-center gap-4 sm:absolute sm:bottom-0 sm:left-[184px] sm:mt-0 lg:static">
-            <Button
-              variant="outline"
-              className="grow rounded-full px-6  py-3 sm:grow-0"
-              onClick={() => router.push(`/profile/${userId}/edit`)}
-            >
-              編輯個人資訊
-            </Button>
-            <Button
-              variant="default"
-              className="grow rounded-full px-6 py-3 sm:grow-0"
-            >
-              預約設定
-            </Button>
+            {isLogging && (
+              <Button
+                variant="outline"
+                className="grow rounded-full px-6  py-3 sm:grow-0"
+                onClick={() => router.push(`/profile/${userId}/edit`)}
+              >
+                編輯個人資訊
+              </Button>
+            )}
+
+            {isLogging && isMentee && (
+              <Button
+                variant="default"
+                className="grow rounded-full px-6 py-3 sm:grow-0"
+              >
+                變成導師
+              </Button>
+            )}
+
+            {isLogging && isMentor && (
+              <Button
+                variant="default"
+                className="grow rounded-full px-6 py-3 sm:grow-0"
+              >
+                預約設定
+              </Button>
+            )}
           </div>
         </div>
 
@@ -107,6 +137,7 @@ export default function Page({
               <p className="text-sm text-gray-400">目前還沒有教育</p>
             </div>
           </div>
+
           <div className="hidden w-1/2 lg:block">
             <div>
               <p className="mb-4 text-xl font-bold">可預約時段</p>

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -32,6 +32,7 @@ export default {
               id: response.data.auth.user_id,
               token: response.data.auth.token,
               onBoarding: response.data.user.onboarding,
+              isMentor: response.data.user.is_mentor,
             };
           }
           return { id: response.code, msg: response.msg };
@@ -92,6 +93,7 @@ export default {
           token.token = user.token as string;
           token.onBoarding = user.onBoarding as boolean;
           token.msg = user.msg;
+          token.isMentor = user.isMentor;
         }
       }
       return token;
@@ -105,6 +107,7 @@ export default {
         name: token.name as string | undefined,
         avatar: token.avatar as string | undefined,
         msg: token.msg as string | undefined,
+        isMentor: token.isMentor as boolean | undefined,
       };
       session.accessToken = token.token as string | undefined;
       session.googleAccessToken = token.access_token as string | undefined;

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -13,6 +13,7 @@ declare module 'next-auth' {
     name?: string;
     avatar?: string;
     msg?: string;
+    isMentor?: boolean;
   }
 
   /**
@@ -25,6 +26,7 @@ declare module 'next-auth' {
       onBoarding?: boolean;
       oauthId?: string;
       msg?: string;
+      isMentor?: boolean;
     } & DefaultSession['user'];
     accessToken?: string;
     googleAccessToken?: string;
@@ -52,5 +54,6 @@ declare module 'next-auth/jwt' {
     token: string;
     onBoarding?: boolean;
     msg?: string;
+    isMentor?: boolean;
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- Dynamically displays the correct button (Mentee or Mentor) based on the user's role.
- Adds isMentor field to the sign-in response for role-based rendering.

## Demo

http://localhost:3000/profile/123

## Screenshot

Mentee
![image](https://github.com/user-attachments/assets/e4ffd9cf-446d-4f26-a72c-93a4dc088251)

Mentor
![image](https://github.com/user-attachments/assets/461f7522-cf1c-438b-831b-68b24d2f3423)


## Anything to Note?

N/A
