### PR TITLE
feat: show booked slots as disabled grey instead of hiding (#143)

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -272,7 +272,11 @@ export default function ProfilePageUI({
                           {slots.map((slot) => (
                             <div
                               key={slot.start.getTime()}
-                              className="flex h-10 select-none items-center justify-center rounded-lg border border-[#E6E8EA] text-sm font-medium"
+                              className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
+                                slot.isBooked
+                                  ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
+                                  : 'border-[#E6E8EA]'
+                              }`}
                             >
                               {formatBookingSlotTime(slot)}
                             </div>

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -253,8 +253,13 @@ export default function MenteeReservationDialog({
                       ? 'default'
                       : 'outline'
                   }
+                  disabled={slot.isBooked}
                   onClick={() => setSelectedSlot(slot)}
-                  className="h-10 w-full text-sm lg:h-11 lg:text-base"
+                  className={`h-10 w-full text-sm lg:h-11 lg:text-base ${
+                    slot.isBooked
+                      ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
+                      : ''
+                  }`}
                 >
                   {formatTimeSlot(slot)}
                 </Button>

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -178,15 +178,16 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         for (const occ of occurrences) {
           if (slot.exdate.includes(occ)) continue;
-          if (bookedStarts.has(occ)) continue;
           result.push({
             start: new Date(occ * 1000),
             end: new Date((occ + slotDuration) * 1000),
             scheduleId: slot.id,
+            isBooked: bookedStarts.has(occ),
           });
         }
       }
 
+      result.sort((a, b) => a.start.getTime() - b.start.getTime());
       return result;
     },
     [draft]

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -37,6 +37,7 @@ export type BookingSlot = {
   start: Date;
   end: Date;
   scheduleId: number; // parent ALLOW slot id
+  isBooked: boolean;
 };
 
 /** Expand an rrule string from dtstart, returning all occurrence dtstart values (unix seconds). */


### PR DESCRIPTION
## What Does This PR Do?

- Add `isBooked` flag to `BookingSlot` and stop filtering BOOKED occurrences out of `generateBookingSlots`; sort results by start time so the timeline stays continuous
- Render booked slots in `MenteeReservationDialog` as disabled grey buttons (cannot be selected)
- Render booked slots in the mentor profile public page (`/profile/[pageUserId]`) with the same grey style for visual consistency across mentor/mentee views

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
