### PR TITLE
feat: add mobile account menu with avatar entry point in header

### DIFF
--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -2,7 +2,6 @@
 
 import { Cross2Icon, HamburgerMenuIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
-import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -44,12 +43,12 @@ export function HamburgerMenu({
       </SheetTrigger>
 
       <SheetContent side="right" className="h-screen w-screen">
-        <div className="flex h-full flex-col justify-between">
+        <div className="flex h-full flex-col">
           <SheetClose asChild className="ml-auto">
             <Cross2Icon className="text-blue-900 h-8 w-8" />
           </SheetClose>
 
-          <div className="flex flex-col items-center gap-10 text-2xl">
+          <div className="flex flex-1 flex-col items-center justify-center gap-10 text-2xl">
             <Link href="/mentor-pool" onClick={close} className="text-black">
               尋找導師
             </Link>
@@ -73,63 +72,31 @@ export function HamburgerMenu({
             <Link href="/about" onClick={close} className="text-black">
               關於 X-Talent
             </Link>
-
-            {!isLoading && isLoggedIn && (
-              <>
-                <Link href={profilePath} onClick={close} className="text-black">
-                  Avatar
-                </Link>
-
-                <Link
-                  href={isMentor ? '/reservation/mentor' : becomeMentorPath}
-                  onClick={close}
-                  className="text-black"
-                >
-                  As a mentor
-                </Link>
-
-                <Link
-                  href="/reservation/mentee"
-                  onClick={close}
-                  className="text-black"
-                >
-                  My reservation
-                </Link>
-              </>
-            )}
           </div>
 
-          <div className="mb-12 flex flex-col items-center gap-6">
-            {isLoading ? (
-              <Skeleton className="h-10 w-40 rounded-md" />
-            ) : !isLoggedIn ? (
-              <>
-                <Link href="/auth/signin" onClick={close}>
-                  <Button className="bg-sky-600 hover:bg-sky-700 w-40">
-                    登入
-                  </Button>
-                </Link>
-                <Link href="/auth/signup" onClick={close}>
-                  <Button
-                    variant="outline"
-                    className="border-sky-600 text-sky-600 hover:text-sky-700 w-40"
-                  >
-                    註冊
-                  </Button>
-                </Link>
-              </>
-            ) : (
-              <Button
-                className="w-40 bg-primary hover:bg-primary"
-                onClick={() => {
-                  close();
-                  signOut();
-                }}
-              >
-                Log out
-              </Button>
-            )}
-          </div>
+          {!isLoggedIn && (
+            <div className="mb-12 flex flex-col items-center gap-6">
+              {isLoading ? (
+                <Skeleton className="h-10 w-40 rounded-md" />
+              ) : (
+                <>
+                  <Link href="/auth/signin" onClick={close}>
+                    <Button className="bg-sky-600 hover:bg-sky-700 w-40">
+                      登入
+                    </Button>
+                  </Link>
+                  <Link href="/auth/signup" onClick={close}>
+                    <Button
+                      variant="outline"
+                      className="border-sky-600 text-sky-600 hover:text-sky-700 w-40"
+                    >
+                      註冊
+                    </Button>
+                  </Link>
+                </>
+              )}
+            </div>
+          )}
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -10,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 
 import { HamburgerMenu } from './HamburgerMenu';
+import { MobileUserMenu } from './MobileUserMenu';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
@@ -68,7 +69,7 @@ function HeaderComponent(): JSX.Element {
           </nav>
         </div>
 
-        <div className="mr-20 flex items-center gap-3">
+        <div className="flex items-center gap-3 md:mr-20">
           <div className="hidden items-center gap-3 md:flex">
             {isLoading ? (
               <Skeleton className="h-8 w-20 rounded-full" />
@@ -92,7 +93,12 @@ function HeaderComponent(): JSX.Element {
             )}
           </div>
 
-          <div className="md:hidden">
+          <div className="flex items-center gap-3 md:hidden">
+            {isLoading ? (
+              <Skeleton className="h-8 w-8 rounded-full" />
+            ) : isLoggedIn ? (
+              <MobileUserMenu user={session!.user} />
+            ) : null}
             <HamburgerMenu
               isLoading={isLoading}
               isLoggedIn={isLoggedIn}

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -1,0 +1,195 @@
+'use client';
+
+import { Cross2Icon } from '@radix-ui/react-icons';
+import Image from 'next/image';
+import { useRouter } from 'next/navigation';
+import type { Session } from 'next-auth';
+import { signOut } from 'next-auth/react';
+import * as React from 'react';
+
+import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
+import { Button } from '@/components/ui/button';
+import {
+  Sheet,
+  SheetClose,
+  SheetContent,
+  SheetTrigger,
+} from '@/components/ui/sheet';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
+
+import { ShareProfileDialog } from './ShareProfileDialog';
+
+export type MobileUserMenuProps = {
+  user: Session['user'];
+};
+
+export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
+  const router = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+
+  const close = (): void => setOpen(false);
+
+  const userId = user.id;
+  const isMentor = Boolean(user.isMentor);
+  const name = user.name ?? '';
+  const avatarSrc = user.avatar
+    ? `${getAvatarThumbUrl(user.avatar)}?cb=${user.avatarUpdatedAt ?? 0}`
+    : '';
+  const jobTitle = user.jobTitle ?? '';
+  const company = user.company ?? '';
+  const personalLinks = user.personalLinks ?? [];
+
+  const profilePath = userId ? `/profile/${userId}` : '/';
+  const profileUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${profilePath}`
+      : profilePath;
+
+  const subtitle =
+    jobTitle && company
+      ? `${jobTitle} at ${company}`
+      : jobTitle || company || '';
+
+  const handleGoProfile = (): void => {
+    close();
+    router.push(profilePath);
+  };
+
+  const handleShareProfile = (): void => {
+    if (!userId) return;
+    // Open dialog directly on top of the sheet (z-[101] > sheet z-50).
+    // Closing the sheet first causes a timing issue where the sheet's close
+    // animation is still running when the dialog tries to mount.
+    setShareDialogOpen(true);
+  };
+
+  const handleAsMentor = (): void => {
+    if (!userId) return;
+    close();
+    router.push(
+      isMentor
+        ? '/reservation/mentor'
+        : `/profile/${userId}/edit?onboarding=true`
+    );
+  };
+
+  const handleMyReservation = (): void => {
+    close();
+    router.push('/reservation/mentee');
+  };
+
+  const handleLogout = (): void => {
+    close();
+    signOut();
+  };
+
+  return (
+    <>
+      <Sheet open={open} onOpenChange={setOpen}>
+        <SheetTrigger asChild>
+          <button
+            type="button"
+            aria-label="Open account menu"
+            className="flex items-center"
+          >
+            <Image
+              src={avatarSrc || DefaultAvatarImgUrl}
+              alt="avatar"
+              width={32}
+              height={32}
+              className="h-8 w-8 rounded-full object-cover"
+              priority
+            />
+          </button>
+        </SheetTrigger>
+
+        <SheetContent side="right" className="h-screen w-screen">
+          <div className="flex h-full flex-col">
+            <SheetClose asChild className="ml-auto">
+              <Cross2Icon className="text-blue-900 h-8 w-8" />
+            </SheetClose>
+
+            {/* Profile header */}
+            <button
+              type="button"
+              onClick={handleGoProfile}
+              className="flex items-center gap-4 pb-6 pt-10 text-left"
+            >
+              <Image
+                src={avatarSrc || DefaultAvatarImgUrl}
+                alt="avatar"
+                width={56}
+                height={56}
+                className="h-14 w-14 rounded-full object-cover"
+              />
+              <div className="min-w-0">
+                <div className="text-black truncate text-2xl font-semibold">
+                  {name || 'My Profile'}
+                </div>
+                {subtitle ? (
+                  <div className="mt-1 truncate text-sm text-gray-500">
+                    {subtitle}
+                  </div>
+                ) : null}
+              </div>
+            </button>
+
+            {/* Share Profile */}
+            <Button
+              variant="outline"
+              className="mb-6 h-12 w-full rounded-2xl text-base font-semibold"
+              onClick={handleShareProfile}
+              disabled={!userId}
+            >
+              Share Profile
+            </Button>
+
+            <div className="h-px w-full bg-muted" />
+
+            {/* Account actions */}
+            <nav className="flex flex-col py-2">
+              <button
+                type="button"
+                onClick={handleAsMentor}
+                disabled={!userId}
+                className="text-black py-4 text-left text-xl disabled:opacity-50"
+              >
+                As a mentor
+              </button>
+              <button
+                type="button"
+                onClick={handleMyReservation}
+                className="text-black py-4 text-left text-xl"
+              >
+                My reservation
+              </button>
+            </nav>
+
+            <div className="mt-auto pb-12">
+              <Button
+                className="w-full bg-primary hover:bg-primary"
+                onClick={handleLogout}
+              >
+                Log out
+              </Button>
+            </div>
+          </div>
+        </SheetContent>
+      </Sheet>
+
+      <ShareProfileDialog
+        open={shareDialogOpen}
+        onOpenChange={(nextOpen) => {
+          setShareDialogOpen(nextOpen);
+          if (!nextOpen) close();
+        }}
+        name={name || 'My Profile'}
+        avatarSrc={avatarSrc}
+        subtitle={subtitle}
+        profileUrl={profileUrl}
+        personalLinks={personalLinks}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
- Add MobileUserMenu sheet triggered by avatar in mobile header, providing the same actions as the desktop UserDropdown (profile, share profile, as a mentor, my reservation, log out)
- Show avatar button in mobile header for logged-in users alongside the hamburger button; scope mr-20 to md and above
- Clean up HamburgerMenu to navigation-only (remove account items now handled by MobileUserMenu)
- Fix hamburger sheet layout: replace justify-between with flex-1 justify-center on nav so links are always vertically centered
- Fix Share Profile: open dialog on top of sheet instead of closing sheet first, avoiding animation timing conflict
- Add close button to MobileUserMenu sheet

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
