### PR TITLE
fix: pass email through Google OAuth session so delete account is visible (#102)

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -47,6 +47,7 @@ type LoginResponse = {
     auth: {
       user_id: number | string;
       token: string;
+      email?: string | null;
     };
     user: OAuthUser;
     id_token?: string | null;
@@ -182,6 +183,7 @@ export default function GoogleOAuthRedirectPage() {
     await signIn('custom-google-token', {
       redirect: false,
       token,
+      email: backendData.auth.email ?? '',
       user: JSON.stringify(user),
     });
 

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -71,6 +71,7 @@ const authOptions = {
       name: 'Custom Google Token',
       credentials: {
         token: { label: 'Token', type: 'text' },
+        email: { label: 'Email', type: 'text' },
         user: { label: 'User JSON', type: 'text' },
       },
       async authorize(credentials) {
@@ -97,6 +98,7 @@ const authOptions = {
           return {
             id: String(user.user_id),
             token: credentials.token,
+            email: (credentials.email as string) || undefined,
             name: user.name,
             avatar: user.avatar,
             avatarUpdatedAt: Date.now(),

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -32,6 +32,7 @@ declare module 'next-auth/jwt' {
   interface JWT {
     id?: string;
     token?: string;
+    email?: string;
     onBoarding?: boolean;
     name?: string | null;
     avatar?: string | null;


### PR DESCRIPTION
## What Does This PR Do?

- Add `email` field to `custom-google-token` CredentialsProvider credentials and `authorize` return value in `auth.config.ts` so `session.user.email` is populated for Google OAuth users
- Add `email?: string | null` to the `LoginResponse.data.auth` local type in `container.tsx` and pass `backendData.auth.email` to the `signIn` call
- Add `email?: string` to the `JWT` interface in `types.d.ts` for TypeScript strict-mode correctness

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

The `canDeleteAccount` guard in `UserDropdown` and `MobileUserMenu` checks `session.user.email` against a hardcoded allowlist of 3 test accounts. Before this fix, Google OAuth login never populated `session.user.email`, so the delete account button was invisible even for those test accounts. The email value comes from `data.auth.email` in the `/v2/oauth/google/callback` response (`GoogleCallbackAuthVO` in the OpenAPI schema).

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
