### PR TITLE
feat: add eye icon to toggle password visibility

### DIFF
--- a/src/components/auth/AuthFormInput.tsx
+++ b/src/components/auth/AuthFormInput.tsx
@@ -1,3 +1,7 @@
+'use client';
+
+import { Eye, EyeOff } from 'lucide-react';
+import { useState } from 'react';
 import { Control, FieldValues, Path } from 'react-hook-form';
 
 import {
@@ -28,6 +32,19 @@ const AuthFormInput = <T extends FieldValues>({
   forgotPasswordLink,
   autocomplete,
 }: AuthFormInputProps<T>) => {
+  const [showPassword, setShowPassword] = useState(false);
+
+  const togglePasswordVisibility = () => {
+    setShowPassword(!showPassword);
+  };
+
+  const isPasswordInput = type === 'password';
+  const inputType = isPasswordInput
+    ? showPassword
+      ? 'text'
+      : 'password'
+    : type;
+
   return (
     <FormField
       control={control}
@@ -35,15 +52,32 @@ const AuthFormInput = <T extends FieldValues>({
       render={({ field }) => (
         <FormItem>
           <FormLabel showErrorStyle={false}>{label}</FormLabel>
-          <FormControl>
-            <Input
-              placeholder={placeholder}
-              type={type}
-              autoComplete={autocomplete}
-              {...field}
-              value={field.value ?? ''}
-            />
-          </FormControl>
+          <div className="relative">
+            <FormControl>
+              <Input
+                placeholder={placeholder}
+                type={inputType}
+                autoComplete={autocomplete}
+                className={isPasswordInput ? 'pr-10' : ''}
+                {...field}
+                value={field.value ?? ''}
+              />
+            </FormControl>
+            {isPasswordInput && (
+              <button
+                type="button"
+                onClick={togglePasswordVisibility}
+                className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 focus:outline-none"
+                aria-label={showPassword ? 'hide password' : 'show password'}
+              >
+                {showPassword ? (
+                  <EyeOff className="h-5 w-5" />
+                ) : (
+                  <Eye className="h-5 w-5" />
+                )}
+              </button>
+            )}
+          </div>
           <FormMessage />
           {forgotPasswordLink}
         </FormItem>


### PR DESCRIPTION
## What Does This PR Do?

Add eye icon to toggle password visibility

## Demo

## Screenshot

invisible
<img width="581" height="564" alt="image" src="https://github.com/user-attachments/assets/6f3b2e25-8a6b-45c7-8bfb-347444229164" />

visible
<img width="482" height="527" alt="image" src="https://github.com/user-attachments/assets/94fbb03c-b24a-44b0-8aad-b7e798854480" />

N/A

## Anything to Note?

N/A
