### PR TITLE
feat: show both mentee and mentor messages in reservation card

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -95,11 +95,7 @@ export default function AcceptReservationDialog({
     }
   }
 
-  // counterpartyMessage on the mentor side is always the mentee's question.
-  const menteeMessage =
-    reservation.counterpartyMessage?.role === 'MENTEE'
-      ? reservation.counterpartyMessage.content
-      : undefined;
+  const menteeMessage = reservation.menteeMessage?.content;
   const trimmedReason = reason.trim();
   const canSubmitReject = trimmedReason.length > 0 && !isSubmitting;
 

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -7,11 +7,6 @@ import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
 import type { Reservation } from './types';
 
-const COUNTERPARTY_LABEL: Record<'MENTEE' | 'MENTOR', string> = {
-  MENTEE: '學員留言',
-  MENTOR: 'Mentor 回覆',
-};
-
 export function ReservationCard({
   item,
   actions,
@@ -23,7 +18,8 @@ export function ReservationCard({
   profileHref?: string;
   onProfileClick?: () => void;
 }) {
-  const { counterpartyMessage } = item;
+  const { menteeMessage, mentorMessage } = item;
+  const hasAnyMessage = Boolean(menteeMessage || mentorMessage);
 
   const initials = item.name
     .split(' ')
@@ -105,20 +101,40 @@ export function ReservationCard({
               </div>
             </div>
 
-            {counterpartyMessage ? (
-              <div className="mt-3 flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
-                <MessageSquare
-                  className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
-                  aria-hidden
-                />
-                <div className="min-w-0 flex-1">
-                  <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
-                    {COUNTERPARTY_LABEL[counterpartyMessage.role]}
+            {hasAnyMessage ? (
+              <div className="mt-3 space-y-2">
+                {menteeMessage ? (
+                  <div className="flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
+                    <MessageSquare
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+                        學員留言
+                      </div>
+                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
+                        {menteeMessage.content}
+                      </p>
+                    </div>
                   </div>
-                  <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
-                    {counterpartyMessage.content}
-                  </p>
-                </div>
+                ) : null}
+                {mentorMessage ? (
+                  <div className="flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
+                    <MessageSquare
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
+                      aria-hidden
+                    />
+                    <div className="min-w-0 flex-1">
+                      <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+                        Mentor 回覆
+                      </div>
+                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
+                        {mentorMessage.content}
+                      </p>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             ) : null}
           </div>

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,5 +1,4 @@
-export type CounterpartyMessage = {
-  role: 'MENTEE' | 'MENTOR';
+export type ReservationMessage = {
   content: string;
 };
 
@@ -10,8 +9,10 @@ export type Reservation = {
   roleLine: string;
   date: string;
   time: string;
-  // Latest message from the OTHER party (mentee question, mentor reply / reason).
-  counterpartyMessage?: CounterpartyMessage;
+  // Latest message authored by each party. Either side may be undefined when
+  // that party hasn't written anything yet.
+  menteeMessage?: ReservationMessage;
+  mentorMessage?: ReservationMessage;
 
   // Required by the PUT reservation status endpoint
   scheduleId: number;

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -4,7 +4,6 @@ import {
   formatDateTime,
   formatExperience,
   mapToReservation,
-  ReservationState,
 } from '@/services/reservations';
 import { components } from '@/types/api';
 
@@ -47,13 +46,6 @@ function makeReservation(
   };
 }
 
-function makeReservationWithState(
-  overrides: Partial<ReservationInfoVO>,
-  state: ReservationState
-) {
-  return mapToReservation(makeReservation(overrides), state);
-}
-
 /* ================================
  * formatExperience
  * ================================ */
@@ -86,18 +78,16 @@ describe('formatDateTime', () => {
  * ================================ */
 
 describe('mapToReservation', () => {
-  it('MENTOR_PENDING → counterpartyMessage picks the mentee message (participant.user_id)', () => {
+  it('mentee message present, mentor silent → menteeMessage set, mentorMessage undefined', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 20, role: 'MENTEE', content: 'Hello mentor!' }],
     });
-    const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.counterpartyMessage).toEqual({
-      role: 'MENTEE',
-      content: 'Hello mentor!',
-    });
+    const result = mapToReservation(reservation);
+    expect(result.menteeMessage).toEqual({ content: 'Hello mentor!' });
+    expect(result.mentorMessage).toBeUndefined();
   });
 
-  it('MENTEE_PENDING → counterpartyMessage picks the mentor reply (participant.user_id)', () => {
+  it('both sides have messages → menteeMessage and mentorMessage both populated', () => {
     const reservation = makeReservation({
       sender: {
         user_id: 30,
@@ -122,38 +112,58 @@ describe('mapToReservation', () => {
         { user_id: 40, role: 'MENTOR', content: 'See you on Google Meet.' },
       ],
     });
-    const result = mapToReservation(reservation, 'MENTEE_PENDING');
-    expect(result.counterpartyMessage).toEqual({
-      role: 'MENTOR',
+    const result = mapToReservation(reservation);
+    expect(result.menteeMessage).toEqual({ content: 'Looking forward!' });
+    expect(result.mentorMessage).toEqual({
       content: 'See you on Google Meet.',
     });
   });
 
-  it('multiple counterparty messages → counterpartyMessage uses the latest one', () => {
+  it('multiple mentee messages → menteeMessage uses the latest one', () => {
     const reservation = makeReservation({
       messages: [
         { user_id: 20, role: 'MENTEE', content: 'First note' },
         { user_id: 20, role: 'MENTEE', content: 'Updated note' },
       ],
     });
-    const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.counterpartyMessage).toEqual({
-      role: 'MENTEE',
-      content: 'Updated note',
-    });
+    const result = mapToReservation(reservation);
+    expect(result.menteeMessage).toEqual({ content: 'Updated note' });
+    expect(result.mentorMessage).toBeUndefined();
   });
 
-  it('blank counterparty message → counterpartyMessage is undefined', () => {
+  it('blank message content → message is undefined', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 20, role: 'MENTEE', content: '   ' }],
     });
-    const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.counterpartyMessage).toBeUndefined();
+    const result = mapToReservation(reservation);
+    expect(result.menteeMessage).toBeUndefined();
+    expect(result.mentorMessage).toBeUndefined();
+  });
+
+  it('message role missing → falls back to user_id → sender/participant role lookup', () => {
+    const reservation = makeReservation({
+      messages: [
+        { user_id: 10, role: null, content: 'From the mentor side' },
+        { user_id: 20, role: undefined, content: 'From the mentee side' },
+      ],
+    });
+    const result = mapToReservation(reservation);
+    expect(result.mentorMessage).toEqual({ content: 'From the mentor side' });
+    expect(result.menteeMessage).toEqual({ content: 'From the mentee side' });
+  });
+
+  it('message from unknown user with unknown role → ignored', () => {
+    const reservation = makeReservation({
+      messages: [{ user_id: 999, role: 'OTHER', content: 'Wrong user' }],
+    });
+    const result = mapToReservation(reservation);
+    expect(result.menteeMessage).toBeUndefined();
+    expect(result.mentorMessage).toBeUndefined();
   });
 
   it('job_title present, years_of_experience empty → roleLine has no trailing comma', () => {
-    const result = makeReservationWithState(
-      {
+    const result = mapToReservation(
+      makeReservation({
         participant: {
           user_id: 20,
           role: 'MENTEE',
@@ -163,15 +173,14 @@ describe('mapToReservation', () => {
           job_title: 'Product Manager',
           years_of_experience: '',
         },
-      },
-      'MENTOR_UPCOMING'
+      })
     );
     expect(result.roleLine).toBe('Product Manager');
   });
 
   it('both job_title and years_of_experience empty → roleLine is empty string', () => {
-    const result = makeReservationWithState(
-      {
+    const result = mapToReservation(
+      makeReservation({
         participant: {
           user_id: 20,
           role: 'MENTEE',
@@ -181,15 +190,14 @@ describe('mapToReservation', () => {
           job_title: '',
           years_of_experience: '',
         },
-      },
-      'MENTOR_UPCOMING'
+      })
     );
     expect(result.roleLine).toBe('');
   });
 
   it('name is empty string → name falls back to "—"', () => {
-    const result = makeReservationWithState(
-      {
+    const result = mapToReservation(
+      makeReservation({
         participant: {
           user_id: 20,
           role: 'MENTEE',
@@ -199,17 +207,8 @@ describe('mapToReservation', () => {
           job_title: '',
           years_of_experience: '',
         },
-      },
-      'MENTOR_UPCOMING'
+      })
     );
     expect(result.name).toBe('—');
-  });
-
-  it('no matching counterparty message → counterpartyMessage is undefined', () => {
-    const reservation = makeReservation({
-      messages: [{ user_id: 999, role: 'OTHER', content: 'Wrong user' }],
-    });
-    const result = mapToReservation(reservation, 'MENTOR_PENDING');
-    expect(result.counterpartyMessage).toBeUndefined();
   });
 });

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -2,8 +2,8 @@ import dayjs from 'dayjs';
 
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 import {
-  CounterpartyMessage,
   Reservation,
+  ReservationMessage,
 } from '@/components/reservation/types';
 import { apiClient } from '@/lib/apiClient';
 import { components } from '@/types/api';
@@ -46,28 +46,25 @@ export function formatDateTime(dtstart: number, dtend: number) {
  * Mapping
  * ================================ */
 
-// Resolve the role of the OTHER party so the UI can label the message
-// ("學員留言" vs "Mentor 回覆") without needing extra context. We try the
-// message's own role first (most authoritative), then the participant's role
-// from the reservation, then fall back to the list state. The state-only
-// fallback can't disambiguate HISTORY, hence the upstream defaults.
-function resolveCounterpartyRole(
-  state: ReservationState,
-  participantRole?: string | null,
-  apiMessageRole?: string | null
+// Classify a single API message as MENTEE / MENTOR / unknown.
+// Trust the message's own role first (most authoritative); fall back to mapping
+// the message's user_id back to sender / participant role.
+function classifyMessageRole(
+  message: components['schemas']['ReservationMessageVO'],
+  userIdToRole: Map<string, string | null | undefined>
 ): 'MENTEE' | 'MENTOR' | undefined {
-  if (apiMessageRole === 'MENTOR' || apiMessageRole === 'MENTEE')
-    return apiMessageRole;
-  if (participantRole === 'MENTOR' || participantRole === 'MENTEE')
-    return participantRole;
-  if (state.startsWith('MENTOR_')) return 'MENTEE';
-  if (state.startsWith('MENTEE_')) return 'MENTOR';
+  if (message.role === 'MENTEE' || message.role === 'MENTOR')
+    return message.role;
+  const fallback =
+    message.user_id != null
+      ? userIdToRole.get(String(message.user_id))
+      : undefined;
+  if (fallback === 'MENTEE' || fallback === 'MENTOR') return fallback;
   return undefined;
 }
 
 export function mapToReservation(
-  reservation: components['schemas']['ReservationInfoVO'],
-  state: ReservationState
+  reservation: components['schemas']['ReservationInfoVO']
 ): Reservation {
   // API 固定結構：sender = 當前使用者，participant = 對方
   const counterparty = reservation.participant;
@@ -79,31 +76,26 @@ export function mapToReservation(
     .filter(Boolean)
     .join(', ');
 
-  // Pick the latest message authored by the counterparty so the viewer always
-  // sees what the OTHER side said (mentee question, mentor accept reply, mentor
-  // rejection / cancellation reason — all flow through the same field).
-  const counterpartyUserId = counterparty.user_id;
-  const counterpartyMessages = (reservation.messages ?? []).filter(
-    (message) =>
-      message.user_id != null &&
-      String(message.user_id) === String(counterpartyUserId) &&
-      typeof message.content === 'string' &&
-      message.content.trim().length > 0
-  );
-  const latestCounterparty =
-    counterpartyMessages[counterpartyMessages.length - 1];
-  const counterpartyRole = resolveCounterpartyRole(
-    state,
-    counterparty.role,
-    latestCounterparty?.role
-  );
-  const counterpartyMessage: CounterpartyMessage | undefined =
-    latestCounterparty && counterpartyRole
-      ? {
-          role: counterpartyRole,
-          content: latestCounterparty.content!.trim(),
-        }
-      : undefined;
+  // Pick the latest non-blank message from each side so the UI can show both
+  // the mentee's question and the mentor's reply / cancellation reason at once.
+  const userIdToRole = new Map<string, string | null | undefined>([
+    [String(reservation.sender.user_id ?? ''), reservation.sender.role],
+    [
+      String(reservation.participant.user_id ?? ''),
+      reservation.participant.role,
+    ],
+  ]);
+
+  let menteeMessage: ReservationMessage | undefined;
+  let mentorMessage: ReservationMessage | undefined;
+  for (const message of reservation.messages ?? []) {
+    if (typeof message.content !== 'string') continue;
+    const trimmed = message.content.trim();
+    if (trimmed.length === 0) continue;
+    const role = classifyMessageRole(message, userIdToRole);
+    if (role === 'MENTEE') menteeMessage = { content: trimmed };
+    else if (role === 'MENTOR') mentorMessage = { content: trimmed };
+  }
 
   return {
     id: String(reservation.id ?? ''),
@@ -112,7 +104,8 @@ export function mapToReservation(
     date,
     time,
     avatar: counterparty.avatar ?? undefined,
-    counterpartyMessage,
+    menteeMessage,
+    mentorMessage,
     scheduleId: reservation.schedule_id,
     dtstart: reservation.dtstart,
     dtend: reservation.dtend,
@@ -145,7 +138,7 @@ export async function fetchReservations(
     throw new Error(`API error: code=${json.code}, msg=${json.msg}`);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
-    mapToReservation(reservation, state)
+    mapToReservation(reservation)
   );
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }


### PR DESCRIPTION
## What Does This PR Do?

- Replace `counterpartyMessage` with role-keyed `menteeMessage` + `mentorMessage` so list cards can show both sides at once
- Rewrite `mapToReservation` to classify each message via its `role` (with `user_id` → sender/participant role as fallback) and pick the latest non-blank message per side
- Update `ReservationCard` to render the mentee question and mentor reply as two stacked message blocks
- Simplify `AcceptReservationDialog` mentee-message extraction to a direct field access
- Update reservations service tests for the new shape; add coverage for both-sides messages, role fallback, and unknown-user cases

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

Closes Xchange-Taiwan/X-Talent-Tracker#152 (Tier 1 + Tier 2 only).

Tier 4 (status-aware labels) is blocked on backend: `ReservationInfoVO` does not return status today, and the `BookingStatus` enum has no `CANCELLED` value — to be tracked in a separate ticket.
