### PR TITLE
fix: use getImage() for full-resolution avatar crop export (#134)

### DIFF
--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -40,13 +40,16 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
 
   const handleSaveImage = () => {
     if (!editorRef.current) return;
-    const editorCanvas = editorRef.current.getImageScaledToCanvas();
+    // getImage() = original-resolution crop; getImageScaledToCanvas() = display size (≤512px) → upscale → blurry
+    const sourceCanvas = editorRef.current.getImage();
     const out = document.createElement('canvas');
     out.width = 1024;
     out.height = 1024;
     const ctx = out.getContext('2d');
     if (!ctx) return;
-    ctx.drawImage(editorCanvas, 0, 0, 1024, 1024);
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(sourceCanvas, 0, 0, 1024, 1024);
     const maxBytes = 2 * 1024 * 1024;
 
     out.toBlob((pngBlob) => {


### PR DESCRIPTION
## What Does This PR Do?

- Replace `getImageScaledToCanvas()` with `getImage()` in `avatar-crop-modal.tsx` to export the cropped area at the original file resolution before scaling down to 1024×1024
- Add `imageSmoothingEnabled` and `imageSmoothingQuality = 'high'` to ensure high-quality downscaling
- Previously, `getImageScaledToCanvas()` returned a canvas at the editor display size (≤512px on desktop, ~200px on mobile), which was upscaled to 1024×1024 — adding no pixel information and causing blurriness

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

- `getImage()` returns the cropped region at the original file resolution (e.g. 3000×3000 for a phone photo), which is then downscaled to 1024×1024 — a lossy compression, not an upscale
- Blurriness was worst on mobile where the editor display size is smallest (~200px), making the upscale ratio highest

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
