### PR TITLE
fix: prevent header role-based flicker on page load and refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,7 @@ next-env.d.ts
 .eslintcache
 # Sentry Config File
 .env.sentry-build-plugin
+
+# Claude Code local config
+.claude/
+CLAUDE.md

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,9 @@ import '../styles/global.css';
 import * as Sentry from '@sentry/nextjs';
 import type { Metadata } from 'next';
 import Script from 'next/script';
+import { getServerSession } from 'next-auth/next';
 
+import authOptions from '@/auth.config';
 import { Footer } from '@/components/layout/Footer';
 import { Header } from '@/components/layout/Header';
 import Providers from '@/components/Providers';
@@ -23,11 +25,13 @@ export function generateMetadata(): Metadata {
   };
 }
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const session = await getServerSession(authOptions);
+
   return (
     <html lang="zh-TW" className={notoSans.className}>
       <body id="app">
@@ -71,7 +75,7 @@ export default function RootLayout({
             }}
           />
         )}
-        <Providers>
+        <Providers session={session}>
           <div className="flex min-h-screen flex-col">
             <Header />
             <main className="grow pt-[70px]">{children}</main>

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import type { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -7,9 +8,15 @@ import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
 import PageViewTracker from '@/components/PageViewTracker';
 import WebVitalsMonitor from '@/components/WebVitalsMonitor';
 
-export default function Providers({ children }: { children: React.ReactNode }) {
+export default function Providers({
+  children,
+  session,
+}: {
+  children: React.ReactNode;
+  session: Session | null;
+}) {
   return (
-    <SessionProvider>
+    <SessionProvider session={session}>
       <GlobalErrorMonitor />
       <WebVitalsMonitor />
       <PageViewTracker />

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -12,14 +12,17 @@ import {
   SheetContent,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export type HamburgerMenuProps = {
+  isLoading: boolean;
   isLoggedIn: boolean;
   isMentor: boolean;
   userId?: string;
 };
 
 export function HamburgerMenu({
+  isLoading,
   isLoggedIn,
   isMentor,
   userId,
@@ -51,7 +54,9 @@ export function HamburgerMenu({
               尋找導師
             </Link>
 
-            {isMentor ? (
+            {isLoading ? (
+              <Skeleton className="h-5 w-24" />
+            ) : isMentor ? (
               <Link href={profilePath} onClick={close} className="text-black">
                 我的導師頁面
               </Link>
@@ -69,7 +74,7 @@ export function HamburgerMenu({
               關於 X-Talent
             </Link>
 
-            {isLoggedIn && (
+            {!isLoading && isLoggedIn && (
               <>
                 <Link href={profilePath} onClick={close} className="text-black">
                   Avatar
@@ -95,7 +100,9 @@ export function HamburgerMenu({
           </div>
 
           <div className="mb-12 flex flex-col items-center gap-6">
-            {!isLoggedIn ? (
+            {isLoading ? (
+              <Skeleton className="h-10 w-40 rounded-md" />
+            ) : !isLoggedIn ? (
               <>
                 <Link href="/auth/signin" onClick={close}>
                   <Button className="bg-sky-600 hover:bg-sky-700 w-40">

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -7,12 +7,14 @@ import { memo } from 'react';
 
 import LogoImgUrl from '@/assets/logo.svg';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
 
 import { HamburgerMenu } from './HamburgerMenu';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
-  const { data: session } = useSession();
+  const { data: session, status } = useSession();
+  const isLoading = status === 'loading';
 
   const isLoggedIn = Boolean(session?.user?.id);
   const isMentor = Boolean(session?.user?.isMentor);
@@ -46,12 +48,16 @@ function HeaderComponent(): JSX.Element {
               尋找導師
             </Link>
 
-            <Link
-              href={leftSecondNav.href}
-              className="text-black font-['Open_Sans'] text-base"
-            >
-              {leftSecondNav.label}
-            </Link>
+            {isLoading ? (
+              <Skeleton className="h-4 w-20" />
+            ) : (
+              <Link
+                href={leftSecondNav.href}
+                className="text-black font-['Open_Sans'] text-base"
+              >
+                {leftSecondNav.label}
+              </Link>
+            )}
 
             <Link
               href="/about"
@@ -64,7 +70,9 @@ function HeaderComponent(): JSX.Element {
 
         <div className="mr-20 flex items-center gap-3">
           <div className="hidden items-center gap-3 md:flex">
-            {!isLoggedIn ? (
+            {isLoading ? (
+              <Skeleton className="h-8 w-20 rounded-full" />
+            ) : !isLoggedIn ? (
               <>
                 <Link href="/auth/signup">
                   <Button
@@ -86,6 +94,7 @@ function HeaderComponent(): JSX.Element {
 
           <div className="md:hidden">
             <HamburgerMenu
+              isLoading={isLoading}
               isLoggedIn={isLoggedIn}
               isMentor={isMentor}
               userId={userId}


### PR DESCRIPTION
- Pre-populate SessionProvider with server-side session so status starts as authenticated/unauthenticated, never loading, on page load
- Gate role-specific nav link and auth controls behind isLoading skeleton so incorrect state is never rendered while session resolves
- Pass isLoading to HamburgerMenu to guard mobile role-specific links

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
