### PR TITLE
fix(reservation): align mentor accept button color with dialog confirm

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -109,7 +109,13 @@ export default function AcceptReservationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
-        <Button size="sm" className={cn('min-h-9 px-3', className)}>
+        <Button
+          size="sm"
+          className={cn(
+            'bg-teal-500 text-white hover:bg-teal-500/90 min-h-9 px-3',
+            className
+          )}
+        >
           接受
         </Button>
       </DialogTrigger>


### PR DESCRIPTION
## What Does This PR Do?

- Apply the teal styling (bg-teal-500) to the mentor-side "接受" trigger button on the reservation list so it matches the confirm button inside AcceptReservationDialog
- Addresses issue 1 of Xchange-Taiwan/X-Talent-Tracker#154 (button color consistency)
- Issue 2 of #154 (spurious failure toast on success) is NOT included — root cause still pending DevTools verification

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- className-only change; no logic, no behavior change
- cn() order keeps the parent-passed `className` last so it can still override
- No changes to reject/cancel buttons or their dialogs
