### PR TITLE
fix: remove PII console.log from resend verification email service (#99)

### DIFF
--- a/src/services/auth/resend.ts
+++ b/src/services/auth/resend.ts
@@ -1,20 +1,9 @@
-import { apiClient, ApiError } from '@/lib/apiClient';
+import { apiClient } from '@/lib/apiClient';
 
 export async function resendVerificationEmail(email: string): Promise<void> {
-  console.log('[resend] request payload:', { email });
   try {
     await apiClient.post('/v1/auth/email/resend', { email }, { auth: false });
-    console.log('[resend] success');
   } catch (error) {
-    if (error instanceof ApiError) {
-      console.log('[resend] ApiError:', {
-        status: error.status,
-        message: error.message,
-        body: error.body,
-      });
-    } else {
-      console.log('[resend] unknown error:', error);
-    }
     throw new Error(error instanceof Error ? error.message : '未知的錯誤發生');
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- Remove all `console.log` calls from `src/services/auth/resend.ts`, including one that logged the user's email in plaintext
- Remove now-unused `ApiError` import
- API error observability is already handled by `captureApiFailure` inside `apiClient.ts`

## Demo

http://localhost:3000/auth/verify-email

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
