### PR TITLE
fix: resolve avatar cache inconsistency after profile update and login

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -5,6 +5,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import avatarImage from '@/assets/default-avatar.png';
 import { SelectFilters } from '@/components/filter/MentorFilterDropdown';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { fetchMentors, MentorType } from '@/services/search-mentor/mentors';
 
 import { filterOptions } from './data';
@@ -89,7 +90,10 @@ export default function MentorPoolContainer() {
     }
     if (rtnList.length > 0) {
       rtnList.forEach((mentor) => {
-        mentor.avatar = avatarImage;
+        mentor.avatar =
+          typeof mentor.avatar === 'string' && mentor.avatar
+            ? getAvatarThumbUrl(mentor.avatar)
+            : avatarImage;
       });
       setMentors(rtnList);
       setMentorCount(rtnList.length);
@@ -121,7 +125,10 @@ export default function MentorPoolContainer() {
     }
     if (rtnList.length > 0) {
       rtnList.forEach((mentor) => {
-        mentor.avatar = avatarImage;
+        mentor.avatar =
+          typeof mentor.avatar === 'string' && mentor.avatar
+            ? getAvatarThumbUrl(mentor.avatar)
+            : avatarImage;
       });
       setMentors((prevMentors) => {
         const newMentors = rtnList.filter(

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -2,8 +2,8 @@
 
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
-import { getSession } from 'next-auth/react';
-import { useEffect, useMemo, useState } from 'react';
+import { useSession } from 'next-auth/react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import useUserData from '@/hooks/user/user-data/useUserData';
@@ -11,10 +11,6 @@ import useUserData from '@/hooks/user/user-data/useUserData';
 import { ProfilePageSkeleton } from './skeleton';
 
 const ProfilePageUI = dynamic(() => import('./ui'));
-
-// Stable within a browser session — lets the browser cache profile avatars
-// across navigations. Resets on full page refresh, ensuring a fresh fetch.
-const AVATAR_CACHE_BUST = Date.now();
 
 interface Props {
   pageUserId: string;
@@ -40,22 +36,25 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded]);
 
-  const [isLogging, setIsLogging] = useState(false);
-  const [loginUserId, setLoginUserId] = useState('');
+  // Stable per-session fallback for other users' profiles — allows browser
+  // caching across navigations. Resets only on full page refresh.
+  const stableCacheBust = useRef(Date.now()).current;
+
+  const { data: session } = useSession();
+  const isLogging = Boolean(session?.user?.id);
+  const loginUserId = session?.user?.id ? String(session.user.id) : '';
+
+  // For the logged-in user's own profile, use the session's avatarUpdatedAt so
+  // the latest avatar appears immediately after a profile update without a full
+  // page reload. For other users' profiles the stable fallback is sufficient.
+  const avatarCacheBust =
+    loginUserId === pageUserId
+      ? (session?.user?.avatarUpdatedAt ?? stableCacheBust)
+      : stableCacheBust;
+
   const [openReservationDialog, setOpenReservationDialog] = useState(false);
   const [openMenteeReservationDialog, setOpenMenteeReservationDialog] =
     useState(false);
-
-  useEffect(() => {
-    const fetchSession = async () => {
-      const session = await getSession();
-      const user = session?.user;
-      setIsLogging(!!user?.id);
-      setLoginUserId(!!user?.id ? String(user?.id) : '');
-    };
-
-    fetchSession();
-  }, []);
 
   const pageUserIdNumber = Number(pageUserId);
   const { userData, isLoading: loading } = useUserData(
@@ -102,7 +101,7 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
       scheduleLoaded={loaded}
       loginUserId={loginUserId}
       isLogging={isLogging}
-      avatarCacheBust={AVATAR_CACHE_BUST}
+      avatarCacheBust={avatarCacheBust}
       allowedDates={allowedDates}
       openReservationDialog={openReservationDialog}
       setOpenReservationDialog={setOpenReservationDialog}

--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -33,23 +33,21 @@ import { useEditProfileData } from '@/hooks/user/profile/useEditProfileData';
 import { useProfileSelectOptions } from '@/hooks/user/profile/useProfileSelectOptions';
 import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
 
-const JobExperienceSection = dynamic(() =>
-  import('@/components/profile/edit/JobExperienceSection').then((m) => ({
-    default: m.JobExperienceSection,
-  }))
-);
+const JobExperienceSection = dynamic(async () => {
+  const m = await import('@/components/profile/edit/JobExperienceSection');
+  return { default: m.JobExperienceSection };
+});
 
-const EducationSection = dynamic(() =>
-  import('@/components/profile/edit/educationSection/educationSection').then(
-    (m) => ({ default: m.EducationSection })
-  )
-);
+const EducationSection = dynamic(async () => {
+  const m =
+    await import('@/components/profile/edit/educationSection/educationSection');
+  return { default: m.EducationSection };
+});
 
-const LinksSection = dynamic(() =>
-  import('@/components/profile/edit/LinkSection').then((m) => ({
-    default: m.LinksSection,
-  }))
-);
+const LinksSection = dynamic(async () => {
+  const m = await import('@/components/profile/edit/LinkSection');
+  return { default: m.LinksSection };
+});
 
 export default function Page({
   params: { pageUserId },

--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -62,6 +62,11 @@ export default function Page({
 
   const { data: session, update: updateSession } = useSession();
 
+  // Stable fallback used when avatarUpdatedAt is absent (e.g. fresh login before
+  // any update). Ensures the browser always fetches the current image on first
+  // load rather than serving a previously-cached ?cb=0 stale copy.
+  const stableEditCacheBust = useRef(Date.now()).current;
+
   const { isAuthorized } = useProfileAuth(pageUserId);
 
   const [isMentor, setIsMentor] = useState(false);
@@ -137,7 +142,7 @@ export default function Page({
             name="avatarFile"
             avatarUrl={
               watchedAvatar
-                ? `${watchedAvatar}?cb=${session?.user?.avatarUpdatedAt ?? 0}`
+                ? `${watchedAvatar}?cb=${session?.user?.avatarUpdatedAt ?? stableEditCacheBust}`
                 : ''
             }
           />

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -55,6 +55,9 @@ const authOptions = {
           isMentor: response.data.user.is_mentor,
           name: response.data.user.name,
           avatar: response.data.user.avatar,
+          // Set on every login so the browser never serves a stale cached avatar
+          // from a previous session (the S3 key never changes between uploads).
+          avatarUpdatedAt: Date.now(),
           jobTitle: response.data.user.job_title ?? '',
           company: response.data.user.company ?? '',
           personalLinks,
@@ -95,6 +98,7 @@ const authOptions = {
             token: credentials.token,
             name: user.name,
             avatar: user.avatar,
+            avatarUpdatedAt: Date.now(),
             isMentor: user.is_mentor,
             onBoarding: user.onboarding,
             jobTitle: user.job_title ?? '',

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -14,6 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
 import { ShareProfileDialog } from './ShareProfileDialog';
 
@@ -31,8 +32,10 @@ export const UserDropdown = React.memo(function UserDropdown({
   const userId = user.id;
   const isMentor = Boolean(user.isMentor);
   const name = user.name ?? '';
+  // Use the thumbnail variant for all small avatar displays in the header /
+  // dropdown / share dialog — the full-size image is only needed on the profile page.
   const avatarSrc = user.avatar
-    ? `${user.avatar}?cb=${user.avatarUpdatedAt ?? 0}`
+    ? `${getAvatarThumbUrl(user.avatar)}?cb=${user.avatarUpdatedAt ?? 0}`
     : '';
   const jobTitle = user.jobTitle ?? '';
   const company = user.company ?? '';

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -20,18 +20,17 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
   const [zoomScale, setZoomScale] = useState(1);
   const editorRef = useRef<AvatarEditor | null>(null);
 
-  const handleSaveImage = () => {
+  const handleSaveImage = async () => {
     if (editorRef.current) {
-      const imageUrl = editorRef.current.getImageScaledToCanvas().toDataURL();
-      fetch(imageUrl)
-        .then((response) => response.blob())
-        .then((blob) => {
-          onSave(blob);
-          onClose();
-        })
-        .catch((error) => {
-          console.error('Error saving image:', error);
-        });
+      try {
+        const imageUrl = editorRef.current.getImageScaledToCanvas().toDataURL();
+        const response = await fetch(imageUrl);
+        const blob = await response.blob();
+        onSave(blob);
+        onClose();
+      } catch (error) {
+        console.error('Error saving image:', error);
+      }
     }
   };
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -538,11 +538,12 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
       backend?.year &&
       backend?.month
     ) {
-      fetchMentorSchedule({
-        userId: backend.userId,
-        year: backend.year,
-        month: backend.month,
-      }).then((data) => {
+      (async () => {
+        const data = await fetchMentorSchedule({
+          userId: backend.userId,
+          year: backend.year,
+          month: backend.month,
+        });
         const raws = (data?.timeslots ?? []).map(backendToRaw).filter((r) => {
           const d = dayjs(r.dtstart * 1000);
           return d.year() === backend.year && d.month() + 1 === backend.month;
@@ -550,7 +551,7 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
         setDraft(raws);
         setSaved(raws);
         setPendingDeleteIds([]);
-      });
+      })();
     } else {
       setDraft(saved);
       setPendingDeleteIds([]);

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -4,6 +4,7 @@ import { Session } from 'next-auth';
 import { useState } from 'react';
 
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
+import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
 import { pollUntilSynced } from '@/lib/profile/pollUntilSynced';
 import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
@@ -124,7 +125,13 @@ export function useProfileSubmit({
       // 4) poll until backend reflects all updated fields (up to 1 min, every 5s)
       const latest = await pollUntilSynced(values, avatar ?? '');
 
-      // 5) update next-auth session (requires jwt trigger update handler!)
+      // 5) invalidate in-memory user data cache so the profile page fetches
+      //    fresh data on next mount instead of a potentially stale promise
+      if (session?.user?.id) {
+        clearUserDataCache(Number(session.user.id), 'zh_TW');
+      }
+
+      // 6) update next-auth session (requires jwt trigger update handler!)
       await updateSession({
         user: {
           // keep id from current session
@@ -140,7 +147,7 @@ export function useProfileSubmit({
         },
       });
 
-      // 6) navigate
+      // 7) navigate
       if (isMentorOnboarding) {
         router.push('/profile/card');
       } else {

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -7,6 +7,16 @@ import { getInterestsCached } from '../interests/useInterests';
 
 const userDtoPromiseCache = new Map<string, Promise<UserDTO | null>>();
 
+/**
+ * Removes a user's entry from the in-memory request cache so the next call to
+ * useUserData for that user triggers a fresh API fetch.  Call this after a
+ * successful profile update to prevent any concurrent mount from receiving
+ * stale data.
+ */
+export function clearUserDataCache(userId: number, language: string): void {
+  userDtoPromiseCache.delete(`${userId}-${language}`);
+}
+
 function fetchUserByIdCached(
   userId: number,
   language: string

--- a/src/lib/avatar/getAvatarThumbUrl.ts
+++ b/src/lib/avatar/getAvatarThumbUrl.ts
@@ -1,0 +1,25 @@
+/**
+ * Returns the thumbnail variant of an S3 avatar URL.
+ *
+ * Pattern: trailing "/avatar" is replaced with "/avatar-thumb".
+ * Query parameters (e.g. cache-busting `?cb=...`) are preserved.
+ *
+ * Use avatar-thumb for small display areas (header, dropdown, reservation cards,
+ * share-profile dialog). Use the original URL for full-size contexts (profile
+ * page, profile edit page, onboarding, profile card).
+ *
+ * @example
+ * // "https://…/files/123/avatar-thumb"
+ * getAvatarThumbUrl("https://…/files/123/avatar")
+ *
+ * // "https://…/files/123/avatar-thumb?cb=1234567890"
+ * getAvatarThumbUrl("https://…/files/123/avatar?cb=1234567890")
+ */
+export function getAvatarThumbUrl(avatarUrl: string): string {
+  if (!avatarUrl) return avatarUrl;
+  const qIdx = avatarUrl.indexOf('?');
+  const base = qIdx === -1 ? avatarUrl : avatarUrl.slice(0, qIdx);
+  const query = qIdx === -1 ? '' : avatarUrl.slice(qIdx);
+  const thumbBase = base.replace(/\/avatar$/, '/avatar-thumb');
+  return thumbBase + query;
+}


### PR DESCRIPTION
- Replace static module-level AVATAR_CACHE_BUST with reactive session.user.avatarUpdatedAt in profile page container so the latest avatar appears immediately after an update without a full reload
- Apply the same stable-fallback pattern to the edit page (was using ?cb=0 when avatarUpdatedAt is absent, causing stale browser cache hits)
- Set avatarUpdatedAt: Date.now() in both authorize callbacks so every login forces a fresh avatar fetch instead of serving a ?cb=0 cached copy
- Add getAvatarThumbUrl utility and apply avatar-thumb to header/dropdown and mentor pool cards; keep original image for profile/edit/onboarding
- Remove mentor pool hardcoded default avatar override so real mentor photos are shown; fall back to default only when avatar is absent
- Export clearUserDataCache from useUserData and call it in useProfileSubmit after poll succeeds to prevent stale in-memory promise on concurrent mounts

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
