### PR TITLE
fix: bust avatar cache on mentor-pool page using updated_at (#128)

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -89,7 +89,7 @@ export default function MentorPoolContainer() {
         ...mentor,
         avatar:
           typeof mentor.avatar === 'string' && mentor.avatar
-            ? mentor.avatar
+            ? `${mentor.avatar}${mentor.updated_at ? `?cb=${mentor.updated_at}` : ''}`
             : avatarImage,
       }));
     } finally {
@@ -124,7 +124,7 @@ export default function MentorPoolContainer() {
         ...mentor,
         avatar:
           typeof mentor.avatar === 'string' && mentor.avatar
-            ? mentor.avatar
+            ? `${mentor.avatar}${mentor.updated_at ? `?cb=${mentor.updated_at}` : ''}`
             : avatarImage,
       }));
     } finally {


### PR DESCRIPTION
## What Does This PR Do?

- In `container.tsx`, both `fetchMentors` and `fetchMoreMentors` now append `?cb=${mentor.updated_at}` to the avatar URL when `updated_at` is available
- Ensures the browser treats each avatar revision as a distinct URL, matching the cache-busting pattern already used in the Header and profile pages
- Falls back gracefully (no query param) when `updated_at` is null

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

`updated_at` reflects the mentor's last profile update time, which is always refreshed when an avatar is changed — making it a reliable cache key for this purpose.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
