### PR TITLE
feat: auto-scroll to first validation error on profile edit save (#127)

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -5,7 +5,7 @@ import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
 import { useRef, useState } from 'react';
-import { useForm } from 'react-hook-form';
+import { FieldErrors, useForm } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
@@ -107,6 +107,32 @@ export default function Page({
     skills,
   });
 
+  const scrollToField = (fieldId: string) => {
+    document
+      .getElementById(fieldId)
+      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const FIELD_SCROLL_ORDER: (keyof ProfileFormValues)[] = [
+    'name',
+    'about',
+    'what_i_offer',
+    'expertises',
+    'location',
+    'years_of_experience',
+    'industry',
+    'interested_positions',
+    'skills',
+    'topics',
+    'work_experiences',
+    'educations',
+  ];
+
+  const onError = (errors: FieldErrors<ProfileFormValues>) => {
+    const firstKey = FIELD_SCROLL_ORDER.find((key) => key in errors);
+    if (firstKey) scrollToField(firstKey);
+  };
+
   const { onSubmit, isSaving } = useProfileSubmit({
     pageUserId,
     isMentorOnboarding,
@@ -114,6 +140,7 @@ export default function Page({
     updateSession,
     jobSectionError,
     educationSectionError,
+    onScrollToError: scrollToField,
   });
 
   if (!isAuthorized) return null;
@@ -132,7 +159,7 @@ export default function Page({
       <Form {...form}>
         <form
           id="edit-profile-form"
-          onSubmit={form.handleSubmit(onSubmit)}
+          onSubmit={form.handleSubmit(onSubmit, onError)}
           className="space-y-10"
         >
           <AvatarSection
@@ -146,6 +173,7 @@ export default function Page({
           />
 
           <Section
+            id="name"
             title={
               <>
                 <span className="text-status-200">* </span>姓名
@@ -156,6 +184,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="about"
             title={
               <>
                 {isMentor && <span className="text-status-200">* </span>}
@@ -168,6 +197,7 @@ export default function Page({
 
           {isMentor && (
             <Section
+              id="what_i_offer"
               title={
                 <>
                   <span className="text-status-200">* </span>我能提供的服務
@@ -188,6 +218,7 @@ export default function Page({
 
           {isMentor && (
             <Section
+              id="expertises"
               title={
                 <>
                   <span className="text-status-200">* </span>專業能力
@@ -207,6 +238,7 @@ export default function Page({
           )}
 
           <Section
+            id="location"
             title={
               <>
                 <span className="text-status-200">* </span>地區
@@ -225,6 +257,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="years_of_experience"
             title={
               <>
                 <span className="text-status-200">* </span>經驗
@@ -240,6 +273,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="industry"
             title={
               <>
                 <span className="text-status-200">* </span>產業
@@ -258,6 +292,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="interested_positions"
             title={
               <>
                 <span className="text-status-200">* </span>有興趣多了解的職位
@@ -276,6 +311,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="skills"
             title={
               <>
                 <span className="text-status-200">* </span>想多了解、加強的技能
@@ -294,6 +330,7 @@ export default function Page({
           </Section>
 
           <Section
+            id="topics"
             title={
               <>
                 <span className="text-status-200">* </span>想多了解的主題
@@ -311,19 +348,23 @@ export default function Page({
             />
           </Section>
 
-          <JobExperienceSection
-            industries={industries}
-            locations={locations}
-            form={form}
-            isMentor={isMentor}
-            onValidationChange={setJobSectionError}
-          />
+          <div id="work_experiences">
+            <JobExperienceSection
+              industries={industries}
+              locations={locations}
+              form={form}
+              isMentor={isMentor}
+              onValidationChange={setJobSectionError}
+            />
+          </div>
 
-          <EducationSection
-            form={form}
-            isMentor={isMentor}
-            onValidationChange={setEducationSectionError}
-          />
+          <div id="educations">
+            <EducationSection
+              form={form}
+              isMentor={isMentor}
+              onValidationChange={setEducationSectionError}
+            />
+          </div>
 
           <LinksSection form={form} />
         </form>

--- a/src/components/profile/edit/Section.tsx
+++ b/src/components/profile/edit/Section.tsx
@@ -9,10 +9,14 @@ import React from 'react';
 interface SectionProps {
   title: string | React.ReactNode;
   children: React.ReactNode;
+  id?: string;
 }
 
-export const Section = ({ title, children }: SectionProps) => (
-  <div className="flex flex-col border-t-2 border-solid border-background-border pt-10 lg:flex-row">
+export const Section = ({ title, children, id }: SectionProps) => (
+  <div
+    id={id}
+    className="flex flex-col border-t-2 border-solid border-background-border pt-10 lg:flex-row"
+  >
     <div className="max-w-80 grow">
       <p className="mb-4 text-xl font-bold">{title}</p>
     </div>

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -20,6 +20,7 @@ interface Options {
   updateSession: (data: unknown) => Promise<Session | null>;
   jobSectionError: boolean;
   educationSectionError: boolean;
+  onScrollToError?: (fieldId: string) => void;
 }
 
 export function useProfileSubmit({
@@ -29,12 +30,16 @@ export function useProfileSubmit({
   updateSession,
   jobSectionError,
   educationSectionError,
+  onScrollToError,
 }: Options) {
   const router = useRouter();
   const [isSaving, setIsSaving] = useState(false);
 
   const onSubmit = async (values: ProfileFormValues) => {
-    if (jobSectionError || educationSectionError) return;
+    if (jobSectionError || educationSectionError) {
+      onScrollToError?.(jobSectionError ? 'work_experiences' : 'educations');
+      return;
+    }
 
     try {
       setIsSaving(true);


### PR DESCRIPTION
## What Does This PR Do?

- Add `onError` callback to `form.handleSubmit` that scrolls to the first field with a validation error (by DOM id) using `scrollIntoView({ behavior: 'smooth', block: 'center' })`
- Define `FIELD_SCROLL_ORDER` to ensure scroll target follows top-to-bottom screen order regardless of `Object.keys` iteration order
- Add `id` props to all `<Section>` components in the profile edit page for DOM targeting
- Wrap `JobExperienceSection` and `EducationSection` in `<div id="work_experiences">` / `<div id="educations">` since they render their own internal `<Section>`
- Extend `useProfileSubmit` with optional `onScrollToError` callback, called before the year-range early return so that date-range errors also trigger scroll
- Add `id?: string` prop to the `Section` component

## Demo

http://localhost:3000/profile/[userId]/edit

## Screenshot

N/A

## Anything to Note?

Year-range errors (`jobSectionError` / `educationSectionError`) pass RHF validation and hit `onSubmit`, not `onError` — so the scroll is triggered from `useProfileSubmit` via the new `onScrollToError` callback rather than from the `onError` path.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
