### PR TITLE
fix: align reservation messages field from msg to content (#35)

### DIFF
--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -123,7 +123,7 @@ export default function MenteeReservationDialog({
         schedule_id: selectedSlot.scheduleId,
         dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
         dtend: Math.floor(selectedSlot.end.getTime() / 1000),
-        messages: [{ user_id: menteeId, msg: bookingQuestion }],
+        messages: [{ user_id: menteeId, content: bookingQuestion }],
         previous_reserve: {},
       };
 

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -58,7 +58,7 @@ export function ReservationList({
           dtstart: it.dtstart,
           dtend: it.dtend,
           messages: message.trim()
-            ? [{ user_id: myId, msg: message.trim() }]
+            ? [{ user_id: myId, content: message.trim() }]
             : [],
           previous_reserve: {},
         },
@@ -102,7 +102,9 @@ export function ReservationList({
           schedule_id: it.scheduleId,
           dtstart: it.dtstart,
           dtend: it.dtend,
-          messages: text.trim() ? [{ user_id: myId, msg: text.trim() }] : [],
+          messages: text.trim()
+            ? [{ user_id: myId, content: text.trim() }]
+            : [],
           previous_reserve: {},
         },
       });

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -220,7 +220,7 @@ export type UpdateReservationPayload = {
   schedule_id: number;
   dtstart: number; // epoch seconds
   dtend: number; // epoch seconds
-  messages?: Array<{ user_id: number | string; msg: string }>;
+  messages?: Array<{ user_id: number | string; content: string }>;
   previous_reserve?: Record<string, unknown> | null;
 };
 
@@ -234,7 +234,7 @@ export type UpdateReservationAPIData = {
   schedule_id: number;
   dtstart: number;
   dtend: number;
-  messages: Array<{ user_id: number | string; msg: string }>;
+  messages: Array<{ user_id: number | string; content: string }>;
   previous_reserve: Record<string, unknown>;
 };
 
@@ -292,7 +292,7 @@ export type CreateReservationPayload = {
   schedule_id: number;
   dtstart: number; // epoch seconds
   dtend: number; // epoch seconds
-  messages: Array<{ user_id: number | string; msg: string }>;
+  messages: Array<{ user_id: number | string; content: string }>;
   previous_reserve: { reserve_id: number } | Record<string, never>;
 };
 
@@ -305,7 +305,7 @@ export type CreateReservationAPIData = {
   schedule_id: number;
   dtstart: number;
   dtend: number;
-  messages: Array<{ user_id: number | string; msg: string }>;
+  messages: Array<{ user_id: number | string; content: string }>;
   previous_reserve: { reserve_id: number } | Record<string, never>;
 };
 


### PR DESCRIPTION
## What Does This PR Do?

- Fix `messages[]` field name from `msg` to `content` in all reservation API payload types (`CreateReservationPayload`, `CreateReservationAPIData`, `UpdateReservationPayload`, `UpdateReservationAPIData`)
- Fix `MenteeReservationDialog` POST payload to send `content` instead of `msg`
- Fix `ReservationList` PUT payloads (accept and reject/cancel) to send `content` instead of `msg`

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

The GET response already typed `messages[].content` correctly — the bug was entirely on the write side. Because `msg` was never a valid backend field, Mentee booking questions were silently discarded and never persisted, causing the accept dialog to always show "（學員未提出問題）".

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
