### PR TITLE
feat: remove avatar upload size limit and auto-compress oversized images (#129)

### DIFF
--- a/src/components/onboarding/steps/WhoAreYou.tsx
+++ b/src/components/onboarding/steps/WhoAreYou.tsx
@@ -27,7 +27,6 @@ export const WhoAreYou: FC<Props> = ({ form, avatarUrl }) => {
       <AvatarUpload
         control={form.control}
         name="avatarFile"
-        maxSize={2 * 1024 * 1024}
         avatarUrl={avatarUrl}
       />
 

--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -19,11 +19,6 @@ export const AvatarSection = <T extends FieldValues>({
   avatarUrl,
 }: AvatarSectionProps<T>) => (
   <Section title="個人頭像">
-    <AvatarUpload
-      control={control}
-      name={name}
-      maxSize={2 * 1024 * 1024}
-      avatarUrl={avatarUrl}
-    />
+    <AvatarUpload control={control} name={name} avatarUrl={avatarUrl} />
   </Section>
 );

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -38,18 +38,29 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
     return () => window.removeEventListener('resize', calculate);
   }, []);
 
-  const handleSaveImage = async () => {
-    if (editorRef.current) {
-      try {
-        const imageUrl = editorRef.current.getImageScaledToCanvas().toDataURL();
-        const response = await fetch(imageUrl);
-        const blob = await response.blob();
-        onSave(blob);
+  const handleSaveImage = () => {
+    if (!editorRef.current) return;
+    const canvas = editorRef.current.getImageScaledToCanvas();
+    const maxBytes = 2 * 1024 * 1024;
+
+    canvas.toBlob((pngBlob) => {
+      if (!pngBlob) return;
+      if (pngBlob.size <= maxBytes) {
+        onSave(pngBlob);
         onClose();
-      } catch (error) {
-        console.error('Error saving image:', error);
+      } else {
+        canvas.toBlob(
+          (jpegBlob) => {
+            if (jpegBlob) {
+              onSave(jpegBlob);
+              onClose();
+            }
+          },
+          'image/jpeg',
+          0.85
+        );
       }
-    }
+    });
   };
 
   return (

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -13,14 +13,12 @@ const AvatarCropModal = dynamic(() => import('./avatar-crop-modal'), {
 interface AvatarUploadProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
-  maxSize?: number;
   avatarUrl?: string;
 }
 
 const AvatarUpload = <T extends FieldValues>({
   control,
   name,
-  maxSize = 2 * 1024 * 1024,
   avatarUrl,
 }: AvatarUploadProps<T>) => {
   const { field } = useController({ control, name });
@@ -37,11 +35,9 @@ const AvatarUpload = <T extends FieldValues>({
   const handleUploadAvatar = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];
     e.target.value = '';
-    if (file && file.size <= maxSize) {
+    if (file) {
       setSelectedImage(file);
       setOpen(true);
-    } else if (file) {
-      alert(`上傳的檔案大小不能超過 ${maxSize / (1024 * 1024)}MB`);
     }
   };
 


### PR DESCRIPTION
## What Does This PR Do?

- Remove the 2MB hard limit on avatar file uploads — any size image can now enter the crop flow
- After cropping, output PNG if the blob is ≤ 2MB; automatically re-encode as JPEG (quality 0.85) if it exceeds 2MB
- Remove unused `maxSize` prop from `AvatarUpload`, `WhoAreYou`, and `AvatarSection`

## Demo

http://localhost:3000/auth/onboarding
http://localhost:3000/profile/[pageUserId]/edit

## Screenshot

N/A

## Anything to Note?

The cropped canvas is always ≤ 512×512px, so JPEG output will typically be 50–200KB — the 2MB threshold is effectively a safety net rather than a realistic limit.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
