### PR TITLE
feat: add adaptor layer to align mentor search types with BFF schema

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -86,7 +86,7 @@ jobs:
         id: depcheck
         run: |
           output=$(npx depcheck \
-            --ignores="@types/*,eslint-*,prettier-*,postcss,autoprefixer,tailwindcss,husky,lint-staged,storybook,@storybook/*,tsconfig-paths-webpack-plugin,tailwindcss-animate,jimp,@playwright/test,@testing-library/user-event" \
+            --ignores="@types/*,eslint-*,prettier-*,postcss,autoprefixer,tailwindcss,husky,lint-staged,storybook,@storybook/*,tsconfig-paths-webpack-plugin,tailwindcss-animate,jimp,@playwright/test,@testing-library/user-event,openapi-typescript" \
             2>&1) || true
           echo "$output"
           if echo "$output" | grep -qE "^Unused (dependencies|devDependencies)"; then

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -104,9 +104,9 @@ export default function MentorPoolContainer() {
           typeof mentor.avatar === 'string' && mentor.avatar
             ? mentor.avatar
             : avatarImage;
-        mentor.skills = (mentor.skills as string[]).map(
+        mentor.skills = mentor.skills.map(
           (s) => skillLabelMapRef.current[s] ?? s
-        ) as [];
+        );
       });
       setMentors(rtnList);
       setMentorCount(rtnList.length);
@@ -142,9 +142,9 @@ export default function MentorPoolContainer() {
           typeof mentor.avatar === 'string' && mentor.avatar
             ? mentor.avatar
             : avatarImage;
-        mentor.skills = (mentor.skills as string[]).map(
+        mentor.skills = mentor.skills.map(
           (s) => skillLabelMapRef.current[s] ?? s
-        ) as [];
+        );
       });
       setMentors((prevMentors) => {
         const newMentors = rtnList.filter(

--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -13,8 +13,11 @@ function deriveCurrentJob(experiences: MentorExperienceBlock[]): {
   company: string;
 } {
   const firstWork = experiences.find((e) => e.category === 'WORK');
-  const metadata: WorkExperienceMetadata | undefined =
-    firstWork?.mentor_experiences_metadata?.data?.[0];
+  const metadata: WorkExperienceMetadata | undefined = (
+    firstWork?.mentor_experiences_metadata as
+      | { data?: WorkExperienceMetadata[] }
+      | undefined
+  )?.data?.[0];
   return {
     job_title: metadata?.job ?? '',
     company: metadata?.company ?? '',

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -13,7 +13,7 @@ export interface MentorCardProps {
   job_title: string;
   company: string;
   personalStatment: string;
-  skills: [];
+  skills: string[];
 }
 
 const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,6 +1,10 @@
 import { StaticImageData } from 'next/image';
 
 import { apiClient } from '@/lib/apiClient';
+import { components } from '@/types/api';
+
+type RawMentor = components['schemas']['SearchMentorProfileVO'];
+type ExperienceCategory = components['schemas']['ExperienceCategory'];
 
 export interface WorkExperienceMetadata {
   job?: string;
@@ -14,9 +18,9 @@ export interface WorkExperienceMetadata {
 
 export interface MentorExperienceBlock {
   id: number;
-  category: string;
+  category: ExperienceCategory;
   order: number;
-  mentor_experiences_metadata?: { data?: WorkExperienceMetadata[] };
+  mentor_experiences_metadata?: Record<string, unknown>;
 }
 
 export interface MentorType {
@@ -27,24 +31,21 @@ export interface MentorType {
   company: string;
   years_of_experience: string;
   location: string;
-  linkedin_profile: string;
-  interested_positions: [];
-  skills: [];
-  topics: [];
-  industry: string;
-  language: string;
   personal_statement: string;
   about: string;
   seniority_level: string;
-  expertises: [];
+  interested_positions: string[];
+  skills: string[];
+  topics: string[];
+  industry: string | null;
+  expertises: string[];
   experiences: MentorExperienceBlock[];
-  created_at: string;
-  updated_at: string;
+  updated_at: number | null;
 }
 
 export interface MentorsType {
   mentors: MentorType[];
-  next_id: number;
+  next_id: number | null;
 }
 
 export interface MentorRequest {
@@ -61,7 +62,41 @@ export interface MentorRequest {
 interface MentorResponse {
   code: string;
   msg: string;
-  data: MentorsType;
+  data: {
+    mentors: RawMentor[];
+    next_id: number | null;
+  };
+}
+
+function mapMentor(raw: RawMentor): MentorType {
+  return {
+    user_id: raw.user_id,
+    name: raw.name ?? '',
+    avatar: raw.avatar ?? '',
+    job_title: raw.job_title ?? '',
+    company: raw.company ?? '',
+    years_of_experience: raw.years_of_experience ?? '',
+    location: raw.location ?? '',
+    personal_statement: raw.personal_statement ?? '',
+    about: raw.about ?? '',
+    seniority_level: raw.seniority_level ?? '',
+    interested_positions:
+      raw.interested_positions?.interests?.map((i) => i.subject_group) ?? [],
+    skills: raw.skills?.interests?.map((i) => i.subject_group) ?? [],
+    topics: raw.topics?.interests?.map((i) => i.subject_group) ?? [],
+    industry: raw.industry?.subject ?? null,
+    expertises: raw.expertises?.professions?.map((p) => p.subject) ?? [],
+    experiences: (raw.experiences ?? []).map((e) => ({
+      id: e.id,
+      category: e.category ?? 'WORK',
+      order: e.order,
+      mentor_experiences_metadata: e.mentor_experiences_metadata as Record<
+        string,
+        unknown
+      >,
+    })),
+    updated_at: raw.updated_at ?? null,
+  };
 }
 
 export async function fetchMentors(
@@ -77,7 +112,7 @@ export async function fetchMentors(
       console.error(`API Error: ${result.msg}`);
       return [];
     }
-    return result.data.mentors;
+    return result.data.mentors.map(mapMentor);
   } catch (error) {
     console.error('Fetch Mentors Error:', error);
     return [];


### PR DESCRIPTION
## What Does This PR Do?

- Replace hand-written `MentorType` fields with types derived from the generated `SearchMentorProfileVO` schema
- Add `mapMentor()` adaptor function in `mentors.ts` to convert raw BFF response into a clean `MentorType` view model
- Map nested objects to flat primitives: `InterestListVO` → `string[]`, `ProfessionVO` → `string | null`, `ProfessionListVO` → `string[]`
- Remove fields absent from search response: `linkedin_profile`, `language`, `created_at`
- Fix `MentorExperienceBlock.mentor_experiences_metadata` type to `Record<string, unknown>` with safe cast in `deriveCurrentJob`
- Remove unsafe `as string[]` / `as []` casts from `container.tsx`
- Fix `MentorCardProps.skills: []` → `string[]` to align with `Information` component

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

`mentor_experiences_metadata` is typed as `Record<string, never>` in the generated OpenAPI spec (undocumented shape). A safe cast to `{ data?: WorkExperienceMetadata[] }` is used in `deriveCurrentJob` since the actual BFF payload still carries that structure.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
