### PR TITLE
fix: improve reservation page RWD, calendar validation, and time slot…

### DIFF
--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -19,8 +19,8 @@ import { Button } from '@/components/ui/button';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import useUserData from '@/hooks/user/user-data/useUserData';
 import {
+  formatBookingSlotTime,
   formatSelectedDate,
-  formatStartTimeSlot,
   toDateKey,
 } from '@/lib/profile/scheduleFormatters';
 
@@ -31,16 +31,31 @@ export default function Page({
 }) {
   const router = useRouter();
 
+  const now = new Date();
   const schedule = useMentorSchedule({
-    storageKey: `mentor.timeslots:${pageUserId}`,
+    mode: 'backend',
+    backend: {
+      userId: pageUserId,
+      year: now.getFullYear(),
+      month: now.getMonth() + 1,
+    },
   });
   const {
     loaded,
     selectedDate,
     setSelectedDate,
-    draftForSelectedDate,
     parsedDraft,
+    generateBookingSlots,
   } = schedule;
+
+  // Auto-select the first available date once schedule is loaded
+  useEffect(() => {
+    if (!loaded) return;
+    const firstSlot = parsedDraft.find((s) => s.type === 'ALLOW');
+    if (firstSlot) setSelectedDate(firstSlot.dateKey);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [loaded]);
+
   const [isLogging, setIsLogging] = useState(false);
   const [loginUserId, setLoginUserId] = useState('');
 
@@ -148,21 +163,13 @@ export default function Page({
 
           <div className="static mt-4 flex items-center justify-center gap-4 sm:absolute sm:bottom-0 sm:left-[184px] sm:mt-0 lg:static">
             {isLogging && pageUserId === loginUserId && (
-              <>
-                <Button
-                  variant="outline"
-                  className="grow rounded-full px-6 py-3 sm:grow-0"
-                  onClick={() => router.push(`/profile/${pageUserId}/edit`)}
-                >
-                  編輯個人資訊
-                </Button>
-                <Button
-                  className="grow rounded-full px-6 py-3 sm:grow-0 lg:hidden"
-                  onClick={() => reservationHandler()}
-                >
-                  預約設定
-                </Button>
-              </>
+              <Button
+                variant="outline"
+                className="grow rounded-full px-6 py-3 sm:grow-0"
+                onClick={() => router.push(`/profile/${pageUserId}/edit`)}
+              >
+                編輯個人資訊
+              </Button>
             )}
 
             {isLogging && !userData.is_mentor && pageUserId === loginUserId && (
@@ -179,8 +186,8 @@ export default function Page({
           </div>
         </div>
 
-        <div className="flex gap-12 ">
-          <div className="w-3/5">
+        <div className="flex flex-col gap-8 lg:flex-row lg:gap-12">
+          <div className="w-full lg:w-3/5">
             <div>
               <p className="mb-4 text-xl font-bold">關於我</p>
               <p className="text-sm text-gray-400">{userData?.about}</p>
@@ -228,22 +235,26 @@ export default function Page({
             </div>
           </div>
 
-          <div className="hidden w-2/5 lg:block">
-            {userData.is_mentor && (
+          {userData.is_mentor && (
+            <div className="w-full lg:w-2/5">
               <div className="flex w-full flex-col gap-4">
                 <p className="text-xl font-bold">可預約日期</p>
 
-                <div className="inline-block w-auto rounded-lg border p-2 shadow-md">
+                <div className="w-full rounded-lg border p-2 shadow-md">
                   <div className="px-3 pb-3 pt-1">
                     <h2 className="text-2xl font-semibold tracking-tight">
                       {formatSelectedDate(
-                        selectedDate ? new Date(selectedDate) : undefined
+                        selectedDate
+                          ? new Date(selectedDate + 'T00:00:00')
+                          : undefined
                       )}
                     </h2>
                   </div>
                   <ScheduleCalendar
                     selected={
-                      selectedDate ? new Date(selectedDate) : new Date()
+                      selectedDate
+                        ? new Date(selectedDate + 'T00:00:00')
+                        : new Date()
                     }
                     onSelect={(d) => setSelectedDate(d ? toDateKey(d) : null)}
                     allowedDates={allowedDates}
@@ -253,24 +264,30 @@ export default function Page({
                 </div>
                 <div className="flex flex-col items-start gap-4">
                   <p>當日可預約時段</p>
-                  {draftForSelectedDate.length === 0 ? (
-                    <div className="flex min-h-10 items-center text-gray-400">
-                      無可預約的時段
-                    </div>
-                  ) : (
-                    <div className="flex flex-wrap gap-2">
-                      {[...draftForSelectedDate]
-                        .sort((a, b) => a.start.getTime() - b.start.getTime())
-                        .map((slot) => (
+                  {(() => {
+                    const slots = selectedDate
+                      ? generateBookingSlots(selectedDate)
+                      : [];
+                    if (slots.length === 0) {
+                      return (
+                        <div className="flex min-h-10 items-center text-gray-400">
+                          無可預約的時段
+                        </div>
+                      );
+                    }
+                    return (
+                      <div className="grid w-full grid-cols-2 gap-2">
+                        {slots.map((slot) => (
                           <div
-                            key={slot.id}
-                            className="flex h-10 w-[140px] select-none items-center justify-center rounded-lg border border-[#E6E8EA] text-sm font-medium"
+                            key={slot.start.getTime()}
+                            className="flex h-10 select-none items-center justify-center rounded-lg border border-[#E6E8EA] text-sm font-medium"
                           >
-                            {formatStartTimeSlot(slot)}
+                            {formatBookingSlotTime(slot)}
                           </div>
                         ))}
-                    </div>
-                  )}
+                      </div>
+                    );
+                  })()}
                 </div>
                 <Button
                   variant="default"
@@ -298,8 +315,8 @@ export default function Page({
                   />
                 )}
               </div>
-            )}
-          </div>
+            </div>
+          )}
         </div>
       </div>
     </div>

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -18,7 +18,7 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { Textarea } from '@/components/ui/textarea';
 import {
-  ParsedMentorTimeslot,
+  BookingSlot,
   UseMentorScheduleReturn,
 } from '@/hooks/useMentorSchedule';
 import { UserType } from '@/hooks/user/user-data/useUserData';
@@ -40,18 +40,17 @@ export default function MenteeReservationDialog({
   schedule: UseMentorScheduleReturn;
   userData: UserType | null;
 }) {
-  const { selectedDate, setSelectedDate, draftForSelectedDate, parsedDraft } =
+  const { selectedDate, setSelectedDate, parsedDraft, generateBookingSlots } =
     schedule;
   const router = useRouter();
 
   const [view, setView] = useState<'selection' | 'confirmation' | 'success'>(
     'selection'
   );
-  const [selectedSlot, setSelectedSlot] = useState<ParsedMentorTimeslot | null>(
-    null
-  );
+  const [selectedSlot, setSelectedSlot] = useState<BookingSlot | null>(null);
   const [bookingQuestion, setBookingQuestion] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
     if (!open) {
@@ -59,6 +58,7 @@ export default function MenteeReservationDialog({
         setView('selection');
         setSelectedSlot(null);
         setBookingQuestion('');
+        setSubmitError(null);
       }, 200);
     }
   }, [open]);
@@ -97,9 +97,9 @@ export default function MenteeReservationDialog({
         my_user_id: menteeId,
         my_status: 'PENDING',
         user_id: userData.user_id,
-        schedule_id: selectedSlot.id,
-        dtstart: Math.floor(new Date(selectedSlot.start).getTime() / 1000),
-        dtend: Math.floor(new Date(selectedSlot.end).getTime() / 1000),
+        schedule_id: selectedSlot.scheduleId,
+        dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
+        dtend: Math.floor(selectedSlot.end.getTime() / 1000),
         messages: [{ user_id: menteeId, msg: bookingQuestion }],
         previous_reserve: {},
       };
@@ -111,26 +111,33 @@ export default function MenteeReservationDialog({
         debug: process.env.NODE_ENV === 'development',
       });
 
+      setSubmitError(null);
       setView('success');
     } catch (error) {
       console.error('Failed to create reservation:', error);
-      alert(
-        `Failed to create reservation: ${
-          error instanceof Error ? error.message : 'Unknown error'
-        }`
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+      const isDuplicate =
+        msg.includes('409') ||
+        msg.toLowerCase().includes('conflict') ||
+        msg.toLowerCase().includes('already');
+      setSubmitError(
+        isDuplicate
+          ? 'This time slot has already been booked. Please choose another slot.'
+          : `Booking failed: ${msg}`
       );
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const formatStartTimeSlot = (slot: ParsedMentorTimeslot) => {
-    const date = new Date(slot.start);
-    return date.toLocaleTimeString('en-US', {
-      hour: '2-digit',
-      minute: '2-digit',
-      hour12: true,
-    });
+  const formatTimeSlot = (slot: BookingSlot) => {
+    const fmt = (d: Date) =>
+      d.toLocaleTimeString('en-US', {
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: true,
+      });
+    return `${fmt(slot.start)} – ${fmt(slot.end)}`;
   };
 
   const formatDate = (date: string | null) => {
@@ -148,11 +155,10 @@ export default function MenteeReservationDialog({
       return '';
     }
     return new Intl.DateTimeFormat('en-US', {
-      timeZone: 'Asia/Taipei',
       weekday: 'short',
       month: 'short',
       day: 'numeric',
-    }).format(new Date(selectedDate));
+    }).format(new Date(selectedDate + 'T00:00:00'));
   };
 
   const allowedDates = parsedDraft
@@ -172,7 +178,9 @@ export default function MenteeReservationDialog({
             </h2>
           </div>
           <ScheduleCalendar
-            selected={selectedDate ? new Date(selectedDate) : new Date()}
+            selected={
+              selectedDate ? new Date(selectedDate + 'T00:00:00') : new Date()
+            }
             onSelect={(d) =>
               setSelectedDate(
                 d
@@ -191,21 +199,32 @@ export default function MenteeReservationDialog({
         <div>
           <p className="font-semibold">Available time slots</p>
           <div className="mt-4 flex flex-row flex-wrap gap-4">
-            {draftForSelectedDate.map((slot) => (
-              <Button
-                key={slot.id}
-                variant={selectedSlot?.id === slot.id ? 'default' : 'outline'}
-                onClick={() => setSelectedSlot(slot)}
-                className="h-[40px] w-[96px]"
-              >
-                {formatStartTimeSlot(slot)}
-              </Button>
-            ))}
-            {draftForSelectedDate.length === 0 && (
-              <div className="text-center text-sm text-gray-500">
-                No available slots for this date.
-              </div>
-            )}
+            {(() => {
+              const slots = selectedDate
+                ? generateBookingSlots(selectedDate)
+                : [];
+              if (slots.length === 0) {
+                return (
+                  <div className="text-center text-sm text-gray-500">
+                    No available slots for this date.
+                  </div>
+                );
+              }
+              return slots.map((slot) => (
+                <Button
+                  key={slot.start.getTime()}
+                  variant={
+                    selectedSlot?.start.getTime() === slot.start.getTime()
+                      ? 'default'
+                      : 'outline'
+                  }
+                  onClick={() => setSelectedSlot(slot)}
+                  className="h-[40px] w-[160px]"
+                >
+                  {formatTimeSlot(slot)}
+                </Button>
+              ));
+            })()}
           </div>
         </div>
       </div>
@@ -262,7 +281,7 @@ export default function MenteeReservationDialog({
             </div>
             <div className="flex items-center gap-2">
               <Clock className="h-4 w-4 text-muted-foreground" />
-              <p>{selectedSlot ? formatStartTimeSlot(selectedSlot) : ''}</p>
+              <p>{selectedSlot ? formatTimeSlot(selectedSlot) : ''}</p>
             </div>
           </div>
         </div>
@@ -280,6 +299,9 @@ export default function MenteeReservationDialog({
           />
         </div>
       </div>
+      {submitError && (
+        <p className="text-red-500 text-center text-sm">{submitError}</p>
+      )}
       <DialogFooter className="justify-center">
         <Button
           onClick={handleConfirm}
@@ -324,7 +346,7 @@ export default function MenteeReservationDialog({
             </div>
             <div className="flex items-center gap-2">
               <Hourglass className="h-4 w-4 text-muted-foreground" />
-              <p>{selectedSlot ? formatStartTimeSlot(selectedSlot) : ''}</p>
+              <p>{selectedSlot ? formatTimeSlot(selectedSlot) : ''}</p>
             </div>
           </div>
         </div>

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -11,7 +11,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
-import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
@@ -22,6 +28,24 @@ type EditingSlot = {
   startMinute: string;
   endHour: string;
   endMinute: string;
+};
+
+type SlotErrors = {
+  timeRange?: string;
+  overlap?: string;
+};
+
+const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) =>
+  String(i).padStart(2, '0')
+);
+const MINUTE_OPTIONS = ['00', '15', '30', '45'];
+
+/** Snap a minute value to the nearest option in [0, 15, 30, 45]. */
+const snapMinute = (m: number): string => {
+  const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
+    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
+  );
+  return String(snapped).padStart(2, '0');
 };
 
 export default function MentorScheduleDialog({
@@ -43,25 +67,40 @@ export default function MentorScheduleDialog({
     resetChanges,
     parsedDraft,
     updateDraftSlot,
+    meetingDurationMinutes,
   } = schedule;
 
   const [isSaving, setIsSaving] = useState(false);
   const [editingSlots, setEditingSlots] = useState<EditingSlot[]>([]);
+  const [slotErrors, setSlotErrors] = useState<Record<number, SlotErrors>>({});
 
   useEffect(() => {
-    const newEditingSlots = draftForSelectedDate.map((slot) => ({
-      id: slot.id,
-      startHour: String(slot.start.getHours()).padStart(2, '0'),
-      startMinute: String(slot.start.getMinutes()).padStart(2, '0'),
-      endHour: String(slot.end.getHours()).padStart(2, '0'),
-      endMinute: String(slot.end.getMinutes()).padStart(2, '0'),
-    }));
-    setEditingSlots(newEditingSlots);
+    setEditingSlots(
+      draftForSelectedDate.map((slot) => ({
+        id: slot.id,
+        startHour: String(slot.start.getHours()).padStart(2, '0'),
+        startMinute: snapMinute(slot.start.getMinutes()),
+        endHour: String(slot.end.getHours()).padStart(2, '0'),
+        endMinute: snapMinute(slot.end.getMinutes()),
+      }))
+    );
+    setSlotErrors({});
   }, [draftForSelectedDate]);
 
   const allowedDates = parsedDraft
     .filter((slot) => slot.type === 'ALLOW')
     .map((slot) => slot.dateKey);
+
+  const hasAnyError = Object.values(slotErrors).some(
+    (e) => e.timeRange || e.overlap
+  );
+
+  const hasInvalidTimes = editingSlots.some((slot) => {
+    const startTotal =
+      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute);
+    const endTotal = parseInt(slot.endHour) * 60 + parseInt(slot.endMinute);
+    return endTotal - startTotal < 30;
+  });
 
   const handleSave = async () => {
     setIsSaving(true);
@@ -70,163 +109,239 @@ export default function MentorScheduleDialog({
     onOpenChange(false);
   };
 
-  const handleLocalTimeChange = (
+  const checkOverlapWithOthers = (
     id: number,
-    part: keyof Omit<EditingSlot, 'id'>,
-    value: string
-  ) => {
-    setEditingSlots((currentSlots) =>
-      currentSlots.map((slot) =>
-        slot.id === id ? { ...slot, [part]: value } : slot
+    startTotal: number,
+    endTotal: number
+  ): boolean => {
+    return parsedDraft
+      .filter(
+        (s) => s.type === 'ALLOW' && s.id !== id && s.dateKey === selectedDate
       )
-    );
+      .some((s) => {
+        const otherStart = s.start.getHours() * 60 + s.start.getMinutes();
+        const otherEnd = s.end.getHours() * 60 + s.end.getMinutes();
+        return startTotal < otherEnd && endTotal > otherStart;
+      });
   };
 
-  const handleTimeBlur = (
+  const handleTimeChange = (
     id: number,
     part: keyof Omit<EditingSlot, 'id'>,
     value: string
   ) => {
-    const numericValue = parseInt(value, 10);
-    const clampedValue = isNaN(numericValue) ? 0 : numericValue;
-    const formattedValue = String(clampedValue).padStart(2, '0');
-
-    handleLocalTimeChange(id, part, formattedValue);
-
     const originalSlot = editingSlots.find((s) => s.id === id);
     if (!originalSlot) return;
 
-    const updatedSlot = { ...originalSlot, [part]: formattedValue };
-    const newStartTime = `${updatedSlot.startHour}:${updatedSlot.startMinute}`;
-    const newEndTime = `${updatedSlot.endHour}:${updatedSlot.endMinute}`;
+    const updatedSlot = { ...originalSlot, [part]: value };
+    setEditingSlots((prev) =>
+      prev.map((slot) => (slot.id === id ? updatedSlot : slot))
+    );
+
+    const startTotal =
+      parseInt(updatedSlot.startHour) * 60 + parseInt(updatedSlot.startMinute);
+    const endTotal =
+      parseInt(updatedSlot.endHour) * 60 + parseInt(updatedSlot.endMinute);
+
+    if (endTotal <= startTotal) {
+      setSlotErrors((prev) => ({
+        ...prev,
+        [id]: { timeRange: 'End time must be after start time' },
+      }));
+      return;
+    }
+
+    if (checkOverlapWithOthers(id, startTotal, endTotal)) {
+      setSlotErrors((prev) => ({
+        ...prev,
+        [id]: { overlap: 'This slot overlaps with another slot' },
+      }));
+      return;
+    }
+
+    setSlotErrors((prev) => {
+      const next = { ...prev };
+      delete next[id];
+      return next;
+    });
 
     updateDraftSlot(id, {
-      startTime: newStartTime,
-      endTime: newEndTime,
+      startTime: `${updatedSlot.startHour}:${updatedSlot.startMinute}`,
+      endTime: `${updatedSlot.endHour}:${updatedSlot.endMinute}`,
     });
   };
 
   const addNewTimeSlot = () => {
+    const slotsToday = parsedDraft
+      .filter((s) => s.type === 'ALLOW' && s.dateKey === selectedDate)
+      .sort((a, b) => a.end.getTime() - b.end.getTime());
+
+    let startH = 9;
+    let startM = 0;
+
+    if (slotsToday.length > 0) {
+      const lastEnd = slotsToday[slotsToday.length - 1].end;
+      startH = lastEnd.getHours();
+      startM = lastEnd.getMinutes();
+      // snap to next 15-min boundary at or after lastEnd's minute
+      const snapped = Math.ceil(startM / 15) * 15;
+      if (snapped >= 60) {
+        startH += 1;
+        startM = 0;
+      } else {
+        startM = snapped;
+      }
+    }
+
+    if (startH >= 24) return;
+
+    const totalEndMin = startH * 60 + startM + meetingDurationMinutes;
+    const endH = Math.floor(totalEndMin / 60);
+    const endM = totalEndMin % 60;
+
+    if (endH >= 24) return;
+
     addSlotForSelectedDate({
       type: 'ALLOW',
-      startTime: '09:00',
-      endTime: '10:00',
+      startTime: `${String(startH).padStart(2, '0')}:${String(startM).padStart(2, '0')}`,
+      endTime: `${String(endH).padStart(2, '0')}:${String(endM).padStart(2, '0')}`,
     });
+  };
+
+  const renderTimeSelect = (
+    id: number,
+    part: keyof Omit<EditingSlot, 'id'>,
+    value: string,
+    options: string[],
+    hasError: boolean
+  ) => (
+    <Select value={value} onValueChange={(v) => handleTimeChange(id, part, v)}>
+      <SelectTrigger
+        className={`w-14 px-2 ${hasError ? 'border-red-500' : ''}`}
+      >
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        {options.map((opt) => (
+          <SelectItem key={opt} value={opt}>
+            {opt}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  );
+
+  const MIN_DURATION = 30; // minutes
+
+  const getEndHourOptions = (slot: EditingSlot): string[] => {
+    const minEnd =
+      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
+    // Keep hours where at least one minute option (max = 45) yields endTotal >= minEnd
+    return HOUR_OPTIONS.filter((h) => parseInt(h) * 60 + 45 >= minEnd);
+  };
+
+  const getEndMinuteOptions = (slot: EditingSlot): string[] => {
+    const minEnd =
+      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
+    return MINUTE_OPTIONS.filter(
+      (m) => parseInt(slot.endHour) * 60 + parseInt(m) >= minEnd
+    );
   };
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[425px]">
+      <DialogContent className="sm:max-w-[440px]">
         <DialogHeader>
           <DialogTitle>Scheduling Setting</DialogTitle>
         </DialogHeader>
         <div className="flex flex-col gap-4 py-4">
-          <div>
-            <ScheduleCalendar
-              selected={selectedDate ? new Date(selectedDate) : new Date()}
-              onSelect={(d) =>
-                setSelectedDate(
-                  d
-                    ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
-                    : null
-                )
-              }
-              allowedDates={allowedDates}
-              showTodayStyle={false}
-              disableEmptyDates={false}
-              highlightAvailableDates={true}
-            />
-          </div>
+          <ScheduleCalendar
+            selected={
+              selectedDate ? new Date(selectedDate + 'T00:00:00') : new Date()
+            }
+            onSelect={(d) =>
+              setSelectedDate(
+                d
+                  ? `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`
+                  : null
+              )
+            }
+            allowedDates={allowedDates}
+            showTodayStyle={false}
+            disableEmptyDates={false}
+            disablePastDates={true}
+            highlightAvailableDates={true}
+          />
+
           <div>
             <p className="font-semibold">Available time slots</p>
-            <div className="mt-4 flex flex-col gap-4">
-              {editingSlots.map((slot, index) => (
-                <div
-                  key={slot.id}
-                  className="flex items-center justify-between"
-                >
-                  <div className="flex flex-nowrap items-center gap-1">
-                    <Input
-                      type="number"
-                      value={slot.startHour}
-                      onChange={(e) =>
-                        handleLocalTimeChange(
-                          slot.id,
-                          'startHour',
-                          e.target.value
-                        )
-                      }
-                      onBlur={(e) =>
-                        handleTimeBlur(slot.id, 'startHour', e.target.value)
-                      }
-                      className="w-14 text-center"
-                    />
-                    <span>:</span>
-                    <Input
-                      type="number"
-                      value={slot.startMinute}
-                      onChange={(e) =>
-                        handleLocalTimeChange(
-                          slot.id,
-                          'startMinute',
-                          e.target.value
-                        )
-                      }
-                      onBlur={(e) =>
-                        handleTimeBlur(slot.id, 'startMinute', e.target.value)
-                      }
-                      className="w-14 text-center"
-                    />
-                    <span className="mx-1">~</span>
-                    <Input
-                      type="number"
-                      value={slot.endHour}
-                      onChange={(e) =>
-                        handleLocalTimeChange(
-                          slot.id,
-                          'endHour',
-                          e.target.value
-                        )
-                      }
-                      onBlur={(e) =>
-                        handleTimeBlur(slot.id, 'endHour', e.target.value)
-                      }
-                      className="w-14 text-center"
-                    />
-                    <span>:</span>
-                    <Input
-                      type="number"
-                      value={slot.endMinute}
-                      onChange={(e) =>
-                        handleLocalTimeChange(
-                          slot.id,
-                          'endMinute',
-                          e.target.value
-                        )
-                      }
-                      onBlur={(e) =>
-                        handleTimeBlur(slot.id, 'endMinute', e.target.value)
-                      }
-                      className="w-14 text-center"
-                    />
-                    <Button
-                      variant="ghost"
-                      onClick={() => deleteDraftSlot(slot.id!)}
-                    >
-                      <X className="h-4 w-4" />
-                    </Button>
-                  </div>
-                  <div className="flex flex-shrink-0 items-center">
-                    {index === editingSlots.length - 1 ? (
-                      <Button variant="ghost" onClick={addNewTimeSlot}>
-                        <Plus className="h-4 w-4" />
+            <div className="mt-3 flex flex-col gap-3">
+              {editingSlots.map((slot, index) => {
+                const errors = slotErrors[slot.id] ?? {};
+                const hasError = Boolean(errors.timeRange || errors.overlap);
+                const endHourOptions = getEndHourOptions(slot);
+                const endMinuteOptions = getEndMinuteOptions(slot);
+                return (
+                  <div key={slot.id} className="flex flex-col gap-1">
+                    <div className="flex items-center gap-1">
+                      {renderTimeSelect(
+                        slot.id,
+                        'startHour',
+                        slot.startHour,
+                        HOUR_OPTIONS,
+                        hasError
+                      )}
+                      <span className="text-muted-foreground">:</span>
+                      {renderTimeSelect(
+                        slot.id,
+                        'startMinute',
+                        slot.startMinute,
+                        MINUTE_OPTIONS,
+                        hasError
+                      )}
+                      <span className="mx-1 text-muted-foreground">–</span>
+                      {renderTimeSelect(
+                        slot.id,
+                        'endHour',
+                        slot.endHour,
+                        endHourOptions,
+                        hasError
+                      )}
+                      <span className="text-muted-foreground">:</span>
+                      {renderTimeSelect(
+                        slot.id,
+                        'endMinute',
+                        slot.endMinute,
+                        endMinuteOptions,
+                        hasError
+                      )}
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        onClick={() => deleteDraftSlot(slot.id)}
+                      >
+                        <X className="h-4 w-4" />
                       </Button>
-                    ) : (
-                      <div className="w-10" />
+                      {index === editingSlots.length - 1 && (
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          onClick={addNewTimeSlot}
+                        >
+                          <Plus className="h-4 w-4" />
+                        </Button>
+                      )}
+                    </div>
+                    {errors.timeRange && (
+                      <p className="text-red-500 text-xs">{errors.timeRange}</p>
+                    )}
+                    {errors.overlap && (
+                      <p className="text-red-500 text-xs">{errors.overlap}</p>
                     )}
                   </div>
-                </div>
-              ))}
+                );
+              })}
+
               {draftForSelectedDate.length === 0 && (
                 <Button
                   variant="ghost"
@@ -239,6 +354,7 @@ export default function MentorScheduleDialog({
             </div>
           </div>
         </div>
+
         <DialogFooter className="justify-center">
           <Button
             variant="outline"
@@ -249,7 +365,10 @@ export default function MentorScheduleDialog({
           >
             Cancel
           </Button>
-          <Button onClick={handleSave} disabled={isSaving}>
+          <Button
+            onClick={handleSave}
+            disabled={isSaving || hasAnyError || hasInvalidTimes}
+          >
             {isSaving ? 'Saving...' : 'Save'}
           </Button>
         </DialogFooter>

--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -11,6 +11,7 @@ interface ScheduleCalendarProps {
   showTodayStyle?: boolean;
   readOnly?: boolean;
   disableEmptyDates?: boolean;
+  disablePastDates?: boolean;
   highlightAvailableDates?: boolean;
 }
 
@@ -21,6 +22,7 @@ export const ScheduleCalendar = ({
   showTodayStyle,
   readOnly = false,
   disableEmptyDates = false,
+  disablePastDates = false,
   highlightAvailableDates = false,
 }: ScheduleCalendarProps) => {
   const handleSelect = (d: Date | undefined) => {
@@ -29,7 +31,7 @@ export const ScheduleCalendar = ({
   };
 
   const availableDays = highlightAvailableDates
-    ? allowedDates.map((dateStr) => new Date(dateStr))
+    ? allowedDates.map((dateStr) => new Date(dateStr + 'T00:00:00'))
     : [];
 
   return (
@@ -49,11 +51,14 @@ export const ScheduleCalendar = ({
         },
       }}
       disabled={(day) => {
+        if (disablePastDates) {
+          const today = new Date();
+          today.setHours(0, 0, 0, 0);
+          if (day < today) return true;
+        }
         if (disableEmptyDates) {
           const dateStr = dayjs(day).format('YYYY-MM-DD');
-          if (allowedDates.length === 0) {
-            return true;
-          }
+          if (allowedDates.length === 0) return true;
           return !allowedDates.includes(dateStr);
         }
         return false;

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -13,6 +13,8 @@ import type { Reservation } from './types';
 
 type Variant = 'upcoming' | 'pending-mentee' | 'pending-mentor' | 'history';
 
+// ── Component ───────────────────────────────────────────────────────────────
+
 export function ReservationList({
   items,
   variant,
@@ -46,12 +48,12 @@ export function ReservationList({
     const otherId = resolveOtherId(myId, it);
 
     await updateReservationStatus({
-      userId: myId, // path :user_id = 自己
+      userId: myId,
       reservationId: id,
       debug: true,
       body: {
-        my_user_id: myId, // 自己
-        user_id: otherId, // 對方
+        my_user_id: myId,
+        user_id: otherId,
         my_status: 'ACCEPT',
         schedule_id: it.scheduleId,
         dtstart: it.dtstart,
@@ -63,7 +65,12 @@ export function ReservationList({
       },
     });
 
-    hardReload(); // ✅ 成功後整頁重載
+    // TODO: block the accepted time slot so other mentees can't book it.
+    // Blocked by backend: PUT /mentors/:id/schedule returns 422 when a BLOCK
+    // slot overlaps an existing ALLOW slot. Re-enable once backend supports it,
+    // or once GET schedule returns booked_slots so the frontend can filter them.
+
+    hardReload();
   };
 
   // Reject & Cancel 共用（API 等同）
@@ -81,8 +88,8 @@ export function ReservationList({
       debug: true,
       body: {
         my_user_id: myId,
-        user_id: otherId, // 對方
-        my_status: 'REJECT', // Reject & Cancel
+        user_id: otherId,
+        my_status: 'REJECT',
         schedule_id: it.scheduleId,
         dtstart: it.dtstart,
         dtend: it.dtend,
@@ -91,7 +98,10 @@ export function ReservationList({
       },
     });
 
-    hardReload(); // ✅ 成功後整頁重載
+    // TODO: remove the BLOCK slot when cancelling an accepted reservation.
+    // Blocked by the same backend limitation as above.
+
+    hardReload();
   };
 
   return (

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -7,6 +7,7 @@ dayjs.extend(isSameOrBefore);
 import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
+  BookedSlot,
   deleteMentorSchedule,
   fetchMentorSchedule,
   saveMentorSchedule,
@@ -32,6 +33,12 @@ export type ParsedMentorTimeslot = {
   dateKey: string; // YYYY-MM-DD (local)
 };
 
+export type BookingSlot = {
+  start: Date;
+  end: Date;
+  scheduleId: number; // parent ALLOW slot id
+};
+
 type Options = {
   storageKey?: string;
   seed?: RawMentorTimeslot[];
@@ -52,6 +59,10 @@ export type UseMentorScheduleReturn = {
 
   parsedDraft: ParsedMentorTimeslot[];
   draftForSelectedDate: ParsedMentorTimeslot[];
+
+  meetingDurationMinutes: number;
+  setMeetingDuration: (minutes: number) => void;
+  generateBookingSlots: (dateKey: string) => BookingSlot[];
 
   addSlotForSelectedDate: (opts: {
     type: 'ALLOW' | 'BLOCK';
@@ -150,6 +161,15 @@ export const useMentorSchedule = (
   /** 被刪除、等 Confirm 才真的 DELETE 的正數 id */
   const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
 
+  const [bookedSlots, setBookedSlots] = useState<BookedSlot[]>([]);
+
+  const [meetingDurationMinutes, setMeetingDurationMinutes] =
+    useState<number>(30);
+
+  const setMeetingDuration = useCallback((minutes: number) => {
+    setMeetingDurationMinutes(minutes);
+  }, []);
+
   const persistedIdSet = useMemo(
     () => new Set(saved.filter((s) => s.id > 0).map((s) => s.id)),
     [saved]
@@ -195,6 +215,10 @@ export const useMentorSchedule = (
             setDraft(raws);
             setLoaded(true);
             setPendingDeleteIds([]);
+            setBookedSlots(data?.booked_slots ?? []);
+            if (data?.meeting_duration_minutes) {
+              setMeetingDurationMinutes(data.meeting_duration_minutes);
+            }
           }
         } catch (e) {
           log('fetchMentorSchedule error:', e);
@@ -232,6 +256,37 @@ export const useMentorSchedule = (
     [parsedDraft, selectedDate]
   );
 
+  const generateBookingSlots = useCallback(
+    (dateKey: string): BookingSlot[] => {
+      const allowSlots = parsedDraft.filter(
+        (slot) => slot.type === 'ALLOW' && slot.dateKey === dateKey
+      );
+      const durationMs = meetingDurationMinutes * 60 * 1000;
+      const result: BookingSlot[] = [];
+      for (const slot of allowSlots) {
+        let cursor = slot.start.getTime();
+        const slotEnd = slot.end.getTime();
+        while (cursor + durationMs <= slotEnd) {
+          const subStart = cursor;
+          const subEnd = cursor + durationMs;
+          const isBooked = bookedSlots.some(
+            (b) => subStart < b.dtend * 1000 && subEnd > b.dtstart * 1000
+          );
+          if (!isBooked) {
+            result.push({
+              start: new Date(subStart),
+              end: new Date(subEnd),
+              scheduleId: slot.id,
+            });
+          }
+          cursor += durationMs;
+        }
+      }
+      return result;
+    },
+    [parsedDraft, meetingDurationMinutes, bookedSlots]
+  );
+
   const dirty = useMemo(
     () =>
       JSON.stringify(saved) !== JSON.stringify(draft) ||
@@ -258,16 +313,31 @@ export const useMentorSchedule = (
         const e = buildDT(selectedDate, endTime);
         if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return;
 
-        setDraft((prev) => [
-          ...prev,
-          {
-            id: nextTempId(prev),
-            type,
-            dtstart: Math.floor(s.valueOf() / 1000),
-            dtend: Math.floor(e.valueOf() / 1000),
-            rrule: '',
-          },
-        ]);
+        const newDtstart = Math.floor(s.valueOf() / 1000);
+        const newDtend = Math.floor(e.valueOf() / 1000);
+
+        setDraft((prev) => {
+          const hasOverlap = prev.some((r) => {
+            const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
+            return (
+              rDate === selectedDate &&
+              newDtstart < r.dtend &&
+              newDtend > r.dtstart
+            );
+          });
+          if (hasOverlap) return prev;
+
+          return [
+            ...prev,
+            {
+              id: nextTempId(prev),
+              type,
+              dtstart: newDtstart,
+              dtend: newDtend,
+              rrule: '',
+            },
+          ];
+        });
       },
       [selectedDate]
     );
@@ -308,13 +378,30 @@ export const useMentorSchedule = (
           return prev;
         }
 
+        const newDtstart = Math.floor(s.valueOf() / 1000);
+        const newDtend = Math.floor(e.valueOf() / 1000);
+        const hasOverlap = prev.some((r) => {
+          if (r.id === id) return false;
+          const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
+          return (
+            rDate === baseDate && newDtstart < r.dtend && newDtend > r.dtstart
+          );
+        });
+        if (hasOverlap) {
+          console.warn('[MentorSchedule] updateDraftSlot overlap detected', {
+            id,
+            baseDate,
+          });
+          return prev;
+        }
+
         const next = prev.map((r) =>
           r.id === id
             ? {
                 ...r,
                 type: patch.type ?? r.type,
-                dtstart: Math.floor(s.valueOf() / 1000),
-                dtend: Math.floor(e.valueOf() / 1000),
+                dtstart: newDtstart,
+                dtend: newDtend,
               }
             : r
         );
@@ -388,6 +475,10 @@ export const useMentorSchedule = (
       setSaved(raws);
       setDraft(raws);
       setPendingDeleteIds([]);
+      setBookedSlots(data?.booked_slots ?? []);
+      if (data?.meeting_duration_minutes) {
+        setMeetingDurationMinutes(data.meeting_duration_minutes);
+      }
       log('refetched after confirm:', { count: raws.length, raws });
     };
 
@@ -401,6 +492,7 @@ export const useMentorSchedule = (
           userId: backend.userId,
           until: endOfMonthUnix,
           timeslots: upsertPayload,
+          meetingDurationMinutes,
         });
         if (ok) await refetch();
         return;
@@ -426,6 +518,7 @@ export const useMentorSchedule = (
         userId: backend.userId,
         until: endOfMonthUnix,
         timeslots: upsertPayload,
+        meetingDurationMinutes,
       });
       if (!ok) throw new Error('PUT failed');
 
@@ -453,6 +546,7 @@ export const useMentorSchedule = (
     toServiceSlot,
     dirty,
     pendingDeleteIds,
+    meetingDurationMinutes,
     log,
     backend,
   ]);
@@ -490,6 +584,9 @@ export const useMentorSchedule = (
     setSelectedDate,
     parsedDraft,
     draftForSelectedDate,
+    meetingDurationMinutes,
+    setMeetingDuration,
+    generateBookingSlots,
     addSlotForSelectedDate,
     updateDraftSlot,
     deleteDraftSlot,

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -1,11 +1,10 @@
-import { ParsedMentorTimeslot } from '@/hooks/useMentorSchedule';
+import { BookingSlot, ParsedMentorTimeslot } from '@/hooks/useMentorSchedule';
 
 export function formatSelectedDate(selectedDate: Date | undefined): string {
   if (!selectedDate) {
     return '';
   }
   return new Intl.DateTimeFormat('en-US', {
-    timeZone: 'Asia/Taipei',
     weekday: 'short',
     month: 'short',
     day: 'numeric',
@@ -15,6 +14,18 @@ export function formatSelectedDate(selectedDate: Date | undefined): string {
 export function formatStartTimeSlot(slot: ParsedMentorTimeslot): string {
   const slotArr = JSON.stringify(slot.formatted)?.split(' ');
   return slotArr ? `${slotArr[1]} ${slotArr[2]}` : '';
+}
+
+const timeFormat: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: true,
+};
+
+export function formatBookingSlotTime(slot: BookingSlot): string {
+  const start = slot.start.toLocaleTimeString('en-US', timeFormat);
+  const end = slot.end.toLocaleTimeString('en-US', timeFormat);
+  return `${start} – ${end}`;
 }
 
 export function toDateKey(d: Date): string {

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -19,8 +19,15 @@ export interface ScheduleTimeSlots {
   exdate: [];
 }
 
+export interface BookedSlot {
+  dtstart: number; // unix seconds
+  dtend: number; // unix seconds
+}
+
 export interface ScheduleType {
   timeslots: ScheduleTimeSlots[] | [];
+  meeting_duration_minutes?: number;
+  booked_slots?: BookedSlot[];
   next_dtstart: string;
 }
 
@@ -67,17 +74,23 @@ export async function saveMentorSchedule(params: {
   userId: string;
   timeslots: UpsertTimeslotBackend[];
   until?: number | null;
+  meetingDurationMinutes?: number;
+  debug?: boolean;
 }): Promise<boolean> {
   const clean = (obj: CleanObject): CleanObject =>
     Object.fromEntries(
       Object.entries(obj).filter(
         ([, v]) =>
-          v !== undefined && v !== null && !(Array.isArray(v) && v.length === 0)
+          v !== undefined &&
+          v !== null &&
+          v !== '' &&
+          !(Array.isArray(v) && v.length === 0)
       )
     );
 
   const body = clean({
     until: params.until,
+    meeting_duration_minutes: params.meetingDurationMinutes,
     timeslots: params.timeslots.map((t) =>
       clean({
         id: t.id,
@@ -90,14 +103,37 @@ export async function saveMentorSchedule(params: {
     ),
   });
 
+  if (params.debug) {
+    console.log(
+      '[saveMentorSchedule] PUT body:',
+      JSON.stringify(body, null, 2)
+    );
+  }
+
   try {
     const result = await apiClient.put<SaveScheduleResponse>(
       `/v1/mentors/${params.userId}/schedule`,
       body,
       { auth: false }
     );
-    return result.code === '0';
-  } catch {
+    if (params.debug) {
+      console.log('[saveMentorSchedule] response:', result);
+    }
+    if (result.code !== '0') {
+      if (params.debug) {
+        console.error(
+          '[saveMentorSchedule] non-zero code:',
+          result.code,
+          result.msg
+        );
+      }
+      return false;
+    }
+    return true;
+  } catch (err) {
+    if (params.debug) {
+      console.error('[saveMentorSchedule] request failed:', err);
+    }
     return false;
   }
 }

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -88,9 +88,13 @@ function pickCounterparty(r: BackendReservation, state: ReservationState) {
   return r.sender;
 }
 
-function formatDateTime(epochSec: number) {
-  const d = dayjs.unix(epochSec);
-  return { date: d.format('ddd, MMM DD, YYYY'), time: d.format('h:mm a') };
+function formatDateTime(dtstart: number, dtend: number) {
+  const start = dayjs.unix(dtstart);
+  const end = dayjs.unix(dtend);
+  return {
+    date: start.format('ddd, MMM DD, YYYY'),
+    time: `${start.format('h:mm a')} – ${end.format('h:mm a')}`,
+  };
 }
 
 /* ================================
@@ -102,7 +106,7 @@ function mapToReservation(
   state: ReservationState
 ): Reservation {
   const counterparty = pickCounterparty(r, state);
-  const { date, time } = formatDateTime(r.dtstart);
+  const { date, time } = formatDateTime(r.dtstart, r.dtend);
   const roleLineParts = [
     counterparty.job_title?.trim() || '',
     prettyYears(counterparty.years_of_experience),


### PR DESCRIPTION

- Fix timezone bug: parse YYYY-MM-DD strings as local time (T00:00:00) to prevent off-by-one day in non-UTC timezones
- Remove hardcoded Asia/Taipei timezone from date formatters
- Fix profile page RWD: full-width layout on mobile, booking section visible on all screen sizes
- Show end time on reservation cards (start – end format)
- MentorScheduleDialog: filter end time dropdowns to enforce min 30-min duration and prevent start > end selection
- Disable Save button when any slot has invalid time range
- Add disablePastDates prop to ScheduleCalendar; enable for mentor schedule dialog
- Remove block/unblock slot logic (blocked by backend 422 on overlapping ALLOW+BLOCK slots)
- Add debug logging to saveMentorSchedule; strip empty string rrule from PUT body
- Slot display: grid 2-column layout on profile page

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
