### PR TITLE
fix: add auth:false to reference data API calls (#100)

### DIFF
--- a/src/services/profile/countries.ts
+++ b/src/services/profile/countries.ts
@@ -16,7 +16,8 @@ export async function fetchCountries(
 ): Promise<LocationType[]> {
   try {
     const data = await apiClient.get<CountryResponse>(
-      `/v1/users/${language}/countries`
+      `/v1/users/${language}/countries`,
+      { auth: false }
     );
 
     return Object.entries(data.data).map(([key, value]) => ({

--- a/src/services/profile/expertises.ts
+++ b/src/services/profile/expertises.ts
@@ -41,7 +41,8 @@ export async function fetchExpertises(
 ): Promise<ExpertiseType[]> {
   try {
     const data = await apiClient.get<ApiResponse>(
-      `/v1/mentors/${language}/expertises`
+      `/v1/mentors/${language}/expertises`,
+      { auth: false }
     );
 
     return (data.data?.professions ?? []).map(toExpertiseType);

--- a/src/services/profile/industries.ts
+++ b/src/services/profile/industries.ts
@@ -41,7 +41,8 @@ export async function fetchIndustries(
 ): Promise<IndustryDTO[]> {
   try {
     const data = await apiClient.get<ApiResponse>(
-      `/v1/users/${language}/industries`
+      `/v1/users/${language}/industries`,
+      { auth: false }
     );
 
     return (data.data?.professions ?? []).map(toIndustryDTO);

--- a/src/services/profile/interests.ts
+++ b/src/services/profile/interests.ts
@@ -42,7 +42,7 @@ export async function fetchInterests(
   try {
     const data = await apiClient.get<ApiResponse>(
       `/v1/users/${language}/interests`,
-      { params: { interest } }
+      { params: { interest }, auth: false }
     );
 
     return (data.data?.interests ?? []).map(toInterestDTO);


### PR DESCRIPTION
## What Does This PR Do?

- Add `auth: false` to `fetchInterests`, `fetchIndustries`, `fetchCountries`, and `fetchExpertises` service calls
- Aligns frontend with backend change (#96) that made these four endpoints public (no JWT required)
- Prevents unnecessary `getSession()` calls for unauthenticated users on public routes such as `/mentor-pool`

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
