### PR TITLE
fix: fix stale avatar display on onboarding page

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -3,7 +3,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -44,6 +44,8 @@ export default function OnboardingContainer() {
     step5?: z.infer<typeof step5Schema>;
   }>({});
 
+  const stableOnboardingCacheBust = useRef(Date.now()).current;
+
   const step1Form = useForm<z.infer<typeof step1Schema>>({
     resolver: zodResolver(step1Schema),
     defaultValues: {
@@ -53,6 +55,11 @@ export default function OnboardingContainer() {
       language: 'zh_TW',
     },
   });
+
+  const watchedAvatar = step1Form.watch('avatar');
+  const avatarDisplayUrl = watchedAvatar
+    ? `${watchedAvatar}?cb=${session?.user?.avatarUpdatedAt ?? stableOnboardingCacheBust}`
+    : '';
 
   useEffect(() => {
     if (status === 'loading') return;
@@ -203,6 +210,7 @@ export default function OnboardingContainer() {
       currentStep={currentStep}
       stepsTotal={STEPS_TOTAL}
       stepTitle={STEP_TITLE}
+      avatarDisplayUrl={avatarDisplayUrl}
       step1Form={step1Form}
       step2Form={step2Form}
       step3Form={step3Form}

--- a/src/app/auth/(sign)/onboarding/ui.tsx
+++ b/src/app/auth/(sign)/onboarding/ui.tsx
@@ -47,6 +47,7 @@ interface Props {
   currentStep: number;
   stepsTotal: number;
   stepTitle: readonly string[];
+  avatarDisplayUrl: string;
   step1Form: UseFormReturn<z.infer<typeof step1Schema>>;
   step2Form: UseFormReturn<z.infer<typeof step2Schema>>;
   step3Form: UseFormReturn<z.infer<typeof step3Schema>>;
@@ -101,6 +102,7 @@ export default function OnboardingUI({
   currentStep,
   stepsTotal,
   stepTitle,
+  avatarDisplayUrl,
   step1Form,
   step2Form,
   step3Form,
@@ -135,10 +137,7 @@ export default function OnboardingUI({
                 showBack={false}
                 onGoToPrev={onGoToPrev}
               />
-              <WhoAreYou
-                form={step1Form}
-                avatarUrl={step1Form.getValues().avatar || ''}
-              />
+              <WhoAreYou form={step1Form} avatarUrl={avatarDisplayUrl} />
               <Button className="rounded-xl px-12" type="submit">
                 下一步
               </Button>


### PR DESCRIPTION
Use watch() for reactivity and add ?cb= cache-busting to prevent browser from serving the old S3 avatar after upload.

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
