### PR TITLE
fix(reservation): guard cancel dialog against duplicate submits (#155)

### DIFF
--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { CalendarDays, Clock } from 'lucide-react';
+import { CalendarDays, Clock, Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
@@ -39,9 +40,12 @@ export default function CancelReservationDialog({
   const [open, setOpen] = useState(false);
   const [step, setStep] = useState<'confirm' | 'reason'>('confirm');
   const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
 
   // Reset to the first step every time the dialog opens
   function onOpenChange(next: boolean) {
+    if (isSubmitting) return;
     setOpen(next);
     if (next) {
       setStep('confirm');
@@ -55,8 +59,18 @@ export default function CancelReservationDialog({
   }
 
   async function handleConfirm() {
-    await onConfirmCancel?.({ id: reservation.id, reason });
-    setOpen(false);
+    setIsSubmitting(true);
+    try {
+      await onConfirmCancel?.({ id: reservation.id, reason });
+      setIsSubmitting(false);
+      setOpen(false);
+    } catch {
+      toast({
+        variant: 'destructive',
+        description: '取消預約失敗,請稍後再試',
+      });
+      setIsSubmitting(false);
+    }
   }
 
   const initials =
@@ -151,19 +165,27 @@ export default function CancelReservationDialog({
               value={reason}
               onChange={(e) => setReason(e.target.value)}
               className="min-h-[140px] resize-y"
+              disabled={isSubmitting}
             />
 
             <DialogFooter className="mt-6 gap-2">
               <DialogClose asChild>
-                <Button variant="outline" className="w-full sm:w-auto">
+                <Button
+                  variant="outline"
+                  className="w-full sm:w-auto"
+                  disabled={isSubmitting}
+                >
                   維持預約
                 </Button>
               </DialogClose>
               <Button
-                disabled={reason.trim().length === 0}
+                disabled={reason.trim().length === 0 || isSubmitting}
                 className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
                 onClick={handleConfirm}
               >
+                {isSubmitting && (
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                )}
                 取消預約
               </Button>
             </DialogFooter>


### PR DESCRIPTION
## What Does This PR Do?

- Add `isSubmitting` flag to `CancelReservationDialog` so the submit button, textarea, and "維持預約" close button are all disabled while the REJECT request is in flight
- Lock `onOpenChange` while submitting so ESC / outside-click can't bypass the guard
- Wrap `handleConfirm` in try/catch: on failure show a destructive toast ("取消預約失敗,請稍後再試") and keep the dialog open on the reason step so the user can retry
- Show a `Loader2` spinner inside the submit button for visual feedback
- Mirrors the existing pattern in `AcceptReservationDialog.tsx` / `MenteeReservationDialog.tsx` (no debounce — codebase convention is the in-flight flag)

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Single-file change, no service/hook/list edits — `ReservationList.rejectOrCancel` already throws on failure, so the dialog's new try/catch finally consumes it instead of bubbling up as an unhandled rejection
- Manual verification recommended on three paths: happy path, rapid double-click on Slow 3G (network tab should show only 1 REJECT), and forced failure (toast + dialog stays open)
