### PR TITLE
feat: integrate Google Analytics 4 with unified analytics layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,10 @@ GITHUB_SECRET=
 # Sentry DSN — get from https://sentry.io → Project Settings → Client Keys
 NEXT_PUBLIC_SENTRY_DSN=
 
+# Google Analytics 4 Measurement ID — get from GA4 → Admin → Data Streams → Measurement ID
+# Format: G-XXXXXXXXXX. Leave empty to disable GA4.
+NEXT_PUBLIC_GA_ID=
+
 # Microsoft Clarity project ID — get from https://clarity.microsoft.com → Settings
 # Leave empty to disable Clarity (e.g. in local development)
 NEXT_PUBLIC_CLARITY_ID=

--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -66,6 +66,15 @@ export default function OnboardingContainer() {
     });
   }, [session?.user?.name, session?.user?.avatar, status, step1Form]);
 
+  // Track which onboarding step the user is currently viewing
+  useEffect(() => {
+    trackEvent({
+      name: 'onboarding_step_viewed',
+      feature: 'onboarding',
+      metadata: { step: currentStep },
+    });
+  }, [currentStep]);
+
   const onSubmitStep1 = (data: z.infer<typeof step1Schema>) => {
     setTempData((prev) => ({ ...prev, step1: data }));
     trackEvent({ name: 'onboarding_step_1_completed', feature: 'onboarding' });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -31,6 +31,30 @@ export default function RootLayout({
   return (
     <html lang="zh-TW" className={notoSans.className}>
       <body id="app">
+        {/* Google Analytics 4 — only loads when NEXT_PUBLIC_GA_ID is set.
+            strategy="afterInteractive" ensures it never blocks page render.
+            Page views are tracked by PageViewTracker on route changes. */}
+        {process.env.NEXT_PUBLIC_GA_ID && (
+          <>
+            <Script
+              src={`https://www.googletagmanager.com/gtag/js?id=${process.env.NEXT_PUBLIC_GA_ID}`}
+              strategy="afterInteractive"
+            />
+            <Script
+              id="google-analytics"
+              strategy="afterInteractive"
+              dangerouslySetInnerHTML={{
+                __html: `
+                  window.dataLayer = window.dataLayer || [];
+                  function gtag(){dataLayer.push(arguments);}
+                  gtag('js', new Date());
+                  gtag('config', '${process.env.NEXT_PUBLIC_GA_ID}', { send_page_view: false });
+                `,
+              }}
+            />
+          </>
+        )}
+
         {/* Microsoft Clarity — behavior tracking for testing phase.
             Only loads when NEXT_PUBLIC_CLARITY_ID is set.
             strategy="afterInteractive" ensures it never blocks page render. */}

--- a/src/components/PageViewTracker.tsx
+++ b/src/components/PageViewTracker.tsx
@@ -1,0 +1,19 @@
+'use client';
+
+// Tracks SPA page views for GA4 on every client-side route change.
+// Mounted once in Providers so it covers the entire app.
+
+import { usePathname } from 'next/navigation';
+import { useEffect } from 'react';
+
+import { trackPageView } from '@/lib/analytics';
+
+export default function PageViewTracker() {
+  const pathname = usePathname();
+
+  useEffect(() => {
+    trackPageView(pathname);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from 'next-auth/react';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
+import PageViewTracker from '@/components/PageViewTracker';
 import WebVitalsMonitor from '@/components/WebVitalsMonitor';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
@@ -11,6 +12,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
     <SessionProvider>
       <GlobalErrorMonitor />
       <WebVitalsMonitor />
+      <PageViewTracker />
       <ErrorBoundary>{children}</ErrorBoundary>
     </SessionProvider>
   );

--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { Button } from '@/components/ui/button';
+import { trackEvent } from '@/lib/analytics';
 import type { PersonalLink } from '@/types/types';
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -53,6 +54,11 @@ export function ShareProfileDialog({
   React.useEffect(() => {
     if (open) {
       setCopied(false);
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'profile',
+        metadata: { dialog: 'share_profile' },
+      });
       document.documentElement.style.setProperty(
         'overflow',
         'hidden',

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -55,7 +55,13 @@ export default function MenteeReservationDialog({
   const [submitError, setSubmitError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!open) {
+    if (open) {
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'reservation',
+        metadata: { dialog: 'mentee_reservation' },
+      });
+    } else {
       const id = setTimeout(() => {
         setView('selection');
         setSelectedSlot(null);

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -19,6 +19,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
+import { trackEvent } from '@/lib/analytics';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
 
@@ -73,6 +74,16 @@ export default function MentorScheduleDialog({
   const [isSaving, setIsSaving] = useState(false);
   const [editingSlots, setEditingSlots] = useState<EditingSlot[]>([]);
   const [slotErrors, setSlotErrors] = useState<Record<number, SlotErrors>>({});
+
+  useEffect(() => {
+    if (open) {
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'reservation',
+        metadata: { dialog: 'mentor_schedule' },
+      });
+    }
+  }, [open]);
 
   useEffect(() => {
     setEditingSlots(

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 import type { Reservation } from './types';
@@ -44,6 +45,11 @@ export default function AcceptReservationDialog({
       setStep('check');
       setMessage('');
       setReason('');
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'reservation',
+        metadata: { dialog: 'accept_reservation' },
+      });
     }
   }
 

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
 import type { Reservation } from './types';
@@ -44,6 +45,11 @@ export default function CancelReservationDialog({
     if (next) {
       setStep('confirm');
       setReason('');
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'reservation',
+        metadata: { dialog: 'cancel_reservation' },
+      });
     }
   }
 

--- a/src/hooks/auth/useSignUpForm.ts
+++ b/src/hooks/auth/useSignUpForm.ts
@@ -1,6 +1,6 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -19,6 +19,11 @@ export default function useSignUpForm(): AuthFormProps<SignUpValues> {
   const [isSubmitting, setIsSubmitting] = useState(false);
   const router = useRouter();
   const { toast } = useToast();
+
+  // Fire once when the sign-up form mounts — user has reached the sign-up page
+  useEffect(() => {
+    trackEvent({ name: 'sign_up_started', feature: 'auth' });
+  }, []);
 
   const form = useForm<z.infer<typeof SignUpSchema>>({
     resolver: zodResolver(SignUpSchema),

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,26 +1,32 @@
 /**
- * Frontend Behavior Analytics — Microsoft Clarity
+ * Frontend Behavior Analytics
  *
- * Wraps Clarity's custom event and tag API for lightweight behavior tracking
- * during the testing phase.
+ * Unified analytics layer that dispatches to both:
+ *   - Microsoft Clarity  (session replay, heatmaps, custom events)
+ *   - Google Analytics 4 (page views, funnel analysis, event reporting)
  *
- * What Clarity captures automatically (no code needed):
- *   - All page views
- *   - All clicks (heatmaps)
- *   - Scroll depth
- *   - Session replay
- *   - Rage clicks, dead clicks
+ * ─── Initialization ────────────────────────────────────────────────────────────
+ * GA4:     Initialized via <Script> in src/app/layout.tsx (gtag.js).
+ * Clarity: Initialized via <Script> in src/app/layout.tsx (clarity snippet).
+ * Both are gated by their respective env vars and are no-ops when absent.
  *
- * This module adds custom event markers and session tags on top, to make
- * important user flows filterable in Clarity dashboards and recordings.
+ * ─── How to add a new event ────────────────────────────────────────────────────
+ * 1. Call trackEvent({ name: 'my_feature_action', feature: 'my_feature' })
+ *    in the relevant hook or component.
+ * 2. The event is automatically sent to both GA4 and Clarity.
+ * 3. Use snake_case names in the format <feature>_<action>.
  *
- * Gated by NEXT_PUBLIC_CLARITY_ID — runs in any environment where Clarity
- * is configured (e.g. testing). Silently no-ops when the env var is absent.
+ * ─── What must NEVER be sent ───────────────────────────────────────────────────
+ * - Passwords or password hints
+ * - Access tokens, refresh tokens, auth headers
+ * - Raw email addresses or phone numbers
+ * - Personal IDs or government ID numbers
+ * - Any raw user-entered private content
  *
- * NEVER pass passwords, tokens, emails, or any sensitive data to these functions.
- *
- * Event naming convention: <feature>_<action>
- * Examples: onboarding_step_1_completed, sign_in_succeeded, reservation_booking_confirmed
+ * ─── Event naming convention ───────────────────────────────────────────────────
+ * Format:  <feature>_<action>
+ * Examples: sign_in_succeeded, onboarding_step_1_completed,
+ *           reservation_booking_confirmed, profile_update_submitted
  */
 
 // ─── Types ─────────────────────────────────────────────────────────────────────
@@ -41,7 +47,7 @@ export interface BehaviorEvent {
   metadata?: Record<string, string | number | boolean>;
 }
 
-// ─── Internal helper ───────────────────────────────────────────────────────────
+// ─── Internal helpers ──────────────────────────────────────────────────────────
 
 type ClarityFn = (...args: unknown[]) => void;
 
@@ -52,28 +58,66 @@ function getClarity(): ClarityFn | undefined {
   return typeof fn === 'function' ? fn : undefined;
 }
 
+type GtagFn = (...args: unknown[]) => void;
+
+function getGtag(): GtagFn | undefined {
+  if (typeof window === 'undefined') return undefined;
+  if (!process.env.NEXT_PUBLIC_GA_ID) return undefined;
+  const fn = (window as Window & { gtag?: GtagFn }).gtag;
+  return typeof fn === 'function' ? fn : undefined;
+}
+
 // ─── Public API ────────────────────────────────────────────────────────────────
 
 /**
- * Fires a named custom event in Clarity.
- * Visible in Clarity → Events and usable as a filter in recordings / heatmaps.
+ * Fires a named custom event to both GA4 and Clarity.
+ *
+ * GA4:     visible in Events report and usable in funnel/exploration reports.
+ * Clarity: visible in Events tab and usable as a filter in recordings/heatmaps.
  *
  * Do NOT include passwords, tokens, emails, or personal info.
  */
 export function trackEvent(event: BehaviorEvent): void {
-  const clarity = getClarity();
-  if (!clarity) return;
-
-  clarity('event', event.name);
-
-  if (event.feature) {
-    clarity('set', 'feature', event.feature);
+  // — GA4 —
+  const gtag = getGtag();
+  if (gtag) {
+    gtag('event', event.name, {
+      ...(event.feature ? { feature: event.feature } : {}),
+      ...event.metadata,
+    });
   }
 
-  if (event.metadata) {
-    for (const [key, value] of Object.entries(event.metadata)) {
-      clarity('set', key, String(value));
+  // — Clarity —
+  const clarity = getClarity();
+  if (clarity) {
+    clarity('event', event.name);
+    if (event.feature) clarity('set', 'feature', event.feature);
+    if (event.metadata) {
+      for (const [key, value] of Object.entries(event.metadata)) {
+        clarity('set', key, String(value));
+      }
     }
+  }
+
+  // — Local dev debug —
+  if (process.env.NODE_ENV === 'development') {
+    console.debug('[analytics] trackEvent', event);
+  }
+}
+
+/**
+ * Tracks a page view in GA4.
+ * Called automatically by PageViewTracker on every route change.
+ * No need to call this manually.
+ */
+export function trackPageView(path: string): void {
+  const gtag = getGtag();
+  if (gtag) {
+    gtag('config', process.env.NEXT_PUBLIC_GA_ID, { page_path: path });
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    console.debug('[analytics] trackPageView', path);
   }
 }
 

--- a/src/types/gtag.d.ts
+++ b/src/types/gtag.d.ts
@@ -1,0 +1,4 @@
+interface Window {
+  gtag: (...args: unknown[]) => void;
+  dataLayer: unknown[];
+}


### PR DESCRIPTION
Extend analytics.ts to dispatch all events to both GA4 and Microsoft Clarity, so existing trackEvent() call sites need no changes.

New in this commit:
- GA4 script initialized in layout.tsx (send_page_view: false to avoid double-counting; PageViewTracker handles SPA route changes instead)
- PageViewTracker component fires trackPageView() on every pathname change
- trackPageView() added to analytics.ts for GA4 config calls
- sign_up_started fires on sign-up form mount
- onboarding_step_viewed fires with step number on every step change
- feature_opened tracked on 5 key dialogs: mentee_reservation, mentor_schedule, accept_reservation, cancel_reservation, share_profile
- Local dev debug logging via console.debug for all tracked events
- NEXT_PUBLIC_GA_ID added to .env.example

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
