### PR TITLE
feat: migrate schedule domain types to generated API types

### DIFF
--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -11,7 +11,7 @@ import {
   deleteMentorSchedule,
   fetchMentorSchedule,
   saveMentorSchedule,
-  ScheduleTimeSlots,
+  TimeSlotVO,
   UpsertTimeslotBackend,
 } from '@/services/mentor-schedule/schedule';
 
@@ -122,19 +122,13 @@ const nextTempId = (rows: RawMentorTimeslot[]) => {
   return negatives.length ? Math.min(...negatives) - 1 : -1;
 };
 
-const backendToRaw = (t: ScheduleTimeSlots): RawMentorTimeslot => {
-  const toUnixSec = (v: unknown): number => {
-    if (typeof v === 'number') return v > 1e12 ? Math.floor(v / 1000) : v;
-    return Math.floor(new Date(v as string | number | Date).getTime() / 1000);
-  };
-  return {
-    id: Number(t.id) || Math.floor(Math.random() * 1e9),
-    type: t.dt_type,
-    dtstart: toUnixSec(t.dtstart),
-    dtend: toUnixSec(t.dtend),
-    rrule: t.rrule ?? '',
-  };
-};
+const backendToRaw = (t: TimeSlotVO): RawMentorTimeslot => ({
+  id: t.id || Math.floor(Math.random() * 1e9),
+  type: t.dt_type as 'ALLOW' | 'BLOCK',
+  dtstart: t.dtstart,
+  dtend: t.dtend,
+  rrule: t.rrule ?? '',
+});
 
 export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
   const {

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/apiClient';
+import { components } from '@/types/api';
 
 export interface ScheduleRequest {
   userId: string;
@@ -6,49 +7,38 @@ export interface ScheduleRequest {
   month: number;
 }
 
-export interface ScheduleTimeSlots {
-  id: string;
-  user_id: string;
-  dt_type: 'ALLOW' | 'BLOCK';
-  dt_year: string;
-  dt_month: string;
-  dtstart: Date;
-  dtend: Date;
-  timezone: string;
-  rrule: string;
-  exdate: [];
-}
+export type TimeSlotVO = components['schemas']['TimeSlotVO'];
 
 export interface BookedSlot {
   dtstart: number; // unix seconds
   dtend: number; // unix seconds
 }
 
-export interface ScheduleType {
-  timeslots: ScheduleTimeSlots[] | [];
+// MentorScheduleVO does not document these fields in the OpenAPI spec;
+// they are kept as optional extensions for runtime compatibility.
+export type ScheduleData = components['schemas']['MentorScheduleVO'] & {
   meeting_duration_minutes?: number;
   booked_slots?: BookedSlot[];
-  next_dtstart: string;
-}
+};
 
-interface ScheduleResponse {
+interface ScheduleApiResponse {
   code: string;
   msg: string;
-  data: ScheduleType;
+  data: ScheduleData;
 }
 
 export async function fetchMentorSchedule(
   param: ScheduleRequest
-): Promise<ScheduleType> {
+): Promise<ScheduleData> {
   try {
-    const result = await apiClient.get<ScheduleResponse>(
+    const result = await apiClient.get<ScheduleApiResponse>(
       `/v1/mentors/${param.userId}/schedule/y/${param.year}/m/${param.month}`,
       { auth: false }
     );
-    if (result.code !== '0') return {} as ScheduleType;
+    if (result.code !== '0') return {} as ScheduleData;
     return result.data;
   } catch {
-    return {} as ScheduleType;
+    return {} as ScheduleData;
   }
 }
 


### PR DESCRIPTION
## What Does This PR Do?

- Replace hand-written `ScheduleTimeSlots`, `ScheduleType`, and `ScheduleResponse` with generated `components['schemas']['TimeSlotVO']` and `MentorScheduleVO`
- Export `TimeSlotVO` alias from service for hook consumption
- Add `ScheduleData` intersection type to extend `MentorScheduleVO` with `meeting_duration_minutes` and `booked_slots` (undocumented in OpenAPI spec, kept for runtime compatibility)
- Remove `toUnixSec` Date-branch in `backendToRaw` — `dtstart`/`dtend` are now correctly typed as `number`
- Add `dt_type as 'ALLOW' | 'BLOCK'` assertion (generated type is `string`)

## Demo

http://localhost:3000/profile/[pageUserId]/edit

## Screenshot

N/A

## Anything to Note?

`meeting_duration_minutes` and `booked_slots` are absent from `MentorScheduleVO` in the OpenAPI spec. They are retained as optional intersection fields until the BFF schema is updated.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
