### PR TITLE
fix: 修正導師 onboarding 標題顯示錯誤及手機版儲存按鈕斷行問題

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -154,7 +154,11 @@ export default function Page({
 
   return (
     <div className="mx-auto w-11/12 max-w-[1064px] pb-20 pt-10">
-      <EditPageHeader isSaving={isSaving} onBack={handleGoToPrev} />
+      <EditPageHeader
+        isSaving={isSaving}
+        onBack={handleGoToPrev}
+        isMentorOnboarding={isMentorOnboarding}
+      />
 
       <Form {...form}>
         <form

--- a/src/components/profile/edit/EditPageHeader.tsx
+++ b/src/components/profile/edit/EditPageHeader.tsx
@@ -6,9 +6,14 @@ import { Button } from '@/components/ui/button';
 interface Props {
   isSaving: boolean;
   onBack: () => void;
+  isMentorOnboarding?: boolean;
 }
 
-export function EditPageHeader({ isSaving, onBack }: Props) {
+export function EditPageHeader({
+  isSaving,
+  onBack,
+  isMentorOnboarding,
+}: Props) {
   return (
     <div className="mb-10 flex justify-between">
       <div className="flex items-center gap-3">
@@ -16,7 +21,9 @@ export function EditPageHeader({ isSaving, onBack }: Props) {
           className={`sm:hidden ${isSaving ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`}
           onClick={isSaving ? undefined : onBack}
         />
-        <p className="text-4xl font-bold">編輯個人頁面</p>
+        <p className="whitespace-nowrap text-4xl font-bold">
+          {isMentorOnboarding ? '完成個人資料' : '編輯個人頁面'}
+        </p>
       </div>
 
       <div className="flex items-center gap-4">
@@ -32,7 +39,7 @@ export function EditPageHeader({ isSaving, onBack }: Props) {
         <Button
           type="submit"
           variant="default"
-          className="grow rounded-full px-6 py-3 sm:grow-0"
+          className="w-[88px] rounded-full py-3 sm:w-auto sm:grow-0 sm:px-6"
           form="edit-profile-form"
           disabled={isSaving}
         >


### PR DESCRIPTION
## What Does This PR Do?

- 在 `EditPageHeader` 新增 `isMentorOnboarding?: boolean` prop，onboarding 情境下標題顯示「完成個人資料」而非「編輯個人頁面」
- 標題 `<p>` 加上 `whitespace-nowrap`，防止手機版空間不足時文字斷行
- 儲存按鈕改為 `w-[88px]`（手機）/ `sm:w-auto`（桌機），鎖定寬度避免 loading 狀態下按鈕撐寬擠壓標題

## Demo

http://localhost:3000/profile/[pageUserId]/edit?onboarding=true

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
