### PR TITLE
fix: enable JWT auth header injection in apiClient (#92)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,9 +4,6 @@ NEXT_PUBLIC_API_URL=
 # Store actual value in .env (gitignored)
 BFF_OPENAPI_URL=
 
-# API client feature flag — set to true once backend JWT auth is fully configured
-NEXT_PUBLIC_USE_API_CLIENT=false
-
 NEXTAUTH_URL=http://localhost:3000/
 NEXTAUTH_SECRET=secret
 

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -6,27 +6,19 @@
  * Usage:
  *   import { apiClient } from '@/lib/apiClient';
  *
- *   // Authenticated (default — token injected when NEXT_PUBLIC_USE_API_CLIENT=true)
+ *   // Authenticated (default — Bearer token injected from NextAuth session)
  *   const data = await apiClient.get<UserDTO>('/v1/mentors/123/en/profile');
  *
- *   // Public endpoint (no token ever)
- *   const data = await apiClient.get<ExpertiseType[]>('/v1/mentors/en/expertises', { auth: false });
+ *   // Public endpoint (no token)
+ *   const data = await apiClient.get<MentorType[]>('/v1/mentors', { auth: false });
  *
  *   // With query params
  *   const mentors = await apiClient.get<MentorType[]>('/v1/mentors', { params: { limit: 10 } });
- *
- * Feature flag:
- *   NEXT_PUBLIC_USE_API_CLIENT=false  → JWT not injected (safe while backend auth isn't ready)
- *   NEXT_PUBLIC_USE_API_CLIENT=true   → JWT auto-injected from NextAuth session
  */
 
 import { getSession } from 'next-auth/react';
 
 import { captureApiFailure } from '@/lib/monitoring';
-
-// ─── Feature flag ────────────────────────────────────────────────────────────
-// Flip to true once backend JWT auth is fully configured.
-const JWT_ENABLED = process.env.NEXT_PUBLIC_USE_API_CLIENT === 'true';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 export class ApiError extends Error {
@@ -68,7 +60,6 @@ function buildUrl(path: string, params?: RequestOptions['params']): string {
 }
 
 async function getAuthHeader(): Promise<Record<string, string>> {
-  if (!JWT_ENABLED) return {};
   const session = await getSession();
   const token = session?.accessToken;
   if (!token) return {};

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -102,8 +102,7 @@ export async function saveMentorSchedule(params: {
   try {
     const result = await apiClient.put<SaveScheduleResponse>(
       `/v1/mentors/${params.userId}/schedule`,
-      body,
-      { auth: false }
+      body
     );
     if (params.debug) {
       console.log('[saveMentorSchedule] response:', result);
@@ -134,8 +133,7 @@ export async function deleteMentorSchedule(params: {
 }): Promise<boolean> {
   try {
     await apiClient.delete(
-      `/v1/mentors/${params.userId}/schedule/${params.scheduleId}`,
-      { auth: false }
+      `/v1/mentors/${params.userId}/schedule/${params.scheduleId}`
     );
     return true;
   } catch {

--- a/src/services/profile/countries.ts
+++ b/src/services/profile/countries.ts
@@ -16,8 +16,7 @@ export async function fetchCountries(
 ): Promise<LocationType[]> {
   try {
     const data = await apiClient.get<CountryResponse>(
-      `/v1/users/${language}/countries`,
-      { auth: false }
+      `/v1/users/${language}/countries`
     );
 
     return Object.entries(data.data).map(([key, value]) => ({

--- a/src/services/profile/expertises.ts
+++ b/src/services/profile/expertises.ts
@@ -41,8 +41,7 @@ export async function fetchExpertises(
 ): Promise<ExpertiseType[]> {
   try {
     const data = await apiClient.get<ApiResponse>(
-      `/v1/mentors/${language}/expertises`,
-      { auth: false }
+      `/v1/mentors/${language}/expertises`
     );
 
     return (data.data?.professions ?? []).map(toExpertiseType);

--- a/src/services/profile/industries.ts
+++ b/src/services/profile/industries.ts
@@ -41,8 +41,7 @@ export async function fetchIndustries(
 ): Promise<IndustryDTO[]> {
   try {
     const data = await apiClient.get<ApiResponse>(
-      `/v1/users/${language}/industries`,
-      { auth: false }
+      `/v1/users/${language}/industries`
     );
 
     return (data.data?.professions ?? []).map(toIndustryDTO);

--- a/src/services/profile/interests.ts
+++ b/src/services/profile/interests.ts
@@ -42,7 +42,7 @@ export async function fetchInterests(
   try {
     const data = await apiClient.get<ApiResponse>(
       `/v1/users/${language}/interests`,
-      { auth: false, params: { interest } }
+      { params: { interest } }
     );
 
     return (data.data?.interests ?? []).map(toInterestDTO);


### PR DESCRIPTION
## What Does This PR Do?

- Remove `JWT_ENABLED` feature flag from `apiClient.ts` — JWT Bearer token is now always injected from the NextAuth session for authenticated requests
- Remove `NEXT_PUBLIC_USE_API_CLIENT` env var from `.env.example` (no longer referenced in code)
- Remove incorrect `auth: false` from endpoints that require JWT per BFF OpenAPI spec:
  - `PUT /v1/mentors/{userId}/schedule` (saveMentorSchedule)
  - `DELETE /v1/mentors/{userId}/schedule/{scheduleId}` (deleteMentorSchedule)
  - `GET /v1/users/{language}/interests`
  - `GET /v1/users/{language}/industries`
  - `GET /v1/mentors/{language}/expertises`
  - `GET /v1/users/{language}/countries`

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/profile/[userId]/edit

## Screenshot

N/A

## Anything to Note?

- `GET /v1/mentors/{userId}/{language}/profile` (`fetchUserById`) keeps `auth: false` pending backend confirmation — see X-Talent-Tracker#93
- Token refresh mechanism is not yet implemented — tracked in X-Talent-Tracker#94 and X-Talent-Tracker#95

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
