### PR TITLE
fix: reset file input value after selection to allow reselecting same image

### DIFF
--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -36,6 +36,7 @@ const AvatarUpload = <T extends FieldValues>({
 
   const handleUploadAvatar = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
+    e.target.value = '';
     if (file && file.size <= maxSize) {
       setSelectedImage(file);
       setOpen(true);


### PR DESCRIPTION
## What Does This PR Do?

- Reset `e.target.value = ''` immediately after reading the file in `handleUploadAvatar`
- Ensures the browser fires `onChange` even when the user selects the same image again after canceling the crop modal

## Demo

http://localhost:3000/profile/edit

## Screenshot

N/A

## Anything to Note?

Clearing `input.value` only resets the browser's internal file-path tracking — it does not affect the `File` object stored in React state or the react-hook-form field value, so the image preview is unaffected.
