### PR TITLE
feat(auth): remember last Google login for one-click sign-in

### DIFF
--- a/src/app/auth/(sign)/signin/page.tsx
+++ b/src/app/auth/(sign)/signin/page.tsx
@@ -1,13 +1,60 @@
 'use client';
 
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+
 import AuthTitle from '@/components/auth/AuthTitle';
 import Divider from '@/components/auth/Divider';
 import GoogleSignUpButton from '@/components/auth/GoogleButton';
 import SignInForm from '@/components/auth/signin/SignInForm';
+import { useToast } from '@/components/ui/use-toast';
 import useSignInForm from '@/hooks/auth/useSignInForm';
+import { trackEvent } from '@/lib/analytics';
+import {
+  clearLastGoogleLoginHint,
+  type LastGoogleLoginHint,
+  readLastGoogleLoginHint,
+} from '@/lib/lastGoogleLoginHint';
+import { getGoogleAuthorizeLoginUrl } from '@/services/auth/googleAuthorize';
 
 export default function Page() {
   const signInFormProps = useSignInForm();
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const [mounted, setMounted] = useState(false);
+  const [hint, setHint] = useState<LastGoogleLoginHint | null>(null);
+  const [isSwitching, setIsSwitching] = useState(false);
+
+  useEffect(() => {
+    setHint(readLastGoogleLoginHint());
+    setMounted(true);
+  }, []);
+
+  const handleSwitchAccount = async (): Promise<void> => {
+    if (isSwitching) return;
+    setIsSwitching(true);
+    clearLastGoogleLoginHint();
+    setHint(null);
+    trackEvent({
+      name: 'google_switch_account_clicked',
+      feature: 'auth',
+      metadata: { has_hint: true },
+    });
+    try {
+      const { authorization_url } = await getGoogleAuthorizeLoginUrl();
+      const sep = authorization_url.includes('?') ? '&' : '?';
+      router.push(`${authorization_url}${sep}prompt=select_account`);
+    } catch (error) {
+      console.error('[GoogleAuth] switch account error:', error);
+      setIsSwitching(false);
+      toast({
+        variant: 'destructive',
+        title: '登入失敗',
+        description: '無法完成 Google 登入，請稍後再試。',
+      });
+    }
+  };
 
   return (
     <div className="flex h-full flex-col items-center justify-center px-5 pb-8 sm:pb-0">
@@ -15,11 +62,31 @@ export default function Page() {
         <AuthTitle>登入 X-Talent 帳戶</AuthTitle>
         <SignInForm {...signInFormProps} />
         <Divider>或</Divider>
-        <GoogleSignUpButton
-          isSubmitting={signInFormProps.isSubmitting}
-          label="使用 Google 帳號登入"
-          isSignIn={true}
-        />
+        {mounted ? (
+          <div className="flex flex-col items-center gap-3">
+            <GoogleSignUpButton
+              isSubmitting={signInFormProps.isSubmitting || isSwitching}
+              label="使用 Google 帳號登入"
+              isSignIn={true}
+              hint={hint}
+            />
+            {hint ? (
+              <button
+                type="button"
+                onClick={handleSwitchAccount}
+                disabled={isSwitching}
+                className="text-sm text-muted-foreground underline-offset-4 hover:underline disabled:opacity-50"
+              >
+                使用其他 Google 帳號
+              </button>
+            ) : null}
+          </div>
+        ) : (
+          <div
+            aria-hidden
+            className="h-12 w-full rounded-full border border-input bg-background"
+          />
+        )}
       </div>
     </div>
   );

--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -8,6 +8,7 @@ import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { useToast } from '@/components/ui/use-toast';
 import { googleCallback } from '@/lib/actions/googleCallback';
 import { trackEvent } from '@/lib/analytics';
+import { writeLastGoogleLoginHint } from '@/lib/lastGoogleLoginHint';
 import { deleteAccount } from '@/services/auth/deleteAccount';
 import type { components } from '@/types/api';
 
@@ -166,6 +167,14 @@ export default function GoogleOAuthRedirectPage() {
       user: JSON.stringify(data.user),
       refreshToken: refreshToken ?? '',
     });
+
+    if (data.auth.email) {
+      writeLastGoogleLoginHint({
+        email: data.auth.email,
+        name: data.user.name ?? null,
+        avatar: data.user.avatar ?? null,
+      });
+    }
 
     const session = await getSession();
 

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -1,8 +1,13 @@
+'use client';
+
 import { useRouter } from 'next/navigation';
 
 import { GoogleColor } from '@/components/icon';
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import { useToast } from '@/components/ui/use-toast';
+import { trackEvent } from '@/lib/analytics';
+import { type LastGoogleLoginHint, maskEmail } from '@/lib/lastGoogleLoginHint';
 import {
   getGoogleAuthorizeLoginUrl,
   getGoogleAuthorizeSignupUrl,
@@ -12,38 +17,96 @@ interface GoogleSignUpButtonProps {
   isSubmitting: boolean;
   isSignIn: boolean;
   label: string;
+  hint?: LastGoogleLoginHint | null;
+}
+
+function appendQueryParams(
+  url: string,
+  params: Record<string, string>
+): string {
+  const entries = Object.entries(params).filter(([, v]) => v.length > 0);
+  if (entries.length === 0) return url;
+  const sep = url.includes('?') ? '&' : '?';
+  const qs = entries
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  return `${url}${sep}${qs}`;
 }
 
 export default function GoogleSignUpButton({
   isSubmitting,
   label,
   isSignIn,
+  hint = null,
 }: GoogleSignUpButtonProps) {
   const { toast } = useToast();
   const router = useRouter();
 
-  const handleGoogleSignUp = async () => {
+  const showPersonalized = isSignIn && !!hint;
+
+  const handleClick = async () => {
     try {
       const { authorization_url } = isSignIn
         ? await getGoogleAuthorizeLoginUrl()
         : await getGoogleAuthorizeSignupUrl();
-      router.push(authorization_url);
+
+      const extra: Record<string, string> = {};
+      if (hint?.email) {
+        extra.login_hint = hint.email;
+      }
+
+      if (isSignIn) {
+        trackEvent({
+          name: 'google_oneclick_clicked',
+          feature: 'auth',
+          metadata: { has_hint: !!hint },
+        });
+      }
+
+      router.push(appendQueryParams(authorization_url, extra));
     } catch (error) {
       console.error('[GoogleAuth] error:', error);
       toast({
         variant: 'destructive',
-        title: '註冊失敗',
-        description: '無法完成 Google 註冊，請稍後再試。',
+        title: isSignIn ? '登入失敗' : '註冊失敗',
+        description: isSignIn
+          ? '無法完成 Google 登入，請稍後再試。'
+          : '無法完成 Google 註冊，請稍後再試。',
       });
     }
   };
+
+  if (showPersonalized && hint) {
+    const displayName = hint.name?.trim() || hint.email.split('@')[0];
+    const masked = maskEmail(hint.email);
+    return (
+      <Button
+        variant="outline"
+        className="h-12 w-full justify-start gap-3 rounded-full px-4"
+        disabled={isSubmitting}
+        onClick={handleClick}
+        aria-label={`以 ${displayName} (${masked}) 繼續`}
+      >
+        <Avatar className="h-7 w-7 shrink-0">
+          {hint.avatar ? <AvatarImage src={hint.avatar} alt="" /> : null}
+          <AvatarFallback>
+            <GoogleColor className="text-base" />
+          </AvatarFallback>
+        </Avatar>
+        <span className="flex flex-1 flex-col items-start text-left leading-tight">
+          <span className="text-sm font-medium">以 {displayName} 繼續</span>
+          <span className="text-xs text-muted-foreground">{masked}</span>
+        </span>
+      </Button>
+    );
+  }
 
   return (
     <Button
       variant="outline"
       className="h-12 w-full rounded-full"
       disabled={isSubmitting}
-      onClick={handleGoogleSignUp}
+      onClick={handleClick}
     >
       <GoogleColor className="mr-3 text-xl" />
       <span className="text-base">{label}</span>

--- a/src/lib/lastGoogleLoginHint.ts
+++ b/src/lib/lastGoogleLoginHint.ts
@@ -1,0 +1,75 @@
+const STORAGE_KEY = 'xtalent.lastGoogleLogin';
+const SCHEMA_VERSION = 1;
+
+export interface LastGoogleLoginHint {
+  email: string;
+  name: string | null;
+  avatar: string | null;
+  savedAt: number;
+}
+
+interface StoredShape extends LastGoogleLoginHint {
+  v: number;
+}
+
+function isBrowser(): boolean {
+  return (
+    typeof window !== 'undefined' && typeof window.localStorage !== 'undefined'
+  );
+}
+
+export function readLastGoogleLoginHint(): LastGoogleLoginHint | null {
+  if (!isBrowser()) return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredShape>;
+    if (parsed.v !== SCHEMA_VERSION) return null;
+    if (typeof parsed.email !== 'string' || !parsed.email) return null;
+    return {
+      email: parsed.email,
+      name: typeof parsed.name === 'string' ? parsed.name : null,
+      avatar: typeof parsed.avatar === 'string' ? parsed.avatar : null,
+      savedAt: typeof parsed.savedAt === 'number' ? parsed.savedAt : 0,
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function writeLastGoogleLoginHint(
+  hint: Omit<LastGoogleLoginHint, 'savedAt'>
+): void {
+  if (!isBrowser()) return;
+  if (!hint.email) return;
+  try {
+    const payload: StoredShape = {
+      v: SCHEMA_VERSION,
+      email: hint.email,
+      name: hint.name ?? null,
+      avatar: hint.avatar ?? null,
+      savedAt: Date.now(),
+    };
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+  } catch {
+    // Storage unavailable (quota, privacy mode) — silently no-op.
+  }
+}
+
+export function clearLastGoogleLoginHint(): void {
+  if (!isBrowser()) return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // no-op
+  }
+}
+
+export function maskEmail(email: string): string {
+  const at = email.indexOf('@');
+  if (at <= 0) return email;
+  const local = email.slice(0, at);
+  const domain = email.slice(at);
+  if (local.length <= 1) return `${local}***${domain}`;
+  return `${local[0]}***${domain}`;
+}


### PR DESCRIPTION
## What Does This PR Do?

- Add localStorage hint helper (`src/lib/lastGoogleLoginHint.ts`) that stores `{ email, name, avatar }` after a Google LOGIN succeeds — no tokens, schema-versioned, SSR-safe, with a `maskEmail` helper for shared-device privacy.
- Write the hint inside `proceedWithSignIn` (LOGIN path only — not deleteAccount, not SIGNUP).
- Personalize `GoogleButton` on signin: when a hint exists, render avatar + "以 {name} 繼續" + masked email, and append `login_hint=<email>` to the OAuth URL so Google can skip the account picker. Also fix the toast title on signin path ("登入失敗" instead of "註冊失敗").
- Signin page reads the hint after mount (avoids hydration mismatch / layout shift) and renders a "使用其他 Google 帳號" text link below the personalized button. Clicking it clears the hint and forces Google's account picker via `prompt=select_account`.
- Track two PII-free GA events: `google_oneclick_clicked` and `google_switch_account_clicked`, both with `{ has_hint: boolean }`.

Closes Xchange-Taiwan/X-Talent-Tracker#157

## Demo

http://localhost:3000/auth/signin

## Screenshot

N/A

## Anything to Note?

- `login_hint` / `prompt=select_account` are appended client-side to the URL returned by `/v2/oauth/google/authorize/login` — no backend change required.
- localStorage only stores email / display name / avatar URL. No tokens.
- Personalized button uses a masked email (`j***@gmail.com`) to limit PII exposure on shared devices.
- Hint is preserved on logout by design — the "使用其他 Google 帳號" link covers the "not me" case.
- `login_hint` is a Google hint, not a hard constraint: if the user is signed into a different Google account, the picker still appears (with the hinted email pre-selected) — expected OAuth behavior.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
