### PR TITLE
fix: prevent iOS Safari auto-zoom on input/textarea/select (#91)

### DIFF
--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -163,7 +163,7 @@ export function ShareProfileDialog({
                   id="share-profile-link"
                   value={profileUrl}
                   readOnly
-                  className="bg-transparent text-black flex-1 border-0 text-[14px] outline-none"
+                  className="bg-transparent text-black flex-1 border-0 text-base outline-none md:text-[14px]"
                 />
 
                 <Button

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -46,7 +46,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'bg-transparent flex h-11 w-full rounded-md py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50',
+        'bg-transparent flex h-11 w-full rounded-md py-3 text-base outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className
       )}
       {...props}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'file:bg-transparent flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50',
+          'file:bg-transparent flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/select-options.tsx
+++ b/src/components/ui/select-options.tsx
@@ -29,7 +29,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
     return (
       <Select.Item
         className={cn(
-          'data-[disabled]:text-mauve8 text-black data-[highlighted]:text-white relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-[13px] leading-none data-[disabled]:pointer-events-none data-[highlighted]:bg-primary data-[highlighted]:outline-none',
+          'data-[disabled]:text-mauve8 text-black data-[highlighted]:text-white relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-base leading-none data-[disabled]:pointer-events-none data-[highlighted]:bg-primary data-[highlighted]:outline-none md:text-[13px]',
           className
         )}
         {...props}
@@ -50,7 +50,7 @@ const SelectOptions = React.forwardRef<HTMLDivElement, SelectOptionsProps>(
     return (
       <Select.Root>
         <Select.Trigger
-          className="text-violet11 inline-flex h-10 items-center gap-[5px] rounded border border-input px-3 py-2 text-sm leading-none outline-none data-[placeholder]:text-muted-foreground"
+          className="text-violet11 inline-flex h-10 items-center gap-[5px] rounded border border-input px-3 py-2 text-base leading-none outline-none data-[placeholder]:text-muted-foreground md:text-sm"
           aria-label="Food"
         >
           <Select.Value placeholder={selectItemData.placeholder} />
@@ -65,7 +65,7 @@ const SelectOptions = React.forwardRef<HTMLDivElement, SelectOptionsProps>(
             </Select.ScrollUpButton>
             <Select.Viewport className="p-[5px]">
               <Select.Group>
-                <Select.Label className="px-[25px] text-xs leading-[25px] text-muted-foreground">
+                <Select.Label className="px-[25px] text-base leading-[25px] text-muted-foreground md:text-xs">
                   {selectItemData.label}
                 </Select.Label>
                 {selectItemData.options.map((option) => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'bg-transparent block w-full rounded-md border border-input px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50',
+          'bg-transparent block w-full rounded-md border border-input px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}


### PR DESCRIPTION
## What Does This PR Do?

- Change font size on all interactive input elements from `text-sm` (14px) to `text-base md:text-sm` (16px on mobile, 14px on desktop)
- iOS Safari auto-zooms when a focused input has font-size < 16px — this fix eliminates that behaviour across the entire app
- Affected components: `Input`, `Textarea`, `SelectTrigger` (shadcn), `CommandInput` (MultiSelect search), `SelectItem`, `Select.Trigger`, `Select.Label` (select-options), and the share-profile link input in `ShareProfileDialog`
- Desktop appearance is fully unchanged

## Demo

http://localhost:3000/auth/signin

## Screenshot

N/A

## Anything to Note?

Only the 8 elements listed in the ticket were changed. Other `text-sm` occurrences in `select.tsx` and `command.tsx` are dropdown list items/labels — they are not focusable inputs and do not trigger iOS zoom, so they were intentionally left unchanged.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
