### PR TITLE
perf: use avatar-thumb in small-display reservation contexts

### DIFF
--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -23,6 +23,7 @@ import {
 } from '@/hooks/useMentorSchedule';
 import { UserType } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { captureFlowFailure } from '@/lib/monitoring';
 import {
   createReservation,
@@ -298,7 +299,11 @@ export default function MenteeReservationDialog({
           <div className="flex items-center gap-4">
             <div className="relative h-16 w-16 flex-shrink-0 rounded-full">
               <Image
-                src={userData?.avatar || DefaultAvatarImgUrl}
+                src={
+                  userData?.avatar
+                    ? getAvatarThumbUrl(userData.avatar)
+                    : DefaultAvatarImgUrl
+                }
                 alt={userData?.name || 'Mentor Avatar'}
                 fill
                 className="rounded-full object-cover"
@@ -363,7 +368,11 @@ export default function MenteeReservationDialog({
           <div className="flex items-center gap-4">
             <div className="relative h-16 w-16 flex-shrink-0 rounded-full">
               <Image
-                src={userData?.avatar || DefaultAvatarImgUrl}
+                src={
+                  userData?.avatar
+                    ? getAvatarThumbUrl(userData.avatar)
+                    : DefaultAvatarImgUrl
+                }
                 alt={userData?.name || 'Mentor Avatar'}
                 fill
                 className="rounded-full object-cover"

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { trackEvent } from '@/lib/analytics';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
 
 import type { Reservation } from './types';
@@ -79,7 +80,11 @@ export default function AcceptReservationDialog({
               <div className="flex items-center gap-3">
                 <Avatar className="h-10 w-10">
                   <AvatarImage
-                    src={reservation.avatar}
+                    src={
+                      reservation.avatar
+                        ? getAvatarThumbUrl(reservation.avatar)
+                        : undefined
+                    }
                     alt={reservation.name}
                   />
                   <AvatarFallback>{initials}</AvatarFallback>

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
 import { trackEvent } from '@/lib/analytics';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
 
 import type { Reservation } from './types';
@@ -91,7 +92,11 @@ export default function CancelReservationDialog({
               <div className="flex items-center gap-3">
                 <Avatar className="h-10 w-10">
                   <AvatarImage
-                    src={reservation.avatar}
+                    src={
+                      reservation.avatar
+                        ? getAvatarThumbUrl(reservation.avatar)
+                        : undefined
+                    }
                     alt={reservation.name}
                   />
                   <AvatarFallback>{initials}</AvatarFallback>

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -3,6 +3,7 @@ import { CalendarDays, Clock } from 'lucide-react';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
 import type { Reservation } from './types';
 
@@ -20,7 +21,10 @@ export function ReservationCard({
           {/* Avatar */}
           <Avatar className="h-10 w-10 shrink-0 sm:h-12 sm:w-12">
             {item.avatar ? (
-              <AvatarImage src={item.avatar} alt={item.name} />
+              <AvatarImage
+                src={getAvatarThumbUrl(item.avatar)}
+                alt={item.name}
+              />
             ) : null}
             <AvatarFallback className="font-medium">
               {item.name


### PR DESCRIPTION
## What Does This PR Do?

- Apply `getAvatarThumbUrl()` to all reservation components that display avatars at 40–64px
- Updated components: `ReservationCard`, `AcceptReservationDialog`, `CancelReservationDialog`, `MenteeReservationDialog` (×2 spots)
- Reduces unnecessary bandwidth by serving pre-generated S3 thumbnails instead of full-size images in small display contexts

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

`avatar` is typed as `string | undefined` in the `Reservation` type, so conditional guards are used (`avatar ? getAvatarThumbUrl(avatar) : undefined`) to stay type-safe. The `getAvatarThumbUrl` helper already handles empty strings internally.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
