### PR TITLE
feat: restrict access to user's own profile and edit page

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 import { zodResolver } from '@hookform/resolvers/zod';
 import ArrowBackIcon from '@mui/icons-material/ArrowBackIosNew';
-import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getSession } from 'next-auth/react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -31,7 +33,30 @@ const onSubmit = (values: z.infer<typeof formSchema>) => {
   console.log(values);
 };
 
-export default function Page() {
+export default function Page({
+  params: { pageUserId },
+}: {
+  params: { pageUserId: string };
+}) {
+  const router = useRouter();
+  const [isAuthorized, setIsAuthorized] = useState(false);
+
+  useEffect(() => {
+    const verifyUser = async () => {
+      const session = await getSession();
+      const loginUserId = String(session?.user?.id);
+
+      if (!loginUserId || loginUserId !== pageUserId) {
+        router.push('/');
+        return;
+      }
+
+      setIsAuthorized(true);
+    };
+
+    verifyUser();
+  }, [pageUserId, router]);
+
   const isMentor = true;
 
   const { locations } = useLocations('zh_TW');
@@ -73,6 +98,10 @@ export default function Page() {
   const [interestedPosition, setInterestedPosition] = useState<string[]>([]);
   const [interestedSkills, setInterestedSkills] = useState<string[]>([]);
   const [interestedTopics, setInterestedTopics] = useState<string[]>([]);
+
+  if (!isAuthorized) {
+    return null;
+  }
 
   const handleGoToPrev = () => {};
   return (

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -26,13 +26,14 @@ const EXPERTISE_SELECTION = [
 ] as const;
 
 export default function Page({
-  params: { userId },
+  params: { pageUserId },
 }: {
-  params: { userId: string };
+  params: { pageUserId: string };
 }) {
   const router = useRouter();
 
   const [isLogging, setIsLogging] = useState(false);
+  const [loginUserId, setLoginUserId] = useState('');
   const [isMentee, setIsMentee] = useState(false);
   const [isMentor, setIsMentor] = useState(false);
 
@@ -42,6 +43,7 @@ export default function Page({
       const user = session?.user;
 
       setIsLogging(!!user?.id);
+      setLoginUserId(!!user?.id ? String(user?.id) : '');
       setIsMentee(user?.isMentor !== true);
       setIsMentor(user?.isMentor === true);
     };
@@ -84,17 +86,17 @@ export default function Page({
           </div>
 
           <div className="static mt-4 flex items-center justify-center gap-4 sm:absolute sm:bottom-0 sm:left-[184px] sm:mt-0 lg:static">
-            {isLogging && (
+            {isLogging && pageUserId === loginUserId && (
               <Button
                 variant="outline"
                 className="grow rounded-full px-6  py-3 sm:grow-0"
-                onClick={() => router.push(`/profile/${userId}/edit`)}
+                onClick={() => router.push(`/profile/${pageUserId}/edit`)}
               >
                 編輯個人資訊
               </Button>
             )}
 
-            {isLogging && isMentee && (
+            {isLogging && isMentee && pageUserId === loginUserId && (
               <Button
                 variant="default"
                 className="grow rounded-full px-6 py-3 sm:grow-0"


### PR DESCRIPTION

## What Does This PR Do?
- Restrict access to the profile and profile edit pages by verifying that the logged-in user ID matches the target user ID.

## Demo

http://localhost:3000/profile/[userId]
http://localhost:3000/profile/[userId]/edit

## Screenshot

![image](https://github.com/user-attachments/assets/4293d81b-8c18-4328-9d07-55a23cb59034)
![image](https://github.com/user-attachments/assets/047813d6-c140-44f6-893f-ada99f2a1a1a)

![image](https://github.com/user-attachments/assets/9e6da184-258c-41da-9af3-12e2f9aeb56d)

No matching, redirecting to homepage
![image](https://github.com/user-attachments/assets/440fe229-2869-4432-86e2-d5a424f89d65)


## Anything to Note?

N/A
