### PR TITLE
feat: add 401 reactive token refresh with retry in apiClient (#110)

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -16,6 +16,7 @@
  *   const mentors = await apiClient.get<MentorType[]>('/v1/mentors', { params: { limit: 10 } });
  */
 
+import type { Session } from 'next-auth';
 import { getSession } from 'next-auth/react';
 
 import { captureApiFailure } from '@/lib/monitoring';
@@ -44,6 +45,19 @@ type RequestOptions = {
 // ─── Internals ───────────────────────────────────────────────────────────────
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 
+// Deduplicate concurrent 401 refresh calls — if multiple requests fail at once,
+// they all wait on the same refresh rather than each triggering a new one.
+let pendingRefresh: Promise<Session | null> | null = null;
+
+function refreshSession(): Promise<Session | null> {
+  if (!pendingRefresh) {
+    pendingRefresh = getSession().finally(() => {
+      pendingRefresh = null;
+    });
+  }
+  return pendingRefresh;
+}
+
 function buildUrl(path: string, params?: RequestOptions['params']): string {
   const url = `${BASE_URL}${path}`;
   if (!params) return url;
@@ -70,7 +84,8 @@ async function request<T>(
   method: string,
   path: string,
   body?: unknown,
-  options: RequestOptions = {}
+  options: RequestOptions = {},
+  isRetry = false
 ): Promise<T> {
   const { auth = true, headers = {}, params } = options;
 
@@ -100,6 +115,13 @@ async function request<T>(
       duration: Date.now() - startTime,
     });
     throw networkError;
+  }
+
+  if (response.status === 401 && auth && !isRetry) {
+    const freshSession = await refreshSession();
+    if (freshSession?.accessToken && !freshSession.error) {
+      return request<T>(method, path, body, options, true);
+    }
   }
 
   if (!response.ok) {


### PR DESCRIPTION
## What Does This PR Do?

- Add `refreshSession()` with a module-level `pendingRefresh` singleton to deduplicate concurrent 401 refresh calls
- Add `isRetry` flag to `request()` to prevent infinite retry loops
- On 401, force a fresh `getSession()` call (triggers NextAuth JWT callback → `refreshAccessToken`), then retry the original request once with the new token
- If retry also fails or refresh returns `RefreshTokenError`, throw `ApiError(401)` as before

## Demo

N/A

## Screenshot

N/A

## Anything to Note?

Complements the existing proactive refresh in `auth.config.ts` (5-minute expiry window). This covers the gaps: clock skew, backend-forced token invalidation, and race conditions where the token expires between `getSession()` and the actual request.
