### PR TITLE
test: add E2E tests for profile edit page (#67)

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -34,7 +34,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@51.2.1
 
       - name: Pull Vercel environment info
         run: vercel pull --yes --environment=production --token=${{ env.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -37,7 +37,7 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@51.2.1
 
       - name: Pull Vercel environment (preview)
         run: vercel pull --yes --environment=preview --token=${{ env.VERCEL_TOKEN }}

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -31,7 +31,7 @@ jobs:
           version: 9
 
       - name: Install Vercel CLI
-        run: npm install --global vercel@latest
+        run: npm install --global vercel@51.2.1
 
       - name: Pull Vercel environment info
         run: vercel pull --yes --environment=production --token=${{ env.VERCEL_TOKEN }}

--- a/e2e/tests/profile/profile-edit.spec.ts
+++ b/e2e/tests/profile/profile-edit.spec.ts
@@ -1,0 +1,444 @@
+import { expect, Page, test } from '@playwright/test';
+import { encode } from 'next-auth/jwt';
+
+import { mockApiRoute } from '../../helpers/route';
+
+const USER_ID = '1';
+const PAGE_URL = `/profile/${USER_ID}/edit`;
+
+// ─── Mock payloads ───────────────────────────────────────────────────────────
+
+function makeSession(isMentor: boolean) {
+  return {
+    user: {
+      id: USER_ID,
+      name: 'Test User',
+      isMentor,
+      onBoarding: true,
+      jobTitle: '',
+      company: '',
+      personalLinks: [],
+    },
+    accessToken: 'mock-token',
+    expires: '2099-01-01T00:00:00.000Z',
+  };
+}
+
+function makeProfile(name: string, isMentor: boolean) {
+  return {
+    code: '0',
+    msg: 'ok',
+    data: {
+      user_id: Number(USER_ID),
+      name,
+      avatar: '',
+      onboarding: true,
+      is_mentor: isMentor,
+      job_title: '',
+      company: '',
+      years_of_experience: 'BELOW_ONE_YEAR',
+      location: 'TWN',
+      personal_statement: '',
+      about: isMentor ? '我是 mentor' : '',
+      language: 'zh_TW',
+      industry: {
+        id: 1,
+        subject_group: 'TECH',
+        subject: '科技業',
+        category: 'INDUSTRY',
+        language: 'zh_TW',
+        profession_metadata: { desc: '', icon: '' },
+      },
+      interested_positions: {
+        interests: [
+          {
+            id: 1,
+            subject_group: 'TEST_POS',
+            subject: '測試職位',
+            category: 'INTERESTED_POSITION',
+            language: 'zh_TW',
+            desc: { icon: '', desc: '' },
+          },
+        ],
+        language: 'zh_TW',
+      },
+      skills: {
+        interests: [
+          {
+            id: 2,
+            subject_group: 'TEST_SKILL',
+            subject: '測試技能',
+            category: 'SKILL',
+            language: 'zh_TW',
+            desc: { icon: '', desc: '' },
+          },
+        ],
+        language: 'zh_TW',
+      },
+      topics: {
+        interests: [
+          {
+            id: 3,
+            subject_group: 'TEST_TOPIC',
+            subject: '測試主題',
+            category: 'TOPIC',
+            language: 'zh_TW',
+            desc: { icon: '', desc: '' },
+          },
+        ],
+        language: 'zh_TW',
+      },
+      expertises: {
+        professions: isMentor
+          ? [
+              {
+                id: 1,
+                subject_group: 'DATA',
+                subject: '資料分析',
+                category: 'EXPERTISE',
+                language: 'zh_TW',
+                profession_metadata: { desc: '', icon: '' },
+              },
+            ]
+          : [],
+        language: 'zh_TW',
+      },
+      // Mentor requires at least one work experience, education, and what_i_offer.
+      experiences: isMentor
+        ? [
+            {
+              id: 1,
+              category: 'WORK',
+              order: 1,
+              mentor_experiences_metadata: {
+                data: [
+                  {
+                    job: '工程師',
+                    company: '測試公司',
+                    jobPeriodStart: '2020',
+                    jobPeriodEnd: '2023',
+                    industry: 'TECH',
+                    jobLocation: 'TWN',
+                    description: '工作內容',
+                  },
+                ],
+              },
+            },
+            {
+              id: 2,
+              category: 'EDUCATION',
+              order: 2,
+              mentor_experiences_metadata: {
+                data: [
+                  {
+                    school: '測試大學',
+                    subject: '資訊工程',
+                    educationPeriodStart: '2016',
+                    educationPeriodEnd: '2020',
+                  },
+                ],
+              },
+            },
+            {
+              id: 4,
+              category: 'WHAT_I_OFFER',
+              order: 4,
+              mentor_experiences_metadata: {
+                data: [{ subject_group: 'CAREER_PLANNING' }],
+              },
+            },
+          ]
+        : [],
+    },
+  };
+}
+
+const MOCK_COUNTRIES = { code: '0', msg: 'ok', data: { TWN: '台灣' } };
+
+const MOCK_INDUSTRIES = {
+  code: '0',
+  msg: 'ok',
+  data: {
+    professions: [
+      {
+        id: 1,
+        subject_group: 'TECH',
+        subject: '科技業',
+        category: 'INDUSTRY',
+        language: 'zh_TW',
+        profession_metadata: { desc: '', icon: '' },
+      },
+    ],
+  },
+};
+
+const MOCK_EXPERTISES = {
+  code: '0',
+  msg: 'ok',
+  data: {
+    professions: [
+      {
+        id: 1,
+        subject_group: 'DATA',
+        subject: '資料分析',
+        category: 'EXPERTISE',
+        language: 'zh_TW',
+        profession_metadata: { desc: '', icon: '' },
+      },
+    ],
+  },
+};
+
+function makeInterest(subject: string) {
+  return {
+    code: '0',
+    msg: 'ok',
+    data: {
+      interests: [
+        {
+          id: 1,
+          subject_group: 'TEST_GROUP',
+          subject,
+          category: 'TEST',
+          language: 'zh_TW',
+          desc: { icon: '', desc: '' },
+        },
+      ],
+      language: 'zh_TW',
+    },
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Encode a signed NextAuth JWT and set it as the session cookie so that:
+ *  1. The Next.js middleware (existence check) lets the request through.
+ *  2. getServerSession() on the server can decode it and return the real
+ *     session object, so SessionProvider initialises as 'authenticated'
+ *     rather than 'unauthenticated', preventing useProfileAuth from
+ *     redirecting to '/' before the client-side session fetch completes.
+ */
+async function setSignedSessionCookie(
+  page: Page,
+  user: {
+    id: string;
+    name: string;
+    isMentor: boolean;
+    onBoarding: boolean;
+    jobTitle: string;
+    company: string;
+    personalLinks: { platform: string; url: string }[];
+  }
+): Promise<void> {
+  const secret = process.env.NEXTAUTH_SECRET ?? 'secret';
+  const value = await encode({
+    token: {
+      sub: user.id,
+      id: user.id,
+      name: user.name,
+      isMentor: user.isMentor,
+      onBoarding: user.onBoarding,
+      jobTitle: user.jobTitle,
+      company: user.company,
+      personalLinks: user.personalLinks,
+      token: 'mock-access-token',
+    },
+    secret,
+  });
+  await page.context().addCookies([
+    {
+      name: 'next-auth.session-token',
+      value,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+/**
+ * Mock GET /api/auth/session so useSession() returns the desired session.
+ * Non-GET requests are passed through (or fall back) to allow PUT mocks
+ * registered later to handle updateSession calls.
+ */
+async function mockSessionGet(page: Page, session: object): Promise<void> {
+  await page.route(/\/api\/auth\/session/, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(session),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock all dropdown option endpoints used by the profile edit page.
+ */
+async function mockDropdowns(page: Page): Promise<void> {
+  await mockApiRoute(page, /\/v1\/users\/zh_TW\/countries/, {
+    body: MOCK_COUNTRIES,
+  });
+  await mockApiRoute(page, /\/v1\/users\/zh_TW\/industries/, {
+    body: MOCK_INDUSTRIES,
+  });
+  await mockApiRoute(page, /\/v1\/mentors\/zh_TW\/expertises/, {
+    body: MOCK_EXPERTISES,
+  });
+  await page.route(/\/v1\/users\/zh_TW\/interests/, (route) => {
+    const url = route.request().url();
+    if (url.includes('INTERESTED_POSITION')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeInterest('測試職位')),
+      });
+    }
+    if (url.includes('SKILL')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeInterest('測試技能')),
+      });
+    }
+    if (url.includes('TOPIC')) {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeInterest('測試主題')),
+      });
+    }
+    return route.continue();
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test('未授權使用者（userId 不符）→ 重導向至 /', async ({ page }) => {
+  await setSignedSessionCookie(page, {
+    id: '999',
+    name: 'Other User',
+    isMentor: false,
+    onBoarding: true,
+    jobTitle: '',
+    company: '',
+    personalLinks: [],
+  });
+  await mockSessionGet(page, {
+    user: {
+      id: '999',
+      name: 'Other User',
+      isMentor: false,
+      onBoarding: true,
+      jobTitle: '',
+      company: '',
+      personalLinks: [],
+    },
+    accessToken: 'mock-token',
+    expires: '2099-01-01T00:00:00.000Z',
+  });
+
+  await page.goto(PAGE_URL);
+
+  await expect(page).toHaveURL('/', { timeout: 10_000 });
+});
+
+test('Mentor 使用者載入編輯頁 → mentor 專屬區塊（我能提供的服務、專業能力）可見', async ({
+  page,
+}) => {
+  await setSignedSessionCookie(page, makeSession(true).user);
+  await mockSessionGet(page, makeSession(true));
+  await mockApiRoute(page, /\/v1\/mentors\/1\/zh_TW\/profile/, {
+    body: makeProfile('Test User', true),
+  });
+  await mockDropdowns(page);
+
+  await page.goto(PAGE_URL);
+
+  await expect(page.getByText('我能提供的服務')).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByText('專業能力')).toBeVisible();
+});
+
+test('Mentee 使用者載入編輯頁 → mentor 專屬區塊不存在', async ({ page }) => {
+  await setSignedSessionCookie(page, makeSession(false).user);
+  await mockSessionGet(page, makeSession(false));
+  await mockApiRoute(page, /\/v1\/mentors\/1\/zh_TW\/profile/, {
+    body: makeProfile('Test User', false),
+  });
+  await mockDropdowns(page);
+
+  await page.goto(PAGE_URL);
+
+  // Wait for the loading state to clear before asserting absence
+  await expect(page.locator('input[name="name"]')).toHaveValue('Test User', {
+    timeout: 15_000,
+  });
+  await expect(page.getByText('我能提供的服務')).not.toBeVisible();
+  await expect(page.getByText('專業能力')).not.toBeVisible();
+});
+
+test('編輯姓名並儲存 → 重導向至 /profile/:userId', async ({ page }) => {
+  await setSignedSessionCookie(page, makeSession(false).user);
+  await mockSessionGet(page, makeSession(false));
+
+  // First GET (initial load) returns the original name.
+  // Subsequent GETs (pollUntilSynced) return the updated name so isProfileSynced
+  // resolves on the first poll and the test doesn't wait the full 60-second timeout.
+  let getProfileCallCount = 0;
+  await page.route(/\/v1\/mentors\/1\/zh_TW\/profile/, (route) => {
+    getProfileCallCount++;
+    const name = getProfileCallCount === 1 ? 'Test User' : 'Updated Name';
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(makeProfile(name, false)),
+    });
+  });
+
+  await mockDropdowns(page);
+
+  // PUT /v1/mentors/1/profile (no zh_TW segment) → updateProfile success.
+  // This pattern does not match the GET zh_TW URL, so the counter handler above
+  // remains the sole handler for GET profile calls.
+  await mockApiRoute(page, /\/v1\/mentors\/1\/profile/, {
+    body: { code: '0', msg: 'ok', data: null },
+  });
+
+  // PUT /api/auth/session → updateSession after save.
+  // GET requests fall back to the handler registered by mockSessionGet above.
+  await page.route(/\/api\/auth\/session/, (route) => {
+    if (route.request().method() === 'PUT') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...makeSession(false),
+          user: { ...makeSession(false).user, name: 'Updated Name' },
+        }),
+      });
+    }
+    return route.fallback();
+  });
+
+  await page.goto(PAGE_URL);
+
+  // Wait for the form to be pre-filled with data from the initial profile fetch
+  await expect(page.locator('input[name="name"]')).toHaveValue('Test User', {
+    timeout: 15_000,
+  });
+
+  // Edit the name field
+  await page.fill('input[name="name"]', 'Updated Name');
+
+  // Submit the form
+  await page.getByRole('button', { name: '儲存' }).click();
+
+  await expect(page).toHaveURL(`/profile/${USER_ID}`, { timeout: 30_000 });
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -58,6 +58,15 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
     },
+    // Profile tests forge their own session cookie (same pattern as onboarding).
+    // No real user or storageState needed.
+    {
+      name: 'chromium-profile',
+      testDir: './e2e/tests/profile',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
   ],
 
   webServer: {


### PR DESCRIPTION
## What Does This PR Do?

- Add `chromium-profile` Playwright project targeting `e2e/tests/profile/`
- Add `profile-edit.spec.ts` covering four scenarios:
  - Unauthorised user (userId mismatch) → redirected to `/`
  - Mentor user → mentor-only sections (我能提供的服務, 專業能力) visible
  - Mentee user → mentor-only sections absent
  - Edit name and save → redirected to `/profile/:userId`
- Replace fake session cookie with a properly signed NextAuth JWT (via `next-auth/jwt` `encode`) so `getServerSession()` on the server returns a valid session and `SessionProvider` initialises as `authenticated`, preventing `useProfileAuth` from redirecting before the client-side session fetch completes

## Demo

http://localhost:3000/profile/1/edit

## Screenshot

N/A

## Anything to Note?

The root cause of previous test failures: `RootLayout` calls `getServerSession()` with the cookie. An invalid/fake JWT makes it return `null`, so `SessionProvider` starts as `status='unauthenticated'` (not `'loading'`), causing `useProfileAuth` to redirect immediately. Using a properly signed JWT fixes the race condition without touching production code.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
