### PR TITLE
feat: add delete account flow for test accounts (#79)

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -51,6 +51,7 @@ const authOptions = {
         return {
           id: String(response.data.auth.user_id),
           token: response.data.auth.token,
+          email: response.data.auth.email,
           onBoarding: response.data.user.onboarding,
           isMentor: response.data.user.is_mentor,
           name: response.data.user.name,
@@ -113,9 +114,13 @@ const authOptions = {
   ],
 
   callbacks: {
-    async jwt({ token, user, trigger, session }) {
+    async jwt({ token, user, account, trigger, session }) {
       if (user) {
-        return { ...token, ...user };
+        return {
+          ...token,
+          ...user,
+          ...(account ? { provider: account.provider } : {}),
+        };
       }
 
       if (trigger === 'update' && session?.user) {
@@ -144,6 +149,9 @@ const authOptions = {
       };
 
       session.accessToken = (token.token as string | undefined) ?? undefined;
+      session.user.provider =
+        (token.provider as string | undefined) ?? undefined;
+      session.user.email = (token.email as string | undefined) ?? undefined;
       return session;
     },
   },

--- a/src/components/auth/DeleteAccountDialog.tsx
+++ b/src/components/auth/DeleteAccountDialog.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import * as React from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import useDeleteAccountForm from '@/hooks/auth/useDeleteAccountForm';
+
+interface DeleteAccountDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function DeleteAccountDialog({
+  open,
+  onOpenChange,
+}: DeleteAccountDialogProps): JSX.Element {
+  const router = useRouter();
+  const { mode, xcForm, isSubmitting, blockedByReservations, onSubmitXC } =
+    useDeleteAccountForm();
+
+  const handleClose = (): void => {
+    if (isSubmitting) return;
+    xcForm.reset();
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="text-destructive">刪除帳號</DialogTitle>
+          <DialogDescription>
+            此操作無法復原。帳號刪除後，所有資料將永久移除。
+          </DialogDescription>
+        </DialogHeader>
+
+        {blockedByReservations && (
+          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+            您目前有未完成或未來的預約，請先處理後再刪除帳號。
+            <button
+              type="button"
+              className="ml-1 underline"
+              onClick={() => {
+                handleClose();
+                router.push('/reservation/mentee');
+              }}
+            >
+              前往預約管理
+            </button>
+          </div>
+        )}
+
+        {mode === 'google' ? (
+          <div className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              Google 帳號的刪除流程需要後端提供 re-auth 授權
+              URL，目前尚未實作。請聯絡客服處理。
+            </p>
+            <DialogFooter>
+              <Button variant="outline" onClick={handleClose}>
+                關閉
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <Form {...xcForm}>
+            <form
+              onSubmit={xcForm.handleSubmit(onSubmitXC)}
+              className="space-y-4"
+            >
+              <FormField
+                control={xcForm.control}
+                name="email"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>電子郵件</FormLabel>
+                    <FormControl>
+                      <Input {...field} type="email" disabled />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={xcForm.control}
+                name="password"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>請輸入密碼確認身分</FormLabel>
+                    <FormControl>
+                      <Input
+                        {...field}
+                        type="password"
+                        placeholder="輸入您的登入密碼"
+                        autoComplete="current-password"
+                      />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <DialogFooter>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={handleClose}
+                  disabled={isSubmitting}
+                >
+                  取消
+                </Button>
+                <Button
+                  type="submit"
+                  variant="destructive"
+                  disabled={isSubmitting}
+                >
+                  {isSubmitting ? '處理中…' : '確認刪除帳號'}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -8,6 +8,7 @@ import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
+import { DeleteAccountDialog } from '@/components/auth/DeleteAccountDialog';
 import { Button } from '@/components/ui/button';
 import {
   Sheet,
@@ -28,11 +29,17 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
   const router = useRouter();
   const [open, setOpen] = React.useState(false);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
   const close = (): void => setOpen(false);
 
   const userId = user.id;
   const isMentor = Boolean(user.isMentor);
+  const canDeleteAccount = [
+    'testing_visitor@xchange.com.tw',
+    'testing_mentee@xchange.com.tw',
+    'testing_mentor@xchange.com.tw',
+  ].includes(user.email ?? '');
   const name = user.name ?? '';
   const avatarSrc = user.avatar
     ? `${getAvatarThumbUrl(user.avatar)}?cb=${user.avatarUpdatedAt ?? 0}`
@@ -78,6 +85,11 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
   const handleMyReservation = (): void => {
     close();
     router.push('/reservation/mentee');
+  };
+
+  const handleDeleteAccount = (): void => {
+    close();
+    requestAnimationFrame(() => setDeleteDialogOpen(true));
   };
 
   const handleLogout = (): void => {
@@ -168,7 +180,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               </button>
             </nav>
 
-            <div className="pb-6">
+            <div className="flex flex-col pb-6">
               <button
                 type="button"
                 className="text-black py-4 text-left text-xl"
@@ -176,10 +188,24 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               >
                 登出
               </button>
+              {canDeleteAccount && (
+                <button
+                  type="button"
+                  className="py-4 text-left text-xl text-destructive"
+                  onClick={handleDeleteAccount}
+                >
+                  刪除帳號
+                </button>
+              )}
             </div>
           </div>
         </SheetContent>
       </Sheet>
+
+      <DeleteAccountDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+      />
 
       <ShareProfileDialog
         open={shareDialogOpen}

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -7,6 +7,7 @@ import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
+import { DeleteAccountDialog } from '@/components/auth/DeleteAccountDialog';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
@@ -28,9 +29,15 @@ export const UserDropdown = React.memo(function UserDropdown({
   const router = useRouter();
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
   const userId = user.id;
   const isMentor = Boolean(user.isMentor);
+  const canDeleteAccount = [
+    'testing_visitor@xchange.com.tw',
+    'testing_mentee@xchange.com.tw',
+    'testing_mentor@xchange.com.tw',
+  ].includes(user.email ?? '');
   const name = user.name ?? '';
   // Use the thumbnail variant for all small avatar displays in the header /
   // dropdown / share dialog — the full-size image is only needed on the profile page.
@@ -80,6 +87,13 @@ export const UserDropdown = React.memo(function UserDropdown({
     setMenuOpen(false);
     router.push('/reservation/mentee');
   }, [router]);
+
+  const handleDeleteAccount = React.useCallback((): void => {
+    setMenuOpen(false);
+    requestAnimationFrame(() => {
+      setDeleteDialogOpen(true);
+    });
+  }, []);
 
   const handleLogout = React.useCallback((): void => {
     setMenuOpen(false);
@@ -167,9 +181,23 @@ export const UserDropdown = React.memo(function UserDropdown({
             >
               登出
             </DropdownMenuItem>
+
+            {canDeleteAccount && (
+              <DropdownMenuItem
+                className="px-4 py-3 text-2xl text-destructive focus:text-destructive"
+                onClick={handleDeleteAccount}
+              >
+                刪除帳號
+              </DropdownMenuItem>
+            )}
           </div>
         </DropdownMenuContent>
       </DropdownMenu>
+
+      <DeleteAccountDialog
+        open={deleteDialogOpen}
+        onOpenChange={setDeleteDialogOpen}
+      />
 
       <ShareProfileDialog
         open={shareDialogOpen}

--- a/src/hooks/auth/useDeleteAccountForm.ts
+++ b/src/hooks/auth/useDeleteAccountForm.ts
@@ -1,0 +1,75 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { signOut, useSession } from 'next-auth/react';
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { useToast } from '@/components/ui/use-toast';
+import { trackEvent } from '@/lib/analytics';
+import { captureFlowFailure } from '@/lib/monitoring';
+import { DeleteAccountXCSchema } from '@/schemas/auth';
+import { deleteAccount } from '@/services/auth/deleteAccount';
+
+type XCValues = z.infer<typeof DeleteAccountXCSchema>;
+
+export type DeleteAccountMode = 'xc' | 'google';
+
+interface UseDeleteAccountFormReturn {
+  mode: DeleteAccountMode;
+  xcForm: ReturnType<typeof useForm<XCValues>>;
+  isSubmitting: boolean;
+  blockedByReservations: boolean;
+  onSubmitXC: (values: XCValues) => Promise<void>;
+}
+
+export default function useDeleteAccountForm(): UseDeleteAccountFormReturn {
+  const { data: session } = useSession();
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [blockedByReservations, setBlockedByReservations] = useState(false);
+
+  const mode: DeleteAccountMode =
+    session?.user?.provider === 'custom-google-token' ? 'google' : 'xc';
+
+  const xcForm = useForm<XCValues>({
+    resolver: zodResolver(DeleteAccountXCSchema),
+    defaultValues: { email: session?.user?.email ?? '', password: '' },
+  });
+
+  const onSubmitXC = async (values: XCValues): Promise<void> => {
+    setIsSubmitting(true);
+    setBlockedByReservations(false);
+    try {
+      const result = await deleteAccount({
+        email: values.email,
+        password: values.password,
+      });
+
+      if (result.status === 'success') {
+        trackEvent({ name: 'delete_account_succeeded', feature: 'auth' });
+        await signOut({ callbackUrl: '/' });
+        return;
+      }
+
+      if (result.status === 'blocked_reservations') {
+        setBlockedByReservations(true);
+        return;
+      }
+
+      captureFlowFailure({
+        flow: 'delete_account',
+        step: 'submit',
+        message: result.message,
+      });
+      toast({
+        variant: 'destructive',
+        description: result.message || '刪除帳號失敗，請稍後再試',
+        duration: 3000,
+      });
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return { mode, xcForm, isSubmitting, blockedByReservations, onSubmitXC };
+}

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -147,6 +147,6 @@ export const apiClient = {
   patch: <T>(path: string, body?: unknown, options?: RequestOptions) =>
     request<T>('PATCH', path, body, options),
 
-  delete: <T>(path: string, options?: RequestOptions) =>
-    request<T>('DELETE', path, undefined, options),
+  delete: <T>(path: string, body?: unknown, options?: RequestOptions) =>
+    request<T>('DELETE', path, body, options),
 };

--- a/src/schemas/auth.ts
+++ b/src/schemas/auth.ts
@@ -32,3 +32,13 @@ export const PasswordResetSchema = z
 export const PasswordForgotSchema = z.object({
   email: z.string().email('請輸入電子郵件'),
 });
+
+export const DeleteAccountXCSchema = z.object({
+  email: z.string().email('請輸入電子郵件'),
+  password: z.string().min(1, '請輸入密碼'),
+});
+
+export const DeleteAccountGoogleSchema = z.object({
+  email: z.string().email('請輸入電子郵件'),
+  id_token: z.string().min(1, '請先完成 Google 身分驗證'),
+});

--- a/src/services/auth/deleteAccount.ts
+++ b/src/services/auth/deleteAccount.ts
@@ -1,0 +1,30 @@
+import { getSession } from 'next-auth/react';
+
+import { apiClient, ApiError } from '@/lib/apiClient';
+import type { components } from '@/types/api';
+
+type DeleteAccountDTO = components['schemas']['DeleteAccountDTO'];
+
+export type DeleteAccountResult =
+  | { status: 'success' }
+  | { status: 'blocked_reservations' }
+  | { status: 'error'; message: string };
+
+export async function deleteAccount(
+  payload: DeleteAccountDTO
+): Promise<DeleteAccountResult> {
+  try {
+    const session = await getSession();
+    const token = session?.accessToken;
+    await apiClient.delete('/v1/auth/account', payload, {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    });
+    return { status: 'success' };
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (error.status === 409) return { status: 'blocked_reservations' };
+      return { status: 'error', message: error.message };
+    }
+    return { status: 'error', message: '系統錯誤，請稍後再試' };
+  }
+}

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -18,6 +18,8 @@ declare module 'next-auth' {
     company?: string;
     personalLinks?: PersonalLink[];
     msg?: string;
+    /** NextAuth provider id: 'credentials' = XC, 'custom-google-token' = Google */
+    provider?: string;
   }
 
   interface Session {
@@ -39,5 +41,6 @@ declare module 'next-auth/jwt' {
     company?: string;
     personalLinks?: PersonalLink[];
     msg?: string;
+    provider?: string;
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- Add `DELETE /v1/auth/account` service with 204/409/error handling, always sending Authorization header regardless of JWT feature flag
- Add `useDeleteAccountForm` hook — detects XC vs Google mode via `session.user.provider`, handles blocked-reservations state
- Add `DeleteAccountDialog` component — XC mode shows password confirmation form; Google mode shows placeholder pending backend re-auth flow
- Expose `email` and `provider` in NextAuth JWT and session callbacks so components can read them
- Show delete account entry in `UserDropdown` and `MobileUserMenu` only for whitelisted test accounts
- Extend `apiClient.delete` to accept a request body (required by the delete account endpoint)

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

- Delete account UI is gated to three test accounts: testing_visitor, testing_mentee, testing_mentor @xchange.com.tw
- Google account deletion is not yet implemented — requires backend to expose a re-auth URL or accept the BFF token as sufficient verification
- `DeleteAccountGoogleSchema` is defined in schemas/auth.ts for future use

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
