### PR TITLE
fix: clarify mentee booking dialog reflects PENDING state (#149)

### DIFF
--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -362,7 +362,9 @@ export default function MenteeReservationDialog({
   const renderSuccessView = () => (
     <>
       <DialogHeader>
-        <DialogTitle className="text-center">預約成功</DialogTitle>
+        <DialogTitle className="text-center">
+          預約已送出，等待導師回復
+        </DialogTitle>
       </DialogHeader>
       <div className="flex flex-col items-center gap-6 py-4">
         <div className="w-full rounded-lg border p-4">
@@ -398,6 +400,9 @@ export default function MenteeReservationDialog({
             </div>
           </div>
         </div>
+        <p className="text-center text-sm text-muted-foreground">
+          導師接受後預約才會成立，可至「我的預約 → 等待回復」追蹤狀態。
+        </p>
       </div>
       <DialogFooter className="flex-col gap-3 sm:flex-col sm:space-x-0">
         <Button onClick={handleGoToReservation} className="w-full">


### PR DESCRIPTION
## What Does This PR Do?

- Change the mentee reservation success dialog title from 「預約成功」 to 「預約已送出，等待導師回復」 so it reflects the actual `PENDING` status returned by the API.
- Add a hint paragraph below the mentor/time card explaining that the booking only becomes confirmed after the mentor accepts, and pointing users to 「我的預約 → 等待回復」 to track status.

## Demo

http://localhost:3000/profile/<mentorUserId>

(open as a mentee → click 預約時間 → pick a slot → 確認 → success view)

## Screenshot

N/A

## Anything to Note?

- Title grew from 4 chars to a full sentence — verify wrapping on narrow mobile widths during QA.
- Analytics event name `reservation_booking_confirmed` and the CTA labels are intentionally unchanged (out of scope per issue #149).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
