### PR TITLE
feat: make profile edit header sticky for always-visible save (#147)

### DIFF
--- a/src/components/profile/edit/EditPageHeader.tsx
+++ b/src/components/profile/edit/EditPageHeader.tsx
@@ -15,7 +15,7 @@ export function EditPageHeader({
   isMentorOnboarding,
 }: Props) {
   return (
-    <div className="mb-10 flex justify-between">
+    <div className="sticky top-[70px] z-40 mb-6 flex justify-between border-b border-gray-200 bg-light/95 py-4 backdrop-blur supports-[backdrop-filter]:bg-light/80">
       <div className="flex items-center gap-3">
         <ArrowBackIcon
           className={`sm:hidden ${isSaving ? 'pointer-events-none opacity-50' : 'cursor-pointer'}`}


### PR DESCRIPTION
## What Does This PR Do?

- Make EditPageHeader stick under the global header (top-[70px], z-40) so the 取消 / 儲存 buttons stay visible while users scroll the long profile edit form
- Add semi-transparent bg-light/95 with backdrop-blur and a supports-[] fallback for browsers without backdrop-filter
- Replace mb-10 with mb-6 + py-4 and a bottom border so the sticky bar reads as a clean, separated chrome

## Demo

http://localhost:3000/profile/<userId>/edit

## Screenshot

N/A

## Anything to Note?

- Only EditPageHeader is changed; the component is used solely on the profile edit page, so no other pages are affected.
- Radix Select / Multi-select popovers render via portal, so they continue to layer above the sticky header.
- Optional follow-ups (dirty-state primary button, Cmd/Ctrl+S shortcut) intentionally left out — can be tracked in separate tickets.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
