### PR TITLE
fix: remove job/company from onboarding and fix mentor card display

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -94,8 +94,6 @@ export default function OnboardingContainer() {
       location: 'TWN',
       years_of_experience: '',
       industry: '',
-      job_title: '',
-      company: '',
     },
   });
   const onSubmitStep2 = (data: z.infer<typeof step2Schema>) => {

--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -1,8 +1,25 @@
 import { memo, useEffect, useRef } from 'react';
 
-import { MentorType } from '@/services/search-mentor/mentors';
+import {
+  MentorExperienceBlock,
+  MentorType,
+  WorkExperienceMetadata,
+} from '@/services/search-mentor/mentors';
 
 import { MentorCard } from '../mentor-card';
+
+function deriveCurrentJob(experiences: MentorExperienceBlock[]): {
+  job_title: string;
+  company: string;
+} {
+  const firstWork = experiences.find((e) => e.category === 'WORK');
+  const metadata: WorkExperienceMetadata | undefined =
+    firstWork?.mentor_experiences_metadata?.data?.[0];
+  return {
+    job_title: metadata?.job ?? '',
+    company: metadata?.company ?? '',
+  };
+}
 
 interface MentorCardListProps {
   mentors: MentorType[];
@@ -47,8 +64,14 @@ const MentorCardListBase = ({
             avatar={mentor.avatar}
             years={mentor.years_of_experience}
             name={mentor.name}
-            job_title={mentor.job_title}
-            company={mentor.company}
+            job_title={
+              deriveCurrentJob(mentor.experiences ?? []).job_title ||
+              mentor.job_title
+            }
+            company={
+              deriveCurrentJob(mentor.experiences ?? []).company ||
+              mentor.company
+            }
             personalStatment={mentor.personal_statement}
             skills={mentor.skills}
           />

--- a/src/components/mentor-pool/mentor-card/Information.tsx
+++ b/src/components/mentor-pool/mentor-card/Information.tsx
@@ -56,11 +56,13 @@ export const Information = ({
     <div className="flex h-full flex-col gap-4">
       <div>
         <h3 className="text-base font-bold tracking-[0.5px]">{name}</h3>
-        <div className="flex gap-[6px] text-sm font-normal tracking-wide">
-          {job_title}
-          <span className="text-[#9DA8B9]">at</span>
-          {company}
-        </div>
+        {(job_title || company) && (
+          <div className="flex gap-[6px] text-sm font-normal tracking-wide">
+            {job_title}
+            {job_title && company && <span className="text-[#9DA8B9]">at</span>}
+            {company}
+          </div>
+        )}
       </div>
       <p className="line-clamp-2 text-sm font-normal tracking-wide text-[#9DA8B9]">
         {personalStatment}

--- a/src/components/onboarding/steps/PersonalInfo.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.tsx
@@ -11,7 +11,6 @@ import {
   FormLabel,
   FormMessage,
 } from '@/components/ui/form';
-import { Input } from '@/components/ui/input';
 import {
   Select,
   SelectContent,
@@ -118,34 +117,6 @@ export const PersonalInfo: FC<Props> = ({
                   ))}
                 </SelectContent>
               </Select>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="job_title"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel showErrorStyle={false}>職稱 (選填)</FormLabel>
-              <FormControl>
-                <Input placeholder="請填入您的職稱" {...field} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="company"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel showErrorStyle={false}>公司名稱 (選填) </FormLabel>
-              <FormControl>
-                <Input placeholder="請填入您的公司名稱" {...field} />
-              </FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/src/components/onboarding/steps/index.ts
+++ b/src/components/onboarding/steps/index.ts
@@ -17,8 +17,6 @@ export const step2Schema = z.object({
   location: z.string({ required_error: '請選擇地區' }),
   years_of_experience: z.string().min(1, '請選擇您的年資區間'),
   industry: z.string({ required_error: '請選擇您的產業類別' }),
-  job_title: z.string().optional(),
-  company: z.string().optional(),
 });
 
 export const step3Schema = z.object({

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -2,10 +2,21 @@ import { StaticImageData } from 'next/image';
 
 import { apiClient } from '@/lib/apiClient';
 
-export interface experienceType {
-  duration: string;
-  company: string;
-  title: string;
+export interface WorkExperienceMetadata {
+  job?: string;
+  company?: string;
+  jobPeriodStart?: string;
+  jobPeriodEnd?: string;
+  jobLocation?: string;
+  description?: string;
+  industry?: string;
+}
+
+export interface MentorExperienceBlock {
+  id: number;
+  category: string;
+  order: number;
+  mentor_experiences_metadata?: { data?: WorkExperienceMetadata[] };
 }
 
 export interface MentorType {
@@ -26,7 +37,7 @@ export interface MentorType {
   about: string;
   seniority_level: string;
   expertises: [];
-  experiences: experienceType[];
+  experiences: MentorExperienceBlock[];
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
## What Does This PR Do?

- Remove `job_title` and `company` fields from onboarding Step 2 (schema, UI, form defaults) — these fields had no edit path after onboarding and caused data inconsistency
- Fix `MentorType.experiences` typing to match the actual API response structure (was using a stale `experienceType` with wrong fields)
- Derive mentor card `job_title`/`company` from the first WORK experience entry, with fallback to the top-level API fields — same logic as the profile page
- Hide the job/company row on the mentor card entirely when both are empty; only show "at" when both values are present

## Demo

http://localhost:3000/auth/onboarding
http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

Existing mentors whose `job_title`/`company` are empty strings but have work experiences populated will now correctly show their job info on the mentor card.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
