### PR TITLE
fix(reservation): refetch schedule on month change in mentee dialog

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -309,6 +309,7 @@ export default function ProfilePageUI({
                       onOpenChange={setOpenMenteeReservationDialog}
                       schedule={schedule}
                       userData={userData}
+                      onMonthChange={onScheduleMonthChange}
                     />
                   )}
                 </div>

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -37,11 +37,13 @@ export default function MenteeReservationDialog({
   onOpenChange,
   schedule,
   userData,
+  onMonthChange,
 }: {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   schedule: UseMentorScheduleReturn;
   userData: UserType | null;
+  onMonthChange?: (date: Date) => void;
 }) {
   const { selectedDate, setSelectedDate, allowedDates, generateBookingSlots } =
     schedule;
@@ -224,6 +226,7 @@ export default function MenteeReservationDialog({
                   : null
               )
             }
+            onMonthChange={onMonthChange}
             allowedDates={allowedDates}
             showTodayStyle={false}
             disableEmptyDates={true}


### PR DESCRIPTION
## What Does This PR Do?

- Wire `onMonthChange` from `MenteeReservationDialog` through to its inner `ScheduleCalendar` so month switches propagate up to the profile container
- Pass the existing `onScheduleMonthChange` handler from `ui.tsx` into `MenteeReservationDialog` (previously only `MentorScheduleDialog` received it)
- Closes #156

## Demo

http://localhost:3000/profile/<mentor-user-id> (sign in as a mentee, open booking dialog, switch month)

## Screenshot

N/A

## Anything to Note?

The hook (`useMentorSchedule`), service (`loadMonthSchedule`), and container month state were already correctly month-keyed — only the mentee dialog's prop wiring was missing. No backend or hook changes required.
