### PR TITLE
fix: prevent text overflow for long About Me and Work Experience cont…

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -136,7 +136,9 @@ export default function ProfilePageUI({
           <div className="w-full lg:w-3/5">
             <div>
               <p className="mb-4 text-xl font-bold">關於我</p>
-              <p className="text-sm text-gray-400">{userData?.about}</p>
+              <p className="break-words text-sm text-gray-400">
+                {userData?.about}
+              </p>
             </div>
 
             {userData.is_mentor && (

--- a/src/components/profile/experience-section/ExperienceSection.tsx
+++ b/src/components/profile/experience-section/ExperienceSection.tsx
@@ -24,18 +24,21 @@ export const ExperienceItemCard = ({
 }: ExperienceItem) => {
   return (
     <section className="mb-6 flex flex-col gap-3">
-      <div className="flex justify-between text-sm text-gray-600">
-        <span>{subtitle}</span>
-        <span className="text-xs">
+      <div className="flex justify-between gap-2 text-sm text-gray-600">
+        <span className="min-w-0 break-words">{subtitle}</span>
+        <span className="shrink-0 text-xs">
           {startDate} - {endDate}
         </span>
       </div>
       <div>
-        <h2 className="mb-1 text-base font-bold" style={{ color: '#49454F' }}>
+        <h2
+          className="mb-1 break-words text-base font-bold"
+          style={{ color: '#49454F' }}
+        >
           {title}
         </h2>
         {description && (
-          <p className="text-sm" style={{ color: '#49454F' }}>
+          <p className="break-words text-sm" style={{ color: '#49454F' }}>
             {description}
           </p>
         )}


### PR DESCRIPTION
…ent on mobile

Add break-words to About Me, job title, and description text, and guard the company/date flex row with min-w-0 and shrink-0 so long content wraps correctly instead of overflowing on mobile viewports.

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
