### PR TITLE
test: add unit tests for auth service functions (#54)

### DIFF
--- a/src/services/auth/resetPassword.test.ts
+++ b/src/services/auth/resetPassword.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetPassword } from '@/services/auth/resetPassword';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiClient: {
+    put: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/apiClient';
+
+describe('resetPassword', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('apiClient.put resolves with code "0" → returns { status: "success", code: 200 }', async () => {
+    vi.mocked(apiClient.put).mockResolvedValue({
+      code: '0',
+      msg: 'ok',
+      data: null,
+    });
+
+    const result = await resetPassword('token123', 'NewPass1!', 'NewPass1!');
+
+    expect(result).toEqual({ status: 'success', code: 200 });
+  });
+
+  it('throws existing AuthResponse error → re-throws original error unchanged', async () => {
+    const authError = { status: 'error', code: 400, message: '無效的 token' };
+    vi.mocked(apiClient.put).mockRejectedValue(authError);
+
+    await expect(
+      resetPassword('token123', 'NewPass1!', 'NewPass1!')
+    ).rejects.toEqual(authError);
+  });
+
+  it('throws unknown error → wraps in createGeneralErrorResponse(500, ...)', async () => {
+    vi.mocked(apiClient.put).mockRejectedValue(new Error('網路錯誤'));
+
+    await expect(
+      resetPassword('token123', 'NewPass1!', 'NewPass1!')
+    ).rejects.toMatchObject({
+      status: 'error',
+      code: 500,
+      message: '網路錯誤',
+    });
+  });
+});

--- a/src/services/auth/resetPassword.ts
+++ b/src/services/auth/resetPassword.ts
@@ -2,19 +2,26 @@ import { apiClient } from '@/lib/apiClient';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 
+interface ResetPasswordApiResponse {
+  code: string;
+  msg: string;
+  data: null;
+}
+
 export async function resetPassword(
   verifyToken: string,
   password: string,
   confirmPassword: string
 ): Promise<AuthResponse> {
   try {
-    await apiClient.put(
+    const result = await apiClient.put<ResetPasswordApiResponse>(
       '/v1/auth/password/reset',
       { password, confirm_password: confirmPassword },
       { auth: false, params: { verify_token: verifyToken } }
     );
 
-    return { status: 'success', code: 200 };
+    if (result.code === '0') return { status: 'success', code: 200 };
+    throw createGeneralErrorResponse(200, result.msg || '密碼重設失敗');
   } catch (error) {
     if ((error as AuthResponse)?.status === 'error') throw error;
     throw createGeneralErrorResponse(

--- a/src/services/auth/resetPasswordByEmail.test.ts
+++ b/src/services/auth/resetPasswordByEmail.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { resetPassword } from '@/services/auth/resetPasswordByEmail';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+  },
+}));
+
+import { apiClient } from '@/lib/apiClient';
+
+describe('resetPasswordByEmail', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('apiClient.get resolves with code "0" → returns { status: "success", code: 200 }', async () => {
+    vi.mocked(apiClient.get).mockResolvedValue({
+      code: '0',
+      msg: 'ok',
+      data: { ttl_secs: 300 },
+    });
+
+    const result = await resetPassword('test@example.com');
+
+    expect(result).toEqual({ status: 'success', code: 200 });
+  });
+
+  it('throws error → wraps in createGeneralErrorResponse(500, ...)', async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error('網路錯誤'));
+
+    await expect(resetPassword('test@example.com')).rejects.toMatchObject({
+      status: 'error',
+      code: 500,
+      message: '網路錯誤',
+    });
+  });
+});

--- a/src/services/auth/resetPasswordByEmail.ts
+++ b/src/services/auth/resetPasswordByEmail.ts
@@ -2,14 +2,26 @@ import { apiClient } from '@/lib/apiClient';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 
+interface ResetPasswordByEmailApiResponse {
+  code: string;
+  msg: string;
+  data: {
+    ttl_secs: number;
+  };
+}
+
 export async function resetPassword(email: string): Promise<AuthResponse> {
   try {
-    await apiClient.get('/v1/auth/password/reset/email', {
-      params: { email },
-      auth: false,
-    });
+    const result = await apiClient.get<ResetPasswordByEmailApiResponse>(
+      '/v1/auth/password/reset/email',
+      {
+        params: { email },
+        auth: false,
+      }
+    );
 
-    return { status: 'success', code: 200 };
+    if (result.code === '0') return { status: 'success', code: 200 };
+    throw createGeneralErrorResponse(200, result.msg || '信件寄送失敗');
   } catch (error) {
     if ((error as AuthResponse)?.status === 'error') throw error;
     throw createGeneralErrorResponse(

--- a/src/services/auth/signUp.test.ts
+++ b/src/services/auth/signUp.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ApiError } from '@/lib/apiClient';
+import { signUp } from '@/services/auth/signUp';
+
+vi.mock('@/lib/apiClient', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/apiClient')>();
+  return {
+    ...actual,
+    apiClient: {
+      post: vi.fn(),
+    },
+  };
+});
+
+import { apiClient } from '@/lib/apiClient';
+
+const validValues = {
+  email: 'test@example.com',
+  password: 'Password1!',
+  confirm_password: 'Password1!',
+  hasReadTermsOfService: true,
+};
+
+describe('signUp', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('apiClient.post resolves with code "0" → returns createSignUpSuccessResponse()', async () => {
+    vi.mocked(apiClient.post).mockResolvedValue({ code: '0' });
+
+    const result = await signUp(validValues);
+
+    expect(result).toEqual({ status: 'success', code: 0, httpStatus: 201 });
+  });
+
+  it('apiClient.post throws ApiError with status 422 → throws createValidationErrorResponse()', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(
+      new ApiError(422, 'Unprocessable Entity')
+    );
+
+    await expect(signUp(validValues)).rejects.toMatchObject({
+      status: 'error',
+      code: 422,
+    });
+  });
+
+  it('apiClient.post throws ApiError with status 406 → throws createEmailAlreadyRegisteredResponse()', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(
+      new ApiError(406, 'Not Acceptable')
+    );
+
+    await expect(signUp(validValues)).rejects.toMatchObject({
+      status: 'error',
+      code: 406,
+    });
+  });
+
+  it('apiClient.post throws ApiError with status 429 → throws createRateLimitResponse()', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(
+      new ApiError(429, 'Too Many Requests')
+    );
+
+    await expect(signUp(validValues)).rejects.toMatchObject({
+      status: 'error',
+      code: 429,
+    });
+  });
+
+  it('apiClient.post throws ApiError with other status → throws createGeneralErrorResponse(status, message)', async () => {
+    vi.mocked(apiClient.post).mockRejectedValue(
+      new ApiError(500, 'Internal Server Error')
+    );
+
+    await expect(signUp(validValues)).rejects.toMatchObject({
+      status: 'error',
+      code: 500,
+      message: 'Internal Server Error',
+    });
+  });
+});


### PR DESCRIPTION
## What Does This PR Do?

- Add unit tests for `signUp`, `resetPassword`, and `resetPasswordByEmail` auth service functions (10 test cases total)
- Fix `resetPassword` and `resetPasswordByEmail` to check `result.code === '0'` instead of assuming success on any non-throwing response — previously the response body was ignored entirely
- Add typed response interfaces (`ResetPasswordApiResponse`, `ResetPasswordByEmailApiResponse`) matching the actual backend contract

## Demo

N/A

## Screenshot

N/A

## Anything to Note?

`apiClient.ts` does not currently parse FastAPI's `detail[0].msg` error format — fallback message is always `"Request failed with status XXX"`. This is a separate issue to be tracked.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
