### PR TITLE
test: add E2E tests for reservation mentee view and fix E2E helpers (#68)

### DIFF
--- a/e2e/helpers/route.ts
+++ b/e2e/helpers/route.ts
@@ -17,11 +17,26 @@ export async function mockApiRoute(
   pattern: string | RegExp,
   options: MockRouteOptions
 ): Promise<void> {
-  await page.route(pattern, (route) =>
-    route.fulfill({
+  await page.route(pattern, (route) => {
+    if (route.request().method() === 'OPTIONS') {
+      return route.fulfill({
+        status: 204,
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Access-Control-Allow-Methods':
+            'GET, POST, PUT, PATCH, DELETE, OPTIONS',
+          'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+        },
+      });
+    }
+
+    return route.fulfill({
       status: options.status ?? 200,
       contentType: 'application/json',
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+      },
       body: JSON.stringify(options.body),
-    })
-  );
+    });
+  });
 }

--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -10,7 +10,7 @@ interface SessionPayload {
   token: string;
   jobTitle?: string;
   company?: string;
-  personalLinks?: unknown[];
+  personalLinks?: { platform: string; url: string }[];
 }
 
 /**

--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -1,5 +1,5 @@
 import { Page } from '@playwright/test';
-import { encode } from 'next-auth/jwt';
+import { encode, JWT } from 'next-auth/jwt';
 
 interface SessionPayload {
   id: string;
@@ -26,7 +26,7 @@ export async function setSignedSessionCookie(
   payload: SessionPayload
 ): Promise<void> {
   const signed = await encode({
-    token: payload,
+    token: payload as JWT,
     secret: process.env.NEXTAUTH_SECRET ?? 'secret',
   });
 

--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -1,0 +1,44 @@
+import { Page } from '@playwright/test';
+import { encode } from 'next-auth/jwt';
+
+interface SessionPayload {
+  id: string;
+  name: string;
+  onBoarding: boolean;
+  isMentor: boolean;
+  /** Becomes session.accessToken via auth.config.ts session callback */
+  token: string;
+  jobTitle?: string;
+  company?: string;
+  personalLinks?: unknown[];
+}
+
+/**
+ * Forge a properly signed next-auth.session-token cookie so that
+ * getSession() / getServerSession() return a real decoded session —
+ * without hitting the real backend.
+ *
+ * The secret must match the running dev server's NEXTAUTH_SECRET.
+ * Defaults to 'secret', which matches .env.development.local.
+ */
+export async function setSignedSessionCookie(
+  page: Page,
+  payload: SessionPayload
+): Promise<void> {
+  const signed = await encode({
+    token: payload,
+    secret: process.env.NEXTAUTH_SECRET ?? 'secret',
+  });
+
+  await page.context().addCookies([
+    {
+      name: 'next-auth.session-token',
+      value: signed,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+}

--- a/e2e/tests/onboarding/onboarding.spec.ts
+++ b/e2e/tests/onboarding/onboarding.spec.ts
@@ -204,13 +204,25 @@ test('complete all 5 steps (happy path) → redirects to /profile/card', async (
     body: { code: '0', msg: 'ok', data: null },
   });
 
-  // PUT /api/auth/session — updateSession after onboarding completes.
-  // Use route.fallback() (not route.continue()) for non-PUT requests so they
-  // fall through to the GET handler registered in setupPageMocks. Without this,
-  // getSession() calls inside updateProfile/fetchUser go to the real server,
-  // which returns null for the fake session cookie → userId is null → submit fails.
+  // Override /api/auth/session for both GET and POST so that:
+  //   GET  → useSession() / getSession() inside updateProfile and fetchUser
+  //          return a valid session (userId present, no real-server decode needed)
+  //   POST → NextAuth's update() call after onboarding; mocking prevents the
+  //          server from trying to decode the fake cookie and clearing it via
+  //          Set-Cookie, which would strip the session cookie and break the
+  //          middleware auth check when router.push('/profile/card') fires.
+  // This handler is registered after setupPageMocks, so it is tried first
+  // (Playwright routes are LIFO) and shadows the GET-only handler above.
   await page.route(/\/api\/auth\/session/, (route) => {
-    if (route.request().method() === 'PUT') {
+    const method = route.request().method();
+    if (method === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(MOCK_CLIENT_SESSION),
+      });
+    }
+    if (method === 'POST') {
       return route.fulfill({
         status: 200,
         contentType: 'application/json',
@@ -220,7 +232,7 @@ test('complete all 5 steps (happy path) → redirects to /profile/card', async (
         }),
       });
     }
-    return route.fallback();
+    return route.continue();
   });
 
   // Step 1 — fill name

--- a/e2e/tests/public/signin.spec.ts
+++ b/e2e/tests/public/signin.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { setSignedSessionCookie } from '../../helpers/session';
+
 test.beforeEach(async ({ page }) => {
   await page.goto('/auth/signin');
 });
@@ -48,27 +50,21 @@ test('invalid credentials → toast shows "Invalid credentials!", stays on sign-
 test('valid credentials + onBoarding: false → redirects to /auth/onboarding', async ({
   page,
 }) => {
-  // /auth/onboarding is a protected route. The middleware checks for the
-  // next-auth.session-token cookie (existence only, no JWT verification).
-  // Set a fake cookie so the middleware lets the navigation through.
-  await page.context().addCookies([
-    {
-      name: 'next-auth.session-token',
-      value: 'fake-session-token',
-      domain: 'localhost',
-      path: '/',
-      httpOnly: true,
-    },
-  ]);
+  // Forge a signed JWT so the middleware (which checks cookie existence) allows
+  // navigation to protected routes after router.push().
+  await setSignedSessionCookie(page, {
+    id: '1',
+    name: 'Test User',
+    onBoarding: false,
+    isMentor: false,
+    token: 'mock-access-token',
+    jobTitle: '',
+    company: '',
+    personalLinks: [],
+  });
 
-  await page.route(/\/api\/auth\/callback\/credentials/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ url: 'http://localhost:3000' }),
-    })
-  );
-
+  // Mock /api/auth/session so getSession() inside useSignInForm returns a
+  // controlled session — avoids relying on the dev server to decode the JWT.
   await page.route(/\/api\/auth\/session/, (route) =>
     route.fulfill({
       status: 200,
@@ -83,9 +79,17 @@ test('valid credentials + onBoarding: false → redirects to /auth/onboarding', 
           company: '',
           personalLinks: [],
         },
-        accessToken: 'mock-token',
+        accessToken: 'mock-access-token',
         expires: '2099-01-01T00:00:00.000Z',
       }),
+    })
+  );
+
+  await page.route(/\/api\/auth\/callback\/credentials/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ url: 'http://localhost:3000' }),
     })
   );
 
@@ -99,13 +103,16 @@ test('valid credentials + onBoarding: false → redirects to /auth/onboarding', 
 test('valid credentials + onBoarding: true → redirects to /mentor-pool', async ({
   page,
 }) => {
-  await page.route(/\/api\/auth\/callback\/credentials/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify({ url: 'http://localhost:3000' }),
-    })
-  );
+  await setSignedSessionCookie(page, {
+    id: '1',
+    name: 'Test User',
+    onBoarding: true,
+    isMentor: false,
+    token: 'mock-access-token',
+    jobTitle: '',
+    company: '',
+    personalLinks: [],
+  });
 
   await page.route(/\/api\/auth\/session/, (route) =>
     route.fulfill({
@@ -121,9 +128,17 @@ test('valid credentials + onBoarding: true → redirects to /mentor-pool', async
           company: '',
           personalLinks: [],
         },
-        accessToken: 'mock-token',
+        accessToken: 'mock-access-token',
         expires: '2099-01-01T00:00:00.000Z',
       }),
+    })
+  );
+
+  await page.route(/\/api\/auth\/callback\/credentials/, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ url: 'http://localhost:3000' }),
     })
   );
 

--- a/e2e/tests/reservation/reservation-mentee.spec.ts
+++ b/e2e/tests/reservation/reservation-mentee.spec.ts
@@ -1,0 +1,216 @@
+import { expect, Page, test } from '@playwright/test';
+import { encode } from 'next-auth/jwt';
+
+const USER_ID = '1';
+const PAGE_URL = '/reservation/mentee';
+
+// ─── Mock payloads ───────────────────────────────────────────────────────────
+
+function makeSession() {
+  return {
+    user: {
+      id: USER_ID,
+      name: 'Test Mentee',
+      isMentor: false,
+      onBoarding: true,
+      jobTitle: '',
+      company: '',
+      personalLinks: [],
+    },
+    accessToken: 'mock-token',
+    expires: '2099-01-01T00:00:00.000Z',
+  };
+}
+
+function makeReservationResponse(reservations: object[]) {
+  return {
+    code: '0',
+    msg: 'ok',
+    data: {
+      reservations,
+      next_dtend: 0,
+    },
+  };
+}
+
+function makeReservation(id: number, mentorName: string) {
+  // For MENTEE_* states: sender = mentee (current user), participant = mentor (counterparty)
+  return {
+    id,
+    sender: {
+      user_id: Number(USER_ID),
+      role: 'MENTEE',
+      status: 'PENDING',
+      name: 'Test Mentee',
+      avatar: '',
+      job_title: 'Engineer',
+      years_of_experience: 'ONE_TO_THREE',
+    },
+    participant: {
+      user_id: 99,
+      role: 'MENTOR',
+      status: 'PENDING',
+      name: mentorName,
+      avatar: '',
+      job_title: 'Senior Engineer',
+      years_of_experience: 'THREE_TO_FIVE',
+    },
+    schedule_id: id,
+    dtstart: 1704099600,
+    dtend: 1704103200,
+    previous_reserve: null,
+    messages: [],
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function setSignedSessionCookie(page: Page): Promise<void> {
+  const secret = process.env.NEXTAUTH_SECRET ?? 'secret';
+  const session = makeSession();
+  const value = await encode({
+    token: {
+      sub: session.user.id,
+      id: session.user.id,
+      name: session.user.name,
+      isMentor: session.user.isMentor,
+      onBoarding: session.user.onBoarding,
+      jobTitle: session.user.jobTitle,
+      company: session.user.company,
+      personalLinks: session.user.personalLinks,
+      token: 'mock-access-token',
+    },
+    secret,
+  });
+  await page.context().addCookies([
+    {
+      name: 'next-auth.session-token',
+      value,
+      domain: 'localhost',
+      path: '/',
+      httpOnly: true,
+      secure: false,
+      sameSite: 'Lax',
+    },
+  ]);
+}
+
+async function mockSessionGet(page: Page): Promise<void> {
+  await page.route(/\/api\/auth\/session/, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSession()),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock all 5 reservation list endpoints that useReservationData calls in
+ * parallel. The `stateData` map lets each test override specific states with
+ * custom payloads; any state not provided gets an empty list.
+ */
+async function mockReservationEndpoints(
+  page: Page,
+  stateData: Partial<Record<string, object[]>> = {}
+): Promise<void> {
+  const defaults: Record<string, object[]> = {
+    MENTEE_UPCOMING: [],
+    MENTEE_PENDING: [],
+    MENTOR_UPCOMING: [],
+    MENTOR_PENDING: [],
+    HISTORY: [],
+  };
+  const data = { ...defaults, ...stateData };
+
+  await page.route(new RegExp(`/v1/users/${USER_ID}/reservations`), (route) => {
+    const url = new URL(route.request().url());
+    const state = url.searchParams.get('state') ?? '';
+    const reservations = data[state] ?? [];
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(makeReservationResponse(reservations)),
+    });
+  });
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test('頁面載入 → 三個 Tab 可見', async ({ page }) => {
+  await setSignedSessionCookie(page);
+  await mockSessionGet(page);
+  await mockReservationEndpoints(page);
+
+  await page.goto(PAGE_URL);
+
+  await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('tab', { name: /等待回復/ })).toBeVisible();
+  await expect(page.getByRole('tab', { name: /歷史紀錄/ })).toBeVisible();
+});
+
+test('點擊等待回復 Tab → pending 預約卡片顯示', async ({ page }) => {
+  await setSignedSessionCookie(page);
+  await mockSessionGet(page);
+  await mockReservationEndpoints(page, {
+    MENTEE_PENDING: [makeReservation(1, 'Mentor Wang')],
+  });
+
+  await page.goto(PAGE_URL);
+
+  // Wait for tabs to be visible before clicking
+  await expect(page.getByRole('tab', { name: /等待回復/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('tab', { name: /等待回復/ }).click();
+
+  await expect(page.getByText('Mentor Wang')).toBeVisible({ timeout: 10_000 });
+});
+
+test('資料載入中 → Skeleton 顯示且不閃爍錯誤內容', async ({ page }) => {
+  await setSignedSessionCookie(page);
+  await mockSessionGet(page);
+
+  // Delay all reservation responses so the skeleton is visible long enough to assert
+  let resolveDelay!: () => void;
+  const delay = new Promise<void>((res) => {
+    resolveDelay = res;
+  });
+
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations`),
+    async (route) => {
+      await delay;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeReservationResponse([])),
+      });
+    }
+  );
+
+  await page.goto(PAGE_URL);
+
+  // Skeleton should be visible while responses are held
+  await expect(page.locator('.animate-pulse').first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Tabs (real content) must not be visible yet
+  await expect(page.getByRole('tab', { name: /即將到來/ })).not.toBeVisible();
+
+  // Release the delayed responses and wait for real content to appear
+  resolveDelay();
+
+  await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Skeleton should be gone once data has loaded
+  await expect(page.locator('.animate-pulse').first()).not.toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -67,6 +67,15 @@ export default defineConfig({
         ...devices['Desktop Chrome'],
       },
     },
+    // Reservation tests forge their own session cookie.
+    // No real user or storageState needed.
+    {
+      name: 'chromium-reservation',
+      testDir: './e2e/tests/reservation',
+      use: {
+        ...devices['Desktop Chrome'],
+      },
+    },
   ],
 
   webServer: {


### PR DESCRIPTION
## What Does This PR Do?

- Add `e2e/helpers/session.ts` — `setSignedSessionCookie()` helper that forges a real signed next-auth JWT cookie so `getSession()` decodes correctly without hitting the real backend
- Fix `e2e/helpers/route.ts` — handle CORS OPTIONS preflight and add `Access-Control-Allow-Origin` header on all mocked responses, fixing flaky tests caused by cross-origin AWS API calls bypassing mocks
- Fix `e2e/tests/public/signin.spec.ts` — replace fake cookie + removed session mock with signed JWT cookie + explicit `/api/auth/session` mock so `getSession()` inside `useSignInForm` returns the expected session
- Fix `e2e/tests/onboarding/onboarding.spec.ts` — change happy-path `/api/auth/session` mock from PUT to POST (NextAuth `update()` sends POST), preventing the real server from decoding the fake cookie and clearing the session cookie via `Set-Cookie`
- Add `chromium-reservation` project to `playwright.config.ts`
- Add `e2e/tests/reservation/reservation-mentee.spec.ts` — covers tab rendering, pending reservation card display, and skeleton loading state for the mentee reservation page

## Demo

http://localhost:3000/reservation/mentee

## Screenshot

N/A

## Anything to Note?

NextAuth `useSession().update()` sends POST (not PUT) to `/api/auth/session`. If the real server receives this with an invalid/fake cookie it calls `sessionStore.clean()`, which sends a `Set-Cookie` header that clears the browser cookie — breaking middleware auth checks on the next navigation. Always mock both GET and POST for `/api/auth/session` in tests that call `updateSession()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)