### PR TITLE
fix: reduce top margin on email-verify pages for mobile (#135)

### DIFF
--- a/src/app/auth/email-verified/ui.tsx
+++ b/src/app/auth/email-verified/ui.tsx
@@ -18,7 +18,7 @@ export default function EmailVerifiedPresentation({
   onSetProfile,
 }: EmailVerifiedPresentationProps) {
   return (
-    <div className="mx-auto my-40 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:max-w-[630px]">
+    <div className="mx-auto my-8 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:my-40 md:max-w-[630px]">
       <div className="relative h-[108px] bg-[#EBFBFB]">
         <Image
           className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-2/3 transform"
@@ -28,7 +28,7 @@ export default function EmailVerifiedPresentation({
           height={80}
         />
       </div>
-      <div className="flex flex-col items-center gap-6 p-20 text-center">
+      <div className="flex flex-col items-center gap-6 px-6 py-10 text-center md:p-20">
         <h1 className="text-[32px] font-bold leading-10">{title}</h1>
 
         <p className="text-neutral-600">{content}</p>

--- a/src/app/auth/email-verify/ui.tsx
+++ b/src/app/auth/email-verify/ui.tsx
@@ -13,7 +13,7 @@ export default function EmailVerificationPage({
   onNavigateHome,
 }: EmailVerificationPageProps) {
   return (
-    <div className="mx-auto my-40 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:max-w-[630px]">
+    <div className="mx-auto my-8 max-w-[90%] overflow-hidden rounded-2xl border-2 border-solid border-background-border md:my-40 md:max-w-[630px]">
       <div className="relative h-[108px] bg-[#EBFBFB]">
         <Image
           className="absolute bottom-0 left-1/2 -translate-x-1/2 translate-y-2/3 transform"


### PR DESCRIPTION
## What Does This PR Do?

- Change `my-40` (160px) to `my-8 md:my-40` on `email-verify/ui.tsx` and `email-verified/ui.tsx` so the card sits near the top of the screen on mobile instead of being pushed far down
- Change `p-20` to `px-6 py-10 md:p-20` on the content area of `email-verified/ui.tsx` to reduce inner padding on mobile
- Desktop layout (`md:` and above) is unchanged

## Demo

http://localhost:3000/auth/email-verify

## Screenshot

N/A

## Anything to Note?

- `password-reset` and `password-reset-success` pages use `py-16` on the outer container (not `my-40`), so they align from the top edge and are unaffected

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
