### PR TITLE
feat: redirect bottons on card page

### DIFF
--- a/src/app/profile/card/page.tsx
+++ b/src/app/profile/card/page.tsx
@@ -55,13 +55,14 @@ export default function Page() {
         <Button
           variant="outline"
           className="grow rounded-full px-6  py-3 sm:grow-0"
-          onClick={() => router.push('/profile/expertise')}
+          onClick={() => router.push(`/profile/${userData?.user_id}/edit`)}
         >
           成為 Mentor
         </Button>
         <Button
           variant="default"
           className="grow rounded-full px-6 py-3 sm:grow-0"
+          onClick={() => router.push('/mentorPool')}
         >
           開始探索 X-Talent
         </Button>


### PR DESCRIPTION
## What Does This PR Do?

* Clicking **"Become a Mentor"** redirects to `/profile/[user_id]/edit`.
* Clicking **"Explore Mentors"** redirects to `/mentorPool`.

## Demo

http://localhost:3000/profile/card

## Screenshot

![image](https://github.com/user-attachments/assets/ecfff6c2-372a-42ea-8d43-a58de9e35a81)


## Anything to Note?

N/A
