### PR TITLE
feat: link reservation card to counterparty profile (#146)

### DIFF
--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -82,6 +82,7 @@ export default function ReservationTabs({
             <ReservationList
               items={upcomingMentee}
               variant="upcoming"
+              sourceRole="mentee"
               hasMore={nextTokens.menteeUpcoming !== 0}
               onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
               isLoadingMore={isLoadingMore}
@@ -92,6 +93,7 @@ export default function ReservationTabs({
             <ReservationList
               items={pendingMentee}
               variant="pending-mentee"
+              sourceRole="mentee"
               hasMore={nextTokens.menteePending !== 0}
               onLoadMore={() => onLoadMore('MENTEE_PENDING')}
               isLoadingMore={isLoadingMore}
@@ -102,6 +104,7 @@ export default function ReservationTabs({
             <ReservationList
               items={history}
               variant="history"
+              sourceRole="mentee"
               hasMore={nextTokens.history !== 0}
               onLoadMore={() => onLoadMore('HISTORY')}
               isLoadingMore={isLoadingMore}

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -81,6 +81,7 @@ export default function ReservationTabs({
             <ReservationList
               items={upcomingMentor}
               variant="upcoming"
+              sourceRole="mentor"
               hasMore={nextTokens.mentorUpcoming !== 0}
               onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
               isLoadingMore={isLoadingMore}
@@ -91,6 +92,7 @@ export default function ReservationTabs({
             <ReservationList
               items={pendingMentor}
               variant="pending-mentor"
+              sourceRole="mentor"
               hasMore={nextTokens.mentorPending !== 0}
               onLoadMore={() => onLoadMore('MENTOR_PENDING')}
               isLoadingMore={isLoadingMore}
@@ -101,6 +103,7 @@ export default function ReservationTabs({
             <ReservationList
               items={history}
               variant="history"
+              sourceRole="mentor"
               hasMore={nextTokens.history !== 0}
               onLoadMore={() => onLoadMore('HISTORY')}
               isLoadingMore={isLoadingMore}

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -1,4 +1,5 @@
 import { CalendarDays, Clock } from 'lucide-react';
+import Link from 'next/link';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Badge } from '@/components/ui/badge';
@@ -10,42 +11,76 @@ import type { Reservation } from './types';
 export function ReservationCard({
   item,
   actions,
+  profileHref,
+  onProfileClick,
 }: {
   item: Reservation;
   actions?: React.ReactNode;
+  profileHref?: string;
+  onProfileClick?: () => void;
 }) {
+  const initials = item.name
+    .split(' ')
+    .map((n) => n[0])
+    .slice(0, 2)
+    .join('');
+
+  const avatar = (
+    <Avatar className="h-10 w-10 sm:h-12 sm:w-12">
+      {item.avatar ? (
+        <AvatarImage src={getAvatarThumbUrl(item.avatar)} alt={item.name} />
+      ) : null}
+      <AvatarFallback className="font-medium">{initials}</AvatarFallback>
+    </Avatar>
+  );
+
+  const profileAriaLabel = `查看 ${item.name} 的個人資料`;
+
   return (
     <Card className="border-muted/40 transition-shadow hover:shadow-sm">
       <CardContent className="p-3 sm:p-4">
         <div className="flex items-start gap-3 sm:gap-4">
           {/* Avatar */}
-          <Avatar className="h-10 w-10 shrink-0 sm:h-12 sm:w-12">
-            {item.avatar ? (
-              <AvatarImage
-                src={getAvatarThumbUrl(item.avatar)}
-                alt={item.name}
-              />
-            ) : null}
-            <AvatarFallback className="font-medium">
-              {item.name
-                .split(' ')
-                .map((n) => n[0])
-                .slice(0, 2)
-                .join('')}
-            </AvatarFallback>
-          </Avatar>
+          {profileHref ? (
+            <Link
+              href={profileHref}
+              aria-label={profileAriaLabel}
+              onClick={onProfileClick}
+              className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              {avatar}
+            </Link>
+          ) : (
+            <div className="shrink-0">{avatar}</div>
+          )}
 
           {/* Main content */}
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center justify-between gap-2">
-              <div className="min-w-0 truncate">
-                <div className="truncate text-sm font-medium sm:text-base">
-                  {item.name}
+              {profileHref ? (
+                <Link
+                  href={profileHref}
+                  aria-label={profileAriaLabel}
+                  onClick={onProfileClick}
+                  className="group min-w-0 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                >
+                  <div className="truncate text-sm font-medium group-hover:underline sm:text-base">
+                    {item.name}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground sm:text-sm">
+                    {item.roleLine}
+                  </div>
+                </Link>
+              ) : (
+                <div className="min-w-0 truncate">
+                  <div className="truncate text-sm font-medium sm:text-base">
+                    {item.name}
+                  </div>
+                  <div className="truncate text-xs text-muted-foreground sm:text-sm">
+                    {item.roleLine}
+                  </div>
                 </div>
-                <div className="truncate text-xs text-muted-foreground sm:text-sm">
-                  {item.roleLine}
-                </div>
-              </div>
+              )}
               <div className="shrink-0">{actions}</div>
             </div>
 

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getSession } from 'next-auth/react';
+import { getSession, useSession } from 'next-auth/react';
 
 import AcceptReservationDialog from '@/components/reservation/AcceptReservationDialog';
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
@@ -15,21 +15,26 @@ import { ReservationCard } from './ReservationCard';
 import type { Reservation } from './types';
 
 type Variant = 'upcoming' | 'pending-mentee' | 'pending-mentor' | 'history';
+type SourceRole = 'mentor' | 'mentee';
 
 export function ReservationList({
   items,
   variant,
+  sourceRole,
   hasMore = false,
   onLoadMore,
   isLoadingMore = false,
 }: {
   items: Reservation[];
   variant: Variant;
+  sourceRole: SourceRole;
   hasMore?: boolean;
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
 }) {
   const { toast } = useToast();
+  const { data: session } = useSession();
+  const myId = session?.user?.id ? String(session.user.id) : '';
 
   const findItem = (id: string): Reservation => {
     const found = items.find((x) => x.id === id);
@@ -145,12 +150,32 @@ export function ReservationList({
     }
   };
 
+  // Build a profile link to the *other* party. Skip when we don't have
+  // a logged-in user (link would be ambiguous) or when the other id would
+  // resolve to the current user (defensive — shouldn't happen in practice).
+  const buildProfileHref = (it: Reservation): string | undefined => {
+    if (!myId) return undefined;
+    const otherId = resolveOtherId(myId, it);
+    if (!otherId || String(otherId) === myId) return undefined;
+    return `/profile/${otherId}`;
+  };
+
+  const handleProfileClick = (): void => {
+    trackEvent({
+      name: 'reservation_profile_viewed',
+      feature: 'reservation',
+      metadata: { source_role: sourceRole },
+    });
+  };
+
   return (
     <div className="space-y-3 sm:space-y-4">
       {items.map((it) => (
         <ReservationCard
           key={it.id}
           item={it}
+          profileHref={buildProfileHref(it)}
+          onProfileClick={handleProfileClick}
           actions={
             variant === 'history' ? null : variant === 'pending-mentor' ? (
               <AcceptReservationDialog


### PR DESCRIPTION
## What Does This PR Do?

- Wrap avatar and name+role in `ReservationCard` with `next/link` Link to `/profile/{otherId}`, so mentees and mentors can reach the counterparty's profile from a reservation.
- Add hover underline, focus-visible ring, and `aria-label` for accessibility.
- Resolve `myId` synchronously in `ReservationList` via `useSession()` and reuse the existing `resolveOtherId` helper to compute the link target. Falls back to plain text when `myId` is empty or would resolve to self.
- Add `sourceRole: 'mentor' | 'mentee'` prop on `ReservationList`; fire `reservation_profile_viewed` analytics event with `source_role` metadata (no PII).
- Pass `sourceRole` from both mentee and mentor `ReservationTabs`.

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Existing async `getSession()` in `accept`/`rejectOrCancel` callbacks is intentionally left alone to keep the diff scoped.
- `/profile/[id]` already handles missing users with a graceful empty state, so the link is safe to follow even for deleted accounts.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
