### PR TITLE
refactor: replace UserDTO with MentorProfileVO from OpenAPI types

### DIFF
--- a/src/components/sort/SortFunction.tsx
+++ b/src/components/sort/SortFunction.tsx
@@ -1,10 +1,10 @@
-import { UserDTO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/services/profile/user';
 export type SortMethod = 'a-z' | 'z-a';
 
 export function sortUsersByName(
-  users: UserDTO[],
+  users: MentorProfileVO[],
   method: SortMethod
-): UserDTO[] {
+): MentorProfileVO[] {
   return [...users].sort((a, b) => {
     const nameA = a.name || '';
     const nameB = b.name || '';

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -36,7 +36,7 @@ import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
-import { UserDTO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/services/profile/user';
 import { mockRouter } from '@/test/mocks/navigation';
 
 import { useProfileSubmit } from './useProfileSubmit';
@@ -46,7 +46,7 @@ const mockUpdateProfile = vi.mocked(updateProfile);
 const mockUpsertMentorExperience = vi.mocked(upsertMentorExperience);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 
-const mockUserDTO: UserDTO = {
+const mockUserDTO: MentorProfileVO = {
   user_id: 1,
   name: 'Test User',
   avatar: 'https://example.com/avatar.jpg',
@@ -68,6 +68,9 @@ const mockUserDTO: UserDTO = {
   onboarding: true,
   is_mentor: true,
   language: 'zh_TW',
+  personal_statement: null,
+  about: null,
+  seniority_level: null,
 };
 
 const mockSession: Session = {

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -2,11 +2,11 @@ import { useEffect, useState } from 'react';
 
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 import { ExperienceType } from '@/services/profile/experienceType';
-import { fetchUserById, UserDTO } from '@/services/profile/user';
+import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
 
 import { getInterestsCached } from '../interests/useInterests';
 
-const userDtoPromiseCache = new Map<string, Promise<UserDTO | null>>();
+const userDtoPromiseCache = new Map<string, Promise<MentorProfileVO | null>>();
 
 /**
  * Removes a user's entry from the in-memory request cache so the next call to
@@ -21,7 +21,7 @@ export function clearUserDataCache(userId: number, language: string): void {
 function fetchUserByIdCached(
   userId: number,
   language: string
-): Promise<UserDTO | null> {
+): Promise<MentorProfileVO | null> {
   const key = `${userId}-${language}`;
   const inflight = userDtoPromiseCache.get(key);
   if (inflight) return inflight;
@@ -87,9 +87,9 @@ type ExperienceBlock = {
 
 type WhatIOfferMetadata = { subject_group: string };
 
-function toInterestList(
-  interests: UserDTO['topics']['interests']
-): InterestType[] {
+type InterestVO = NonNullable<MentorProfileVO['topics']>['interests'][number];
+
+function toInterestList(interests: InterestVO[]): InterestType[] {
   return interests.map((i) => ({
     subject_group: i.subject_group,
     subject: i.subject ?? '',
@@ -97,7 +97,7 @@ function toInterestList(
 }
 
 function getBlocksByCategory(
-  experiences: UserDTO['experiences'] | undefined,
+  experiences: MentorProfileVO['experiences'],
   category: ExperienceType
 ): ExperienceBlock[] {
   if (!experiences) return [];
@@ -128,7 +128,7 @@ function buildWhatIOffers(
 }
 
 function parseUserDtoToUserType(
-  userDto: UserDTO,
+  userDto: MentorProfileVO,
   labelByGroup: Map<string, string>
 ): UserType {
   const workBlocks = getBlocksByCategory(
@@ -177,22 +177,23 @@ function parseUserDtoToUserType(
 
   return {
     user_id: userDto.user_id,
-    name: userDto.name,
-    avatar: userDto.avatar,
+    name: userDto.name ?? '',
+    avatar: userDto.avatar ?? '',
     job_title,
     company,
     interested_positions: toInterestList(
-      userDto.interested_positions.interests
+      userDto.interested_positions?.interests ?? []
     ),
-    skills: toInterestList(userDto.skills.interests),
-    topics: toInterestList(userDto.topics.interests),
-    is_mentor: userDto.is_mentor,
+    skills: toInterestList(userDto.skills?.interests ?? []),
+    topics: toInterestList(userDto.topics?.interests ?? []),
+    is_mentor: userDto.is_mentor ?? false,
     about: userDto.about ?? '',
-    years_of_experience:
-      TotalWorkSpanEnum[
-        userDto.years_of_experience as keyof typeof TotalWorkSpanEnum
-      ] ?? userDto.years_of_experience,
-    industry: userDto.industry?.subject,
+    years_of_experience: userDto.years_of_experience
+      ? (TotalWorkSpanEnum[
+          userDto.years_of_experience as keyof typeof TotalWorkSpanEnum
+        ] ?? userDto.years_of_experience)
+      : undefined,
+    industry: userDto.industry?.subject ?? undefined,
     expertises,
     what_i_offers,
     workExperiences,

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,9 +1,9 @@
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
-import { fetchUser, UserDTO } from '@/services/profile/user';
+import { fetchUser, MentorProfileVO } from '@/services/profile/user';
 
 function isProfileSynced(
   values: ProfileFormValues,
-  latest: UserDTO,
+  latest: MentorProfileVO,
   avatar: string
 ): boolean {
   if (latest.name !== values.name) return false;
@@ -24,7 +24,7 @@ export async function pollUntilSynced(
   avatar: string,
   maxRetries = 12,
   intervalMs = 5000
-): Promise<UserDTO | null> {
+): Promise<MentorProfileVO | null> {
   let latest = await fetchUser('zh_TW');
   for (
     let i = 1;

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -3,54 +3,14 @@ import { getSession } from 'next-auth/react';
 import { apiClient } from '@/lib/apiClient';
 import type { components } from '@/types/api';
 
-type ProfessionVO = components['schemas']['ProfessionVO'];
-type InterestVO = components['schemas']['InterestVO'];
+export type MentorProfileVO = components['schemas']['MentorProfileVO'];
 
-export interface ExperienceType {
-  [key: string]: unknown;
-}
+type ApiResponseMentorProfileVO =
+  components['schemas']['ApiResponse_MentorProfileVO_'];
 
-export interface UserDTO {
-  user_id: number;
-  name: string;
-  avatar: string;
-  job_title: string;
-  company: string;
-  years_of_experience: string;
-  location: string;
-  interested_positions: {
-    interests: InterestVO[];
-    language: string | null;
-  };
-  skills: {
-    interests: InterestVO[];
-    language: string | null;
-  };
-  topics: {
-    interests: InterestVO[];
-    language: string | null;
-  };
-  industry: ProfessionVO;
-  onboarding: boolean;
-  is_mentor: boolean;
-  language: string;
-  personal_statement?: string;
-  about?: string;
-  seniority_level?: string;
-  expertises?: {
-    professions: ProfessionVO[];
-    language: string | null;
-  };
-  experiences?: ExperienceType[];
-}
-
-interface UserResponseDTO {
-  code: string;
-  msg: string;
-  data: UserDTO;
-}
-
-export async function fetchUser(language: string): Promise<UserDTO | null> {
+export async function fetchUser(
+  language: string
+): Promise<MentorProfileVO | null> {
   const session = await getSession();
   const userId = session?.user?.id;
 
@@ -64,9 +24,9 @@ export async function fetchUser(language: string): Promise<UserDTO | null> {
 export async function fetchUserById(
   userId: number,
   language: string
-): Promise<UserDTO | null> {
+): Promise<MentorProfileVO | null> {
   try {
-    const result = await apiClient.get<UserResponseDTO>(
+    const result = await apiClient.get<ApiResponseMentorProfileVO>(
       `/v1/mentors/${userId}/${language}/profile`,
       { auth: false }
     );
@@ -76,7 +36,7 @@ export async function fetchUserById(
       return null;
     }
 
-    return result.data;
+    return result.data ?? null;
   } catch (error) {
     console.error('Fetch User Error:', error);
     return null;


### PR DESCRIPTION
## What Does This PR Do?

- Removes hand-written `UserDTO` interface from `src/services/profile/user.ts` and replaces it with the OpenAPI-generated `MentorProfileVO` type
- Updates `fetchUser` / `fetchUserById` return types to `MentorProfileVO | null`
- Adds null guards in `parseUserDtoToUserType` for all fields that become nullable under `MentorProfileVO` (`name`, `avatar`, `is_mentor`, `interested_positions`, `skills`, `topics`, `years_of_experience`)
- Updates `pollUntilSynced`, `SortFunction`, and `useProfileSubmit` test to use `MentorProfileVO` instead of `UserDTO`

## Demo

http://localhost:3000/profile/[pageUserId]/edit

## Screenshot

N/A

## Anything to Note?

Two extra files beyond the ticket scope (`src/lib/profile/pollUntilSynced.ts` and `src/components/sort/SortFunction.tsx`) were updated because they directly imported `UserDTO` — omitting them would have caused type-check failures.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
