### PR TITLE
fix: improve avatar uploader mobile experience

### DIFF
--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -168,13 +168,14 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               </button>
             </nav>
 
-            <div className="mt-auto pb-6">
-              <Button
-                className="w-full bg-primary hover:bg-primary"
+            <div className="pb-6">
+              <button
+                type="button"
+                className="text-black py-4 text-left text-xl"
                 onClick={handleLogout}
               >
                 登出
-              </Button>
+              </button>
             </div>
           </div>
         </SheetContent>

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -68,6 +68,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
               border={50}
               borderRadius={300}
               scale={zoomScale}
+              style={{ touchAction: 'none' }}
             />
           )}
           <Slider
@@ -78,7 +79,14 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
             onChange={(_, newScale) => setZoomScale(newScale as number)}
             className="mt-4"
           />
-          <div className="mt-4 flex justify-center">
+          <div className="mt-4 flex justify-center gap-3">
+            <Button
+              variant="outline"
+              onClick={onClose}
+              className="rounded-xl px-12"
+            >
+              取消
+            </Button>
             <Button onClick={handleSaveImage} className="rounded-xl px-12">
               儲存
             </Button>

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -57,7 +57,7 @@ const AvatarUpload = <T extends FieldValues>({
   return (
     <div className="mb-10 flex justify-center lg:justify-start">
       <div
-        className="group relative flex h-16 w-16 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 border-[#B7CBCB] bg-[#F4FCFC] sm:h-24 sm:w-24 lg:h-[100px] lg:w-[100px]"
+        className="group relative flex h-36 w-36 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 border-[#B7CBCB] bg-[#F4FCFC] lg:h-[150px] lg:w-[150px]"
         onClick={() => document.getElementById('fileInput')?.click()}
       >
         <input


### PR DESCRIPTION
## What Does This PR Do?

- Fix avatar crop editor not responding to touch drag on mobile by adding `touchAction: none` to the AvatarEditor canvas
- Add a cancel button to the avatar crop modal to close without saving
- Increase avatar upload area size on mobile (h-16→h-36, lg:h-[150px])
- Fix mobile logout button styling in MobileUserMenu (plain button instead of primary Button)

## Demo

http://localhost:3000/profile/edit

## Screenshot

N/A

## Anything to Note?

The `touchAction: none` fix prevents the `overflow-y-auto` modal container from intercepting touch events intended for the AvatarEditor canvas drag gesture.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
