### PR TITLE
feat: migrate auth service types to generated API types (#83)

### DIFF
--- a/src/services/auth/googleSignUp.ts
+++ b/src/services/auth/googleSignUp.ts
@@ -1,4 +1,5 @@
 import { apiClient, ApiError } from '@/lib/apiClient';
+import type { components } from '@/types/api';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 import {
@@ -14,10 +15,8 @@ export interface GoogleSignUpType {
   oauth_id: string;
 }
 
-interface GoogleSignUpApiResponse {
-  code: string;
-  message?: string;
-}
+type GoogleSignUpApiResponse =
+  components['schemas']['ApiResponse_GoogleCallbackVO_'];
 
 export async function googleSignUp(
   values: GoogleSignUpType
@@ -30,7 +29,7 @@ export async function googleSignUp(
     );
 
     if (result.code === '0') return createSignUpSuccessResponse();
-    throw createGeneralErrorResponse(200, result.message || '註冊失敗');
+    throw createGeneralErrorResponse(200, result.msg || '註冊失敗');
   } catch (error) {
     if (error instanceof ApiError) {
       if (error.status === 422) throw createValidationErrorResponse();

--- a/src/services/auth/resetPassword.ts
+++ b/src/services/auth/resetPassword.ts
@@ -1,12 +1,9 @@
 import { apiClient } from '@/lib/apiClient';
+import type { components } from '@/types/api';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 
-interface ResetPasswordApiResponse {
-  code: string;
-  msg: string;
-  data: null;
-}
+type ResetPasswordApiResponse = components['schemas']['ApiResponse_NoneType_'];
 
 export async function resetPassword(
   verifyToken: string,

--- a/src/services/auth/resetPasswordByEmail.ts
+++ b/src/services/auth/resetPasswordByEmail.ts
@@ -1,14 +1,10 @@
 import { apiClient } from '@/lib/apiClient';
+import type { components } from '@/types/api';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 
-interface ResetPasswordByEmailApiResponse {
-  code: string;
-  msg: string;
-  data: {
-    ttl_secs: number;
-  };
-}
+type ResetPasswordByEmailApiResponse =
+  components['schemas']['ApiResponse_EmailSentVO_'];
 
 export async function resetPassword(email: string): Promise<AuthResponse> {
   try {

--- a/src/services/auth/signUp.ts
+++ b/src/services/auth/signUp.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 
 import { apiClient, ApiError } from '@/lib/apiClient';
 import { SignUpSchema } from '@/schemas/auth';
+import type { components } from '@/types/api';
 
 import { AuthResponse, createGeneralErrorResponse } from '../types';
 import {
@@ -11,10 +12,7 @@ import {
   createValidationErrorResponse,
 } from './signUpResponseHandlers';
 
-interface SignUpApiResponse {
-  code: string;
-  message?: string;
-}
+type SignUpApiResponse = components['schemas']['ApiResponse_SignupResponseVO_'];
 
 export async function signUp(
   values: z.infer<typeof SignUpSchema>
@@ -31,7 +29,7 @@ export async function signUp(
     );
 
     if (result.code === '0') return createSignUpSuccessResponse();
-    throw createGeneralErrorResponse(200, result.message || '註冊失敗');
+    throw createGeneralErrorResponse(200, result.msg || '註冊失敗');
   } catch (error) {
     if (error instanceof ApiError) {
       if (error.status === 422) throw createValidationErrorResponse();


### PR DESCRIPTION
## What Does This PR Do?

- Replace handwritten `SignUpApiResponse` interface with `components['schemas']['ApiResponse_SignupResponseVO_']`
- Replace handwritten `GoogleSignUpApiResponse` interface with `components['schemas']['ApiResponse_GoogleCallbackVO_']`
- Replace handwritten `ResetPasswordApiResponse` interface with `components['schemas']['ApiResponse_NoneType_']`
- Replace handwritten `ResetPasswordByEmailApiResponse` interface with `components['schemas']['ApiResponse_EmailSentVO_']`
- Update `result.message` → `result.msg` in `signUp.ts` and `googleSignUp.ts` to align with generated type field names

## Demo

http://localhost:3000/auth/signup

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
