### PR TITLE
refactor: remove unused updateUserProfile dead code (#97)

### DIFF
--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -82,31 +82,3 @@ export async function fetchUserById(
     return null;
   }
 }
-
-export async function updateUserProfile(
-  userData: Partial<UserDTO>
-): Promise<boolean> {
-  const session = await getSession();
-  const userId = session?.user?.id;
-
-  if (!userId) {
-    throw new Error('未找到使用者 ID。請重新登入。');
-  }
-
-  try {
-    const result = await apiClient.put<UserResponseDTO>(
-      `/v1/mentors/${userId}/profile`,
-      userData
-    );
-
-    if (result.code !== '0') {
-      console.error('API Error:', result.msg);
-      return false;
-    }
-
-    return true;
-  } catch (error) {
-    console.error('Update User Error:', error);
-    return false;
-  }
-}


### PR DESCRIPTION
## What Does This PR Do?

- Delete `updateUserProfile` from `src/services/profile/user.ts` (lines 86–112)
- The function was never called anywhere in the codebase — no hook or component referenced it
- The actual profile update path uses `updateProfile` in `src/services/profile/updateProfile.ts`
- Keeping both created confusion due to differing type signatures (`Partial<UserDTO>` vs validated form schema union)

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

`UserDTO` interface and `fetchUser` / `fetchUserById` functions are unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
