### PR TITLE
302 reset password page integration

### DIFF
--- a/src/app/auth/password-reset-success/page.tsx
+++ b/src/app/auth/password-reset-success/page.tsx
@@ -3,37 +3,46 @@
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
-import { VectorSolid } from '@/components/Icon';
 import { Button } from '@/components/ui/button';
 
 export default function Page() {
   const router = useRouter();
 
   return (
-    <div className="mx-auto flex h-screen max-w-[400px] flex-col gap-6 px-5 py-10 sm:px-0 sm:py-[120px]">
-      <main className="flex flex-auto flex-col justify-center gap-6 sm:flex-none ">
-        <div className="mb-6 flex flex-col items-center gap-6">
-          <div className="rounded-full bg-[#EBFBFB] p-4">
-            <VectorSolid className="text-2xl" />
+    <div className="bg-white">
+      <main className="px-6 pb-20 pt-16">
+        <div className="bg-white mx-auto w-full max-w-[554px] overflow-hidden rounded-[16px] border border-[#E5E7EB] shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
+          <div className="h-[88px] bg-[linear-gradient(90deg,#EAFBFB_0%,#CFEFFF_45%,#EAE4FF_100%)]" />
+
+          <div className="px-8 pb-10">
+            <h1 className="relative -mt-5 text-center text-[32px] font-bold leading-[1.2] text-[#1E1E1E]">
+              密碼重設成功
+            </h1>
+
+            <p className="mt-4 text-center text-base leading-6 text-[#52525B]">
+              您現在可以使用新密碼登入。
+            </p>
+
+            <div className="mt-8 flex justify-center">
+              <Button
+                className="text-white h-[36px] min-w-[92px] rounded-full bg-[#35C9CF] px-6 text-sm font-semibold hover:bg-[#2fbec4]"
+                onClick={() => router.push('/auth/signin')}
+              >
+                前往登入
+              </Button>
+            </div>
+
+            <div className="mt-5 text-center">
+              <Link
+                href="/"
+                className="text-sm text-[#1E1E1E] underline underline-offset-2"
+              >
+                回首頁
+              </Link>
+            </div>
           </div>
-          <h1 className="text-[32px] font-bold leading-10">密碼更改成功</h1>
-          <p className="text-neutral-600 text-center">
-            您的密碼已成功更改，請使用新的密碼進行登入。
-          </p>
         </div>
       </main>
-      <footer className="flex flex-col gap-4">
-        <Button
-          className="rounded-full"
-          onClick={() => router.push('/auth/signin')}
-        >
-          前往會員登入
-        </Button>
-
-        <Link href="/" className="text-center underline underline-offset-2">
-          回首頁
-        </Link>
-      </footer>
     </div>
   );
 }

--- a/src/app/auth/password-reset/page.tsx
+++ b/src/app/auth/password-reset/page.tsx
@@ -1,8 +1,77 @@
+'use client';
+
 import Link from 'next/link';
+import { Suspense } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
+import usePasswordResetForm from '@/hooks/auth/usePasswordResetForm';
+
+function PasswordResetForm() {
+  const { form, isSubmitting, onSubmit } = usePasswordResetForm();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = form;
+
+  return (
+    <form onSubmit={handleSubmit(onSubmit)} noValidate>
+      <div className="space-y-6">
+        <div className="space-y-2">
+          <Label
+            htmlFor="password"
+            className="text-base font-normal text-[#2B2B2B]"
+          >
+            新密碼
+          </Label>
+          <Input
+            id="password"
+            type="password"
+            placeholder="請輸入新密碼"
+            className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
+            {...register('password')}
+          />
+          {errors.password && (
+            <p className="text-red-500 text-sm">{errors.password.message}</p>
+          )}
+        </div>
+
+        <div className="space-y-2">
+          <Label
+            htmlFor="confirm_password"
+            className="text-base font-normal text-[#2B2B2B]"
+          >
+            確認新密碼
+          </Label>
+          <Input
+            id="confirm_password"
+            type="password"
+            placeholder="請再次輸入新密碼"
+            className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
+            {...register('confirm_password')}
+          />
+          {errors.confirm_password && (
+            <p className="text-red-500 text-sm">
+              {errors.confirm_password.message}
+            </p>
+          )}
+        </div>
+      </div>
+
+      <div className="mt-8 flex justify-center">
+        <Button
+          type="submit"
+          disabled={isSubmitting}
+          className="text-white h-[36px] min-w-[92px] rounded-full bg-[#35C9CF] px-6 text-sm font-semibold hover:bg-[#2fbec4] disabled:opacity-50"
+        >
+          {isSubmitting ? '處理中...' : '更改密碼'}
+        </Button>
+      </div>
+    </form>
+  );
+}
 
 export default function Page() {
   return (
@@ -14,43 +83,9 @@ export default function Page() {
               重設密碼
             </h1>
 
-            <div className="space-y-6">
-              <div className="space-y-2">
-                <Label
-                  htmlFor="password"
-                  className="text-base font-normal text-[#2B2B2B]"
-                >
-                  新密碼
-                </Label>
-                <Input
-                  id="password"
-                  type="password"
-                  placeholder="請輸入新密碼"
-                  className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
-                />
-              </div>
-
-              <div className="space-y-2">
-                <Label
-                  htmlFor="password-confirm"
-                  className="text-base font-normal text-[#2B2B2B]"
-                >
-                  確認新密碼
-                </Label>
-                <Input
-                  id="password-confirm"
-                  type="password"
-                  placeholder="請再次輸入新密碼"
-                  className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
-                />
-              </div>
-            </div>
-
-            <div className="mt-8 flex justify-center">
-              <Button className="text-white h-[36px] min-w-[92px] rounded-full bg-[#35C9CF] px-6 text-sm font-semibold hover:bg-[#2fbec4]">
-                更改密碼
-              </Button>
-            </div>
+            <Suspense>
+              <PasswordResetForm />
+            </Suspense>
 
             <div className="mt-6 text-center">
               <Link

--- a/src/app/auth/password-reset/page.tsx
+++ b/src/app/auth/password-reset/page.tsx
@@ -1,48 +1,68 @@
 import Link from 'next/link';
 
-import { LockSolid } from '@/components/Icon';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
 export default function Page() {
   return (
-    <div className="mx-auto flex h-screen max-w-[400px] flex-col gap-6 px-5 py-10 sm:px-0 sm:py-[120px]">
-      <main className="flex flex-auto flex-col justify-center gap-6 sm:flex-none ">
-        <div className="mb-6 flex flex-col items-center gap-6">
-          <div className="rounded-full bg-[#EBFBFB] p-4">
-            <LockSolid className="text-2xl" />
-          </div>
-          <h1 className="text-[32px] font-bold leading-10">重設密碼</h1>
-        </div>
+    <div className="bg-white">
+      <main className="px-6 py-16">
+        <div className="bg-white mx-auto w-full max-w-[556px] rounded-[16px] border border-[#E5E7EB] px-9 py-14 shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
+          <div className="mx-auto w-full max-w-[484px]">
+            <h1 className="mb-8 text-center text-[32px] font-bold leading-[1.2] text-[#1E1E1E]">
+              重設密碼
+            </h1>
 
-        <div className="flex flex-col gap-4">
-          <div className="grid w-full max-w-sm items-center gap-1.5">
-            <Label htmlFor="password">新密碼</Label>
-            <Input id="password" type="password" placeholder="請輸入新密碼" />
-          </div>
+            <div className="space-y-6">
+              <div className="space-y-2">
+                <Label
+                  htmlFor="password"
+                  className="text-base font-normal text-[#2B2B2B]"
+                >
+                  新密碼
+                </Label>
+                <Input
+                  id="password"
+                  type="password"
+                  placeholder="請輸入新密碼"
+                  className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
+                />
+              </div>
 
-          <div className="grid w-full max-w-sm items-center gap-1.5">
-            <Label htmlFor="password-confirm">確認新密碼</Label>
-            <Input
-              id="password-confirm"
-              type="password"
-              placeholder="請再次輸入新密碼"
-            />
+              <div className="space-y-2">
+                <Label
+                  htmlFor="password-confirm"
+                  className="text-base font-normal text-[#2B2B2B]"
+                >
+                  確認新密碼
+                </Label>
+                <Input
+                  id="password-confirm"
+                  type="password"
+                  placeholder="請再次輸入新密碼"
+                  className="h-[36px] rounded-[8px] border border-[#D9D9D9] px-3 text-sm placeholder:text-[#B3B3B3]"
+                />
+              </div>
+            </div>
+
+            <div className="mt-8 flex justify-center">
+              <Button className="text-white h-[36px] min-w-[92px] rounded-full bg-[#35C9CF] px-6 text-sm font-semibold hover:bg-[#2fbec4]">
+                更改密碼
+              </Button>
+            </div>
+
+            <div className="mt-6 text-center">
+              <Link
+                href="/auth/signin"
+                className="text-sm text-[#1E1E1E] underline underline-offset-2"
+              >
+                返回登入頁
+              </Link>
+            </div>
           </div>
         </div>
       </main>
-
-      <footer className="flex flex-col gap-4">
-        <Button className="rounded-full">更改密碼</Button>
-
-        <Link
-          href="/auth/signin"
-          className="text-center underline underline-offset-2"
-        >
-          返回登入頁
-        </Link>
-      </footer>
     </div>
   );
 }

--- a/src/hooks/auth/usePasswordResetForm.ts
+++ b/src/hooks/auth/usePasswordResetForm.ts
@@ -1,0 +1,62 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { useToast } from '@/components/ui/use-toast';
+import { PasswordResetSchema } from '@/schemas/auth';
+import { resetPassword } from '@/services/auth/resetPassword';
+import { AuthResponse } from '@/services/types';
+
+type PasswordResetValues = z.infer<typeof PasswordResetSchema>;
+
+export default function usePasswordResetForm() {
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const { toast } = useToast();
+
+  const form = useForm<PasswordResetValues>({
+    resolver: zodResolver(PasswordResetSchema),
+    defaultValues: {
+      password: '',
+      confirm_password: '',
+    },
+  });
+
+  const onSubmit = async (values: PasswordResetValues) => {
+    const verifyToken = searchParams.get('token');
+
+    if (!verifyToken) {
+      toast({
+        variant: 'destructive',
+        title: '驗證失敗',
+        description: '缺少驗證 Token，請重新申請密碼重設。',
+      });
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      await resetPassword(
+        verifyToken,
+        values.password,
+        values.confirm_password
+      );
+      router.push('/auth/password-reset-success');
+    } catch (error) {
+      const err = error as AuthResponse;
+      toast({
+        variant: 'destructive',
+        title: '密碼重設失敗',
+        description: err.message || '發生錯誤，請稍後再試。',
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { form, isSubmitting, onSubmit };
+}

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -18,3 +18,13 @@ export const SignUpSchema = z
     message: '密碼與確認密碼不符',
     path: ['confirm_password'],
   });
+
+export const PasswordResetSchema = z
+  .object({
+    password: z.string().min(8, { message: '密碼至少需為 8 個字' }),
+    confirm_password: z.string().min(8, { message: '密碼至少需為 8 個字' }),
+  })
+  .refine((data) => data.password === data.confirm_password, {
+    message: '密碼與確認密碼不符',
+    path: ['confirm_password'],
+  });

--- a/src/services/auth/resetPassword.ts
+++ b/src/services/auth/resetPassword.ts
@@ -1,0 +1,45 @@
+import { AuthResponse, createGeneralErrorResponse } from '../types';
+
+export async function resetPassword(
+  verifyToken: string,
+  password: string,
+  confirmPassword: string
+): Promise<AuthResponse> {
+  try {
+    const response = await fetch(
+      `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/password/reset?verify_token=${encodeURIComponent(verifyToken)}`,
+      {
+        method: 'PUT',
+        body: JSON.stringify({
+          password,
+          confirm_password: confirmPassword,
+        }),
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
+
+    const result = await response.json();
+
+    if (response.ok) {
+      return { status: 'success', code: response.status };
+    }
+
+    throw createGeneralErrorResponse(
+      response.status,
+      result.message || '密碼重設失敗'
+    );
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw createGeneralErrorResponse(
+        0,
+        '無法連接到伺服器。請檢查您的網絡連接。'
+      );
+    }
+
+    if ((error as AuthResponse)?.status === 'error') {
+      throw error;
+    }
+
+    throw createGeneralErrorResponse(500, '系統錯誤，請稍後再試');
+  }
+}


### PR DESCRIPTION
## What Does This PR Do?

  - Integrate the password reset page with the backend `PUT /api/v1/auth/password/reset` API
  - Read `token` from the URL query string and pass it as a query parameter
  - On success, redirect to the password reset success page (`/auth/password-reset-success`)
  - On failure, show a destructive toast error (same pattern as signin/signup pages)
  - Show a toast error if `verify_token` is missing from the URL, without calling the API
  - Disable the submit button while the request is in progress to prevent duplicate submissions
  - Add `PasswordResetSchema` (Zod) for form validation with password match refinement
  - Add `resetPassword` service function under `src/services/auth/`
  - Add `usePasswordResetForm` hook under `src/hooks/auth/`

  ## Demo

  http://localhost:3000/auth/password-reset?token=<verify_token>

  ## Screenshot

<img width="2536" height="1166" alt="image" src="https://github.com/user-attachments/assets/b3a0bccc-31ff-45e5-bd30-544266c85953" />


  ## Anything to Note?

  - The page uses `useSearchParams` which requires a `<Suspense>` boundary — the form is extracted into a
  `PasswordResetForm` component wrapped in `<Suspense>` to satisfy Next.js App Router requirements
  - Query param key used is `token` (not `verify_token`) — aligns with the actual link sent in the reset email