### PR TITLE
feat: support rrule-based recurring slots in mentor schedule

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.49.3",
+    "rrule": "^2.8.1",
     "sharp": "^0.33.2",
     "swiper": "^12.1.2",
     "tailwind-merge": "^2.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       react-hook-form:
         specifier: ^7.49.3
         version: 7.71.1(react@18.2.0)
+      rrule:
+        specifier: ^2.8.1
+        version: 2.8.1
       sharp:
         specifier: ^0.33.2
         version: 0.33.5
@@ -6092,6 +6095,9 @@ packages:
     resolution: {integrity: sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  rrule@2.8.1:
+    resolution: {integrity: sha512-hM3dHSBMeaJ0Ktp7W38BJZ7O1zOgaFEsn41PDk+yHoEtfLV+PoJt9E9xAlZiWgf/iqEqionN0ebHFZIDAp+iGw==}
 
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
@@ -13525,6 +13531,10 @@ snapshots:
       '@rollup/rollup-win32-x64-gnu': 4.59.0
       '@rollup/rollup-win32-x64-msvc': 4.59.0
       fsevents: 2.3.3
+
+  rrule@2.8.1:
+    dependencies:
+      tslib: 2.8.1
 
   run-parallel@1.2.0:
     dependencies:

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -28,10 +28,9 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
   };
 
   const schedule = useMentorSchedule({
-    mode: 'backend',
     backend: { userId: pageUserId, year, month },
   });
-  const { loaded, setSelectedDate, parsedDraft } = schedule;
+  const { loaded, setSelectedDate, parsedDraft, allowedDates } = schedule;
 
   // Auto-select the first available date once schedule is loaded
   useEffect(() => {
@@ -78,10 +77,6 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
       </div>
     );
   }
-
-  const allowedDates = parsedDraft
-    .filter((slot) => slot.type === 'ALLOW')
-    .map((slot) => slot.dateKey);
 
   const reservationHandler = () => {
     if (!loginUserId) {

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -43,7 +43,7 @@ export default function MenteeReservationDialog({
   schedule: UseMentorScheduleReturn;
   userData: UserType | null;
 }) {
-  const { selectedDate, setSelectedDate, parsedDraft, generateBookingSlots } =
+  const { selectedDate, setSelectedDate, allowedDates, generateBookingSlots } =
     schedule;
   const router = useRouter();
 
@@ -192,10 +192,6 @@ export default function MenteeReservationDialog({
       day: 'numeric',
     }).format(new Date(selectedDate + 'T00:00:00'));
   };
-
-  const allowedDates = parsedDraft
-    .filter((slot) => slot.type === 'ALLOW')
-    .map((slot) => slot.dateKey);
 
   const renderSelectionView = () => (
     <>

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -18,7 +18,10 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
-import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
+import {
+  expandRrule,
+  UseMentorScheduleReturn,
+} from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
@@ -41,12 +44,18 @@ const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) =>
 );
 const MINUTE_OPTIONS = ['00', '15', '30', '45'];
 
-/** Snap a minute value to the nearest option in [0, 15, 30, 45]. */
 const snapMinute = (m: number): string => {
   const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
     Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
   );
   return String(snapped).padStart(2, '0');
+};
+
+const fmtTime = (unix: number): string => {
+  const d = new Date(unix * 1000);
+  const h = String(d.getHours()).padStart(2, '0');
+  const m = String(d.getMinutes()).padStart(2, '0');
+  return `${h}:${m}`;
 };
 
 export default function MentorScheduleDialog({
@@ -66,9 +75,11 @@ export default function MentorScheduleDialog({
     draftForSelectedDate,
     addSlotForSelectedDate,
     deleteDraftSlot,
+    toggleOccurrence,
     confirmChanges,
     resetChanges,
     parsedDraft,
+    allowedDates,
     updateDraftSlot,
     meetingDurationMinutes,
   } = schedule;
@@ -87,22 +98,35 @@ export default function MentorScheduleDialog({
     }
   }, [open]);
 
+  // Only show ALLOW/BLOCK slots in the editor; BOOKED/PENDING are read-only
+  const editableSlotsForDate = draftForSelectedDate.filter(
+    (s) => s.type === 'ALLOW'
+  );
+
+  // Collect booked dtstart values for the selected date (for locking sub-slots)
+  const bookedStartsForDate = new Set(
+    draftForSelectedDate
+      .filter((s) => s.type === 'BOOKED')
+      .map((s) => Math.floor(s.start.getTime() / 1000))
+  );
+
   useEffect(() => {
     setEditingSlots(
-      draftForSelectedDate.map((slot) => ({
-        id: slot.id,
-        startHour: String(slot.start.getHours()).padStart(2, '0'),
-        startMinute: snapMinute(slot.start.getMinutes()),
-        endHour: String(slot.end.getHours()).padStart(2, '0'),
-        endMinute: snapMinute(slot.end.getMinutes()),
-      }))
+      editableSlotsForDate.map((slot) => {
+        const endHM = fmtTime(Math.floor(slot.end.getTime() / 1000));
+        const [endH, endM] = endHM.split(':');
+        return {
+          id: slot.id,
+          startHour: String(slot.start.getHours()).padStart(2, '0'),
+          startMinute: snapMinute(slot.start.getMinutes()),
+          endHour: endH ?? '00',
+          endMinute: snapMinute(parseInt(endM ?? '0')),
+        };
+      })
     );
     setSlotErrors({});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [draftForSelectedDate]);
-
-  const allowedDates = parsedDraft
-    .filter((slot) => slot.type === 'ALLOW')
-    .map((slot) => slot.dateKey);
 
   const hasAnyError = Object.values(slotErrors).some(
     (e) => e.timeRange || e.overlap
@@ -196,7 +220,6 @@ export default function MentorScheduleDialog({
       const lastEnd = slotsToday[slotsToday.length - 1].end;
       startH = lastEnd.getHours();
       startM = lastEnd.getMinutes();
-      // snap to next 15-min boundary at or after lastEnd's minute
       const snapped = Math.ceil(startM / 15) * 15;
       if (snapped >= 60) {
         startH += 1;
@@ -244,12 +267,11 @@ export default function MentorScheduleDialog({
     </Select>
   );
 
-  const MIN_DURATION = 30; // minutes
+  const MIN_DURATION = 30;
 
   const getEndHourOptions = (slot: EditingSlot): string[] => {
     const minEnd =
       parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
-    // Keep hours where at least one minute option (max = 45) yields endTotal >= minEnd
     return HOUR_OPTIONS.filter((h) => parseInt(h) * 60 + 45 >= minEnd);
   };
 
@@ -258,6 +280,53 @@ export default function MentorScheduleDialog({
       parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
     return MINUTE_OPTIONS.filter(
       (m) => parseInt(slot.endHour) * 60 + parseInt(m) >= minEnd
+    );
+  };
+
+  /** Render the sub-slot chips for an ALLOW block so mentor can toggle individual occurrences. */
+  const renderSubSlots = (slotId: number) => {
+    const parsed = editableSlotsForDate.find((s) => s.id === slotId);
+    if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
+
+    const occurrences = expandRrule(
+      Math.floor(parsed.start.getTime() / 1000),
+      parsed.rrule
+    );
+    if (occurrences.length <= 1) return null;
+
+    const slotDurSec = parsed.slotDurationSeconds;
+
+    return (
+      <div className="mt-2 flex flex-wrap gap-1.5">
+        {occurrences.map((occ) => {
+          const isBooked = bookedStartsForDate.has(occ);
+          const isExcluded = parsed.exdate?.includes(occ) ?? false;
+          const startLabel = fmtTime(occ);
+          const endLabel = fmtTime(occ + slotDurSec);
+
+          return (
+            <button
+              key={occ}
+              type="button"
+              disabled={isBooked}
+              onClick={() => toggleOccurrence(slotId, occ)}
+              className={[
+                'rounded border px-2 py-0.5 text-xs transition-colors',
+                isBooked
+                  ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
+                  : isExcluded
+                    ? 'bg-white border-gray-300 text-gray-400 line-through'
+                    : 'border-primary bg-primary/10 text-primary hover:bg-primary/20',
+              ].join(' ')}
+            >
+              {startLabel}–{endLabel}
+              {isBooked && (
+                <span className="ml-1 text-[10px] text-gray-400">已預約</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
     );
   };
 
@@ -372,6 +441,8 @@ export default function MentorScheduleDialog({
                       </div>
                     </div>
 
+                    {renderSubSlots(slot.id)}
+
                     {errors.timeRange && (
                       <p className="text-red-500 text-xs lg:text-sm">
                         {errors.timeRange}
@@ -387,7 +458,7 @@ export default function MentorScheduleDialog({
                 );
               })}
 
-              {draftForSelectedDate.length === 0 && (
+              {editableSlotsForDate.length === 0 && (
                 <Button
                   variant="ghost"
                   onClick={addNewTimeSlot}

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -98,7 +98,7 @@ export default function MentorScheduleDialog({
     }
   }, [open]);
 
-  // Only show ALLOW/BLOCK slots in the editor; BOOKED/PENDING are read-only
+  // Only ALLOW slots are editable; BOOKED/PENDING are read-only
   const editableSlotsForDate = draftForSelectedDate.filter(
     (s) => s.type === 'ALLOW'
   );

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 dayjs.extend(isSameOrBefore);
 
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import {
   BookingSlot,
@@ -23,12 +23,7 @@ import {
   syncMonthSchedule,
 } from '@/services/mentor-schedule/sync';
 
-export type {
-  BookingSlot,
-  DtType,
-  ParsedMentorTimeslot,
-  RawMentorTimeslot,
-} from '@/lib/profile/scheduleHelpers';
+export type { BookingSlot } from '@/lib/profile/scheduleHelpers';
 export { expandRrule } from '@/lib/profile/scheduleHelpers';
 
 type Options = {
@@ -37,12 +32,10 @@ type Options = {
     year: number;
     month: number; // 1-12
   };
-  debug?: boolean;
 };
 
 export type UseMentorScheduleReturn = {
   loaded: boolean;
-  dirty: boolean;
   selectedDate: string | null;
   setSelectedDate: (dateStr: string | null) => void;
 
@@ -52,7 +45,6 @@ export type UseMentorScheduleReturn = {
   allowedDates: string[];
 
   meetingDurationMinutes: number;
-  setMeetingDuration: (minutes: number) => void;
   generateBookingSlots: (dateKey: string) => BookingSlot[];
 
   addSlotForSelectedDate: (opts: {
@@ -79,13 +71,7 @@ export type UseMentorScheduleReturn = {
 };
 
 export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
-  const { backend, debug = false } = opts;
-
-  const debugRef = useRef(debug);
-  debugRef.current = debug;
-  const log = useCallback((...args: unknown[]) => {
-    if (debugRef.current) console.log('[MentorSchedule]', ...args);
-  }, []);
+  const { backend } = opts;
 
   const [saved, setSaved] = useState<RawMentorTimeslot[]>([]);
   const [draft, setDraft] = useState<RawMentorTimeslot[]>([]);
@@ -96,10 +82,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
   const [meetingDurationMinutes, setMeetingDurationMinutes] =
     useState<number>(30);
-
-  const setMeetingDuration = useCallback((minutes: number) => {
-    setMeetingDurationMinutes(minutes);
-  }, []);
 
   const persistedIdSet = useMemo(
     () => new Set(saved.filter((s) => s.id > 0).map((s) => s.id)),
@@ -125,7 +107,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     if (!backend.userId || !backend.year || !backend.month) return;
     let ignore = false;
     (async () => {
-      log('init load:', { backend });
       try {
         const raws = await loadMonthSchedule(backend);
         if (ignore) return;
@@ -141,8 +122,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           );
           if (derived > 0) setMeetingDurationMinutes(derived);
         }
-      } catch (e) {
-        log('fetchMentorSchedule error:', e);
+      } catch {
         if (!ignore) setLoaded(true);
       }
     })();
@@ -210,13 +190,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       return result;
     },
     [draft]
-  );
-
-  const dirty = useMemo(
-    () =>
-      JSON.stringify(saved) !== JSON.stringify(draft) ||
-      pendingDeleteIds.length > 0,
-    [saved, draft, pendingDeleteIds]
   );
 
   const addSlotForSelectedDate: UseMentorScheduleReturn['addSlotForSelectedDate'] =
@@ -348,8 +321,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     []
   );
 
+  const dirty =
+    JSON.stringify(saved) !== JSON.stringify(draft) ||
+    pendingDeleteIds.length > 0;
+
   const confirmChanges = useCallback(async () => {
-    log('confirmChanges clicked:', { backend, dirty, pendingDeleteIds });
     if (!dirty) return;
     if (!backend.userId) return;
 
@@ -374,13 +350,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
     const idsToDelete = [...pendingDeleteIds, ...extraDeleteIds];
 
-    log('confirmChanges dedup:', {
-      rawUpsertCount: rawUpsert.length,
-      upsertPayloadCount: upsertPayload.length,
-      extraDeleteIds,
-      idsToDelete,
-    });
-
     const raws = await syncMonthSchedule({
       ref: backend,
       upsertPayload,
@@ -390,9 +359,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       setSaved(raws);
       setDraft(raws);
       setPendingDeleteIds([]);
-      log('refetched after confirm:', { count: raws.length });
     }
-  }, [draft, toServiceSlot, dirty, pendingDeleteIds, log, backend]);
+  }, [draft, toServiceSlot, dirty, pendingDeleteIds, backend]);
 
   const resetChanges = useCallback(() => {
     if (!backend.userId || !backend.year || !backend.month) return;
@@ -407,14 +375,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   return {
     loaded,
-    dirty,
     selectedDate,
     setSelectedDate,
     parsedDraft,
     draftForSelectedDate,
     allowedDates,
     meetingDurationMinutes,
-    setMeetingDuration,
     generateBookingSlots,
     addSlotForSelectedDate,
     updateDraftSlot,

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -7,43 +7,32 @@ dayjs.extend(isSameOrBefore);
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
-  BookedSlot,
-  deleteMentorSchedule,
-  fetchMentorSchedule,
-  saveMentorSchedule,
-  TimeSlotVO,
-  UpsertTimeslotBackend,
-} from '@/services/mentor-schedule/schedule';
+  BookingSlot,
+  buildDateTime,
+  buildRrule,
+  expandRrule,
+  formatTimeslot,
+  hasOverlapAt,
+  nextTempId,
+  ParsedMentorTimeslot,
+  RawMentorTimeslot,
+} from '@/lib/profile/scheduleHelpers';
+import { UpsertTimeslotBackend } from '@/services/mentor-schedule/schedule';
+import {
+  loadMonthSchedule,
+  syncMonthSchedule,
+} from '@/services/mentor-schedule/sync';
 
-export type RawMentorTimeslot = {
-  id: number; // negative ids are used as temporary local ids for new slots (-1, -2, ...)
-  type: 'ALLOW' | 'BLOCK';
-  dtstart: number; // unix seconds
-  dtend: number; // unix seconds
-  rrule?: string; // required by the backend; defaults to empty string for new slots
-};
-
-export type ParsedMentorTimeslot = {
-  id: number;
-  type: 'ALLOW' | 'BLOCK';
-  start: Date;
-  end: Date;
-  durationMinutes: number;
-  formatted: string;
-  dateKey: string; // YYYY-MM-DD (local)
-};
-
-export type BookingSlot = {
-  start: Date;
-  end: Date;
-  scheduleId: number; // parent ALLOW slot id
-};
+export type {
+  BookingSlot,
+  DtType,
+  ParsedMentorTimeslot,
+  RawMentorTimeslot,
+} from '@/lib/profile/scheduleHelpers';
+export { expandRrule } from '@/lib/profile/scheduleHelpers';
 
 type Options = {
-  storageKey?: string;
-  seed?: RawMentorTimeslot[];
-  mode?: 'local' | 'backend';
-  backend?: {
+  backend: {
     userId: string;
     year: number;
     month: number; // 1-12
@@ -59,22 +48,22 @@ export type UseMentorScheduleReturn = {
 
   parsedDraft: ParsedMentorTimeslot[];
   draftForSelectedDate: ParsedMentorTimeslot[];
+  /** All local dates (YYYY-MM-DD) that have at least one ALLOW occurrence after expanding rrules. */
+  allowedDates: string[];
 
   meetingDurationMinutes: number;
   setMeetingDuration: (minutes: number) => void;
   generateBookingSlots: (dateKey: string) => BookingSlot[];
 
   addSlotForSelectedDate: (opts: {
-    type: 'ALLOW' | 'BLOCK';
+    type: 'ALLOW';
     startTime: string; // HH:mm
     endTime: string; // HH:mm
   }) => void;
 
-  /** Update a slot in the draft without persisting — changes are sent only when the user confirms. */
   updateDraftSlot: (
     id: number,
     patch: {
-      type?: 'ALLOW' | 'BLOCK';
       startTime?: string; // HH:mm
       endTime?: string; // HH:mm
     }
@@ -82,62 +71,15 @@ export type UseMentorScheduleReturn = {
 
   deleteDraftSlot: (id: number) => void;
 
+  /** Toggle a single sub-slot occurrence in/out of exdate for an ALLOW slot. */
+  toggleOccurrence: (slotId: number, occurrenceDtstart: number) => void;
+
   confirmChanges: () => void;
   resetChanges: () => void;
 };
 
-const format = (r: RawMentorTimeslot): ParsedMentorTimeslot => {
-  const start = new Date(r.dtstart * 1000);
-  const end = new Date(r.dtend * 1000);
-  const durationMinutes = Math.round(
-    (end.getTime() - start.getTime()) / (1000 * 60)
-  );
-  const dateKey = dayjs(start).format('YYYY-MM-DD');
-  return {
-    id: r.id,
-    type: r.type,
-    start,
-    end,
-    durationMinutes,
-    formatted: `${dayjs(start).format('YYYY-MM-DD hh:mm A')} ~ ${dayjs(end).format('hh:mm A')}`,
-    dateKey,
-  };
-};
-
-const readFromStorage = (key: string): RawMentorTimeslot[] | null => {
-  try {
-    const str = localStorage.getItem(key);
-    return str ? (JSON.parse(str) as RawMentorTimeslot[]) : null;
-  } catch {
-    return null;
-  }
-};
-
-const writeToStorage = (key: string, data: RawMentorTimeslot[]) => {
-  localStorage.setItem(key, JSON.stringify(data));
-};
-
-const nextTempId = (rows: RawMentorTimeslot[]) => {
-  const negatives = rows.filter((r) => r.id < 0).map((r) => r.id);
-  return negatives.length ? Math.min(...negatives) - 1 : -1;
-};
-
-const backendToRaw = (t: TimeSlotVO): RawMentorTimeslot => ({
-  id: t.id || Math.floor(Math.random() * 1e9),
-  type: t.dt_type as 'ALLOW' | 'BLOCK',
-  dtstart: t.dtstart,
-  dtend: t.dtend,
-  rrule: t.rrule ?? '',
-});
-
-export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
-  const {
-    storageKey = 'mentor.timeslots',
-    seed = [],
-    mode = 'local',
-    backend,
-    debug = false,
-  } = opts;
+export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
+  const { backend, debug = false } = opts;
 
   const debugRef = useRef(debug);
   debugRef.current = debug;
@@ -151,12 +93,7 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
   const [selectedDate, setSelectedDate] = useState<string | null>(
     dayjs().format('YYYY-MM-DD')
   );
-
-  /** Positive ids removed from the draft, pending actual backend DELETE on confirm */
   const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
-
-  const [bookedSlots, setBookedSlots] = useState<BookedSlot[]>([]);
-
   const [meetingDurationMinutes, setMeetingDurationMinutes] =
     useState<number>(30);
 
@@ -172,10 +109,11 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
   const toServiceSlot = useCallback(
     (r: RawMentorTimeslot): UpsertTimeslotBackend => {
       const slot: UpsertTimeslotBackend = {
-        dt_type: r.type,
+        dt_type: 'ALLOW',
         dtstart: r.dtstart,
         dtend: r.dtend,
-        rrule: r.rrule ?? '',
+        rrule: r.rrule,
+        exdate: r.exdate,
       };
       if (r.id > 0 && persistedIdSet.has(r.id)) slot.id = r.id;
       return slot;
@@ -184,59 +122,41 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
   );
 
   useEffect(() => {
+    if (!backend.userId || !backend.year || !backend.month) return;
     let ignore = false;
     (async () => {
-      log('init load:', { mode, backend, storageKey });
-      if (
-        mode === 'backend' &&
-        backend?.userId &&
-        backend?.year &&
-        backend?.month
-      ) {
-        try {
-          const data = await fetchMentorSchedule({
-            userId: backend.userId,
-            year: backend.year,
-            month: backend.month,
-          });
-          const raws = (data?.timeslots ?? []).map(backendToRaw).filter((r) => {
-            const d = dayjs(r.dtstart * 1000);
-            return d.year() === backend.year && d.month() + 1 === backend.month;
-          });
-          if (!ignore) {
-            setSaved(raws);
-            setDraft(raws);
-            setLoaded(true);
-            setPendingDeleteIds([]);
-            setBookedSlots(data?.booked_slots ?? []);
-            if (data?.meeting_duration_minutes) {
-              setMeetingDurationMinutes(data.meeting_duration_minutes);
-            }
-          }
-        } catch (e) {
-          log('fetchMentorSchedule error:', e);
-          if (!ignore) setLoaded(true);
+      log('init load:', { backend });
+      try {
+        const raws = await loadMonthSchedule(backend);
+        if (ignore) return;
+        setSaved(raws);
+        setDraft(raws);
+        setLoaded(true);
+        setPendingDeleteIds([]);
+        // Derive meeting duration from the first ALLOW slot's sub-slot size
+        const firstAllow = raws.find((r) => r.type === 'ALLOW');
+        if (firstAllow) {
+          const derived = Math.round(
+            (firstAllow.dtend - firstAllow.dtstart) / 60
+          );
+          if (derived > 0) setMeetingDurationMinutes(derived);
         }
-      } else {
-        const fromStore = readFromStorage(storageKey);
-        const base = fromStore ?? seed ?? [];
-        if (!ignore) {
-          setSaved(base);
-          setDraft(base);
-          setLoaded(true);
-          setPendingDeleteIds([]);
-        }
+      } catch (e) {
+        log('fetchMentorSchedule error:', e);
+        if (!ignore) setLoaded(true);
       }
     })();
     return () => {
       ignore = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mode, storageKey, backend?.userId, backend?.year, backend?.month]);
+  }, [backend.userId, backend.year, backend.month]);
 
   const parsedDraft = useMemo(
     () =>
-      draft.map(format).sort((a, b) => a.start.getTime() - b.start.getTime()),
+      draft
+        .map(formatTimeslot)
+        .sort((a, b) => a.start.getTime() - b.start.getTime()),
     [draft]
   );
 
@@ -248,35 +168,48 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
     [parsedDraft, selectedDate]
   );
 
+  const allowedDates = useMemo(() => {
+    const dates = new Set<string>();
+    for (const slot of draft) {
+      if (slot.type !== 'ALLOW') continue;
+      const occurrences = expandRrule(slot.dtstart, slot.rrule);
+      for (const occ of occurrences) {
+        if (slot.exdate.includes(occ)) continue;
+        dates.add(dayjs(occ * 1000).format('YYYY-MM-DD'));
+      }
+    }
+    return Array.from(dates);
+  }, [draft]);
+
   const generateBookingSlots = useCallback(
     (dateKey: string): BookingSlot[] => {
-      const allowSlots = parsedDraft.filter(
-        (slot) => slot.type === 'ALLOW' && slot.dateKey === dateKey
+      const bookedStarts = new Set(
+        draft.filter((s) => s.type === 'BOOKED').map((s) => s.dtstart)
       );
-      const durationMs = meetingDurationMinutes * 60 * 1000;
       const result: BookingSlot[] = [];
-      for (const slot of allowSlots) {
-        let cursor = slot.start.getTime();
-        const slotEnd = slot.end.getTime();
-        while (cursor + durationMs <= slotEnd) {
-          const subStart = cursor;
-          const subEnd = cursor + durationMs;
-          const isBooked = bookedSlots.some(
-            (b) => subStart < b.dtend * 1000 && subEnd > b.dtstart * 1000
-          );
-          if (!isBooked) {
-            result.push({
-              start: new Date(subStart),
-              end: new Date(subEnd),
-              scheduleId: slot.id,
-            });
-          }
-          cursor += durationMs;
+
+      for (const slot of draft) {
+        if (slot.type !== 'ALLOW') continue;
+        const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
+        if (slotDateKey !== dateKey) continue;
+
+        const occurrences = expandRrule(slot.dtstart, slot.rrule);
+        const slotDuration = slot.dtend - slot.dtstart;
+
+        for (const occ of occurrences) {
+          if (slot.exdate.includes(occ)) continue;
+          if (bookedStarts.has(occ)) continue;
+          result.push({
+            start: new Date(occ * 1000),
+            end: new Date((occ + slotDuration) * 1000),
+            scheduleId: slot.id,
+          });
         }
       }
+
       return result;
     },
-    [parsedDraft, meetingDurationMinutes, bookedSlots]
+    [draft]
   );
 
   const dirty = useMemo(
@@ -288,49 +221,51 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
 
   const addSlotForSelectedDate: UseMentorScheduleReturn['addSlotForSelectedDate'] =
     useCallback(
-      ({ type, startTime, endTime }) => {
+      ({ startTime, endTime }) => {
         if (!selectedDate || !startTime || !endTime) return;
 
-        const buildDT = (dateStr: string, timeStr: string) => {
-          const [h, m] = timeStr.split(':').map(Number);
-          return dayjs(dateStr)
-            .hour(h ?? 0)
-            .minute(m ?? 0)
-            .second(0)
-            .millisecond(0);
-        };
-
-        const s = buildDT(selectedDate, startTime);
-        const e = buildDT(selectedDate, endTime);
+        const s = buildDateTime(selectedDate, startTime);
+        const e = buildDateTime(selectedDate, endTime);
         if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return;
 
         const newDtstart = Math.floor(s.valueOf() / 1000);
-        const newDtend = Math.floor(e.valueOf() / 1000);
+        const blockDurationSeconds =
+          Math.floor(e.valueOf() / 1000) - newDtstart;
+        const slotDurationSeconds = meetingDurationMinutes * 60;
+        const newDtend = newDtstart + slotDurationSeconds;
 
         setDraft((prev) => {
-          const hasOverlap = prev.some((r) => {
-            const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
-            return (
-              rDate === selectedDate &&
-              newDtstart < r.dtend &&
-              newDtend > r.dtstart
-            );
-          });
-          if (hasOverlap) return prev;
+          if (
+            hasOverlapAt(
+              prev,
+              null,
+              selectedDate,
+              newDtstart,
+              blockDurationSeconds
+            )
+          ) {
+            return prev;
+          }
+
+          const rrule =
+            blockDurationSeconds > slotDurationSeconds
+              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
+              : undefined;
 
           return [
             ...prev,
             {
               id: nextTempId(prev),
-              type,
+              type: 'ALLOW' as const,
               dtstart: newDtstart,
               dtend: newDtend,
-              rrule: '',
+              rrule,
+              exdate: [],
             },
           ];
         });
       },
-      [selectedDate]
+      [selectedDate, meetingDurationMinutes]
     );
 
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
@@ -339,105 +274,91 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
         const target = prev.find((r) => r.id === id);
         if (!target) return prev;
 
-        // Use the slot's own date as base and apply the new time on top
         const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
-
         const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
         const startHM = patch.startTime ?? fmtHM(target.dtstart);
-        const endHM = patch.endTime ?? fmtHM(target.dtend);
 
-        const buildDT = (dateStr: string, timeStr: string) => {
-          const [h, m] = timeStr.split(':').map(Number);
-          return dayjs(dateStr)
-            .hour(h ?? 0)
-            .minute(m ?? 0)
-            .second(0)
-            .millisecond(0);
-        };
+        const occs = expandRrule(target.dtstart, target.rrule);
+        const lastOcc = occs[occs.length - 1] ?? target.dtstart;
+        const endHM =
+          patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
 
-        const s = buildDT(baseDate, startHM);
-        const e = buildDT(baseDate, endHM);
-        if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) {
-          return prev;
-        }
+        const s = buildDateTime(baseDate, startHM);
+        const e = buildDateTime(baseDate, endHM);
+        if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return prev;
 
         const newDtstart = Math.floor(s.valueOf() / 1000);
-        const newDtend = Math.floor(e.valueOf() / 1000);
-        const hasOverlap = prev.some((r) => {
-          if (r.id === id) return false;
-          const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
-          return (
-            rDate === baseDate && newDtstart < r.dtend && newDtend > r.dtstart
-          );
-        });
-        if (hasOverlap) {
+        const blockDurationSeconds =
+          Math.floor(e.valueOf() / 1000) - newDtstart;
+        const slotDurationSeconds = target.dtend - target.dtstart;
+        const newDtend = newDtstart + slotDurationSeconds;
+
+        if (
+          hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
+        ) {
           return prev;
         }
 
-        const next = prev.map((r) =>
+        const newRrule =
+          blockDurationSeconds > slotDurationSeconds
+            ? buildRrule(blockDurationSeconds, slotDurationSeconds)
+            : undefined;
+
+        const newBlockEnd = newDtstart + blockDurationSeconds;
+        const cleanedExdate = target.exdate.filter(
+          (occ) => occ >= newDtstart && occ < newBlockEnd
+        );
+
+        return prev.map((r) =>
           r.id === id
             ? {
                 ...r,
-                type: patch.type ?? r.type,
                 dtstart: newDtstart,
                 dtend: newDtend,
+                rrule: newRrule,
+                exdate: cleanedExdate,
               }
             : r
         );
-        return next;
       });
     }, []);
 
-  const deleteDraftSlot = useCallback(
-    (id: number) => {
-      setDraft((prev) => prev.filter((r) => r.id !== id));
-      if (mode === 'backend' && id > 0) {
-        setPendingDeleteIds((prev) =>
-          prev.includes(id) ? prev : [...prev, id]
-        );
-      }
+  const deleteDraftSlot = useCallback((id: number) => {
+    setDraft((prev) => prev.filter((r) => r.id !== id));
+    if (id > 0) {
+      setPendingDeleteIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+    }
+  }, []);
+
+  const toggleOccurrence = useCallback(
+    (slotId: number, occurrenceDtstart: number) => {
+      setDraft((prev) =>
+        prev.map((r) => {
+          if (r.id !== slotId || r.type !== 'ALLOW') return r;
+          const isExcluded = r.exdate.includes(occurrenceDtstart);
+          return {
+            ...r,
+            exdate: isExcluded
+              ? r.exdate.filter((d) => d !== occurrenceDtstart)
+              : [...r.exdate, occurrenceDtstart],
+          };
+        })
+      );
     },
-    [mode]
+    []
   );
 
   const confirmChanges = useCallback(async () => {
-    log('confirmChanges clicked:', { mode, backend, dirty, pendingDeleteIds });
+    log('confirmChanges clicked:', { backend, dirty, pendingDeleteIds });
     if (!dirty) return;
+    if (!backend.userId) return;
 
-    if (mode !== 'backend') {
-      // local
-      writeToStorage(storageKey, draft);
-      setSaved(draft);
-      setPendingDeleteIds([]);
-      return;
-    }
-
-    if (!backend?.userId) {
-      log('fallback to local: missing backend.userId');
-      writeToStorage(storageKey, draft);
-      setSaved(draft);
-      setPendingDeleteIds([]);
-      return;
-    }
-
-    // End of month at 23:59:59
-    const endOfMonthUnix = dayjs(
-      `${backend.year}-${String(backend.month).padStart(2, '0')}-01`
-    )
-      .endOf('month')
-      .hour(23)
-      .minute(59)
-      .second(59)
-      .millisecond(0)
-      .unix();
-
-    // Payload to upsert this round (excluding pending deletes)
     const rawUpsert = draft
-      .filter((r) => !pendingDeleteIds.includes(r.id))
+      .filter((r) => !pendingDeleteIds.includes(r.id) && r.type === 'ALLOW')
       .map(toServiceSlot);
 
-    // Deduplicate by (dtstart, dtend): keep first occurrence, schedule extras for deletion
-    // Prevents backend 400 "conflict" errors caused by duplicate timeslots in the DB.
+    // Dedupe by (dtstart, dtend); when two slots collide on the same key,
+    // keep the first and queue any persisted duplicate for deletion.
     const seenKeys = new Map<string, number>();
     const upsertPayload: UpsertTimeslotBackend[] = [];
     const extraDeleteIds: number[] = [];
@@ -458,122 +379,31 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
       upsertPayloadCount: upsertPayload.length,
       extraDeleteIds,
       idsToDelete,
-      upsertPayload: JSON.stringify(upsertPayload),
     });
 
-    // Refetch the current month and sync saved/draft state
-    const refetch = async () => {
-      const data = await fetchMentorSchedule({
-        userId: backend.userId,
-        year: backend.year,
-        month: backend.month,
-      });
-      const raws = (data?.timeslots ?? []).map(backendToRaw).filter((r) => {
-        const d = dayjs(r.dtstart * 1000);
-        return d.year() === backend.year && d.month() + 1 === backend.month;
-      });
+    const raws = await syncMonthSchedule({
+      ref: backend,
+      upsertPayload,
+      deleteIds: idsToDelete,
+    });
+    if (raws) {
       setSaved(raws);
       setDraft(raws);
       setPendingDeleteIds([]);
-      setBookedSlots(data?.booked_slots ?? []);
-      if (data?.meeting_duration_minutes) {
-        setMeetingDurationMinutes(data.meeting_duration_minutes);
-      }
-      log('refetched after confirm:', { count: raws.length, raws });
-    };
-
-    const doPut = upsertPayload.length > 0;
-    const doDelete = idsToDelete.length > 0;
-
-    try {
-      // PUT only
-      if (doPut && !doDelete) {
-        const ok = await saveMentorSchedule({
-          userId: backend.userId,
-          until: endOfMonthUnix,
-          timeslots: upsertPayload,
-          meetingDurationMinutes,
-        });
-        if (ok) await refetch();
-        return;
-      }
-
-      // DELETE only
-      if (!doPut && doDelete) {
-        await Promise.all(
-          idsToDelete.map(async (id) => {
-            const ok = await deleteMentorSchedule({
-              userId: backend.userId,
-              scheduleId: id,
-            });
-            if (!ok) throw new Error(`DELETE failed: ${id}`);
-          })
-        );
-        await refetch();
-        return;
-      }
-
-      // PUT + DELETE together
-      const ok = await saveMentorSchedule({
-        userId: backend.userId,
-        until: endOfMonthUnix,
-        timeslots: upsertPayload,
-        meetingDurationMinutes,
-      });
-      if (!ok) throw new Error('PUT failed');
-
-      await Promise.all(
-        idsToDelete.map(async (id) => {
-          const okDel = await deleteMentorSchedule({
-            userId: backend.userId,
-            scheduleId: id,
-          });
-          if (!okDel) throw new Error(`DELETE failed: ${id}`);
-        })
-      );
-
-      await refetch();
-    } catch (e) {
-      console.error('[MentorSchedule] confirm failed:', e);
+      log('refetched after confirm:', { count: raws.length });
     }
-  }, [
-    mode,
-    draft,
-    storageKey,
-    toServiceSlot,
-    dirty,
-    pendingDeleteIds,
-    meetingDurationMinutes,
-    log,
-    backend,
-  ]);
+  }, [draft, toServiceSlot, dirty, pendingDeleteIds, log, backend]);
 
   const resetChanges = useCallback(() => {
-    if (
-      mode === 'backend' &&
-      backend?.userId &&
-      backend?.year &&
-      backend?.month
-    ) {
-      (async () => {
-        const data = await fetchMentorSchedule({
-          userId: backend.userId,
-          year: backend.year,
-          month: backend.month,
-        });
-        const raws = (data?.timeslots ?? []).map(backendToRaw).filter((r) => {
-          const d = dayjs(r.dtstart * 1000);
-          return d.year() === backend.year && d.month() + 1 === backend.month;
-        });
-        setDraft(raws);
-        setSaved(raws);
-        setPendingDeleteIds([]);
-      })();
-    } else {
-      setDraft(saved);
+    if (!backend.userId || !backend.year || !backend.month) return;
+    (async () => {
+      const raws = await loadMonthSchedule(backend);
+      setDraft(raws);
+      setSaved(raws);
       setPendingDeleteIds([]);
-    }
-  }, [mode, backend?.userId, backend?.year, backend?.month, saved]);
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [backend.userId, backend.year, backend.month]);
 
   return {
     loaded,
@@ -582,12 +412,14 @@ export function useMentorSchedule(opts: Options = {}): UseMentorScheduleReturn {
     setSelectedDate,
     parsedDraft,
     draftForSelectedDate,
+    allowedDates,
     meetingDurationMinutes,
     setMeetingDuration,
     generateBookingSlots,
     addSlotForSelectedDate,
     updateDraftSlot,
     deleteDraftSlot,
+    toggleOccurrence,
     confirmChanges,
     resetChanges,
   };

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -1,4 +1,4 @@
-import { BookingSlot, ParsedMentorTimeslot } from '@/hooks/useMentorSchedule';
+import { BookingSlot } from '@/hooks/useMentorSchedule';
 
 export function formatSelectedDate(selectedDate: Date | undefined): string {
   if (!selectedDate) {
@@ -9,11 +9,6 @@ export function formatSelectedDate(selectedDate: Date | undefined): string {
     month: 'short',
     day: 'numeric',
   }).format(selectedDate);
-}
-
-export function formatStartTimeSlot(slot: ParsedMentorTimeslot): string {
-  const slotArr = JSON.stringify(slot.formatted)?.split(' ');
-  return slotArr ? `${slotArr[1]} ${slotArr[2]}` : '';
 }
 
 const timeFormat: Intl.DateTimeFormatOptions = {

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -1,0 +1,146 @@
+import dayjs from 'dayjs';
+import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
+import { RRule } from 'rrule';
+
+import { SegmentVO } from '@/services/mentor-schedule/schedule';
+
+dayjs.extend(isSameOrBefore);
+
+export type DtType = 'ALLOW' | 'BOOKED' | 'PENDING';
+
+// id: negative values are temporary local ids for new slots (-1, -2, ...)
+// type: narrowed from SegmentVO.dt_type
+// exdate: nulls excluded from SegmentVO.exdate
+export type RawMentorTimeslot = Pick<
+  SegmentVO,
+  'dtstart' | 'dtend' | 'rrule'
+> & {
+  id: number;
+  type: DtType;
+  exdate: number[];
+};
+
+export type ParsedMentorTimeslot = {
+  id: number;
+  type: DtType;
+  start: Date; // block start (= dtstart for all types)
+  end: Date; // block end: last occurrence end for ALLOW (derived from rrule), dtend for others
+  durationMinutes: number;
+  formatted: string;
+  dateKey: string; // YYYY-MM-DD (local)
+  rrule?: string;
+  exdate: number[];
+  slotDurationSeconds: number; // duration of one sub-slot (dtend - dtstart)
+};
+
+export type BookingSlot = {
+  start: Date;
+  end: Date;
+  scheduleId: number; // parent ALLOW slot id
+};
+
+/** Expand an rrule string from dtstart, returning all occurrence dtstart values (unix seconds). */
+export function expandRrule(
+  dtstart: number,
+  rruleStr: string | undefined | null
+): number[] {
+  if (!rruleStr) return [dtstart];
+  try {
+    const options = RRule.parseString(rruleStr);
+    options.dtstart = new Date(dtstart * 1000);
+    const rule = new RRule(options);
+    return rule.all().map((d) => Math.floor(d.getTime() / 1000));
+  } catch {
+    return [dtstart];
+  }
+}
+
+export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
+  return {
+    id: t.id ?? Math.floor(Math.random() * 1e9),
+    type: t.dt_type as RawMentorTimeslot['type'],
+    dtstart: t.dtstart,
+    dtend: t.dtend,
+    rrule: t.rrule ?? undefined,
+    exdate: (t.exdate ?? []).filter((x): x is number => x !== null),
+  };
+}
+
+export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
+  const start = new Date(r.dtstart * 1000);
+  const slotDurationSeconds = r.dtend - r.dtstart;
+
+  let end: Date;
+  if (r.type === 'ALLOW' && r.rrule) {
+    const occurrences = expandRrule(r.dtstart, r.rrule);
+    const lastOccDtstart = occurrences[occurrences.length - 1] ?? r.dtstart;
+    end = new Date((lastOccDtstart + slotDurationSeconds) * 1000);
+  } else {
+    end = new Date(r.dtend * 1000);
+  }
+
+  const durationMinutes = Math.round(
+    (end.getTime() - start.getTime()) / (1000 * 60)
+  );
+  const dateKey = dayjs(start).format('YYYY-MM-DD');
+  return {
+    id: r.id,
+    type: r.type,
+    start,
+    end,
+    durationMinutes,
+    formatted: `${dayjs(start).format('YYYY-MM-DD hh:mm A')} ~ ${dayjs(end).format('hh:mm A')}`,
+    dateKey,
+    rrule: r.rrule ?? undefined,
+    exdate: r.exdate,
+    slotDurationSeconds,
+  };
+}
+
+export function nextTempId(rows: RawMentorTimeslot[]): number {
+  const negatives = rows.filter((r) => r.id < 0).map((r) => r.id);
+  return negatives.length ? Math.min(...negatives) - 1 : -1;
+}
+
+export function buildRrule(
+  blockDurationSeconds: number,
+  slotDurationSeconds: number
+): string {
+  const count = Math.round(blockDurationSeconds / slotDurationSeconds);
+  const intervalMinutes = Math.round(slotDurationSeconds / 60);
+  return `FREQ=MINUTELY;INTERVAL=${intervalMinutes};COUNT=${count}`;
+}
+
+/** Build a dayjs from a YYYY-MM-DD date and HH:mm time. */
+export function buildDateTime(dateStr: string, timeStr: string) {
+  const [h, m] = timeStr.split(':').map(Number);
+  return dayjs(dateStr)
+    .hour(h ?? 0)
+    .minute(m ?? 0)
+    .second(0)
+    .millisecond(0);
+}
+
+/**
+ * Whether [dtstart, dtstart+blockDurationSeconds) overlaps any other ALLOW
+ * block on the same local date in `rows`. Pass `ignoreId` to skip the slot
+ * being edited; pass `null` when adding a brand-new slot.
+ */
+export function hasOverlapAt(
+  rows: RawMentorTimeslot[],
+  ignoreId: number | null,
+  dateKey: string,
+  dtstart: number,
+  blockDurationSeconds: number
+): boolean {
+  const blockEnd = dtstart + blockDurationSeconds;
+  return rows.some((r) => {
+    if (r.id === ignoreId) return false;
+    if (r.type !== 'ALLOW') return false;
+    const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
+    if (rDate !== dateKey) return false;
+    const occs = expandRrule(r.dtstart, r.rrule);
+    const rEnd = (occs[occs.length - 1] ?? r.dtstart) + (r.dtend - r.dtstart);
+    return dtstart < rEnd && blockEnd > r.dtstart;
+  });
+}

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -7,19 +7,10 @@ export interface ScheduleRequest {
   month: number;
 }
 
-export type TimeSlotVO = components['schemas']['TimeSlotVO'];
+export type SegmentVO = components['schemas']['MentorScheduleSegmentVO'];
+export type ScheduleData = components['schemas']['MentorScheduleQueryVO'];
 
-export interface BookedSlot {
-  dtstart: number; // unix seconds
-  dtend: number; // unix seconds
-}
-
-// MentorScheduleVO does not document these fields in the OpenAPI spec;
-// they are kept as optional extensions for runtime compatibility.
-export type ScheduleData = components['schemas']['MentorScheduleVO'] & {
-  meeting_duration_minutes?: number;
-  booked_slots?: BookedSlot[];
-};
+type TimeSlotDTO = components['schemas']['TimeSlotDTO'];
 
 interface ScheduleApiResponse {
   code: string;
@@ -42,13 +33,13 @@ export async function fetchMentorSchedule(
   }
 }
 
-export type UpsertTimeslotBackend = {
-  id?: string | number;
-  user_id?: string | number;
-  dt_type: 'ALLOW' | 'BLOCK';
-  dtstart: number; // unix seconds
-  dtend: number; // unix seconds
-  rrule?: string;
+export type UpsertTimeslotBackend = Pick<
+  TimeSlotDTO,
+  'dtstart' | 'dtend' | 'rrule'
+> & {
+  id?: number;
+  dt_type: 'ALLOW';
+  exdate: number[]; // nulls excluded from TimeSlotDTO.exdate
 };
 
 interface SaveScheduleResponse {
@@ -63,65 +54,46 @@ export async function saveMentorSchedule(params: {
   userId: string;
   timeslots: UpsertTimeslotBackend[];
   until?: number | null;
-  meetingDurationMinutes?: number;
-  debug?: boolean;
 }): Promise<boolean> {
-  const clean = (obj: CleanObject): CleanObject =>
+  const cleanOptional = (obj: CleanObject): CleanObject =>
     Object.fromEntries(
       Object.entries(obj).filter(
-        ([, v]) =>
-          v !== undefined &&
-          v !== null &&
-          v !== '' &&
-          !(Array.isArray(v) && v.length === 0)
+        ([, v]) => v !== undefined && v !== null && v !== ''
       )
     );
 
-  const body = clean({
+  const body = cleanOptional({
     until: params.until,
-    meeting_duration_minutes: params.meetingDurationMinutes,
     timeslots: params.timeslots.map((t) =>
-      clean({
+      cleanOptional({
         id: t.id,
-        user_id: params.userId,
+        user_id: Number(params.userId),
         dt_type: t.dt_type,
         dtstart: t.dtstart,
         dtend: t.dtend,
         rrule: t.rrule,
+        timezone: 'UTC',
+        exdate: t.exdate,
       })
     ),
   });
-
-  if (params.debug) {
-    console.log(
-      '[saveMentorSchedule] PUT body:',
-      JSON.stringify(body, null, 2)
-    );
-  }
 
   try {
     const result = await apiClient.put<SaveScheduleResponse>(
       `/v1/mentors/${params.userId}/schedule`,
       body
     );
-    if (params.debug) {
-      console.log('[saveMentorSchedule] response:', result);
-    }
     if (result.code !== '0') {
-      if (params.debug) {
-        console.error(
-          '[saveMentorSchedule] non-zero code:',
-          result.code,
-          result.msg
-        );
-      }
+      console.error(
+        '[saveMentorSchedule] non-zero code:',
+        result.code,
+        result.msg
+      );
       return false;
     }
     return true;
   } catch (err) {
-    if (params.debug) {
-      console.error('[saveMentorSchedule] request failed:', err);
-    }
+    console.error('[saveMentorSchedule] request failed:', err);
     return false;
   }
 }

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -1,0 +1,77 @@
+import dayjs from 'dayjs';
+
+import { RawMentorTimeslot, segmentToRaw } from '@/lib/profile/scheduleHelpers';
+
+import {
+  deleteMentorSchedule,
+  fetchMentorSchedule,
+  saveMentorSchedule,
+  UpsertTimeslotBackend,
+} from './schedule';
+
+export interface ScheduleMonthRef {
+  userId: string;
+  year: number;
+  month: number; // 1-12
+}
+
+/** Fetch + filter to slots whose dtstart falls in the requested local month. */
+export async function loadMonthSchedule(
+  ref: ScheduleMonthRef
+): Promise<RawMentorTimeslot[]> {
+  const data = await fetchMentorSchedule(ref);
+  return (data?.segments ?? []).map(segmentToRaw).filter((r) => {
+    const d = dayjs(r.dtstart * 1000);
+    return d.year() === ref.year && d.month() + 1 === ref.month;
+  });
+}
+
+/**
+ * PUT all upsert slots, DELETE all removed ids, then reload the month.
+ * Returns the freshly loaded slots, or null if any sync request failed.
+ */
+export async function syncMonthSchedule(params: {
+  ref: ScheduleMonthRef;
+  upsertPayload: UpsertTimeslotBackend[];
+  deleteIds: number[];
+}): Promise<RawMentorTimeslot[] | null> {
+  const { ref, upsertPayload, deleteIds } = params;
+
+  const endOfMonthUnix = dayjs(
+    `${ref.year}-${String(ref.month).padStart(2, '0')}-01`
+  )
+    .endOf('month')
+    .hour(23)
+    .minute(59)
+    .second(59)
+    .millisecond(0)
+    .unix();
+
+  try {
+    if (upsertPayload.length > 0) {
+      const ok = await saveMentorSchedule({
+        userId: ref.userId,
+        until: endOfMonthUnix,
+        timeslots: upsertPayload,
+      });
+      if (!ok) throw new Error('PUT failed');
+    }
+
+    if (deleteIds.length > 0) {
+      await Promise.all(
+        deleteIds.map(async (id) => {
+          const ok = await deleteMentorSchedule({
+            userId: ref.userId,
+            scheduleId: id,
+          });
+          if (!ok) throw new Error(`DELETE failed: ${id}`);
+        })
+      );
+    }
+
+    return await loadMonthSchedule(ref);
+  } catch (e) {
+    console.error('[MentorSchedule] sync failed:', e);
+    return null;
+  }
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -660,6 +660,26 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v2/oauth/google/callback-test': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Oauth Callback Get
+     * @description Google 授權完成後以 GET 導回（query 帶 code、state）。與 POST /callback 行為相同，方便本機或未接前端的 redirect_uri 直接指到 BFF。
+     */
+    get: operations['oauth_callback_get_api_v2_oauth_google_callback_test_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/gateway/{term}': {
     parameters: {
       query?: never;
@@ -820,6 +840,20 @@ export interface components {
        */
       msg: string;
       data?: components['schemas']['MentorProfileVO'] | null;
+    };
+    /** ApiResponse[MentorScheduleQueryVO] */
+    ApiResponse_MentorScheduleQueryVO_: {
+      /**
+       * Code
+       * @default 0
+       */
+      code: string;
+      /**
+       * Msg
+       * @default ok
+       */
+      msg: string;
+      data?: components['schemas']['MentorScheduleQueryVO'] | null;
     };
     /** ApiResponse[MentorScheduleVO] */
     ApiResponse_MentorScheduleVO_: {
@@ -1212,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-24T07:25:00.505055Z
+       * @default 2026-04-26T04:35:57.666240Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-24T07:25:00.505070Z
+       * @default 2026-04-26T04:35:57.666249Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1481,6 +1515,77 @@ export interface components {
        * @default []
        */
       timeslots: components['schemas']['TimeSlotDTO'][];
+    };
+    /** MentorScheduleQueryVO */
+    MentorScheduleQueryVO: {
+      /**
+       * Segments
+       * @default []
+       */
+      segments: components['schemas']['MentorScheduleSegmentVO'][] | null;
+      /**
+       * Next Dtstart
+       * @example 0
+       */
+      next_dtstart?: number | null;
+    };
+    /** MentorScheduleSegmentVO */
+    MentorScheduleSegmentVO: {
+      /**
+       * Id
+       * @example 0
+       */
+      id?: number | null;
+      /**
+       * User Id
+       * @example 1
+       */
+      user_id: number;
+      /**
+       * Dt Type
+       * @example ALLOW
+       */
+      dt_type: string;
+      /**
+       * Dtstart
+       * @example 1717203600
+       */
+      dtstart: number;
+      /**
+       * Dtend
+       * @example 1717207200
+       */
+      dtend: number;
+      /**
+       * Rrule
+       * @example FREQ=WEEKLY;COUNT=4
+       */
+      rrule?: string | null;
+      /**
+       * Timezone
+       * @default UTC
+       * @example UTC
+       */
+      timezone: string;
+      /**
+       * Exdate
+       * @default []
+       * @example [
+       *       1718413200,
+       *       1719622800
+       *     ]
+       */
+      exdate: (number | null)[];
+      /**
+       * Source
+       * @example schedule
+       */
+      source: string;
+      /**
+       * Source Id
+       * @example 100
+       */
+      source_id?: number | null;
     };
     /** MentorScheduleVO */
     MentorScheduleVO: {
@@ -1994,6 +2099,21 @@ export interface components {
        * @example FREQ=WEEKLY;COUNT=4
        */
       rrule?: string | null;
+      /**
+       * Timezone
+       * @default UTC
+       * @example UTC
+       */
+      timezone: string;
+      /**
+       * Exdate
+       * @default []
+       * @example [
+       *       1718413200,
+       *       1719622800
+       *     ]
+       */
+      exdate: (number | null)[];
     };
     /** TimeSlotVO */
     TimeSlotVO: {
@@ -2037,6 +2157,21 @@ export interface components {
        * @example FREQ=WEEKLY;COUNT=4
        */
       rrule?: string | null;
+      /**
+       * Timezone
+       * @default UTC
+       * @example UTC
+       */
+      timezone: string;
+      /**
+       * Exdate
+       * @default []
+       * @example [
+       *       1718413200,
+       *       1719622800
+       *     ]
+       */
+      exdate: (number | null)[];
     };
     /** TokenRefreshAuthVO */
     TokenRefreshAuthVO: {
@@ -3293,7 +3428,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['ApiResponse_MentorScheduleVO_'];
+          'application/json': components['schemas']['ApiResponse_MentorScheduleQueryVO_'];
         };
       };
       /** @description Not found */
@@ -3791,6 +3926,45 @@ export interface operations {
         'application/json': components['schemas']['Body_oauth_callback_api_v2_oauth_google_callback_post'];
       };
     };
+    responses: {
+      /** @description Successful Response */
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiResponse_GoogleCallbackVO_'];
+        };
+      };
+      /** @description Not found */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  oauth_callback_get_api_v2_oauth_google_callback_test_get: {
+    parameters: {
+      query: {
+        code: string;
+        state: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
     responses: {
       /** @description Successful Response */
       201: {


### PR DESCRIPTION
## What Does This PR Do?

- Switch GET /schedule to read `MentorScheduleQueryVO.segments` (was the unused `MentorScheduleVO.timeslots`) so fetched slots reach the calendar.
- Expand rrule occurrences when computing `allowedDates` so multi-occurrence ALLOW slots highlight every available day, not just `dtstart`'s day.
- Add `exdate` round-trip plus a `toggleOccurrence` API so mentors can exclude individual sub-slots from a block.
- Send `timezone` and `exdate` on PUT, and accept the new `SegmentVO` shape (renamed from the deprecated `TimeSlotVO` alias).
- Drop the unused local-storage fallback (`mode`, `storageKey`, `seed`, `readFromStorage`/`writeToStorage`) — `useMentorSchedule` is backend-only now.
- Extract pure helpers to `src/lib/profile/scheduleHelpers.ts` (`expandRrule`, `formatTimeslot`, `segmentToRaw`, `nextTempId`, `buildRrule`, `buildDateTime`, `hasOverlapAt`) and the PUT/DELETE/refetch flow to `src/services/mentor-schedule/sync.ts` (`loadMonthSchedule`, `syncMonthSchedule`).
- Share one `hasOverlapAt` helper between `addSlotForSelectedDate` and `updateDraftSlot` instead of duplicating the overlap check.

## Demo

http://localhost:3000/profile/<mentor-user-id>

## Screenshot

N/A

## Anything to Note?

`draftForSelectedDate` and `generateBookingSlots` still match by `dtstart`'s local date, which is correct for the same-day MINUTELY rrules the frontend produces. If the backend ever returns multi-day rrules (e.g. `FREQ=WEEKLY`), those two paths will need a follow-up to match by occurrence date.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
