### PR TITLE
feat: migrate search domain types to generated API types

### DIFF
--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -1,9 +1,9 @@
 import { memo, useEffect, useRef } from 'react';
 
+import { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
 import {
   MentorExperienceBlock,
   MentorType,
-  WorkExperienceMetadata,
 } from '@/services/search-mentor/mentors';
 
 import { MentorCard } from '../mentor-card';

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -43,7 +43,9 @@ export interface WorkExperienceMetadata {
   company?: string;
   jobPeriodStart?: string;
   jobPeriodEnd?: string;
+  jobLocation?: string;
   description?: string;
+  industry?: string;
 }
 
 export interface EducationExperienceMetadata {

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,20 +1,15 @@
 import { StaticImageData } from 'next/image';
 
+import { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
 import { apiClient } from '@/lib/apiClient';
 import { components } from '@/types/api';
 
 type RawMentor = components['schemas']['SearchMentorProfileVO'];
 type ExperienceCategory = components['schemas']['ExperienceCategory'];
+type MentorListResponse =
+  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
 
-export interface WorkExperienceMetadata {
-  job?: string;
-  company?: string;
-  jobPeriodStart?: string;
-  jobPeriodEnd?: string;
-  jobLocation?: string;
-  description?: string;
-  industry?: string;
-}
+export type { WorkExperienceMetadata };
 
 export interface MentorExperienceBlock {
   id: number;
@@ -43,10 +38,7 @@ export interface MentorType {
   updated_at: number | null;
 }
 
-export interface MentorsType {
-  mentors: MentorType[];
-  next_id: number | null;
-}
+export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
 
 export interface MentorRequest {
   searchPattern?: string;
@@ -57,15 +49,6 @@ export interface MentorRequest {
   filter_industries?: string;
   limit: number;
   cursor?: string;
-}
-
-interface MentorResponse {
-  code: string;
-  msg: string;
-  data: {
-    mentors: RawMentor[];
-    next_id: number | null;
-  };
 }
 
 function mapMentor(raw: RawMentor): MentorType {
@@ -103,7 +86,7 @@ export async function fetchMentors(
   param: MentorRequest
 ): Promise<MentorType[]> {
   try {
-    const result = await apiClient.get<MentorResponse>('/v1/mentors', {
+    const result = await apiClient.get<MentorListResponse>('/v1/mentors', {
       auth: false,
       params: param as unknown as Record<string, string | number | undefined>,
     });
@@ -112,7 +95,7 @@ export async function fetchMentors(
       console.error(`API Error: ${result.msg}`);
       return [];
     }
-    return result.data.mentors.map(mapMentor);
+    return (result.data?.mentors ?? []).map(mapMentor);
   } catch (error) {
     console.error('Fetch Mentors Error:', error);
     return [];


### PR DESCRIPTION
## What Does This PR Do?

- Remove hand-written `MentorResponse` wrapper interface in `mentors.ts`; replace with generated `ApiResponse_SearchMentorProfileListVO_` type
- Replace hand-written `MentorsType` with a `SearchMentorProfileListVO` type alias
- Add null guard on `result.data?.mentors` to match the generated type's optional field
- Consolidate duplicate `WorkExperienceMetadata` definition into `useUserData.ts` (canonical source); add missing `jobLocation` and `industry` fields
- Re-export `WorkExperienceMetadata` from `mentors.ts` for backward compatibility
- Update `mentor-card-list/index.tsx` import to source `WorkExperienceMetadata` from `useUserData.ts`

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

Adaptor layer (`RawMentor → MentorType`) is untouched. `MentorType` remains as a front-end display type produced by the adaptor.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
