### PR TITLE
test: add unit tests for reservation data helpers

### DIFF
--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -1,0 +1,173 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  BackendReservation,
+  formatDateTime,
+  formatExperience,
+  mapToReservation,
+  ReservationState,
+} from '@/services/reservations';
+
+// 2024-01-01 09:00:00 UTC (epoch seconds)
+const DTSTART = 1704099600;
+// 2024-01-01 10:00:00 UTC (epoch seconds)
+const DTEND = 1704103200;
+
+function makeReservation(
+  overrides: Partial<BackendReservation> = {}
+): BackendReservation {
+  return {
+    id: 1,
+    sender: {
+      user_id: 10,
+      role: 'MENTOR',
+      status: 'ACCEPT',
+      name: 'Alice',
+      avatar: '',
+      job_title: 'Engineer',
+      years_of_experience: 'THREE_TO_FIVE',
+    },
+    participant: {
+      user_id: 20,
+      role: 'MENTEE',
+      status: 'PENDING',
+      name: 'Bob',
+      avatar: '',
+      job_title: 'Designer',
+      years_of_experience: 'ONE_TO_THREE',
+    },
+    schedule_id: 1,
+    dtstart: DTSTART,
+    dtend: DTEND,
+    previous_reserve: null,
+    messages: [],
+    ...overrides,
+  };
+}
+
+function makeReservationWithState(
+  overrides: Partial<BackendReservation>,
+  state: ReservationState
+) {
+  return mapToReservation(makeReservation(overrides), state);
+}
+
+/* ================================
+ * formatExperience
+ * ================================ */
+
+describe('formatExperience', () => {
+  it('valid TotalWorkSpanEnum key → returns mapped string', () => {
+    expect(formatExperience('THREE_TO_FIVE')).toBe('3~5 年');
+  });
+
+  it('unknown/invalid key → returns empty string', () => {
+    expect(formatExperience('NOT_A_VALID_KEY')).toBe('');
+  });
+});
+
+/* ================================
+ * formatDateTime
+ * ================================ */
+
+describe('formatDateTime', () => {
+  it('epoch seconds → returns correctly formatted date and time', () => {
+    expect(formatDateTime(DTSTART, DTEND)).toEqual({
+      date: 'Mon, Jan 01, 2024',
+      time: '9:00 am – 10:00 am',
+    });
+  });
+});
+
+/* ================================
+ * mapToReservation
+ * ================================ */
+
+describe('mapToReservation', () => {
+  it('MENTOR_PENDING → menteeMessage looked up using participant.user_id', () => {
+    const reservation = makeReservation({
+      messages: [{ user_id: 20, role: 'MENTEE', content: 'Hello mentor!' }],
+    });
+    const result = mapToReservation(reservation, 'MENTOR_PENDING');
+    expect(result.note).toBe('Hello mentor!');
+  });
+
+  it('MENTEE_PENDING → menteeMessage looked up using sender.user_id', () => {
+    const reservation = makeReservation({
+      sender: {
+        user_id: 30,
+        role: 'MENTEE',
+        status: 'PENDING',
+        name: 'Carol',
+        avatar: '',
+        job_title: 'PM',
+        years_of_experience: 'ONE_TO_THREE',
+      },
+      messages: [{ user_id: 30, role: 'MENTEE', content: 'Looking forward!' }],
+    });
+    const result = mapToReservation(reservation, 'MENTEE_PENDING');
+    expect(result.note).toBe('Looking forward!');
+  });
+
+  it('job_title present, years_of_experience empty → roleLine has no trailing comma', () => {
+    const result = makeReservationWithState(
+      {
+        participant: {
+          user_id: 20,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Product Manager',
+          years_of_experience: '',
+        },
+      },
+      'MENTOR_UPCOMING'
+    );
+    expect(result.roleLine).toBe('Product Manager');
+  });
+
+  it('both job_title and years_of_experience empty → roleLine is empty string', () => {
+    const result = makeReservationWithState(
+      {
+        participant: {
+          user_id: 20,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: '',
+          years_of_experience: '',
+        },
+      },
+      'MENTOR_UPCOMING'
+    );
+    expect(result.roleLine).toBe('');
+  });
+
+  it('name is empty string → name falls back to "—"', () => {
+    const result = makeReservationWithState(
+      {
+        participant: {
+          user_id: 20,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: '',
+          avatar: '',
+          job_title: '',
+          years_of_experience: '',
+        },
+      },
+      'MENTOR_UPCOMING'
+    );
+    expect(result.name).toBe('—');
+  });
+
+  it('no matching message for mentee in messages → note is undefined', () => {
+    const reservation = makeReservation({
+      messages: [{ user_id: 999, role: 'OTHER', content: 'Wrong user' }],
+    });
+    const result = mapToReservation(reservation, 'MENTOR_PENDING');
+    expect(result.note).toBeUndefined();
+  });
+});

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -59,7 +59,7 @@ export type FetchOptions = {
  * Helpers
  * ================================ */
 
-function formatExperience(
+export function formatExperience(
   yearsOfExperience?: BackendReservation['sender']['years_of_experience']
 ) {
   return (
@@ -67,7 +67,7 @@ function formatExperience(
   );
 }
 
-function formatDateTime(dtstart: number, dtend: number) {
+export function formatDateTime(dtstart: number, dtend: number) {
   const start = dayjs.unix(dtstart);
   const end = dayjs.unix(dtend);
   return {
@@ -80,7 +80,7 @@ function formatDateTime(dtstart: number, dtend: number) {
  * Mapping
  * ================================ */
 
-function mapToReservation(
+export function mapToReservation(
   reservation: BackendReservation,
   state: ReservationState
 ): Reservation {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -12,6 +12,9 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: true,
+    env: {
+      TZ: 'UTC',
+    },
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}'],
     typecheck: {


### PR DESCRIPTION
## What Does This PR Do?

- Export `formatExperience`, `formatDateTime`, and `mapToReservation` from `src/services/reservations/index.ts` to make them directly testable
- Add `src/services/reservations/index.test.ts` with 9 unit tests covering all cases specified in #52
- Set `TZ: 'UTC'` in `vitest.config.ts` to ensure `formatDateTime` date/time assertions are environment-independent

## Demo

http://localhost:3000/reservations

## Screenshot

N/A

## Anything to Note?

All tested functions are pure data-transformation helpers — no mocks required.
