### PR TITLE
fix(reservation): improve mentor pending dialog UX (#145)

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Clock } from 'lucide-react';
+import { CalendarDays, Clock, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
@@ -38,8 +39,11 @@ export default function AcceptReservationDialog({
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<'check' | 'reject'>('check');
   const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
 
   function onOpenChange(next: boolean) {
+    if (isSubmitting) return;
     setOpen(next);
     if (next) {
       setStep('check');
@@ -51,6 +55,36 @@ export default function AcceptReservationDialog({
       });
     }
   }
+
+  async function handleAccept() {
+    setIsSubmitting(true);
+    try {
+      await onAccept?.({ id: reservation.id, message: '' });
+    } catch {
+      toast({
+        variant: 'destructive',
+        description: '接受預約失敗,請稍後再試',
+      });
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleReject() {
+    setIsSubmitting(true);
+    try {
+      await onReject?.({ id: reservation.id, reason });
+    } catch {
+      toast({
+        variant: 'destructive',
+        description: '拒絕預約失敗,請稍後再試',
+      });
+      setIsSubmitting(false);
+    }
+  }
+
+  const hasNote = Boolean(reservation.note?.trim());
+  const trimmedReason = reason.trim();
+  const canSubmitReject = trimmedReason.length > 0 && !isSubmitting;
 
   const initials =
     reservation.name
@@ -109,25 +143,24 @@ export default function AcceptReservationDialog({
               </div>
             </div>
 
-            <div className="mt-6">
-              <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
-              <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
-                {reservation.note ? (
+            {hasNote && (
+              <div className="mt-6">
+                <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
+                <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
                   <p className="whitespace-pre-wrap text-foreground">
                     {reservation.note}
                   </p>
-                ) : (
-                  <p className="text-muted-foreground">（學員未提出問題）</p>
-                )}
+                </div>
               </div>
-            </div>
+            )}
 
             <DialogFooter className="mt-6 gap-2">
               <Button
                 type="button"
-                variant="secondary"
-                className="w-full bg-secondary text-destructive hover:bg-secondary/80 sm:w-auto"
+                variant="outline"
+                className="w-full border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
                 onClick={() => setStep('reject')}
+                disabled={isSubmitting}
               >
                 拒絕
               </Button>
@@ -135,12 +168,13 @@ export default function AcceptReservationDialog({
               <Button
                 type="button"
                 className="bg-teal-500 text-white hover:bg-teal-500/90 w-full sm:w-auto"
-                onClick={async () => {
-                  await onAccept?.({ id: reservation.id, message: '' });
-                  setOpen(false);
-                }}
+                onClick={handleAccept}
+                disabled={isSubmitting}
               >
-                接收
+                {isSubmitting && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
+                接受
               </Button>
             </DialogFooter>
           </div>
@@ -161,12 +195,22 @@ export default function AcceptReservationDialog({
                 className="min-h-[120px] resize-y border-0 shadow-none focus-visible:ring-0"
                 value={reason}
                 onChange={(e) => setReason(e.target.value)}
+                disabled={isSubmitting}
               />
             </div>
+            {trimmedReason.length === 0 && (
+              <p className="mt-2 text-xs text-muted-foreground">
+                請填寫拒絕原因
+              </p>
+            )}
 
             <DialogFooter className="mt-6 gap-2">
               <DialogClose asChild>
-                <Button variant="outline" className="w-full sm:w-auto">
+                <Button
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  disabled={isSubmitting}
+                >
                   捨棄
                 </Button>
               </DialogClose>
@@ -174,12 +218,12 @@ export default function AcceptReservationDialog({
               <Button
                 type="button"
                 className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
-                disabled={reason.trim().length === 0}
-                onClick={async () => {
-                  await onReject?.({ id: reservation.id, reason });
-                  setOpen(false);
-                }}
+                disabled={!canSubmitReject}
+                onClick={handleReject}
               >
+                {isSubmitting && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
                 拒絕
               </Button>
             </DialogFooter>

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -6,6 +6,7 @@ import AcceptReservationDialog from '@/components/reservation/AcceptReservationD
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateReservationStatus } from '@/services/reservations';
@@ -28,6 +29,8 @@ export function ReservationList({
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
 }) {
+  const { toast } = useToast();
+
   const findItem = (id: string): Reservation => {
     const found = items.find((x) => x.id === id);
     if (!found)
@@ -39,9 +42,11 @@ export function ReservationList({
   const resolveOtherId = (myId: string, it: Reservation): string | number =>
     String(it.senderUserId) === myId ? it.participantUserId : it.senderUserId;
 
-  // Hard reload the page to reflect updated reservation state
+  // Hard reload the page to reflect updated reservation state.
+  // Delayed so the success toast has time to render before the page reloads.
   const hardReload = () => {
-    if (typeof window !== 'undefined') window.location.reload();
+    if (typeof window === 'undefined') return;
+    setTimeout(() => window.location.reload(), 800);
   };
 
   // Accept a booking request (mentor side, pending-mentor variant)
@@ -77,6 +82,7 @@ export function ReservationList({
       // or once GET schedule returns booked_slots so the frontend can filter them.
 
       trackEvent({ name: 'reservation_accepted', feature: 'reservation' });
+      toast({ description: '已接受預約' });
       hardReload();
     } catch (err) {
       captureFlowFailure({
@@ -90,7 +96,11 @@ export function ReservationList({
   };
 
   // Shared handler for both reject and cancel (same API call)
-  const rejectOrCancel = async (id: string, text: string) => {
+  const rejectOrCancel = async (
+    id: string,
+    text: string,
+    successMessage: string
+  ) => {
     try {
       const session = await getSession();
       const myId = String(session?.user?.id ?? '');
@@ -120,6 +130,7 @@ export function ReservationList({
       // Blocked by the same backend limitation as above.
 
       trackEvent({ name: 'reservation_rejected', feature: 'reservation' });
+      toast({ description: successMessage });
       hardReload();
     } catch (err) {
       captureFlowFailure({
@@ -145,13 +156,15 @@ export function ReservationList({
               <AcceptReservationDialog
                 reservation={it}
                 onAccept={accept}
-                onReject={async ({ id, reason }) => rejectOrCancel(id, reason)}
+                onReject={async ({ id, reason }) =>
+                  rejectOrCancel(id, reason, '已拒絕預約')
+                }
               />
             ) : (
               <CancelReservationDialog
                 reservation={it}
                 onConfirmCancel={async ({ id, reason }) =>
-                  rejectOrCancel(id, reason)
+                  rejectOrCancel(id, reason, '已取消預約')
                 }
               />
             )


### PR DESCRIPTION
## What Does This PR Do?

- Fix typo on confirm button: 接收 → 接受 to match the card trigger
- Replace ambiguous secondary+red reject button with an outline + red border style so reject and accept have equal visual weight
- Add isSubmitting state with Loader2 spinner and disabled buttons during async accept/reject to prevent double-submit
- Show destructive toast on accept/reject failure instead of silently swallowing the error
- Show success toast (已接受預約 / 已拒絕預約 / 已取消預約) and delay hardReload by 800ms so the toast renders before the page navigates
- Add helper text below the reject reason textarea when empty, so the disabled submit button is no longer unexplained
- Hide the entire 學員所提出的問題 section when the mentee did not submit a question, instead of rendering an empty grey box

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- ReservationList.rejectOrCancel now takes a successMessage param so the AcceptReservationDialog and CancelReservationDialog show the right toast text. CancelReservationDialog also benefits from the toast + delayed reload as a side effect.
- Out of scope (deferred from analysis): wording fixes for 「查看我的預約」, 「拒絕 Mentee 預約的原因」, 「捨棄」.

Closes Xchange-Taiwan/X-Talent-Tracker#145

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
