### PR TITLE
fix: remove duplicate Bearer token injection in deleteAccount

### DIFF
--- a/src/services/auth/deleteAccount.ts
+++ b/src/services/auth/deleteAccount.ts
@@ -1,5 +1,3 @@
-import { getSession } from 'next-auth/react';
-
 import { apiClient, ApiError } from '@/lib/apiClient';
 import type { components } from '@/types/api';
 
@@ -14,11 +12,7 @@ export async function deleteAccount(
   payload: DeleteAccountDTO
 ): Promise<DeleteAccountResult> {
   try {
-    const session = await getSession();
-    const token = session?.accessToken;
-    await apiClient.delete('/v1/auth/account', payload, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
+    await apiClient.delete('/v1/auth/account', payload);
     return { status: 'success' };
   } catch (error) {
     if (error instanceof ApiError) {


### PR DESCRIPTION
## What Does This PR Do?

- Remove manual `getSession()` call and custom `Authorization` header from `deleteAccount.ts`
- Let `apiClient` handle token injection automatically via its default `auth: true` behaviour
- Eliminates a redundant `getSession()` call and clarifies the auth responsibility boundary

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

The duplicate injection was harmless (custom header overrode the auto-injected one with the same value), but caused unnecessary `getSession()` overhead and made the auth flow ambiguous. Relates to #103.
