### PR TITLE
feat(reservation): bidirectional messages and card UX (#148)

### DIFF
--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -15,6 +15,7 @@ export type ReservationTabsProps = {
   nextTokens: NextTokens;
   isLoadingMore: boolean;
   onLoadMore: (state: ReservationState) => void;
+  onMutationSuccess?: (id: string) => void;
 };
 
 export default function ReservationTabs({
@@ -26,6 +27,7 @@ export default function ReservationTabs({
   nextTokens,
   isLoadingMore,
   onLoadMore,
+  onMutationSuccess,
 }: ReservationTabsProps) {
   // This file is for mentee UI; keep mentor props to match type and avoid lint issues.
   void upcomingMentor;
@@ -85,6 +87,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.menteeUpcoming !== 0}
               onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
 
@@ -95,6 +98,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.menteePending !== 0}
               onLoadMore={() => onLoadMore('MENTEE_PENDING')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
 
@@ -105,6 +109,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.history !== 0}
               onLoadMore={() => onLoadMore('HISTORY')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
         </div>

--- a/src/app/reservation/mentee/container.tsx
+++ b/src/app/reservation/mentee/container.tsx
@@ -9,7 +9,8 @@ import { ReservationSkeleton } from '../skeleton';
 const ReservationPresentation = dynamic(() => import('./ui'));
 
 export default function ReservationContainer() {
-  const { data, isLoading, isLoadingMore, loadMore } = useReservationData();
+  const { data, isLoading, isLoadingMore, loadMore, onMutationSuccess } =
+    useReservationData();
 
   if (isLoading || !data) return <ReservationSkeleton />;
   return (
@@ -17,6 +18,7 @@ export default function ReservationContainer() {
       {...data}
       isLoadingMore={isLoadingMore}
       onLoadMore={loadMore}
+      onMutationSuccess={onMutationSuccess}
     />
   );
 }

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -15,6 +15,7 @@ export type ReservationTabsProps = {
   nextTokens: NextTokens;
   isLoadingMore: boolean;
   onLoadMore: (state: ReservationState) => void;
+  onMutationSuccess?: (id: string) => void;
 };
 
 export default function ReservationTabs({
@@ -26,6 +27,7 @@ export default function ReservationTabs({
   nextTokens,
   isLoadingMore,
   onLoadMore,
+  onMutationSuccess,
 }: ReservationTabsProps) {
   void upcomingMentee;
   void pendingMentee;
@@ -84,6 +86,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.mentorUpcoming !== 0}
               onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
 
@@ -94,6 +97,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.mentorPending !== 0}
               onLoadMore={() => onLoadMore('MENTOR_PENDING')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
 
@@ -104,6 +108,7 @@ export default function ReservationTabs({
               hasMore={nextTokens.history !== 0}
               onLoadMore={() => onLoadMore('HISTORY')}
               isLoadingMore={isLoadingMore}
+              onMutationSuccess={onMutationSuccess}
             />
           </TabsContent>
         </div>

--- a/src/app/reservation/mentor/container.tsx
+++ b/src/app/reservation/mentor/container.tsx
@@ -9,7 +9,8 @@ import { ReservationSkeleton } from '../skeleton';
 const ReservationPresentation = dynamic(() => import('./ui'));
 
 export default function ReservationContainer() {
-  const { data, isLoading, isLoadingMore, loadMore } = useReservationData();
+  const { data, isLoading, isLoadingMore, loadMore, onMutationSuccess } =
+    useReservationData();
 
   if (isLoading || !data) return <ReservationSkeleton />;
   return (
@@ -17,6 +18,7 @@ export default function ReservationContainer() {
       {...data}
       isLoadingMore={isLoadingMore}
       onLoadMore={loadMore}
+      onMutationSuccess={onMutationSuccess}
     />
   );
 }

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Clock, Loader2 } from 'lucide-react';
+import { CalendarDays, Clock, Loader2, MessageSquarePlus } from 'lucide-react';
 import { useState } from 'react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -39,6 +39,8 @@ export default function AcceptReservationDialog({
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<'check' | 'reject'>('check');
   const [reason, setReason] = useState('');
+  const [replyOpen, setReplyOpen] = useState(false);
+  const [reply, setReply] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
 
@@ -48,6 +50,8 @@ export default function AcceptReservationDialog({
     if (next) {
       setStep('check');
       setReason('');
+      setReply('');
+      setReplyOpen(false);
       trackEvent({
         name: 'feature_opened',
         feature: 'reservation',
@@ -59,7 +63,14 @@ export default function AcceptReservationDialog({
   async function handleAccept() {
     setIsSubmitting(true);
     try {
-      await onAccept?.({ id: reservation.id, message: '' });
+      await onAccept?.({ id: reservation.id, message: reply.trim() });
+      trackEvent({
+        name: 'reservation_accepted',
+        feature: 'reservation',
+        metadata: { has_reply: reply.trim().length > 0 },
+      });
+      setIsSubmitting(false);
+      setOpen(false);
     } catch {
       toast({
         variant: 'destructive',
@@ -73,6 +84,8 @@ export default function AcceptReservationDialog({
     setIsSubmitting(true);
     try {
       await onReject?.({ id: reservation.id, reason });
+      setIsSubmitting(false);
+      setOpen(false);
     } catch {
       toast({
         variant: 'destructive',
@@ -82,7 +95,11 @@ export default function AcceptReservationDialog({
     }
   }
 
-  const hasNote = Boolean(reservation.note?.trim());
+  // counterpartyMessage on the mentor side is always the mentee's question.
+  const menteeMessage =
+    reservation.counterpartyMessage?.role === 'MENTEE'
+      ? reservation.counterpartyMessage.content
+      : undefined;
   const trimmedReason = reason.trim();
   const canSubmitReject = trimmedReason.length > 0 && !isSubmitting;
 
@@ -143,16 +160,45 @@ export default function AcceptReservationDialog({
               </div>
             </div>
 
-            {hasNote && (
+            {menteeMessage ? (
               <div className="mt-6">
                 <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
                 <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
                   <p className="whitespace-pre-wrap text-foreground">
-                    {reservation.note}
+                    {menteeMessage}
                   </p>
                 </div>
               </div>
-            )}
+            ) : null}
+
+            <div className="mt-6">
+              {replyOpen ? (
+                <div>
+                  <div className="mb-2 text-sm font-medium">
+                    給學員的回覆（選填）
+                  </div>
+                  <div className="rounded-2xl border p-2">
+                    <Textarea
+                      placeholder="例如：屆時於 Google Meet 見，請先準備一份履歷。"
+                      className="min-h-[96px] resize-y border-0 shadow-none focus-visible:ring-0"
+                      value={reply}
+                      onChange={(e) => setReply(e.target.value)}
+                      disabled={isSubmitting}
+                    />
+                  </div>
+                </div>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setReplyOpen(true)}
+                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                  disabled={isSubmitting}
+                >
+                  <MessageSquarePlus className="h-4 w-4" aria-hidden />
+                  附上回覆訊息（選填）
+                </button>
+              )}
+            </div>
 
             <DialogFooter className="mt-6 gap-2">
               <Button

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -1,11 +1,15 @@
-import { CalendarDays, Clock } from 'lucide-react';
+import { CalendarDays, Clock, MessageSquare } from 'lucide-react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { Badge } from '@/components/ui/badge';
 import { Card, CardContent } from '@/components/ui/card';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
 import type { Reservation } from './types';
+
+const COUNTERPARTY_LABEL: Record<'MENTEE' | 'MENTOR', string> = {
+  MENTEE: '學員留言',
+  MENTOR: 'Mentor 回覆',
+};
 
 export function ReservationCard({
   item,
@@ -14,6 +18,8 @@ export function ReservationCard({
   item: Reservation;
   actions?: React.ReactNode;
 }) {
+  const { counterpartyMessage } = item;
+
   return (
     <Card className="border-muted/40 transition-shadow hover:shadow-sm">
       <CardContent className="p-3 sm:p-4">
@@ -62,15 +68,24 @@ export function ReservationCard({
                 <Clock className="h-4 w-4" aria-hidden />
                 <span className="truncate">{item.time}</span>
               </div>
-              {item.note ? (
-                <Badge
-                  variant="secondary"
-                  className="rounded-full text-[11px] sm:text-xs"
-                >
-                  {item.note}
-                </Badge>
-              ) : null}
             </div>
+
+            {counterpartyMessage ? (
+              <div className="mt-3 flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
+                <MessageSquare
+                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
+                  aria-hidden
+                />
+                <div className="min-w-0 flex-1">
+                  <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+                    {COUNTERPARTY_LABEL[counterpartyMessage.role]}
+                  </div>
+                  <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
+                    {counterpartyMessage.content}
+                  </p>
+                </div>
+              </div>
+            ) : null}
           </div>
         </div>
       </CardContent>

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -22,12 +22,16 @@ export function ReservationList({
   hasMore = false,
   onLoadMore,
   isLoadingMore = false,
+  onMutationSuccess,
 }: {
   items: Reservation[];
   variant: Variant;
   hasMore?: boolean;
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
+  // Called after a successful accept / reject / cancel so the parent hook can
+  // optimistically remove the operated item and refetch in the background.
+  onMutationSuccess?: (id: string) => void;
 }) {
   const { toast } = useToast();
 
@@ -41,13 +45,6 @@ export function ReservationList({
   // Resolve the other party's user_id based on who is currently logged in
   const resolveOtherId = (myId: string, it: Reservation): string | number =>
     String(it.senderUserId) === myId ? it.participantUserId : it.senderUserId;
-
-  // Hard reload the page to reflect updated reservation state.
-  // Delayed so the success toast has time to render before the page reloads.
-  const hardReload = () => {
-    if (typeof window === 'undefined') return;
-    setTimeout(() => window.location.reload(), 800);
-  };
 
   // Accept a booking request (mentor side, pending-mentor variant)
   const accept = async ({ id, message }: { id: string; message: string }) => {
@@ -81,9 +78,8 @@ export function ReservationList({
       // slot overlaps an existing ALLOW slot. Re-enable once backend supports it,
       // or once GET schedule returns booked_slots so the frontend can filter them.
 
-      trackEvent({ name: 'reservation_accepted', feature: 'reservation' });
       toast({ description: '已接受預約' });
-      hardReload();
+      onMutationSuccess?.(id);
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_accept',
@@ -131,7 +127,7 @@ export function ReservationList({
 
       trackEvent({ name: 'reservation_rejected', feature: 'reservation' });
       toast({ description: successMessage });
-      hardReload();
+      onMutationSuccess?.(id);
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_reject',

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,3 +1,8 @@
+export type CounterpartyMessage = {
+  role: 'MENTEE' | 'MENTOR';
+  content: string;
+};
+
 export type Reservation = {
   id: string;
   name: string;
@@ -5,7 +10,8 @@ export type Reservation = {
   roleLine: string;
   date: string;
   time: string;
-  note?: string;
+  // Latest message from the OTHER party (mentee question, mentor reply / reason).
+  counterpartyMessage?: CounterpartyMessage;
 
   // Required by the PUT reservation status endpoint
   scheduleId: number;

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -46,6 +46,14 @@ const STATE_TO_DATA_KEY: Record<
   HISTORY: 'history',
 };
 
+const ALL_STATES: ReservationState[] = [
+  'MENTEE_UPCOMING',
+  'MENTEE_PENDING',
+  'MENTOR_UPCOMING',
+  'MENTOR_PENDING',
+  'HISTORY',
+];
+
 export function useReservationData() {
   const { data: session } = useSession();
   const loginUserId = session?.user?.id ? String(session.user.id) : '';
@@ -102,6 +110,78 @@ export function useReservationData() {
     };
   }, [loginUserId]);
 
+  // Optimistic helper: drop the operated item from every list so the user
+  // doesn't see it lingering while the background refetch runs.
+  const removeItem = useCallback((id: string) => {
+    setData((prev) => {
+      if (!prev) return prev;
+      return {
+        ...prev,
+        upcomingMentee: prev.upcomingMentee.filter((it) => it.id !== id),
+        pendingMentee: prev.pendingMentee.filter((it) => it.id !== id),
+        upcomingMentor: prev.upcomingMentor.filter((it) => it.id !== id),
+        pendingMentor: prev.pendingMentor.filter((it) => it.id !== id),
+        history: prev.history.filter((it) => it.id !== id),
+      };
+    });
+  }, []);
+
+  // Refetch every state in parallel, asking the backend for at least as many
+  // rows as are currently displayed so previously load-more'd items don't
+  // disappear after a mutation.
+  const refetchAll = useCallback(async () => {
+    if (!loginUserId) return;
+    try {
+      const results = await Promise.all(
+        ALL_STATES.map((state) => {
+          const dataKey = STATE_TO_DATA_KEY[state];
+          const currentCount = (data?.[dataKey] as Reservation[] | undefined)
+            ?.length;
+          return fetchReservations({
+            userId: loginUserId,
+            state,
+            batch: Math.max(currentCount ?? 10, 10),
+          });
+        })
+      );
+
+      setData((prev) => {
+        if (!prev) return prev;
+        const next: ReservationData = {
+          ...prev,
+          nextTokens: { ...prev.nextTokens },
+        };
+        ALL_STATES.forEach((state, idx) => {
+          const dataKey = STATE_TO_DATA_KEY[state];
+          const tokenKey = STATE_TO_TOKEN_KEY[state];
+          (next as unknown as Record<string, Reservation[]>)[dataKey] =
+            results[idx].items;
+          next.nextTokens[tokenKey] = results[idx].next_dtend;
+        });
+        return next;
+      });
+    } catch (err) {
+      captureFlowFailure({
+        flow: 'reservation_refetch',
+        step: 'fetch_all',
+        message:
+          err instanceof Error ? err.message : 'Failed to refetch reservations',
+      });
+      console.error('[useReservationData] refetch error:', err);
+    }
+  }, [loginUserId, data]);
+
+  // Single entry point used by mutation handlers in ReservationList: optimistic
+  // remove first (so the card disappears immediately), then refetch in the
+  // background to pick up the moved item in its destination state.
+  const onMutationSuccess = useCallback(
+    (id: string) => {
+      removeItem(id);
+      void refetchAll();
+    },
+    [removeItem, refetchAll]
+  );
+
   const loadMore = useCallback(
     async (state: ReservationState): Promise<void> => {
       if (!data || !loginUserId) return;
@@ -149,5 +229,11 @@ export function useReservationData() {
     [data, loginUserId]
   );
 
-  return { data, isLoading, isLoadingMore, loadMore };
+  return {
+    data,
+    isLoading,
+    isLoadingMore,
+    loadMore,
+    onMutationSuccess,
+  };
 }

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -86,15 +86,18 @@ describe('formatDateTime', () => {
  * ================================ */
 
 describe('mapToReservation', () => {
-  it('MENTOR_PENDING → menteeMessage looked up using participant.user_id', () => {
+  it('MENTOR_PENDING → counterpartyMessage picks the mentee message (participant.user_id)', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 20, role: 'MENTEE', content: 'Hello mentor!' }],
     });
     const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.note).toBe('Hello mentor!');
+    expect(result.counterpartyMessage).toEqual({
+      role: 'MENTEE',
+      content: 'Hello mentor!',
+    });
   });
 
-  it('MENTEE_PENDING → menteeMessage looked up using sender.user_id', () => {
+  it('MENTEE_PENDING → counterpartyMessage picks the mentor reply (participant.user_id)', () => {
     const reservation = makeReservation({
       sender: {
         user_id: 30,
@@ -105,10 +108,47 @@ describe('mapToReservation', () => {
         job_title: 'PM',
         years_of_experience: 'ONE_TO_THREE',
       },
-      messages: [{ user_id: 30, role: 'MENTEE', content: 'Looking forward!' }],
+      participant: {
+        user_id: 40,
+        role: 'MENTOR',
+        status: 'ACCEPT',
+        name: 'Dave',
+        avatar: '',
+        job_title: 'Engineer',
+        years_of_experience: 'THREE_TO_FIVE',
+      },
+      messages: [
+        { user_id: 30, role: 'MENTEE', content: 'Looking forward!' },
+        { user_id: 40, role: 'MENTOR', content: 'See you on Google Meet.' },
+      ],
     });
     const result = mapToReservation(reservation, 'MENTEE_PENDING');
-    expect(result.note).toBe('Looking forward!');
+    expect(result.counterpartyMessage).toEqual({
+      role: 'MENTOR',
+      content: 'See you on Google Meet.',
+    });
+  });
+
+  it('multiple counterparty messages → counterpartyMessage uses the latest one', () => {
+    const reservation = makeReservation({
+      messages: [
+        { user_id: 20, role: 'MENTEE', content: 'First note' },
+        { user_id: 20, role: 'MENTEE', content: 'Updated note' },
+      ],
+    });
+    const result = mapToReservation(reservation, 'MENTOR_PENDING');
+    expect(result.counterpartyMessage).toEqual({
+      role: 'MENTEE',
+      content: 'Updated note',
+    });
+  });
+
+  it('blank counterparty message → counterpartyMessage is undefined', () => {
+    const reservation = makeReservation({
+      messages: [{ user_id: 20, role: 'MENTEE', content: '   ' }],
+    });
+    const result = mapToReservation(reservation, 'MENTOR_PENDING');
+    expect(result.counterpartyMessage).toBeUndefined();
   });
 
   it('job_title present, years_of_experience empty → roleLine has no trailing comma', () => {
@@ -165,11 +205,11 @@ describe('mapToReservation', () => {
     expect(result.name).toBe('—');
   });
 
-  it('no matching message for mentee in messages → note is undefined', () => {
+  it('no matching counterparty message → counterpartyMessage is undefined', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 999, role: 'OTHER', content: 'Wrong user' }],
     });
     const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.note).toBeUndefined();
+    expect(result.counterpartyMessage).toBeUndefined();
   });
 });

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -1,7 +1,10 @@
 import dayjs from 'dayjs';
 
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
-import { Reservation } from '@/components/reservation/types';
+import {
+  CounterpartyMessage,
+  Reservation,
+} from '@/components/reservation/types';
 import { apiClient } from '@/lib/apiClient';
 import { components } from '@/types/api';
 
@@ -43,6 +46,25 @@ export function formatDateTime(dtstart: number, dtend: number) {
  * Mapping
  * ================================ */
 
+// Resolve the role of the OTHER party so the UI can label the message
+// ("學員留言" vs "Mentor 回覆") without needing extra context. We try the
+// message's own role first (most authoritative), then the participant's role
+// from the reservation, then fall back to the list state. The state-only
+// fallback can't disambiguate HISTORY, hence the upstream defaults.
+function resolveCounterpartyRole(
+  state: ReservationState,
+  participantRole?: string | null,
+  apiMessageRole?: string | null
+): 'MENTEE' | 'MENTOR' | undefined {
+  if (apiMessageRole === 'MENTOR' || apiMessageRole === 'MENTEE')
+    return apiMessageRole;
+  if (participantRole === 'MENTOR' || participantRole === 'MENTEE')
+    return participantRole;
+  if (state.startsWith('MENTOR_')) return 'MENTEE';
+  if (state.startsWith('MENTEE_')) return 'MENTOR';
+  return undefined;
+}
+
 export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO'],
   state: ReservationState
@@ -57,17 +79,31 @@ export function mapToReservation(
     .filter(Boolean)
     .join(', ');
 
-  // Extract the mentee's booking message, shown read-only in the mentor Accept dialog.
-  // For MENTOR_* states the backend sets sender = mentor (current user), participant = mentee.
-  // For MENTEE_* / HISTORY states the sender is the mentee.
-  const menteeUserId = state.startsWith('MENTOR_')
-    ? reservation.participant.user_id
-    : reservation.sender.user_id;
-  const menteeMessage = reservation.messages?.find(
+  // Pick the latest message authored by the counterparty so the viewer always
+  // sees what the OTHER side said (mentee question, mentor accept reply, mentor
+  // rejection / cancellation reason — all flow through the same field).
+  const counterpartyUserId = counterparty.user_id;
+  const counterpartyMessages = (reservation.messages ?? []).filter(
     (message) =>
       message.user_id != null &&
-      String(message.user_id) === String(menteeUserId)
+      String(message.user_id) === String(counterpartyUserId) &&
+      typeof message.content === 'string' &&
+      message.content.trim().length > 0
   );
+  const latestCounterparty =
+    counterpartyMessages[counterpartyMessages.length - 1];
+  const counterpartyRole = resolveCounterpartyRole(
+    state,
+    counterparty.role,
+    latestCounterparty?.role
+  );
+  const counterpartyMessage: CounterpartyMessage | undefined =
+    latestCounterparty && counterpartyRole
+      ? {
+          role: counterpartyRole,
+          content: latestCounterparty.content!.trim(),
+        }
+      : undefined;
 
   return {
     id: String(reservation.id ?? ''),
@@ -76,7 +112,7 @@ export function mapToReservation(
     date,
     time,
     avatar: counterparty.avatar ?? undefined,
-    note: menteeMessage?.content ?? undefined,
+    counterpartyMessage,
     scheduleId: reservation.schedule_id,
     dtstart: reservation.dtstart,
     dtend: reservation.dtend,


### PR DESCRIPTION
## What Does This PR Do?

- Replace `Reservation.note` with `counterpartyMessage` (role + content) so the OTHER party's message (mentee question, mentor accept reply, mentor reject / cancel reason) flows through one channel
- `mapToReservation` now picks the latest counterparty message and resolves role from message → participant → list state
- `ReservationCard` drops the `Badge` wrapper for long notes; renders an inline preview with author label, message icon, and `line-clamp-2`
- `AcceptReservationDialog` adds a collapsible "附上回覆訊息（選填）" textarea and forwards the actual message to `onAccept` instead of hardcoding `''`; closes itself on success and tracks `has_reply` analytics
- `useReservationData` exposes `onMutationSuccess(id)` (optimistic remove + background refetchAll) so `ReservationList` no longer triggers `window.location.reload()`; refetch uses per-state batch sizing to preserve load-more results
- Wire `onMutationSuccess` through mentor / mentee container → ReservationTabs → ReservationList

## Demo

http://localhost:3000/reservation/mentor
http://localhost:3000/reservation/mentee

## Screenshot

N/A

## Anything to Note?

- Semantic change: mentee no longer sees their own booking message echoed back in their own tabs (only the mentor's reply is shown). This matches the AC and matches how mentee already knows what they wrote.
- `onMutationSuccess` fires `refetchAll` (5 parallel requests). Acceptable at current data scale; can be narrowed to source/dest states if it becomes a bottleneck.
- HISTORY tab still shows only one counterparty message (the latest); full message timeline is out of scope per ticket and tracked as a follow-up.
