### PR TITLE
fix(reservation): restore accept/reject button colors

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -109,13 +109,7 @@ export default function AcceptReservationDialog({
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogTrigger asChild>
-        <Button
-          size="sm"
-          className={cn(
-            'bg-teal-500 text-white hover:bg-teal-500/90 min-h-9 px-3',
-            className
-          )}
-        >
+        <Button size="sm" className={cn('min-h-9 px-3', className)}>
           接受
         </Button>
       </DialogTrigger>
@@ -205,8 +199,8 @@ export default function AcceptReservationDialog({
             <DialogFooter className="mt-6 gap-2">
               <Button
                 type="button"
-                variant="outline"
-                className="w-full border-destructive text-destructive hover:bg-destructive/10 hover:text-destructive sm:w-auto"
+                variant="destructive"
+                className="w-full sm:w-auto"
                 onClick={() => setStep('reject')}
                 disabled={isSubmitting}
               >
@@ -215,7 +209,7 @@ export default function AcceptReservationDialog({
 
               <Button
                 type="button"
-                className="bg-teal-500 text-white hover:bg-teal-500/90 w-full sm:w-auto"
+                className="w-full sm:w-auto"
                 onClick={handleAccept}
                 disabled={isSubmitting}
               >


### PR DESCRIPTION
## What Does This PR Do?

- Drop hardcoded `bg-teal-500` from the accept dialog trigger and inner confirm button — `teal-500` is not in this project's design tokens (`tailwind.config.js` replaces, not extends, the default palette), so the class was silently dropped and the buttons rendered white.
- Both accept buttons now fall back to `Button`'s default variant (`bg-primary`), matching the rest of the app's primary actions.
- Switch the first-step "拒絕" button from outline to `variant="destructive"` so it is solid red, aligned with the second-step reject button and the cancel dialog.

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

Addresses problem 1 of issue #154 only. Problem 2 (success path showing a destructive toast) was not reproducible from a static read of the code — no other reservation-related destructive toasts exist outside the dialogs' own catch blocks. Will be tracked separately once the failing path can be captured via DevTools/Sentry.
