### PR TITLE
test: setup React Testing Library and vi.mock helpers for hooks (#55)

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
         id: depcheck
         run: |
           output=$(npx depcheck \
-            --ignores="@types/*,eslint-*,prettier-*,postcss,autoprefixer,tailwindcss,husky,lint-staged,storybook,@storybook/*,tsconfig-paths-webpack-plugin,tailwindcss-animate,jimp,@playwright/test" \
+            --ignores="@types/*,eslint-*,prettier-*,postcss,autoprefixer,tailwindcss,husky,lint-staged,storybook,@storybook/*,tsconfig-paths-webpack-plugin,tailwindcss-animate,jimp,@playwright/test,@testing-library/user-event" \
             2>&1) || true
           echo "$output"
           if echo "$output" | grep -qE "^Unused (dependencies|devDependencies)"; then

--- a/package.json
+++ b/package.json
@@ -68,6 +68,8 @@
     "@storybook/react": "^8.6.17",
     "@storybook/test": "^8.6.17",
     "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/node": "20.11.7",
     "@types/path-to-regexp": "^1.7.0",
     "@types/react": "18.2.48",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -152,6 +152,12 @@ importers:
       '@testing-library/jest-dom':
         specifier: ^6.9.1
         version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.3.2
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.0)
       '@types/node':
         specifier: 20.11.7
         version: 20.11.7
@@ -2913,8 +2919,29 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.5.2':
     resolution: {integrity: sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
@@ -9878,7 +9905,21 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@18.2.18)(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.6
+      '@testing-library/dom': 10.4.0
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 18.2.48
+      '@types/react-dom': 18.2.18
+
   '@testing-library/user-event@14.5.2(@testing-library/dom@10.4.0)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
       '@testing-library/dom': 10.4.0
 

--- a/src/test/mocks/navigation.ts
+++ b/src/test/mocks/navigation.ts
@@ -1,0 +1,23 @@
+import { vi } from 'vitest';
+
+export const mockRouter = {
+  push: vi.fn(),
+  replace: vi.fn(),
+  back: vi.fn(),
+  forward: vi.fn(),
+  refresh: vi.fn(),
+  prefetch: vi.fn(),
+};
+
+export const mockSearchParams = {
+  get: vi.fn().mockReturnValue(null),
+  getAll: vi.fn().mockReturnValue([]),
+  has: vi.fn().mockReturnValue(false),
+  toString: vi.fn().mockReturnValue(''),
+};
+
+export const navigationMockFactory = () => ({
+  useRouter: () => mockRouter,
+  useSearchParams: () => mockSearchParams,
+  usePathname: vi.fn().mockReturnValue('/'),
+});

--- a/src/test/mocks/nextAuth.ts
+++ b/src/test/mocks/nextAuth.ts
@@ -1,0 +1,31 @@
+import type { Session } from 'next-auth';
+import { vi } from 'vitest';
+
+export const mockSession: Session = {
+  user: {
+    id: 'test-user-id',
+    email: 'test@example.com',
+    name: 'Test User',
+    onBoarding: true,
+    isMentor: false,
+  },
+  accessToken: 'mock-access-token',
+  expires: '2099-01-01T00:00:00.000Z',
+};
+
+export const mockUseSession = vi.fn().mockReturnValue({
+  data: mockSession,
+  status: 'authenticated',
+  update: vi.fn(),
+});
+
+export const mockGetSession = vi.fn().mockResolvedValue(mockSession);
+
+export const mockSignIn = vi.fn().mockResolvedValue({ error: null });
+
+export const nextAuthMockFactory = () => ({
+  useSession: mockUseSession,
+  getSession: mockGetSession,
+  signIn: mockSignIn,
+  signOut: vi.fn(),
+});

--- a/src/test/mocks/useToast.ts
+++ b/src/test/mocks/useToast.ts
@@ -1,0 +1,11 @@
+import { vi } from 'vitest';
+
+export const mockToast = vi.fn();
+
+export const useToastMockFactory = () => ({
+  useToast: () => ({
+    toast: mockToast,
+    dismiss: vi.fn(),
+    toasts: [],
+  }),
+});

--- a/src/test/renderHook.test.tsx
+++ b/src/test/renderHook.test.tsx
@@ -1,0 +1,17 @@
+import { act, renderHook } from '@testing-library/react';
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+
+describe('renderHook setup', () => {
+  it('should render a hook and track state updates with act', () => {
+    const { result } = renderHook(() => useState(0));
+
+    expect(result.current[0]).toBe(0);
+
+    act(() => {
+      result.current[1](1);
+    });
+
+    expect(result.current[0]).toBe(1);
+  });
+});


### PR DESCRIPTION
## What Does This PR Do?

- Install `@testing-library/react` and `@testing-library/user-event`
- Add shared mock helpers in `src/test/mocks/` for `next/navigation`, `next-auth/react`, and `@/components/ui/use-toast`
- Add `renderHook.test.tsx` to verify `renderHook` + `act` works in the jsdom environment
- Ignore `@testing-library/user-event` in depcheck (installed now, used in future component test tickets)

## Demo

N/A

## Screenshot

N/A

## Anything to Note?

Mock helpers expose factory functions (`navigationMockFactory`, `nextAuthMockFactory`, `useToastMockFactory`) and named `vi.fn()` refs (`mockRouter`, `mockSession`, `mockToast`) for per-test overrides via `mockReturnValueOnce`.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
