### PR TITLE
test: add E2E tests for reservation mentor view (#69)

### DIFF
--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -1,0 +1,54 @@
+/**
+ * Pre-warm all pages tested in the E2E suite.
+ *
+ * Next.js dev server compiles pages on first request, which can cause the very
+ * first test to time out while waiting for compilation to finish. This setup
+ * fires one HTTP GET per page before any test starts, so the compiled bundles
+ * are already cached when Playwright begins navigating.
+ *
+ * The requests are intentionally unauthenticated — we only care that Next.js
+ * has finished compiling the page, not that it renders correctly.
+ */
+
+import { request } from '@playwright/test';
+
+const BASE_URL = 'http://localhost:3000';
+
+/**
+ * Every page route exercised by at least one spec file.
+ *
+ * Next.js API routes (e.g. /api/auth/session) are compiled on first access
+ * just like page routes. Each page that renders the Header calls useSession(),
+ * which immediately hits /api/auth/session. Including it here ensures the
+ * NextAuth route handler is compiled before any test runs.
+ */
+const PAGES_TO_WARM = [
+  // Next.js API routes
+  '/api/auth/session',
+  '/api/auth/providers',
+  // App pages
+  '/',
+  '/mentor-pool',
+  '/auth/signin',
+  '/auth/signup',
+  '/auth/onboarding',
+  '/auth/password-forgot',
+  '/auth/password-reset',
+  '/profile/1/edit',
+  '/reservation/mentee',
+  '/reservation/mentor',
+];
+
+export default async function globalSetup(): Promise<void> {
+  const context = await request.newContext({ baseURL: BASE_URL });
+
+  await Promise.allSettled(
+    PAGES_TO_WARM.map((path) =>
+      context.get(path, { timeout: 60_000 }).catch(() => {
+        // Ignore errors (e.g. redirect, 401) — we only need compilation to start.
+      })
+    )
+  );
+
+  await context.dispose();
+}

--- a/e2e/helpers/route.ts
+++ b/e2e/helpers/route.ts
@@ -1,5 +1,32 @@
 import { Page } from '@playwright/test';
 
+const EXTERNAL_API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+/**
+ * Intercept any external API call that was NOT explicitly mocked by the test.
+ *
+ * Register this **after** all your `page.route(...)` mocks so it sits at the
+ * bottom of Playwright's LIFO stack and only catches unhandled requests.
+ * Unhandled calls are aborted immediately instead of waiting for the real AWS
+ * endpoint to time out.
+ *
+ * @example
+ * test.beforeEach(async ({ page }) => {
+ *   await page.route(/\/v1\/mentors/, handler);        // explicit mock
+ *   await blockUnmockedExternalApi(page);              // catch-all — register last
+ * });
+ */
+export async function blockUnmockedExternalApi(page: Page): Promise<void> {
+  if (!EXTERNAL_API_URL) return;
+
+  await page.route(EXTERNAL_API_URL + '**', (route) => {
+    console.warn(
+      `[E2E] Unmocked external API call aborted: ${route.request().url()}`
+    );
+    return route.abort('failed');
+  });
+}
+
 interface MockRouteOptions {
   status?: number;
   body: unknown;

--- a/e2e/tests/public/mentor-pool.spec.ts
+++ b/e2e/tests/public/mentor-pool.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { blockUnmockedExternalApi } from '../../helpers/route';
+
 // ─── Fixtures ────────────────────────────────────────────────────────────────
 
 const MOCK_INTERESTS = {
@@ -34,7 +36,7 @@ function makeMentor(id: number) {
 }
 
 function mentorResponse(mentors: ReturnType<typeof makeMentor>[]) {
-  return { code: '0', msg: 'ok', data: mentors };
+  return { code: '0', msg: 'ok', data: { mentors, next_id: 0 } };
 }
 
 const PAGE_LIMIT = 9;
@@ -50,6 +52,9 @@ test.beforeEach(async ({ page }) => {
       body: JSON.stringify(MOCK_INTERESTS),
     })
   );
+  // Abort any external API call not explicitly mocked above so tests fail fast
+  // instead of waiting for the real AWS endpoint to time out.
+  await blockUnmockedExternalApi(page);
 });
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/e2e/tests/reservation/reservation-mentor.spec.ts
+++ b/e2e/tests/reservation/reservation-mentor.spec.ts
@@ -1,0 +1,395 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { setSignedSessionCookie } from '../../helpers/session';
+
+const USER_ID = '1';
+const PAGE_URL = '/reservation/mentor';
+
+// ─── Mock payloads ───────────────────────────────────────────────────────────
+
+function makeSession() {
+  return {
+    user: {
+      id: USER_ID,
+      name: 'Test Mentor',
+      isMentor: true,
+      onBoarding: true,
+      jobTitle: '',
+      company: '',
+      personalLinks: [],
+    },
+    accessToken: 'mock-token',
+    expires: '2099-01-01T00:00:00.000Z',
+  };
+}
+
+function makeReservationResponse(reservations: object[]) {
+  return {
+    code: '0',
+    msg: 'ok',
+    data: {
+      reservations,
+      next_dtend: 0,
+    },
+  };
+}
+
+/**
+ * For MENTOR_* states the backend sets sender = mentor (current user),
+ * participant = mentee (the counterparty displayed in the card).
+ */
+function makeReservation(id: number, menteeName: string) {
+  return {
+    id,
+    sender: {
+      user_id: Number(USER_ID),
+      role: 'MENTOR',
+      status: 'PENDING',
+      name: 'Test Mentor',
+      avatar: '',
+      job_title: 'Senior Engineer',
+      years_of_experience: 'THREE_TO_FIVE',
+    },
+    participant: {
+      user_id: 99,
+      role: 'MENTEE',
+      status: 'PENDING',
+      name: menteeName,
+      avatar: '',
+      job_title: 'Engineer',
+      years_of_experience: 'ONE_TO_THREE',
+    },
+    schedule_id: id,
+    dtstart: 1704099600,
+    dtend: 1704103200,
+    previous_reserve: null,
+    messages: [],
+  };
+}
+
+function makePutResponse(id: number, status: 'ACCEPT' | 'REJECT') {
+  return {
+    code: '0',
+    msg: 'ok',
+    data: {
+      id,
+      status,
+      my_user_id: Number(USER_ID),
+      my_status: status,
+      my_role: 'MENTOR',
+      user_id: 99,
+      schedule_id: id,
+      dtstart: 1704099600,
+      dtend: 1704103200,
+      messages: [],
+      previous_reserve: {},
+    },
+  };
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+async function mockSessionGet(page: Page): Promise<void> {
+  await page.route(/\/api\/auth\/session/, (route) => {
+    if (route.request().method() === 'GET') {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeSession()),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Mock all 5 reservation list endpoints. The `stateData` map lets each test
+ * override specific states with custom payloads; any state not provided gets an
+ * empty list.
+ */
+async function mockReservationListEndpoints(
+  page: Page,
+  stateData: Partial<Record<string, object[]>> = {}
+): Promise<void> {
+  const defaults: Record<string, object[]> = {
+    MENTEE_UPCOMING: [],
+    MENTEE_PENDING: [],
+    MENTOR_UPCOMING: [],
+    MENTOR_PENDING: [],
+    HISTORY: [],
+  };
+  const data = { ...defaults, ...stateData };
+
+  // Pattern ends with `\?` to match only list endpoints (not /reservations/:id)
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations\\?`),
+    (route) => {
+      const url = new URL(route.request().url());
+      const state = url.searchParams.get('state') ?? '';
+      const reservations = data[state] ?? [];
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeReservationResponse(reservations)),
+      });
+    }
+  );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test('頁面載入 → 三個 Tab 可見', async ({ page }) => {
+  await setSignedSessionCookie(page, {
+    id: USER_ID,
+    name: 'Test Mentor',
+    isMentor: true,
+    onBoarding: true,
+    token: 'mock-access-token',
+  });
+  await mockSessionGet(page);
+  await mockReservationListEndpoints(page);
+
+  await page.goto(PAGE_URL);
+
+  await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible();
+  await expect(page.getByRole('tab', { name: /歷史紀錄/ })).toBeVisible();
+});
+
+test('待您回復 Tab → pending 預約卡片顯示，含接受與拒絕按鈕', async ({
+  page,
+}) => {
+  await setSignedSessionCookie(page, {
+    id: USER_ID,
+    name: 'Test Mentor',
+    isMentor: true,
+    onBoarding: true,
+    token: 'mock-access-token',
+  });
+  await mockSessionGet(page);
+  await mockReservationListEndpoints(page, {
+    MENTOR_PENDING: [makeReservation(1, 'Mentee Lee')],
+  });
+
+  await page.goto(PAGE_URL);
+
+  await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('tab', { name: /待您回復/ }).click();
+
+  // Card with the mentee's name appears
+  await expect(page.getByText('Mentee Lee')).toBeVisible({ timeout: 10_000 });
+
+  // AcceptReservationDialog trigger button
+  await expect(page.getByRole('button', { name: /接受/ })).toBeVisible();
+});
+
+test('點擊接受並確認 → 卡片移至即將到來 Tab', async ({ page }) => {
+  await setSignedSessionCookie(page, {
+    id: USER_ID,
+    name: 'Test Mentor',
+    isMentor: true,
+    onBoarding: true,
+    token: 'mock-access-token',
+  });
+  await mockSessionGet(page);
+
+  // State flag: after PUT succeeds, reload should return updated lists
+  let putCalled = false;
+
+  // Intercept PUT to flip the state flag
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations/\\d+`),
+    (route) => {
+      if (route.request().method() === 'PUT') {
+        putCalled = true;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(makePutResponse(1, 'ACCEPT')),
+        });
+      }
+      return route.continue();
+    }
+  );
+
+  // List endpoints — respond based on whether PUT has been called
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations\\?`),
+    (route) => {
+      const url = new URL(route.request().url());
+      const state = url.searchParams.get('state') ?? '';
+      const reservations = putCalled
+        ? state === 'MENTOR_UPCOMING'
+          ? [makeReservation(1, 'Mentee Lee')]
+          : []
+        : state === 'MENTOR_PENDING'
+          ? [makeReservation(1, 'Mentee Lee')]
+          : [];
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeReservationResponse(reservations)),
+      });
+    }
+  );
+
+  await page.goto(PAGE_URL);
+
+  // Navigate to 待您回復 and open the accept dialog
+  await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('tab', { name: /待您回復/ }).click();
+  await expect(page.getByText('Mentee Lee')).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole('button', { name: /接受/ }).click();
+
+  // Dialog opens at step 'check'; confirm by clicking 接收
+  await expect(page.getByRole('button', { name: /接收/ })).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.getByRole('button', { name: /接收/ }).click();
+
+  // Page reloads; wait for tabs to re-render
+  await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // The accepted reservation should now appear in 即將到來
+  await page.getByRole('tab', { name: /即將到來/ }).click();
+  await expect(page.getByText('Mentee Lee')).toBeVisible({ timeout: 10_000 });
+
+  // 待您回復 should now be empty
+  await page.getByRole('tab', { name: /待您回復/ }).click();
+  await expect(page.getByText('Mentee Lee')).not.toBeVisible();
+});
+
+test('點擊拒絕並填入原因後確認 → 卡片從待您回復消失', async ({ page }) => {
+  await setSignedSessionCookie(page, {
+    id: USER_ID,
+    name: 'Test Mentor',
+    isMentor: true,
+    onBoarding: true,
+    token: 'mock-access-token',
+  });
+  await mockSessionGet(page);
+
+  let putCalled = false;
+
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations/\\d+`),
+    (route) => {
+      if (route.request().method() === 'PUT') {
+        putCalled = true;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(makePutResponse(1, 'REJECT')),
+        });
+      }
+      return route.continue();
+    }
+  );
+
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations\\?`),
+    (route) => {
+      const url = new URL(route.request().url());
+      const state = url.searchParams.get('state') ?? '';
+      const reservations =
+        !putCalled && state === 'MENTOR_PENDING'
+          ? [makeReservation(1, 'Mentee Lee')]
+          : [];
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeReservationResponse(reservations)),
+      });
+    }
+  );
+
+  await page.goto(PAGE_URL);
+
+  // Navigate to 待您回復 and open the accept dialog
+  await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('tab', { name: /待您回復/ }).click();
+  await expect(page.getByText('Mentee Lee')).toBeVisible({ timeout: 10_000 });
+
+  await page.getByRole('button', { name: /接受/ }).click();
+
+  // Dialog opens at step 'check'; click 拒絕 to go to step 'reject'
+  await expect(page.getByRole('button', { name: /拒絕/ }).first()).toBeVisible({
+    timeout: 5_000,
+  });
+  await page.getByRole('button', { name: /拒絕/ }).first().click();
+
+  // Step 'reject': textarea must be filled before confirming
+  await page.getByPlaceholder(/請在此輸入原因/).fill('時間不符');
+
+  // Confirm rejection
+  await page.getByRole('button', { name: /拒絕/ }).click();
+
+  // Page reloads; wait for tabs to re-render
+  await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible({
+    timeout: 15_000,
+  });
+  await page.getByRole('tab', { name: /待您回復/ }).click();
+
+  // Card should be gone
+  await expect(page.getByText('Mentee Lee')).not.toBeVisible();
+});
+
+test('資料載入中 → Skeleton 顯示且不閃爍錯誤內容', async ({ page }) => {
+  await setSignedSessionCookie(page, {
+    id: USER_ID,
+    name: 'Test Mentor',
+    isMentor: true,
+    onBoarding: true,
+    token: 'mock-access-token',
+  });
+  await mockSessionGet(page);
+
+  // Hold all reservation responses until we release the promise
+  let resolveDelay!: () => void;
+  const delay = new Promise<void>((res) => {
+    resolveDelay = res;
+  });
+
+  await page.route(
+    new RegExp(`/v1/users/${USER_ID}/reservations\\?`),
+    async (route) => {
+      await delay;
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(makeReservationResponse([])),
+      });
+    }
+  );
+
+  await page.goto(PAGE_URL);
+
+  // Skeleton should be visible while responses are held
+  await expect(page.locator('.animate-pulse').first()).toBeVisible({
+    timeout: 10_000,
+  });
+
+  // Real tabs must not be visible yet
+  await expect(page.getByRole('tab', { name: /即將到來/ })).not.toBeVisible();
+
+  // Release responses and wait for real content
+  resolveDelay();
+
+  await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({
+    timeout: 15_000,
+  });
+
+  // Skeleton should be gone
+  await expect(page.locator('.animate-pulse').first()).not.toBeVisible();
+});

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -14,6 +14,7 @@ config({ path: path.resolve(__dirname, '.env.e2e.local'), override: true });
 
 export default defineConfig({
   testDir: './e2e/tests',
+  globalSetup: './e2e/global-setup.ts',
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,


### PR DESCRIPTION
## What Does This PR Do?

- Add `e2e/tests/reservation/reservation-mentor.spec.ts` with 5 tests covering the mentor reservation page: tab visibility, pending card display, accept/reject flows, and skeleton loading state
- Add `e2e/global-setup.ts` to pre-warm Next.js pages before tests run, preventing first-test compilation timeouts
- Add `blockUnmockedExternalApi` helper to abort unmocked external API calls immediately instead of waiting for timeout
- Fix `mentorResponse` shape in `mentor-pool.spec.ts` to include `next_id: 0` matching the updated API response
- Wire `globalSetup` into `playwright.config.ts`

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
