### PR TITLE
fix: export avatar at fixed 512×512 regardless of display size

### DIFF
--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -40,16 +40,22 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
 
   const handleSaveImage = () => {
     if (!editorRef.current) return;
-    const canvas = editorRef.current.getImageScaledToCanvas();
+    const editorCanvas = editorRef.current.getImageScaledToCanvas();
+    const out = document.createElement('canvas');
+    out.width = 512;
+    out.height = 512;
+    const ctx = out.getContext('2d');
+    if (!ctx) return;
+    ctx.drawImage(editorCanvas, 0, 0, 512, 512);
     const maxBytes = 2 * 1024 * 1024;
 
-    canvas.toBlob((pngBlob) => {
+    out.toBlob((pngBlob) => {
       if (!pngBlob) return;
       if (pngBlob.size <= maxBytes) {
         onSave(pngBlob);
         onClose();
       } else {
-        canvas.toBlob(
+        out.toBlob(
           (jpegBlob) => {
             if (jpegBlob) {
               onSave(jpegBlob);


### PR DESCRIPTION
## What Does This PR Do?

- In `avatar-crop-modal.tsx`, after calling `getImageScaledToCanvas()`, draw the result onto a new fixed 512×512 canvas before exporting
- Decouples the export resolution from the responsive `editorSize` (which shrinks to ~179 px on mobile)
- Preserves the existing PNG → JPEG fallback compression logic unchanged
- Adds a null guard for `getContext('2d')` to satisfy TypeScript strict mode

## Demo

http://localhost:3000/profile/edit

## Screenshot

N/A

## Anything to Note?

Previously, avatars uploaded from mobile devices could be as small as 179×179 px, causing visible blur on the mentor-pool page where cards render at 334–413 px. With this fix, S3 always receives a 512×512 image regardless of the user's device or viewport.
