### PR TITLE
fix: fix mobile calendar UI overflow on small screens

### DIFF
--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -203,7 +203,7 @@ export default function MenteeReservationDialog({
         <DialogTitle>預約時段</DialogTitle>
       </DialogHeader>
       <div className="flex flex-col gap-4 py-4">
-        <div className="inline-block w-auto rounded-lg border p-2 shadow-md">
+        <div className="w-full rounded-lg border p-2 shadow-md">
           <div className="px-3 pb-3 pt-1">
             <h2 className="text-2xl font-semibold tracking-tight">
               {formatSelectedDate(selectedDate)}

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -230,7 +230,7 @@ export default function MentorScheduleDialog({
   ) => (
     <Select value={value} onValueChange={(v) => handleTimeChange(id, part, v)}>
       <SelectTrigger
-        className={`w-14 px-2 ${hasError ? 'border-red-500' : ''}`}
+        className={`w-12 px-1 ${hasError ? 'border-red-500' : ''}`}
       >
         <SelectValue />
       </SelectTrigger>
@@ -297,54 +297,58 @@ export default function MentorScheduleDialog({
                 const endMinuteOptions = getEndMinuteOptions(slot);
                 return (
                   <div key={slot.id} className="flex flex-col gap-1">
-                    <div className="flex items-center gap-1">
-                      {renderTimeSelect(
-                        slot.id,
-                        'startHour',
-                        slot.startHour,
-                        HOUR_OPTIONS,
-                        hasError
-                      )}
-                      <span className="text-muted-foreground">:</span>
-                      {renderTimeSelect(
-                        slot.id,
-                        'startMinute',
-                        slot.startMinute,
-                        MINUTE_OPTIONS,
-                        hasError
-                      )}
-                      <span className="mx-1 text-muted-foreground">–</span>
-                      {renderTimeSelect(
-                        slot.id,
-                        'endHour',
-                        slot.endHour,
-                        endHourOptions,
-                        hasError
-                      )}
-                      <span className="text-muted-foreground">:</span>
-                      {renderTimeSelect(
-                        slot.id,
-                        'endMinute',
-                        slot.endMinute,
-                        endMinuteOptions,
-                        hasError
-                      )}
-                      <Button
-                        variant="ghost"
-                        size="icon"
-                        onClick={() => deleteDraftSlot(slot.id)}
-                      >
-                        <X className="h-4 w-4" />
-                      </Button>
-                      {index === editingSlots.length - 1 && (
+                    <div className="flex flex-wrap items-center gap-1">
+                      <div className="flex items-center gap-1">
+                        {renderTimeSelect(
+                          slot.id,
+                          'startHour',
+                          slot.startHour,
+                          HOUR_OPTIONS,
+                          hasError
+                        )}
+                        <span className="text-muted-foreground">:</span>
+                        {renderTimeSelect(
+                          slot.id,
+                          'startMinute',
+                          slot.startMinute,
+                          MINUTE_OPTIONS,
+                          hasError
+                        )}
+                        <span className="mx-0.5 text-muted-foreground">–</span>
+                        {renderTimeSelect(
+                          slot.id,
+                          'endHour',
+                          slot.endHour,
+                          endHourOptions,
+                          hasError
+                        )}
+                        <span className="text-muted-foreground">:</span>
+                        {renderTimeSelect(
+                          slot.id,
+                          'endMinute',
+                          slot.endMinute,
+                          endMinuteOptions,
+                          hasError
+                        )}
+                      </div>
+                      <div className="ml-auto flex items-center gap-1">
                         <Button
                           variant="ghost"
                           size="icon"
-                          onClick={addNewTimeSlot}
+                          onClick={() => deleteDraftSlot(slot.id)}
                         >
-                          <Plus className="h-4 w-4" />
+                          <X className="h-4 w-4" />
                         </Button>
-                      )}
+                        {index === editingSlots.length - 1 && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            onClick={addNewTimeSlot}
+                          >
+                            <Plus className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
                     </div>
                     {errors.timeRange && (
                       <p className="text-red-500 text-xs">{errors.timeRange}</p>

--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -44,7 +44,7 @@ export const ScheduleCalendar = ({
       selected={selected}
       onSelect={handleSelect}
       onMonthChange={onMonthChange}
-      className="w-full"
+      className="w-full [--cell-size:1.75rem] sm:[--cell-size:2rem]"
       modifiers={{
         available: availableDays,
       }}


### PR DESCRIPTION
## What Does This PR Do?

- Fix `MenteeReservationDialog` calendar wrapper using `inline-block w-auto`, which caused the calendar to escape the dialog boundary on mobile by not being constrained to the available width
- Fix `MentorScheduleDialog` time slot row overflowing on narrow screens by grouping selects and action buttons into separate flex children with `flex-wrap`, and reducing select trigger width from `w-14` to `w-12`
- Fix `ScheduleCalendar` calendar cell minimum width causing horizontal overflow on small viewports by making `--cell-size` responsive (`1.75rem` on mobile, `2rem` on sm+); applies to both the profile page calendar and the booking dialogs

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

The `--cell-size` CSS variable controls both the day cell size and the minimum button touch target in react-day-picker. Reducing it to `1.75rem` (28px) on mobile keeps the calendar within viewport on screens as narrow as 290px while remaining accessible. On `sm` breakpoints (640px+) it reverts to the original `2rem`.

Closes #362

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
