### PR TITLE
test: add unit tests for signUpResponseHandlers and createGeneralErrorResponse

### DIFF
--- a/src/services/auth/signUpResponseHandlers.test.ts
+++ b/src/services/auth/signUpResponseHandlers.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  createEmailAlreadyRegisteredResponse,
+  createRateLimitResponse,
+  createSignUpSuccessResponse,
+  createValidationErrorResponse,
+} from '@/services/auth/signUpResponseHandlers';
+
+describe('createSignUpSuccessResponse', () => {
+  it('returns status success, code 0, httpStatus 201', () => {
+    expect(createSignUpSuccessResponse()).toEqual({
+      status: 'success',
+      code: 0,
+      httpStatus: 201,
+    });
+  });
+});
+
+describe('createValidationErrorResponse', () => {
+  it('returns status error, code 422', () => {
+    expect(createValidationErrorResponse()).toMatchObject({
+      status: 'error',
+      code: 422,
+    });
+  });
+});
+
+describe('createEmailAlreadyRegisteredResponse', () => {
+  it('returns status error, code 406', () => {
+    expect(createEmailAlreadyRegisteredResponse()).toMatchObject({
+      status: 'error',
+      code: 406,
+    });
+  });
+});
+
+describe('createRateLimitResponse', () => {
+  it('returns status error, code 429', () => {
+    expect(createRateLimitResponse()).toMatchObject({
+      status: 'error',
+      code: 429,
+    });
+  });
+});

--- a/src/services/types.test.ts
+++ b/src/services/types.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+import { createGeneralErrorResponse } from '@/services/types';
+
+describe('createGeneralErrorResponse', () => {
+  it('returns status error with given httpStatus as code and message', () => {
+    expect(createGeneralErrorResponse(404, 'Not found')).toEqual({
+      status: 'error',
+      code: 404,
+      httpStatus: 404,
+      message: 'Not found',
+    });
+  });
+});


### PR DESCRIPTION
## What Does This PR Do?

- Add unit tests for all 4 factory functions in `signUpResponseHandlers.ts` (`createSignUpSuccessResponse`, `createValidationErrorResponse`, `createEmailAlreadyRegisteredResponse`, `createRateLimitResponse`)
- Add unit test for `createGeneralErrorResponse` in `src/services/types.ts`
- All 5 test cases pass with no mocks required

## Demo

N/A

## Screenshot

N/A

## Anything to Note?

N/A
