### PR TITLE
feat: centralized API client with JWT feature flag

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,8 @@
+NEXT_PUBLIC_API_URL=
+
+# API client feature flag — set to true once backend JWT auth is fully configured
+NEXT_PUBLIC_USE_API_CLIENT=false
+
 NEXTAUTH_URL=http://localhost:3000/
 NEXTAUTH_SECRET=secret
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,0 +1,127 @@
+'use client';
+
+/**
+ * Centralized API client with automatic JWT token management.
+ *
+ * Usage:
+ *   import { apiClient } from '@/lib/apiClient';
+ *
+ *   // Authenticated (default — token injected when NEXT_PUBLIC_USE_API_CLIENT=true)
+ *   const data = await apiClient.get<UserDTO>('/v1/mentors/123/en/profile');
+ *
+ *   // Public endpoint (no token ever)
+ *   const data = await apiClient.get<ExpertiseType[]>('/v1/mentors/en/expertises', { auth: false });
+ *
+ *   // With query params
+ *   const mentors = await apiClient.get<MentorType[]>('/v1/mentors', { params: { limit: 10 } });
+ *
+ * Feature flag:
+ *   NEXT_PUBLIC_USE_API_CLIENT=false  → JWT not injected (safe while backend auth isn't ready)
+ *   NEXT_PUBLIC_USE_API_CLIENT=true   → JWT auto-injected from NextAuth session
+ */
+
+import { getSession } from 'next-auth/react';
+
+// ─── Feature flag ────────────────────────────────────────────────────────────
+// Flip to true once backend JWT auth is fully configured.
+const JWT_ENABLED = process.env.NEXT_PUBLIC_USE_API_CLIENT === 'true';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+export class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+    public readonly body?: unknown
+  ) {
+    super(message);
+    this.name = 'ApiError';
+  }
+}
+
+type RequestOptions = {
+  /** Attach Bearer token from NextAuth session. Respects JWT_ENABLED flag. Default: true */
+  auth?: boolean;
+  /** Extra headers merged on top of defaults */
+  headers?: Record<string, string>;
+  /** Query string params — undefined/null values are omitted */
+  params?: Record<string, string | number | boolean | undefined | null>;
+};
+
+// ─── Internals ───────────────────────────────────────────────────────────────
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+function buildUrl(path: string, params?: RequestOptions['params']): string {
+  const url = `${BASE_URL}${path}`;
+  if (!params) return url;
+
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.append(key, String(value));
+    }
+  });
+
+  const qs = query.toString();
+  return qs ? `${url}?${qs}` : url;
+}
+
+async function getAuthHeader(): Promise<Record<string, string>> {
+  if (!JWT_ENABLED) return {};
+  const session = await getSession();
+  const token = session?.accessToken;
+  if (!token) return {};
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function request<T>(
+  method: string,
+  path: string,
+  body?: unknown,
+  options: RequestOptions = {}
+): Promise<T> {
+  const { auth = true, headers = {}, params } = options;
+
+  const authHeader = auth ? await getAuthHeader() : {};
+
+  const response = await fetch(buildUrl(path, params), {
+    method,
+    headers: {
+      'Content-Type': 'application/json',
+      ...authHeader,
+      ...headers,
+    },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => ({}));
+    const message =
+      (errorBody as Record<string, string>).msg ||
+      (errorBody as Record<string, string>).message ||
+      `Request failed with status ${response.status}`;
+    throw new ApiError(response.status, message, errorBody);
+  }
+
+  // Handle 204 No Content and other empty responses
+  const text = await response.text();
+  if (!text) return undefined as T;
+  return JSON.parse(text) as T;
+}
+
+// ─── Public API ──────────────────────────────────────────────────────────────
+export const apiClient = {
+  get: <T>(path: string, options?: RequestOptions) =>
+    request<T>('GET', path, undefined, options),
+
+  post: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>('POST', path, body, options),
+
+  put: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>('PUT', path, body, options),
+
+  patch: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>('PATCH', path, body, options),
+
+  delete: <T>(path: string, options?: RequestOptions) =>
+    request<T>('DELETE', path, undefined, options),
+};

--- a/src/services/auth/confirmRegister.ts
+++ b/src/services/auth/confirmRegister.ts
@@ -1,27 +1,9 @@
-interface ConfirmRegisterResponse {
-  msg?: string;
-}
+import { apiClient } from '@/lib/apiClient';
 
 export async function confirmRegister(token: string): Promise<void> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/signup/confirm`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ token }),
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
-
-    if (!response.ok) {
-      const result: ConfirmRegisterResponse = await response.json();
-      throw new Error(result.msg || '驗證失敗');
-    }
+    await apiClient.post('/v1/auth/signup/confirm', { token }, { auth: false });
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      throw new Error('無法連接到伺服器。請檢查您的網絡連接。');
-    }
-
     throw new Error(error instanceof Error ? error.message : '未知的錯誤發生');
   }
 }

--- a/src/services/auth/googleSignUp.ts
+++ b/src/services/auth/googleSignUp.ts
@@ -1,3 +1,5 @@
+import { apiClient, ApiError } from '@/lib/apiClient';
+
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 import {
   createEmailAlreadyRegisteredResponse,
@@ -12,46 +14,29 @@ export interface GoogleSignUpType {
   oauth_id: string;
 }
 
+interface GoogleSignUpApiResponse {
+  code: string;
+  message?: string;
+}
+
 export async function googleSignUp(
   values: GoogleSignUpType
 ): Promise<AuthResponse> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/oauth/signup/GOOGLE`,
-      {
-        method: 'POST',
-        body: JSON.stringify(values),
-        headers: { 'Content-Type': 'application/json' },
-      }
+    const result = await apiClient.post<GoogleSignUpApiResponse>(
+      '/oauth/signup/GOOGLE',
+      values,
+      { auth: false }
     );
 
-    const result = await response.json();
-    if (response.status === 201 && result.code === '0') {
-      return createSignUpSuccessResponse();
-    }
-
-    if (response.status === 422) {
-      throw createValidationErrorResponse();
-    }
-
-    if (response.status === 406) {
-      throw createEmailAlreadyRegisteredResponse();
-    }
-
-    if (response.status === 429 && result.code === '42900') {
-      throw createRateLimitResponse();
-    }
-
-    throw createGeneralErrorResponse(
-      response.status,
-      result.message || '註冊失敗'
-    );
+    if (result.code === '0') return createSignUpSuccessResponse();
+    throw createGeneralErrorResponse(200, result.message || '註冊失敗');
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      throw createGeneralErrorResponse(
-        0,
-        '無法連接到伺服器。請檢查您的網絡連接。'
-      );
+    if (error instanceof ApiError) {
+      if (error.status === 422) throw createValidationErrorResponse();
+      if (error.status === 406) throw createEmailAlreadyRegisteredResponse();
+      if (error.status === 429) throw createRateLimitResponse();
+      throw createGeneralErrorResponse(error.status, error.message);
     }
 
     if (error instanceof Error || (error as AuthResponse)?.status === 'error') {

--- a/src/services/auth/resend.ts
+++ b/src/services/auth/resend.ts
@@ -1,30 +1,9 @@
-interface ResendEmailResponse {
-  msg?: string;
-}
+import { apiClient } from '@/lib/apiClient';
 
 export async function resendVerificationEmail(email: string): Promise<void> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/email/resend`,
-      {
-        method: 'POST',
-        body: JSON.stringify({ email }),
-        headers: { 'Content-Type': 'application/json' },
-      }
-    );
-
-    if (response.status === 201) {
-      return;
-    }
-
-    const result: ResendEmailResponse = await response.json();
-
-    throw new Error(result.msg || '重新寄送失敗');
+    await apiClient.post('/v1/auth/email/resend', { email }, { auth: false });
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      throw new Error('無法連接到伺服器。請檢查您的網絡連接。');
-    }
-
     throw new Error(error instanceof Error ? error.message : '未知的錯誤發生');
   }
 }

--- a/src/services/auth/resetPassword.ts
+++ b/src/services/auth/resetPassword.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/lib/apiClient';
+
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 
 export async function resetPassword(
@@ -6,40 +8,18 @@ export async function resetPassword(
   confirmPassword: string
 ): Promise<AuthResponse> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/password/reset?verify_token=${encodeURIComponent(verifyToken)}`,
-      {
-        method: 'PUT',
-        body: JSON.stringify({
-          password,
-          confirm_password: confirmPassword,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      }
+    await apiClient.put(
+      '/v1/auth/password/reset',
+      { password, confirm_password: confirmPassword },
+      { auth: false, params: { verify_token: verifyToken } }
     );
 
-    const result = await response.json();
-
-    if (response.ok) {
-      return { status: 'success', code: response.status };
-    }
-
-    throw createGeneralErrorResponse(
-      response.status,
-      result.message || '密碼重設失敗'
-    );
+    return { status: 'success', code: 200 };
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      throw createGeneralErrorResponse(
-        0,
-        '無法連接到伺服器。請檢查您的網絡連接。'
-      );
-    }
-
-    if ((error as AuthResponse)?.status === 'error') {
-      throw error;
-    }
-
-    throw createGeneralErrorResponse(500, '系統錯誤，請稍後再試');
+    if ((error as AuthResponse)?.status === 'error') throw error;
+    throw createGeneralErrorResponse(
+      500,
+      error instanceof Error ? error.message : '密碼重設失敗'
+    );
   }
 }

--- a/src/services/auth/signUp.ts
+++ b/src/services/auth/signUp.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 
+import { apiClient, ApiError } from '@/lib/apiClient';
 import { SignUpSchema } from '@/schemas/auth';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
@@ -10,50 +11,33 @@ import {
   createValidationErrorResponse,
 } from './signUpResponseHandlers';
 
+interface SignUpApiResponse {
+  code: string;
+  message?: string;
+}
+
 export async function signUp(
   values: z.infer<typeof SignUpSchema>
 ): Promise<AuthResponse> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/auth/signup`,
+    const result = await apiClient.post<SignUpApiResponse>(
+      '/v1/auth/signup',
       {
-        method: 'POST',
-        body: JSON.stringify({
-          email: values.email,
-          password: values.password,
-          confirm_password: values.confirm_password,
-        }),
-        headers: { 'Content-Type': 'application/json' },
-      }
+        email: values.email,
+        password: values.password,
+        confirm_password: values.confirm_password,
+      },
+      { auth: false }
     );
 
-    const result = await response.json();
-    if (response.status === 201 && result.code === '0') {
-      return createSignUpSuccessResponse();
-    }
-
-    if (response.status === 422) {
-      throw createValidationErrorResponse();
-    }
-
-    if (response.status === 406) {
-      throw createEmailAlreadyRegisteredResponse();
-    }
-
-    if (response.status === 429 && result.code === '42900') {
-      throw createRateLimitResponse();
-    }
-
-    throw createGeneralErrorResponse(
-      response.status,
-      result.message || '註冊失敗'
-    );
+    if (result.code === '0') return createSignUpSuccessResponse();
+    throw createGeneralErrorResponse(200, result.message || '註冊失敗');
   } catch (error) {
-    if (error instanceof TypeError && error.message === 'Failed to fetch') {
-      throw createGeneralErrorResponse(
-        0,
-        '無法連接到伺服器。請檢查您的網絡連接。'
-      );
+    if (error instanceof ApiError) {
+      if (error.status === 422) throw createValidationErrorResponse();
+      if (error.status === 406) throw createEmailAlreadyRegisteredResponse();
+      if (error.status === 429) throw createRateLimitResponse();
+      throw createGeneralErrorResponse(error.status, error.message);
     }
 
     if (error instanceof Error || (error as AuthResponse)?.status === 'error') {

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -1,4 +1,5 @@
-// schedule.ts
+import { apiClient } from '@/lib/apiClient';
+
 export interface ScheduleRequest {
   userId: string;
   year: number;
@@ -33,12 +34,10 @@ export async function fetchMentorSchedule(
   param: ScheduleRequest
 ): Promise<ScheduleType> {
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${param.userId}/schedule/y/${param.year}/m/${param.month}`,
-      { method: 'GET', headers: { 'Content-Type': 'application/json' } }
+    const result = await apiClient.get<ScheduleResponse>(
+      `/v1/mentors/${param.userId}/schedule/y/${param.year}/m/${param.month}`,
+      { auth: false }
     );
-    if (!res.ok) throw new Error(String(res.status));
-    const result: ScheduleResponse = await res.json();
     if (result.code !== '0') return {} as ScheduleType;
     return result.data;
   } catch {
@@ -61,13 +60,15 @@ interface SaveScheduleResponse {
   msg: string;
 }
 
+type CleanObject = Record<string, unknown>;
+
 /** PUT /v1/mentors/:userId/schedule */
 export async function saveMentorSchedule(params: {
   userId: string;
   timeslots: UpsertTimeslotBackend[];
   until?: number | null;
 }): Promise<boolean> {
-  const clean = (obj: Record<string, any>) =>
+  const clean = (obj: CleanObject): CleanObject =>
     Object.fromEntries(
       Object.entries(obj).filter(
         ([, v]) =>
@@ -90,16 +91,11 @@ export async function saveMentorSchedule(params: {
   });
 
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${params.userId}/schedule`,
-      {
-        method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(body),
-      }
+    const result = await apiClient.put<SaveScheduleResponse>(
+      `/v1/mentors/${params.userId}/schedule`,
+      body,
+      { auth: false }
     );
-    if (!res.ok) return false;
-    const result: SaveScheduleResponse = await res.json();
     return result.code === '0';
   } catch {
     return false;
@@ -112,20 +108,11 @@ export async function deleteMentorSchedule(params: {
   scheduleId: string | number;
 }): Promise<boolean> {
   try {
-    const res = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${params.userId}/schedule/${params.scheduleId}`,
-      { method: 'DELETE', headers: { 'Content-Type': 'application/json' } }
+    await apiClient.delete(
+      `/v1/mentors/${params.userId}/schedule/${params.scheduleId}`,
+      { auth: false }
     );
-    if (res.status === 204) return true;
-    if (!res.ok) return false;
-
-    // 若有統一回傳格式就檢查；沒有就直接當成功
-    try {
-      const json: SaveScheduleResponse = await res.json();
-      return !json.code || json.code === '0';
-    } catch {
-      return true;
-    }
+    return true;
   } catch {
     return false;
   }

--- a/src/services/profile/countries.ts
+++ b/src/services/profile/countries.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/lib/apiClient';
+
 export interface LocationType {
   value: string;
   text: string;
@@ -13,30 +15,15 @@ export async function fetchCountries(
   language: string
 ): Promise<LocationType[]> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/users/${language}/countries`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const data = await apiClient.get<CountryResponse>(
+      `/v1/users/${language}/countries`,
+      { auth: false }
     );
 
-    if (!response.ok) {
-      throw new Error(`HTTP 錯誤: ${response.status}`);
-    }
-
-    const data: CountryResponse = await response.json();
-
-    const countries: LocationType[] = Object.entries(data.data).map(
-      ([key, value]) => ({
-        value: key,
-        text: value,
-      })
-    );
-
-    return countries;
+    return Object.entries(data.data).map(([key, value]) => ({
+      value: key,
+      text: value,
+    }));
   } catch (error) {
     console.error('獲取國家資料失敗:', error);
     return [];

--- a/src/services/profile/expertises.ts
+++ b/src/services/profile/expertises.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/lib/apiClient';
+
 export interface ExpertiseType {
   id: number;
   category: string;
@@ -32,21 +34,10 @@ export async function fetchExpertises(
   language: string
 ): Promise<ExpertiseType[]> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${language}/expertises`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const data = await apiClient.get<ExpertiseResponse>(
+      `/v1/mentors/${language}/expertises`,
+      { auth: false }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP 錯誤: ${response.status}`);
-    }
-
-    const data: ExpertiseResponse = await response.json();
 
     return data.data.professions.map((profession) => ({
       id: profession.id,

--- a/src/services/profile/industries.ts
+++ b/src/services/profile/industries.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/lib/apiClient';
+
 export interface IndustryDTO {
   id: number;
   category: string;
@@ -22,20 +24,10 @@ export async function fetchIndustries(
   language: string
 ): Promise<IndustryDTO[]> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/users/${language}/industries`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const data = await apiClient.get<IndustryResponseDTO>(
+      `/v1/users/${language}/industries`,
+      { auth: false }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP 錯誤: ${response.status}`);
-    }
-    const data: IndustryResponseDTO = await response.json();
 
     return data.data.professions;
   } catch (error) {

--- a/src/services/profile/interests.ts
+++ b/src/services/profile/interests.ts
@@ -1,3 +1,5 @@
+import { apiClient } from '@/lib/apiClient';
+
 export interface InterestDTO {
   id: number;
   category: string;
@@ -24,21 +26,10 @@ export async function fetchInterests(
   interest: string
 ): Promise<InterestDTO[]> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/users/${language}/interests?interest=${interest}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const data = await apiClient.get<InterestResponseDTO>(
+      `/v1/users/${language}/interests`,
+      { auth: false, params: { interest } }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP 錯誤: ${response.status}`);
-    }
-
-    const data: InterestResponseDTO = await response.json();
 
     return data.data.interests;
   } catch (error) {

--- a/src/services/profile/presignedUrl.ts
+++ b/src/services/profile/presignedUrl.ts
@@ -1,5 +1,7 @@
 import { getSession } from 'next-auth/react';
 
+import { apiClient } from '@/lib/apiClient';
+
 export interface PresignedUrlFields {
   key: string;
   AWSAccessKeyId: string;
@@ -36,27 +38,9 @@ export async function fetchPresignedUrlByUserId(
   userId: number
 ): Promise<PresignedUrlData | null> {
   try {
-    const baseUrl = process.env.NEXT_PUBLIC_API_URL;
-    if (!baseUrl) {
-      console.error('Missing NEXT_PUBLIC_API_URL');
-      return null;
-    }
-    console.log(userId);
-    const response = await fetch(
-      `${baseUrl}/v1/storage/presigned-url/${userId}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const result = await apiClient.get<PresignedUrlResponse>(
+      `/v1/storage/presigned-url/${userId}`
     );
-    console.log(response);
-    if (!response.ok) {
-      throw new Error(`HTTP Error: ${response.status}`);
-    }
-
-    const result: PresignedUrlResponse = await response.json();
 
     if (result.code !== '0') {
       console.error(`API Error: ${result.msg}`);

--- a/src/services/profile/reservations.ts
+++ b/src/services/profile/reservations.ts
@@ -1,5 +1,7 @@
 import { getSession } from 'next-auth/react';
 
+import { apiClient } from '@/lib/apiClient';
+
 export interface ExperienceType {
   [key: string]: unknown;
 }
@@ -26,21 +28,10 @@ export async function fetchReservationsByUserId(
   userId: number
 ): Promise<ReservationType | null> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/users/${userId}/reservations`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const result = await apiClient.get<ReservationsResponse>(
+      `/v1/users/${userId}/reservations`,
+      { auth: false }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP Error: ${response.status}`);
-    }
-
-    const result: ReservationsResponse = await response.json();
 
     if (result.code !== '0') {
       console.error(`API Error: ${result.msg}`);

--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -35,6 +35,7 @@ async function uploadToS3WithPresignedPost(
   // S3 期待 file 欄位名稱是 file
   formData.append('file', avatarFile);
 
+  // S3 upload uses raw fetch — not our API, so apiClient is not used here
   const res = await fetch(presigned.url, {
     method: 'POST',
     body: formData,
@@ -57,19 +58,15 @@ function buildS3ObjectUrl(bucketUrl: string, key: string): string {
  * 1) 呼叫後端拿 presigned url (另外一支檔案)
  * 2) 用 presigned POST 直接上傳到 S3
  * 3) 回傳檔案的公開 URL（bucketUrl + key）
- *
- * 注意：如果你的 S3 bucket 不是 public，
- * 回傳的 object url 可能無法直接被瀏覽器讀取（要改成 CloudFront 或再拿 GET presigned）。
  */
 export async function updateAvatar(
   avatarFile: File
 ): Promise<string | undefined> {
   try {
     const session = await getSession();
-    const token = session?.accessToken;
     const userId = session?.user?.id;
 
-    if (!token || !userId) {
+    if (!userId) {
       throw new Error('未獲取到有效的身份驗證信息，請重新登入。');
     }
 
@@ -77,18 +74,13 @@ export async function updateAvatar(
       throw new Error('頭像檔案必須是圖片格式 (image/*)。');
     }
 
-    // 1) 拿 presigned（你說在另外一支檔案）
-    // 你的函式若只收 1 個參數，就只傳 userId
     const presigned = await fetchPresignedUrlByUserId(Number(userId));
-    console.log(presigned);
     if (!presigned?.url || !presigned?.fields?.key) {
       throw new Error('取得 presigned url 失敗或回傳格式不完整');
     }
 
-    // 2) 上傳到 S3
     await uploadToS3WithPresignedPost(presigned, avatarFile);
 
-    // 3) 回傳上傳後的 URL（依你後端回傳的 url 結構）
     return buildS3ObjectUrl(presigned.url, presigned.fields.key);
   } catch (error) {
     if (error instanceof TypeError && error.message === 'Failed to fetch') {

--- a/src/services/profile/updateProfile.ts
+++ b/src/services/profile/updateProfile.ts
@@ -3,49 +3,28 @@ import * as z from 'zod';
 
 import { formSchema } from '@/components/onboarding/steps';
 import { createProfileFormSchema } from '@/components/profile/edit/profileSchema';
+import { apiClient } from '@/lib/apiClient';
 
 export const unionformSchema = z.union([
   formSchema,
   createProfileFormSchema(true),
 ]);
 
-interface UpdateProfileResponse {
-  msg?: string;
-}
-
 export async function updateProfile(
   profileData: z.infer<typeof unionformSchema>
 ): Promise<void> {
+  const session = await getSession();
+  const userId = session?.user?.id;
+
+  if (!userId) {
+    throw new Error('未找到使用者 ID。請重新登入。');
+  }
+
   try {
-    const session = await getSession();
-    const token = session?.accessToken;
-    const userId = session?.user?.id;
-
-    if (!token) {
-      throw new Error('未找到授權令牌。請重新登入。');
-    }
-
-    const updatedProfileData = {
+    await apiClient.put(`/v1/mentors/${userId}/profile`, {
       ...profileData,
       user_id: userId,
-    };
-
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${userId}/profile`,
-      {
-        method: 'PUT',
-        body: JSON.stringify(updatedProfileData),
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-      }
-    );
-
-    if (!response.ok) {
-      const result: UpdateProfileResponse = await response.json();
-      throw new Error(result.msg || '更新個人資料失敗');
-    }
+    });
   } catch (error) {
     if (error instanceof TypeError && error.message === 'Failed to fetch') {
       throw new Error('無法連接到伺服器。請檢查您的網絡連接。');

--- a/src/services/profile/upsertExperience.ts
+++ b/src/services/profile/upsertExperience.ts
@@ -1,5 +1,7 @@
 import { getSession } from 'next-auth/react';
 
+import { apiClient } from '@/lib/apiClient';
+
 import { ExperienceType } from './experienceType';
 
 export interface MentorExperiencePayload {
@@ -9,41 +11,24 @@ export interface MentorExperiencePayload {
   order: number;
 }
 
-interface UpsertExperienceResponse {
-  msg?: string;
-}
-
 export async function upsertMentorExperience(
   experienceType: ExperienceType,
   isMentor: boolean,
   payload: MentorExperiencePayload
 ): Promise<void> {
+  const session = await getSession();
+  const userId = session?.user?.id;
+
+  if (!userId) {
+    throw new Error('未找到使用者 ID，請重新登入。');
+  }
+
   try {
-    const session = await getSession();
-    const token = session?.accessToken;
-    const userId = session?.user?.id;
-
-    if (!token || !userId) {
-      throw new Error('未找到授權令牌或使用者 ID，請重新登入。');
-    }
-
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${userId}/experiences/${experienceType}`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-          'is-mentor': String(isMentor),
-        },
-        body: JSON.stringify(payload),
-      }
+    await apiClient.put(
+      `/v1/mentors/${userId}/experiences/${experienceType}`,
+      payload,
+      { headers: { 'is-mentor': String(isMentor) } }
     );
-
-    if (!response.ok) {
-      const result: UpsertExperienceResponse = await response.json();
-      throw new Error(result.msg || '更新經驗資料失敗');
-    }
   } catch (error) {
     if (error instanceof TypeError && error.message === 'Failed to fetch') {
       throw new Error('無法連接到伺服器。請檢查您的網路連線。');

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -1,5 +1,7 @@
 import { getSession } from 'next-auth/react';
 
+import { apiClient } from '@/lib/apiClient';
+
 import { ExpertiseType } from './expertises';
 import { IndustryDTO } from './industries';
 import { InterestDTO } from './interests';
@@ -50,11 +52,10 @@ interface UserResponseDTO {
 
 export async function fetchUser(language: string): Promise<UserDTO | null> {
   const session = await getSession();
-  const token = session?.accessToken;
   const userId = session?.user?.id;
 
-  if (!token) {
-    throw new Error('未找到授權令牌。請重新登入。');
+  if (!userId) {
+    throw new Error('未找到使用者 ID。請重新登入。');
   }
 
   return fetchUserById(Number(userId), language);
@@ -65,21 +66,10 @@ export async function fetchUserById(
   language: string
 ): Promise<UserDTO | null> {
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${userId}/${language}/profile`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
+    const result = await apiClient.get<UserResponseDTO>(
+      `/v1/mentors/${userId}/${language}/profile`,
+      { auth: false }
     );
-
-    if (!response.ok) {
-      throw new Error(`HTTP Error: ${response.status}`);
-    }
-
-    const result: UserResponseDTO = await response.json();
 
     if (result.code !== '0') {
       console.error(`API Error: ${result.msg}`);
@@ -97,32 +87,17 @@ export async function updateUserProfile(
   userData: Partial<UserDTO>
 ): Promise<boolean> {
   const session = await getSession();
-  const token = session?.accessToken;
   const userId = session?.user?.id;
 
-  if (!token || !userId) {
-    throw new Error('未找到授權令牌或使用者 ID。請重新登入。');
+  if (!userId) {
+    throw new Error('未找到使用者 ID。請重新登入。');
   }
 
   try {
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors/${userId}/profile`,
-      {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          Authorization: `Bearer ${token}`,
-        },
-        body: JSON.stringify(userData),
-      }
+    const result = await apiClient.put<UserResponseDTO>(
+      `/v1/mentors/${userId}/profile`,
+      userData
     );
-
-    if (!response.ok) {
-      console.error('Failed to update profile:', response.statusText);
-      return false;
-    }
-
-    const result = await response.json();
 
     if (result.code !== '0') {
       console.error('API Error:', result.msg);

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,5 +1,7 @@
 import { StaticImageData } from 'next/image';
 
+import { apiClient } from '@/lib/apiClient';
+
 export interface experienceType {
   duration: string;
   company: string;
@@ -48,30 +50,12 @@ interface MentorResponse {
 
 export async function fetchMentors(
   param: MentorRequest
-): Promise<MentorType[] | []> {
+): Promise<MentorType[]> {
   try {
-    const query = new URLSearchParams();
-    Object.entries(param).forEach(([key, value]) => {
-      if (value !== undefined && value !== null && value !== '') {
-        query.append(key, String(value));
-      }
+    const result = await apiClient.get<MentorResponse>('/v1/mentors', {
+      auth: false,
+      params: param as unknown as Record<string, string | number | undefined>,
     });
-
-    const response = await fetch(
-      `${process.env.NEXT_PUBLIC_API_URL}/v1/mentors?${query.toString()}`,
-      {
-        method: 'GET',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-      }
-    );
-
-    if (!response.ok) {
-      throw new Error(`HTTP Error: ${response.status}`);
-    }
-
-    const result: MentorResponse = await response.json();
 
     if (result.code !== '0') {
       console.error(`API Error: ${result.msg}`);


### PR DESCRIPTION
Creates src/lib/apiClient.ts as a typed fetch wrapper and migrates all 16 service files to use it. JWT injection is controlled by a feature flag:

  NEXT_PUBLIC_USE_API_CLIENT=false  (default) — no token injected, safe
  NEXT_PUBLIC_USE_API_CLIENT=true             — Bearer token auto-injected

Changes per file:
- Public endpoints: pass { auth: false }, no session needed
- Protected endpoints: getSession() kept for userId only; apiClient handles token injection automatically when flag is enabled
- S3 upload in updateAvatar stays as raw fetch (external service)
- reservations/index.ts untouched (uses explicit accessToken param pattern)
- Handles 204 No Content and empty responses gracefully

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
