### PR TITLE
perf(mentor-pool): enable Next.js image optimization for avatars

### DIFF
--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -20,7 +20,6 @@ export const AvatarWithBadge = ({ avatar, years }: AvatarWithBadgeProps) => {
         fill
         sizes="(max-width: 768px) 334px, 413px"
         className="h-full object-cover"
-        unoptimized={typeof avatar === 'string'}
       />
       <figcaption className="absolute bottom-[30px] right-[30px] rounded-lg bg-[#000000]/30 px-2.5 py-1 text-text-white">
         {displayYears}工作經驗


### PR DESCRIPTION
## What Does This PR Do?

- Remove `unoptimized={typeof avatar === 'string'}` from `AvatarWithBadge` so S3 mentor avatars are routed through the Next.js Image optimizer
- Avatars are now served as WebP at the size declared by `sizes`, and benefit from the 30-day server cache (`minimumCacheTTL` in `next.config.js`)
- Existing `?cb=${updated_at}` cache-buster still works — verified that X-Career-Search bumps `updated_at` whenever a mentor profile (including avatar) is upserted via SQS, so a new avatar produces a new URL and bypasses the cache

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- DevTools Network: avatar requests now go through `/_next/image?url=...&w=...&q=75` and return `image/webp`
- Closes Xchange-Taiwan/X-Talent-Tracker#153

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
