### PR TITLE
fix: prevent dropdown and dialog overflow on mobile landscape viewport

### DIFF
--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -89,6 +89,9 @@ export function ShareProfileDialog({
         <Dialog.Overlay className="fixed inset-0 z-[100] bg-dark/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
 
         <Dialog.Content className="fixed left-1/2 top-1/2 z-[101] w-[calc(100%-32px)] max-w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-[24px] border border-[#D9DEE3] bg-light shadow-2xl focus:outline-none">
+          <Dialog.Description className="sr-only">
+            複製個人頁面連結以分享給他人
+          </Dialog.Description>
           <div className="rounded-[24px] bg-light px-6 pb-8 pt-6 sm:px-8">
             <div className="relative mb-8 flex items-center justify-center">
               <Dialog.Title className="text-black text-center text-[36px] font-semibold leading-none">

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -107,7 +107,11 @@ export const UserDropdown = React.memo(function UserDropdown({
           </button>
         </DropdownMenuTrigger>
 
-        <DropdownMenuContent align="end" className="w-[360px] rounded-2xl p-0">
+        <DropdownMenuContent
+          align="end"
+          collisionPadding={8}
+          className="max-h-[var(--radix-dropdown-menu-content-available-height)] w-[360px] overflow-y-auto rounded-2xl p-0"
+        >
           <button
             type="button"
             onClick={handleGoProfile}

--- a/src/components/onboarding/steps/SkillsToImprove.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.tsx
@@ -25,7 +25,7 @@ interface Props {
 export const SkillsToImprove: FC<Props> = ({ form, skillOptions }) => {
   return (
     <>
-      <div className="grid grid-cols-2 gap-4">
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
         {skillOptions.map((option) => (
           <FormField
             key={option.subject_group}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -75,12 +75,14 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        'relative z-50 max-h-96 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        position === 'popper' &&
-          'data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1',
+        'relative z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+        position === 'popper'
+          ? 'max-h-[var(--radix-select-content-available-height)] data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1'
+          : 'max-h-96',
         className
       )}
       position={position}
+      collisionPadding={8}
       {...props}
     >
       <SelectScrollUpButton />


### PR DESCRIPTION
- UserDropdown: add collisionPadding={8} and max-h constraint via --radix-dropdown-menu-content-available-height so the menu stays within the 375px viewport height on 812×375 landscape
- SelectContent: replace fixed max-h-96 (384px) with --radix-select-content-available-height in popper mode so Radix can dynamically cap the height; keep max-h-96 for item-aligned mode
- ShareProfileDialog: add sr-only Dialog.Description to resolve Radix accessibility console warning

## What Does This PR Do?

<!-- The fixes & changes you made -->

## Demo

<!-- Provide the local path, e.g., http://localhost:3000/profile/card -->

## Screenshot

N/A

## Anything to Note?

N/A
