### PR TITLE
feat: implement JWT token auto-refresh mechanism

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -6,13 +6,12 @@ import { useEffect, useState } from 'react';
 
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { useToast } from '@/components/ui/use-toast';
+import { googleCallback } from '@/lib/actions/googleCallback';
 import { trackEvent } from '@/lib/analytics';
 import { deleteAccount } from '@/services/auth/deleteAccount';
 import type { components } from '@/types/api';
 
 type GoogleCallbackVO = components['schemas']['GoogleCallbackVO'];
-type OAuthCallbackResponse =
-  components['schemas']['ApiResponse_GoogleCallbackVO_'];
 
 export default function GoogleOAuthRedirectPage() {
   const searchParams = useSearchParams();
@@ -36,16 +35,7 @@ export default function GoogleOAuthRedirectPage() {
       }
 
       try {
-        const res = await fetch(
-          `${process.env.NEXT_PUBLIC_API_URL}/v2/oauth/google/callback`,
-          {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ code, state }),
-          }
-        );
-
-        const response: OAuthCallbackResponse = await res.json();
+        const response = await googleCallback(code, state);
         console.log('[Google OAuth] backend response:', response);
 
         const callbackData = response.data;
@@ -59,14 +49,20 @@ export default function GoogleOAuthRedirectPage() {
           return;
         }
 
+        const refreshToken = response.refreshToken;
+
         const deleteEmail = sessionStorage.getItem('delete_account_email');
         if (deleteEmail) {
           sessionStorage.removeItem('delete_account_email');
-          await handleDeleteAccountFlow(callbackData, deleteEmail);
+          await handleDeleteAccountFlow(
+            callbackData,
+            deleteEmail,
+            refreshToken
+          );
           return;
         }
 
-        await proceedWithSignIn(callbackData);
+        await proceedWithSignIn(callbackData, refreshToken);
       } catch (err) {
         toast({
           variant: 'destructive',
@@ -84,7 +80,8 @@ export default function GoogleOAuthRedirectPage() {
 
   const handleDeleteAccountFlow = async (
     data: GoogleCallbackVO,
-    email: string
+    email: string,
+    refreshToken: string | null
   ) => {
     if (data.auth_type !== 'LOGIN') {
       toast({
@@ -113,6 +110,7 @@ export default function GoogleOAuthRedirectPage() {
       token: auth.token,
       email: auth.email ?? '',
       user: JSON.stringify(user),
+      refreshToken: refreshToken ?? '',
     });
 
     const result = await deleteAccount({ email, id_token });
@@ -141,7 +139,10 @@ export default function GoogleOAuthRedirectPage() {
     router.push('/auth/signin');
   };
 
-  const proceedWithSignIn = async (data: GoogleCallbackVO) => {
+  const proceedWithSignIn = async (
+    data: GoogleCallbackVO,
+    refreshToken: string | null
+  ) => {
     if (data.auth_type === 'SIGNUP') {
       sessionStorage.setItem('email', data.auth.email ?? '');
       router.push('/auth/email-verify');
@@ -163,6 +164,7 @@ export default function GoogleOAuthRedirectPage() {
       token: data.auth.token,
       email: data.auth.email ?? '',
       user: JSON.stringify(data.user),
+      refreshToken: refreshToken ?? '',
     });
 
     const session = await getSession();

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -2,6 +2,27 @@ import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
 
 import { SignInSchema } from '@/schemas/auth';
+import { refreshAccessToken } from '@/services/auth/refreshToken';
+
+function decodeJwtExp(jwtString: string): number | null {
+  try {
+    const base64 = jwtString
+      .split('.')[1]
+      .replace(/-/g, '+')
+      .replace(/_/g, '/');
+    const payload = JSON.parse(
+      Buffer.from(base64, 'base64').toString('utf-8')
+    ) as Record<string, unknown>;
+    return typeof payload.exp === 'number' ? payload.exp : null;
+  } catch {
+    return null;
+  }
+}
+
+function extractRefreshToken(headers: Headers): string | undefined {
+  const setCookie = headers.get('set-cookie') ?? '';
+  return setCookie.match(/refresh_token=([^;,]+)/)?.[1] ?? undefined;
+}
 
 const authOptions = {
   session: { strategy: 'jwt' },
@@ -51,6 +72,7 @@ const authOptions = {
         return {
           id: String(response.data.auth.user_id),
           token: response.data.auth.token,
+          refreshToken: extractRefreshToken(res.headers),
           email: response.data.auth.email,
           onBoarding: response.data.user.onboarding,
           isMentor: response.data.user.is_mentor,
@@ -73,6 +95,7 @@ const authOptions = {
         token: { label: 'Token', type: 'text' },
         email: { label: 'Email', type: 'text' },
         user: { label: 'User JSON', type: 'text' },
+        refreshToken: { label: 'Refresh Token', type: 'text' },
       },
       async authorize(credentials) {
         if (!credentials?.token || !credentials?.user) return null;
@@ -98,6 +121,7 @@ const authOptions = {
           return {
             id: String(user.user_id),
             token: credentials.token,
+            refreshToken: (credentials.refreshToken as string) || undefined,
             email: (credentials.email as string) || undefined,
             name: user.name,
             avatar: user.avatar,
@@ -132,6 +156,29 @@ const authOptions = {
         };
       }
 
+      const backendToken = token.token;
+      const storedRefreshToken = token.refreshToken;
+
+      if (backendToken && storedRefreshToken) {
+        const exp = decodeJwtExp(backendToken);
+        const isExpiringSoon = exp !== null && exp - Date.now() / 1000 < 300;
+
+        if (isExpiringSoon) {
+          try {
+            const { token: newToken, refreshToken: newRefreshToken } =
+              await refreshAccessToken(storedRefreshToken);
+            return {
+              ...token,
+              token: newToken,
+              refreshToken: newRefreshToken ?? storedRefreshToken,
+              error: undefined,
+            };
+          } catch {
+            return { ...token, error: 'RefreshTokenError' as const };
+          }
+        }
+      }
+
       return token;
     },
 
@@ -154,6 +201,7 @@ const authOptions = {
       session.user.provider =
         (token.provider as string | undefined) ?? undefined;
       session.user.email = (token.email as string | undefined) ?? undefined;
+      session.error = token.error;
       return session;
     },
   },

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -6,6 +6,7 @@ import { SessionProvider } from 'next-auth/react';
 import ErrorBoundary from '@/components/ErrorBoundary';
 import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
 import PageViewTracker from '@/components/PageViewTracker';
+import SessionErrorWatcher from '@/components/SessionErrorWatcher';
 import WebVitalsMonitor from '@/components/WebVitalsMonitor';
 
 export default function Providers({
@@ -20,6 +21,7 @@ export default function Providers({
       <GlobalErrorMonitor />
       <WebVitalsMonitor />
       <PageViewTracker />
+      <SessionErrorWatcher />
       <ErrorBoundary>{children}</ErrorBoundary>
     </SessionProvider>
   );

--- a/src/components/SessionErrorWatcher.tsx
+++ b/src/components/SessionErrorWatcher.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { signOut, useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
+export default function SessionErrorWatcher() {
+  const { data: session } = useSession();
+
+  useEffect(() => {
+    if (session?.error === 'RefreshTokenError') {
+      signOut({ callbackUrl: '/auth/signin' });
+    }
+  }, [session?.error]);
+
+  return null;
+}

--- a/src/lib/actions/googleCallback.ts
+++ b/src/lib/actions/googleCallback.ts
@@ -1,0 +1,28 @@
+'use server';
+
+import type { components } from '@/types/api';
+
+type OAuthCallbackResponse =
+  components['schemas']['ApiResponse_GoogleCallbackVO_'];
+
+const BFF_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+function extractRefreshToken(headers: Headers): string | null {
+  const setCookie = headers.get('set-cookie') ?? '';
+  return setCookie.match(/refresh_token=([^;,]+)/)?.[1] ?? null;
+}
+
+export async function googleCallback(
+  code: string,
+  state: string
+): Promise<OAuthCallbackResponse & { refreshToken: string | null }> {
+  const res = await fetch(`${BFF_URL}/v2/oauth/google/callback`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ code, state }),
+  });
+
+  const data = (await res.json()) as OAuthCallbackResponse;
+
+  return { ...data, refreshToken: extractRefreshToken(res.headers) };
+}

--- a/src/services/auth/refreshToken.ts
+++ b/src/services/auth/refreshToken.ts
@@ -1,0 +1,43 @@
+import type { components } from '@/types/api';
+
+type RefreshResponse = components['schemas']['ApiResponse_TokenRefreshVO_'];
+
+const BFF_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+interface RefreshResult {
+  token: string;
+  refreshToken: string | null;
+}
+
+function extractRefreshToken(headers: Headers): string | null {
+  const setCookie = headers.get('set-cookie') ?? '';
+  return setCookie.match(/refresh_token=([^;,]+)/)?.[1] ?? null;
+}
+
+export async function refreshAccessToken(
+  currentRefreshToken: string
+): Promise<RefreshResult> {
+  const res = await fetch(`${BFF_URL}/v1/auth/token`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({
+      grant_type: 'refresh_token',
+      refresh_token: currentRefreshToken,
+    }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Token refresh failed with status ${res.status}`);
+  }
+
+  const data = (await res.json()) as RefreshResponse;
+
+  if (!data.data?.auth.token) {
+    throw new Error('Token refresh response missing token');
+  }
+
+  return {
+    token: data.data.auth.token,
+    refreshToken: extractRefreshToken(res.headers),
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1212,12 +1212,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-24T06:29:43.873734Z
+       * @default 2026-04-24T07:25:00.505055Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-24T06:29:43.873750Z
+       * @default 2026-04-24T07:25:00.505070Z
        */
       update_time: string | null;
       /** Create User Id */

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -9,6 +9,7 @@ declare module 'next-auth' {
   interface User {
     id?: string;
     token?: string;
+    refreshToken?: string;
     onBoarding?: boolean;
     name?: string | null;
     avatar?: string | null;
@@ -23,8 +24,9 @@ declare module 'next-auth' {
   }
 
   interface Session {
-    user: Omit<User, 'token'> & DefaultSession['user'];
+    user: Omit<User, 'token' | 'refreshToken'> & DefaultSession['user'];
     accessToken?: string;
+    error?: 'RefreshTokenError';
   }
 }
 
@@ -32,6 +34,7 @@ declare module 'next-auth/jwt' {
   interface JWT {
     id?: string;
     token?: string;
+    refreshToken?: string;
     email?: string;
     onBoarding?: boolean;
     name?: string | null;
@@ -43,5 +46,6 @@ declare module 'next-auth/jwt' {
     personalLinks?: PersonalLink[];
     msg?: string;
     provider?: string;
+    error?: 'RefreshTokenError';
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- Decode backend JWT exp on every session read; auto-call `POST /v1/auth/token` when token expires within 5 minutes
- XC Account login: extract refresh token from `Set-Cookie` response header and store it in NextAuth encrypted JWT
- Google OAuth login: proxy backend call through a server action (`src/lib/actions/googleCallback.ts`) to capture refresh token from `Set-Cookie` header, then pass it via `signIn()` credentials
- Both providers: new token and rotated refresh token are written back into the NextAuth JWT after a successful refresh
- On refresh failure, set `session.error = 'RefreshTokenError'`; new `SessionErrorWatcher` component detects this and calls `signOut()` to force re-login
- Add `refreshToken` and `error` fields to NextAuth `User`, `JWT`, and `Session` types

## Demo

http://localhost:3000/auth/signin

## Screenshot

N/A

## Anything to Note?

- Refresh token is stored inside NextAuth's encrypted session cookie (NEXTAUTH_SECRET), not exposed to client JS
- `src/services/auth/refreshToken.ts` uses `ApiResponse_TokenRefreshVO_` VO type from `src/types/api.ts`
- The 5-minute threshold can be adjusted in `auth.config.ts` (`decodeJwtExp` + `isExpiringSoon` check)

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
