### PR TITLE
fix: prevent header skeleton flash during profile save (#45)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -3,7 +3,7 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
-import { memo } from 'react';
+import { memo, useRef } from 'react';
 
 import LogoImgUrl from '@/assets/logo.svg';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,9 @@ import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
   const { data: session, status } = useSession();
-  const isLoading = status === 'loading';
+  const wasAuthenticated = useRef(false);
+  if (status === 'authenticated') wasAuthenticated.current = true;
+  const isLoading = status === 'loading' && !wasAuthenticated.current;
 
   const isLoggedIn = Boolean(session?.user?.id);
   const isMentor = Boolean(session?.user?.isMentor);


### PR DESCRIPTION
## What Does This PR Do?

- Track whether the session has ever reached `authenticated` state via a `wasAuthenticated` ref in `Header`
- `isLoading` now only becomes `true` on initial page load, not when `updateSession()` temporarily sets status back to `loading`
- Prevents the "成為導師" nav link and personal icon from flashing as grey skeletons during profile save

## Demo

http://localhost:3000/profile/[userId]/edit

## Screenshot

N/A

## Anything to Note?

The session data (name, avatar, isMentor, etc.) still updates correctly after save — only the intermediate skeleton flash is suppressed.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
