### PR TITLE
feat: implement Google OAuth delete account flow

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { getSession, signIn } from 'next-auth/react';
+import { getSession, signIn, signOut } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { useToast } from '@/components/ui/use-toast';
+import { trackEvent } from '@/lib/analytics';
+import { deleteAccount } from '@/services/auth/deleteAccount';
 
 type OAuthUser = {
   user_id: number | string;
@@ -47,6 +49,7 @@ type LoginResponse = {
       token: string;
     };
     user: OAuthUser;
+    id_token?: string | null;
   };
 };
 
@@ -86,6 +89,13 @@ export default function GoogleOAuthRedirectPage() {
         const data: OAuthResponse = await res.json();
         console.log('[Google OAuth] backend response:', data);
 
+        const deleteEmail = sessionStorage.getItem('delete_account_email');
+        if (deleteEmail) {
+          sessionStorage.removeItem('delete_account_email');
+          await handleDeleteAccountFlow(data, deleteEmail);
+          return;
+        }
+
         await proceedWithSignIn(data);
       } catch (err) {
         toast({
@@ -101,6 +111,49 @@ export default function GoogleOAuthRedirectPage() {
 
     handleOAuthFlow();
   }, []);
+
+  const handleDeleteAccountFlow = async (
+    data: OAuthResponse,
+    email: string
+  ) => {
+    const id_token =
+      data.data.auth_type === 'LOGIN' ? data.data.id_token : null;
+
+    if (!id_token) {
+      toast({
+        variant: 'destructive',
+        title: '刪除帳號失敗',
+        description: '無法取得 Google 憑證，請稍後再試',
+      });
+      router.push('/auth/signin');
+      return;
+    }
+
+    const result = await deleteAccount({ email, id_token });
+
+    if (result.status === 'success') {
+      trackEvent({ name: 'delete_account_succeeded', feature: 'auth' });
+      await signOut({ callbackUrl: '/' });
+      return;
+    }
+
+    if (result.status === 'blocked_reservations') {
+      toast({
+        variant: 'destructive',
+        title: '無法刪除帳號',
+        description: '您目前有未完成或未來的預約，請先處理後再刪除帳號。',
+      });
+      router.push('/reservation/mentee');
+      return;
+    }
+
+    toast({
+      variant: 'destructive',
+      title: '刪除帳號失敗',
+      description: result.message || '系統錯誤，請稍後再試',
+    });
+    router.push('/auth/signin');
+  };
 
   const proceedWithSignIn = async (data: OAuthResponse) => {
     const backendData = data.data;

--- a/src/components/auth/DeleteAccountDialog.tsx
+++ b/src/components/auth/DeleteAccountDialog.tsx
@@ -33,8 +33,14 @@ export function DeleteAccountDialog({
   onOpenChange,
 }: DeleteAccountDialogProps): JSX.Element {
   const router = useRouter();
-  const { mode, xcForm, isSubmitting, blockedByReservations, onSubmitXC } =
-    useDeleteAccountForm();
+  const {
+    mode,
+    xcForm,
+    isSubmitting,
+    blockedByReservations,
+    onSubmitXC,
+    initiateGoogleReauth,
+  } = useDeleteAccountForm();
 
   const handleClose = (): void => {
     if (isSubmitting) return;
@@ -71,12 +77,25 @@ export function DeleteAccountDialog({
         {mode === 'google' ? (
           <div className="space-y-4">
             <p className="text-sm text-muted-foreground">
-              Google 帳號的刪除流程需要後端提供 re-auth 授權
-              URL，目前尚未實作。請聯絡客服處理。
+              系統將引導您前往 Google
+              完成身分驗證，確認後帳號將被永久刪除且無法復原。
             </p>
             <DialogFooter>
-              <Button variant="outline" onClick={handleClose}>
-                關閉
+              <Button
+                type="button"
+                variant="outline"
+                onClick={handleClose}
+                disabled={isSubmitting}
+              >
+                取消
+              </Button>
+              <Button
+                type="button"
+                variant="destructive"
+                onClick={initiateGoogleReauth}
+                disabled={isSubmitting}
+              >
+                {isSubmitting ? '處理中…' : '前往 Google 驗證並刪除帳號'}
               </Button>
             </DialogFooter>
           </div>

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -3,6 +3,10 @@ import { useRouter } from 'next/navigation';
 import { GoogleColor } from '@/components/icon';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
+import {
+  getGoogleAuthorizeLoginUrl,
+  getGoogleAuthorizeSignupUrl,
+} from '@/services/auth/googleAuthorize';
 
 interface GoogleSignUpButtonProps {
   isSubmitting: boolean;
@@ -20,27 +24,10 @@ export default function GoogleSignUpButton({
 
   const handleGoogleSignUp = async () => {
     try {
-      const endpoint = isSignIn
-        ? '/v2/oauth/google/authorize/login'
-        : '/v2/oauth/google/authorize/signup';
-
-      const url = `${process.env.NEXT_PUBLIC_API_URL}${endpoint}`;
-
-      const res = await fetch(url, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-        },
-      });
-
-      const json = await res.json();
-
-      if (res.ok && json.data?.authorization_url) {
-        router.push(json.data.authorization_url);
-      } else {
-        throw new Error(json.msg || '無法取得授權連結');
-      }
+      const { authorization_url } = isSignIn
+        ? await getGoogleAuthorizeLoginUrl()
+        : await getGoogleAuthorizeSignupUrl();
+      router.push(authorization_url);
     } catch (error) {
       console.error('[GoogleAuth] error:', error);
       toast({

--- a/src/hooks/auth/useDeleteAccountForm.ts
+++ b/src/hooks/auth/useDeleteAccountForm.ts
@@ -1,4 +1,5 @@
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
 import { signOut, useSession } from 'next-auth/react';
 import { useState } from 'react';
 import { useForm } from 'react-hook-form';
@@ -9,6 +10,7 @@ import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { DeleteAccountXCSchema } from '@/schemas/auth';
 import { deleteAccount } from '@/services/auth/deleteAccount';
+import { getGoogleAuthorizeLoginUrl } from '@/services/auth/googleAuthorize';
 
 type XCValues = z.infer<typeof DeleteAccountXCSchema>;
 
@@ -20,11 +22,13 @@ interface UseDeleteAccountFormReturn {
   isSubmitting: boolean;
   blockedByReservations: boolean;
   onSubmitXC: (values: XCValues) => Promise<void>;
+  initiateGoogleReauth: () => Promise<void>;
 }
 
 export default function useDeleteAccountForm(): UseDeleteAccountFormReturn {
   const { data: session } = useSession();
   const { toast } = useToast();
+  const router = useRouter();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [blockedByReservations, setBlockedByReservations] = useState(false);
 
@@ -71,5 +75,32 @@ export default function useDeleteAccountForm(): UseDeleteAccountFormReturn {
     }
   };
 
-  return { mode, xcForm, isSubmitting, blockedByReservations, onSubmitXC };
+  const initiateGoogleReauth = async (): Promise<void> => {
+    setIsSubmitting(true);
+    try {
+      sessionStorage.setItem(
+        'delete_account_email',
+        session?.user?.email ?? ''
+      );
+      const { authorization_url } = await getGoogleAuthorizeLoginUrl();
+      router.push(authorization_url);
+    } catch {
+      sessionStorage.removeItem('delete_account_email');
+      toast({
+        variant: 'destructive',
+        description: '無法取得 Google 授權連結，請稍後再試',
+        duration: 3000,
+      });
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    mode,
+    xcForm,
+    isSubmitting,
+    blockedByReservations,
+    onSubmitXC,
+    initiateGoogleReauth,
+  };
 }

--- a/src/services/auth/googleAuthorize.ts
+++ b/src/services/auth/googleAuthorize.ts
@@ -1,0 +1,29 @@
+import { apiClient } from '@/lib/apiClient';
+import type { components } from '@/types/api';
+
+type ApiResponse = components['schemas']['ApiResponse_GoogleAuthorizeVO_'];
+type GoogleAuthorizeVO = components['schemas']['GoogleAuthorizeVO'];
+
+export async function getGoogleAuthorizeLoginUrl(): Promise<GoogleAuthorizeVO> {
+  const res = await apiClient.post<ApiResponse>(
+    '/v2/oauth/google/authorize/login',
+    {},
+    { auth: false }
+  );
+  if (!res.data?.authorization_url) {
+    throw new Error('無法取得 Google 授權連結');
+  }
+  return res.data;
+}
+
+export async function getGoogleAuthorizeSignupUrl(): Promise<GoogleAuthorizeVO> {
+  const res = await apiClient.post<ApiResponse>(
+    '/v2/oauth/google/authorize/signup',
+    {},
+    { auth: false }
+  );
+  if (!res.data?.authorization_url) {
+    throw new Error('無法取得 Google 授權連結');
+  }
+  return res.data;
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1235,12 +1235,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-20T16:17:37.452678Z
+       * @default 2026-04-24T01:40:06.322029Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-20T16:17:37.452692Z
+       * @default 2026-04-24T01:40:06.322038Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1288,6 +1288,8 @@ export interface components {
       user?: components['schemas']['ProfileVO'] | null;
       /** Ttl Secs */
       ttl_secs?: number | null;
+      /** Id Token */
+      id_token?: string | null;
     };
     /** HTTPValidationError */
     HTTPValidationError: {
@@ -1326,11 +1328,7 @@ export interface components {
        * @default
        */
       subject: string | null;
-      /**
-       * Desc
-       * @default {}
-       */
-      desc: Record<string, never> | null;
+      desc?: components['schemas']['MetadataVO'] | null;
     };
     /**
      * Language
@@ -1533,6 +1531,13 @@ export interface components {
        */
       next_dtstart?: number | null;
     };
+    /** MetadataVO */
+    MetadataVO: {
+      /** Desc */
+      desc?: string | null;
+      /** Icon */
+      icon?: string | null;
+    };
     /**
      * OAuthType
      * @enum {string}
@@ -1571,11 +1576,8 @@ export interface components {
        * @default
        */
       subject: string;
-      /**
-       * Profession Metadata
-       * @default {}
-       */
-      profession_metadata: Record<string, never>;
+      /** @default {} */
+      profession_metadata: components['schemas']['MetadataVO'];
     };
     /** ProfileDTO */
     ProfileDTO: {


### PR DESCRIPTION
## What Does This PR Do?

- Add `src/services/auth/googleAuthorize.ts` with `getGoogleAuthorizeLoginUrl` and `getGoogleAuthorizeSignupUrl`, replacing inline fetch in `GoogleButton.tsx`
- Add `initiateGoogleReauth()` to `useDeleteAccountForm` hook: stores email in sessionStorage and redirects user to Google for re-authentication
- Update `GoogleOAuthRedirectPage` callback to detect delete intent from sessionStorage; on match, extracts `id_token` from callback response and calls `deleteAccount({ email, id_token })`, then `signOut`
- Replace placeholder text in `DeleteAccountDialog` Google mode with a real confirmation UI and CTA button
- Regenerate `src/types/api.ts` from latest BFF OpenAPI spec (includes new OAuth endpoints and `id_token` field in `GoogleCallbackVO`)

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

- The re-auth flow uses the existing `/auth/google/callback/redirect` route — no new callback page needed; intent is passed via `sessionStorage`
- If `blocked_reservations` is returned after deletion attempt, user is redirected to `/reservation/mentee`
- XC (email/password) delete flow is unaffected

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
