### PR TITLE
fix: clarify only reject releases pending reservation slot (#150)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -523,7 +523,7 @@ export default function MentorScheduleDialog({
           <DialogHeader>
             <DialogTitle>此時段有未處理的預約申請</DialogTitle>
             <DialogDescription>
-              請至「預約管理」頁面接受或拒絕該申請,確認後此時段才會釋出。
+              請至「預約管理」頁面接受或拒絕該申請,僅在拒絕後此時段才會重新釋出。
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="justify-center">


### PR DESCRIPTION
## What Does This PR Do?

- Update the mentor schedule dialog copy that appears when clicking a slot with a PENDING reservation
- Old wording implied both accept and reject would release the slot; in reality only reject does
- Change description to: "請至「預約管理」頁面接受或拒絕該申請,僅在拒絕後此時段才會重新釋出。"

## Demo

http://localhost:3000/profile/<userId>/edit (mentor → schedule dialog → click a slot with PENDING reservation)

## Screenshot

N/A

## Anything to Note?

N/A
