### PR TITLE
fix: increase avatar export resolution and bypass Next.js image cache for mentor cards (#133)

### DIFF
--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -20,6 +20,7 @@ export const AvatarWithBadge = ({ avatar, years }: AvatarWithBadgeProps) => {
         fill
         sizes="(max-width: 768px) 334px, 413px"
         className="h-full object-cover"
+        unoptimized={typeof avatar === 'string'}
       />
       <figcaption className="absolute bottom-[30px] right-[30px] rounded-lg bg-[#000000]/30 px-2.5 py-1 text-text-white">
         {displayYears}工作經驗

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -42,11 +42,11 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
     if (!editorRef.current) return;
     const editorCanvas = editorRef.current.getImageScaledToCanvas();
     const out = document.createElement('canvas');
-    out.width = 512;
-    out.height = 512;
+    out.width = 1024;
+    out.height = 1024;
     const ctx = out.getContext('2d');
     if (!ctx) return;
-    ctx.drawImage(editorCanvas, 0, 0, 512, 512);
+    ctx.drawImage(editorCanvas, 0, 0, 1024, 1024);
     const maxBytes = 2 * 1024 * 1024;
 
     out.toBlob((pngBlob) => {


### PR DESCRIPTION
## What Does This PR Do?

- Increase avatar export canvas from 512×512 to 1024×1024 in `avatar-crop-modal.tsx` so newly uploaded avatars are sharp on large mentor card displays (334px mobile / 413px desktop)
- Add `unoptimized={typeof avatar === 'string'}` to `<Image>` in `AvatarWithBadge.tsx` to bypass Next.js Image Optimization for S3 avatar URLs, allowing the existing `?cb=updated_at` query param to bust the browser cache immediately on avatar update

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Resolution improvement only applies to avatars uploaded after this change; existing accounts must re-upload to benefit
- Bypassing Next.js optimisation means the browser downloads the full 1024×1024 PNG for each mentor card; WebP conversion and server-side resize are no longer applied to these images

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
