### PR TITLE
feat: add reorder buttons to education items (#119)

### DIFF
--- a/src/components/profile/edit/educationSection/educationSection.tsx
+++ b/src/components/profile/edit/educationSection/educationSection.tsx
@@ -1,6 +1,11 @@
 'use client';
 
-import { PlusIcon, TrashIcon } from '@radix-ui/react-icons';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  PlusIcon,
+  TrashIcon,
+} from '@radix-ui/react-icons';
 import { Check, ChevronsUpDown } from 'lucide-react';
 import React, { useEffect, useState } from 'react';
 import { useFieldArray, UseFormReturn, useWatch } from 'react-hook-form';
@@ -122,7 +127,7 @@ export const EducationSection = ({
     formState: { errors },
   } = form;
 
-  const { fields, append, remove } = useFieldArray({
+  const { fields, append, remove, move } = useFieldArray({
     control,
     name: 'educations',
   });
@@ -186,7 +191,29 @@ export const EducationSection = ({
           start && end && end !== 'now' && Number(start) > Number(end);
 
         return (
-          <div key={field.id} className="mb-8 border-b pb-4">
+          <div key={field.id} className="mb-4 rounded-lg border p-4">
+            {fields.length > 1 && (
+              <div className="mb-4 flex justify-end gap-1">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  disabled={index === 0}
+                  onClick={() => move(index, index - 1)}
+                >
+                  <ChevronUpIcon className="h-5 w-5" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  disabled={index === fields.length - 1}
+                  onClick={() => move(index, index + 1)}
+                >
+                  <ChevronDownIcon className="h-5 w-5" />
+                </Button>
+              </div>
+            )}
             <div className="mb-6 gap-6 md:flex">
               <FormField
                 control={control}


### PR DESCRIPTION
## What Does This PR Do?

- Add up/down chevron buttons to each Education item in Profile Edit
- Buttons appear only when there are 2+ items; first item's ↑ and last item's ↓ are disabled
- Uses `useFieldArray`'s built-in `move()` — no new dependencies
- Wrap each item in a card border (`rounded-lg border`) matching the Work Experience layout (#118)

## Demo

http://localhost:3000/profile/edit

## Screenshot

N/A

## Anything to Note?

Implementation mirrors #118 exactly. `useProfileSubmit` and `profileSchema` required no changes.
