### PR TITLE
fix: 修正手機漢堡選單底部註冊按鈕被裁切的問題

### DIFF
--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -43,7 +43,7 @@ export function HamburgerMenu({
         </Button>
       </SheetTrigger>
 
-      <SheetContent side="right" className="h-screen w-screen">
+      <SheetContent side="right" className="h-dvh w-screen">
         <SheetTitle className="sr-only">導航選單</SheetTitle>
         <div className="flex h-full flex-col">
           <SheetClose asChild className="ml-auto">


### PR DESCRIPTION
## What Does This PR Do?

- 將 `HamburgerMenu` 的 `SheetContent` 高度從 `h-screen`（`100vh`）改為 `h-dvh`（`100dvh`）
- `100vh` 在 iOS Safari 等行動瀏覽器上包含瀏覽器 UI 高度，導致底部「登入 / 註冊」按鈕被裁切
- `100dvh`（dynamic viewport height）正確對應可視區域高度，與專案中 Dialog 元件的現有慣例一致

## Demo

http://localhost:3000（手機尺寸，未登入狀態，開啟漢堡選單）

## Screenshot

N/A

## Anything to Note?

`dvh` 支援 iOS Safari 15.4+、Chrome 108+，現代手機全覆蓋。

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
