### PR TITLE
feat: integrate Microsoft Clarity for behavior tracking (testing phase)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,7 @@ GITHUB_SECRET=
 
 # Sentry DSN — get from https://sentry.io → Project Settings → Client Keys
 NEXT_PUBLIC_SENTRY_DSN=
+
+# Microsoft Clarity project ID — get from https://clarity.microsoft.com → Settings
+# Leave empty to disable Clarity (e.g. in local development)
+NEXT_PUBLIC_CLARITY_ID=

--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -18,6 +18,7 @@ import {
 import useLocations from '@/hooks/user/country/useLocations';
 import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests from '@/hooks/user/interests/useInterests';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
@@ -67,6 +68,7 @@ export default function OnboardingContainer() {
 
   const onSubmitStep1 = (data: z.infer<typeof step1Schema>) => {
     setTempData((prev) => ({ ...prev, step1: data }));
+    trackEvent({ name: 'onboarding_step_1_completed', feature: 'onboarding' });
     setCurrentStep(2);
   };
 
@@ -82,6 +84,7 @@ export default function OnboardingContainer() {
   });
   const onSubmitStep2 = (data: z.infer<typeof step2Schema>) => {
     setTempData((prev) => ({ ...prev, step2: data }));
+    trackEvent({ name: 'onboarding_step_2_completed', feature: 'onboarding' });
     setCurrentStep(3);
   };
 
@@ -93,6 +96,7 @@ export default function OnboardingContainer() {
   });
   const onSubmitStep3 = (data: z.infer<typeof step3Schema>) => {
     setTempData((prev) => ({ ...prev, step3: data }));
+    trackEvent({ name: 'onboarding_step_3_completed', feature: 'onboarding' });
     setCurrentStep(4);
   };
 
@@ -104,6 +108,7 @@ export default function OnboardingContainer() {
   });
   const onSubmitStep4 = (data: z.infer<typeof step4Schema>) => {
     setTempData((prev) => ({ ...prev, step4: data }));
+    trackEvent({ name: 'onboarding_step_4_completed', feature: 'onboarding' });
     setCurrentStep(5);
   };
 
@@ -171,6 +176,7 @@ export default function OnboardingContainer() {
         throw err;
       }
 
+      trackEvent({ name: 'onboarding_completed', feature: 'onboarding' });
       router.push('/profile/card');
     } catch {
       // submit failed silently — user stays on page

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import '../styles/global.css';
 
 import * as Sentry from '@sentry/nextjs';
 import type { Metadata } from 'next';
+import Script from 'next/script';
 
 import { Footer } from '@/components/layout/Footer';
 import { Header } from '@/components/layout/Header';
@@ -30,6 +31,22 @@ export default function RootLayout({
   return (
     <html lang="zh-TW" className={notoSans.className}>
       <body id="app">
+        {/* Microsoft Clarity — behavior tracking for testing phase.
+            Only loads when NEXT_PUBLIC_CLARITY_ID is set.
+            strategy="afterInteractive" ensures it never blocks page render. */}
+        {process.env.NEXT_PUBLIC_CLARITY_ID && (
+          <Script
+            id="microsoft-clarity"
+            strategy="afterInteractive"
+            dangerouslySetInnerHTML={{
+              __html: `(function(c,l,a,r,i,t,y){
+                c[a]=c[a]||function(){(c[a].q=c[a].q||[]).push(arguments)};
+                t=l.createElement(r);t.async=1;t.src="https://www.clarity.ms/tag/"+i;
+                y=l.getElementsByTagName(r)[0];y.parentNode.insertBefore(t,y);
+              })(window,document,"clarity","script","${process.env.NEXT_PUBLIC_CLARITY_ID}");`,
+            }}
+          />
+        )}
         <Providers>
           <div className="flex min-h-screen flex-col">
             <Header />

--- a/src/components/auth/AuthFormInput.tsx
+++ b/src/components/auth/AuthFormInput.tsx
@@ -59,6 +59,7 @@ const AuthFormInput = <T extends FieldValues>({
                 type={inputType}
                 autoComplete={autocomplete}
                 className={isPasswordInput ? 'pr-10' : ''}
+                {...(isPasswordInput ? { 'data-clarity-mask': 'true' } : {})}
                 {...field}
                 value={field.value ?? ''}
               />

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -22,6 +22,7 @@ import {
   UseMentorScheduleReturn,
 } from '@/hooks/useMentorSchedule';
 import { UserType } from '@/hooks/user/user-data/useUserData';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import {
   createReservation,
@@ -67,6 +68,10 @@ export default function MenteeReservationDialog({
 
   const handleSave = () => {
     if (selectedDate && selectedSlot) {
+      trackEvent({
+        name: 'reservation_booking_started',
+        feature: 'reservation',
+      });
       setView('confirmation');
     }
   };
@@ -114,6 +119,10 @@ export default function MenteeReservationDialog({
       });
 
       setSubmitError(null);
+      trackEvent({
+        name: 'reservation_booking_confirmed',
+        feature: 'reservation',
+      });
       setView('success');
     } catch (error) {
       console.error('Failed to create reservation:', error);

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -5,6 +5,7 @@ import { getSession } from 'next-auth/react';
 import AcceptReservationDialog from '@/components/reservation/AcceptReservationDialog';
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
 import { Card, CardContent } from '@/components/ui/card';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateReservationStatus } from '@/services/reservations';
 
@@ -68,6 +69,7 @@ export function ReservationList({
       // slot overlaps an existing ALLOW slot. Re-enable once backend supports it,
       // or once GET schedule returns booked_slots so the frontend can filter them.
 
+      trackEvent({ name: 'reservation_accepted', feature: 'reservation' });
       hardReload();
     } catch (err) {
       captureFlowFailure({
@@ -108,6 +110,7 @@ export function ReservationList({
       // TODO: remove the BLOCK slot when cancelling an accepted reservation.
       // Blocked by the same backend limitation as above.
 
+      trackEvent({ name: 'reservation_rejected', feature: 'reservation' });
       hardReload();
     } catch (err) {
       captureFlowFailure({

--- a/src/hooks/auth/useSignInForm.ts
+++ b/src/hooks/auth/useSignInForm.ts
@@ -8,6 +8,7 @@ import * as z from 'zod';
 import { AuthFormProps } from '@/components/auth/types';
 import { useToast } from '@/components/ui/use-toast';
 import { validateSignIn } from '@/lib/actions/signIn';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { SignInSchema } from '@/schemas/auth';
 
@@ -80,6 +81,8 @@ export default function useSignInForm(): AuthFormProps<SignInValues> {
         });
         return;
       }
+
+      trackEvent({ name: 'sign_in_succeeded', feature: 'auth' });
 
       if (session.user.onBoarding === false) {
         router.push('/auth/onboarding');

--- a/src/hooks/auth/useSignUpForm.ts
+++ b/src/hooks/auth/useSignUpForm.ts
@@ -6,6 +6,7 @@ import * as z from 'zod';
 
 import { AuthFormProps } from '@/components/auth/types';
 import { useToast } from '@/components/ui/use-toast';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { SignUpSchema } from '@/schemas/auth';
 import { signUp } from '@/services/auth/signUp';
@@ -35,6 +36,7 @@ export default function useSignUpForm(): AuthFormProps<SignUpValues> {
       const result = await signUp(values);
 
       if (result.status === 'success') {
+        trackEvent({ name: 'sign_up_succeeded', feature: 'auth' });
         sessionStorage.setItem('email', values.email);
         router.push('/auth/email-verify');
         return;

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
 import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
+import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { pollUntilSynced } from '@/lib/profile/pollUntilSynced';
 import { ExperienceType } from '@/services/profile/experienceType';
@@ -178,6 +179,7 @@ export function useProfileSubmit({
       });
 
       // 7) navigate
+      trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
       if (isMentorOnboarding) {
         router.push('/profile/card');
       } else {

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,92 @@
+/**
+ * Frontend Behavior Analytics — Microsoft Clarity
+ *
+ * Wraps Clarity's custom event and tag API for lightweight behavior tracking
+ * during the testing phase.
+ *
+ * What Clarity captures automatically (no code needed):
+ *   - All page views
+ *   - All clicks (heatmaps)
+ *   - Scroll depth
+ *   - Session replay
+ *   - Rage clicks, dead clicks
+ *
+ * This module adds custom event markers and session tags on top, to make
+ * important user flows filterable in Clarity dashboards and recordings.
+ *
+ * Gated by NEXT_PUBLIC_CLARITY_ID — runs in any environment where Clarity
+ * is configured (e.g. testing). Silently no-ops when the env var is absent.
+ *
+ * NEVER pass passwords, tokens, emails, or any sensitive data to these functions.
+ *
+ * Event naming convention: <feature>_<action>
+ * Examples: onboarding_step_1_completed, sign_in_succeeded, reservation_booking_confirmed
+ */
+
+// ─── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * A structured behavior event for Clarity.
+ * All fields are sent as Clarity custom events or session tags.
+ */
+export interface BehaviorEvent {
+  /** snake_case event name — format: <feature>_<action> */
+  name: string;
+  /** Module or feature area this event belongs to */
+  feature?: 'auth' | 'onboarding' | 'reservation' | 'profile';
+  /**
+   * Optional key-value metadata for additional context.
+   * Do NOT include passwords, tokens, emails, or personal info.
+   */
+  metadata?: Record<string, string | number | boolean>;
+}
+
+// ─── Internal helper ───────────────────────────────────────────────────────────
+
+type ClarityFn = (...args: unknown[]) => void;
+
+function getClarity(): ClarityFn | undefined {
+  if (typeof window === 'undefined') return undefined;
+  if (!process.env.NEXT_PUBLIC_CLARITY_ID) return undefined;
+  const fn = (window as Window & { clarity?: ClarityFn }).clarity;
+  return typeof fn === 'function' ? fn : undefined;
+}
+
+// ─── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Fires a named custom event in Clarity.
+ * Visible in Clarity → Events and usable as a filter in recordings / heatmaps.
+ *
+ * Do NOT include passwords, tokens, emails, or personal info.
+ */
+export function trackEvent(event: BehaviorEvent): void {
+  const clarity = getClarity();
+  if (!clarity) return;
+
+  clarity('event', event.name);
+
+  if (event.feature) {
+    clarity('set', 'feature', event.feature);
+  }
+
+  if (event.metadata) {
+    for (const [key, value] of Object.entries(event.metadata)) {
+      clarity('set', key, String(value));
+    }
+  }
+}
+
+/**
+ * Sets a session-level custom tag in Clarity.
+ * Tags persist for the session and can be used to filter recordings.
+ *
+ * Example: setAnalyticsTag('onboarding_step', '3')
+ *
+ * Do NOT use for sensitive data.
+ */
+export function setAnalyticsTag(key: string, value: string): void {
+  const clarity = getClarity();
+  if (!clarity) return;
+  clarity('set', key, value);
+}

--- a/src/types/clarity.d.ts
+++ b/src/types/clarity.d.ts
@@ -1,0 +1,3 @@
+interface Window {
+  clarity: ((...args: unknown[]) => void) | undefined;
+}


### PR DESCRIPTION
Add lightweight frontend behavior tracking via Microsoft Clarity to support UX analysis during the testing phase. Clarity auto-captures all page views, clicks, heatmaps, scroll depth, and session replay with no extra code.

Custom event instrumentation added for key flows:
- auth: sign_in_succeeded, sign_up_succeeded
- onboarding: onboarding_step_1..5_completed, onboarding_completed
- reservation: reservation_booking_started, reservation_booking_confirmed, reservation_accepted, reservation_rejected
- profile: profile_update_submitted

Privacy: data-clarity-mask added to password inputs; analytics.ts is a no-op when NEXT_PUBLIC_CLARITY_ID is unset (safe in local dev).

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
