### PR TITLE
fix(mentor-pool): prevent search bar placeholder truncation on mobile/tablet

### DIFF
--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -44,7 +44,11 @@ export default function MentorPoolUI({
         和 Mentors 一起提升你的職涯經驗吧！
       </section>
       <div className="absolute left-[calc(50%-169px)] top-[172px] h-20 w-[338px] md:left-[calc(50%-344px)] md:w-[688px] xl:left-[calc(50%-423px)] xl:w-[846px]">
-        <SearchBar onSearch={onSearch} />
+        <SearchBar
+          onSearch={onSearch}
+          mobilePlaceholder="搜尋職位、公司或領域"
+          tabletPlaceholder="搜尋職位、公司或想精進的領域"
+        />
       </div>
       <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
         <div className="mx-auto w-full max-w-[1280px] ">

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -3,11 +3,22 @@ import { Loader2 } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+
 interface SearchBarProps {
   onSearch: (query: string) => Promise<void>;
+  placeholder?: string;
+  mobilePlaceholder?: string;
+  tabletPlaceholder?: string;
 }
 
-const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
+const DEFAULT_PLACEHOLDER = '搜尋有興趣職位、公司或是想精進的領域';
+
+const SearchBar: React.FC<SearchBarProps> = ({
+  onSearch,
+  placeholder = DEFAULT_PLACEHOLDER,
+  mobilePlaceholder,
+  tabletPlaceholder,
+}) => {
   const [query, setQuery] = useState('');
   const [isLoading, setIsLoading] = useState(false);
 
@@ -29,29 +40,53 @@ const SearchBar: React.FC<SearchBarProps> = ({ onSearch }) => {
     }
   };
 
+  const sharedInputProps = {
+    type: 'text' as const,
+    value: query,
+    onChange: (e: React.ChangeEvent<HTMLInputElement>) =>
+      setQuery(e.target.value),
+    onKeyDown: handleKeyDown,
+    'aria-label': '搜尋',
+  };
+
+  const inputClass = 'h-5 min-w-0 flex-auto truncate text-base outline-none';
+
   return (
-    <>
-      <div className="flex w-full max-w-[846px] items-center rounded-2xl border border-[#E6E8EA] bg-background-white px-3 py-1.5 md:px-6 md:py-4">
-        <SearchIcon className="mr-2 h-6 w-6 text-gray-500" />
+    <div className="flex w-full max-w-[846px] items-center rounded-2xl border border-[#E6E8EA] bg-background-white px-3 py-1.5 md:px-6 md:py-4">
+      <SearchIcon className="mr-2 h-6 w-6 shrink-0 text-gray-500" />
 
-        <input
-          type="text"
-          value={query}
-          onChange={(e) => setQuery(e.target.value)}
-          onKeyDown={handleKeyDown}
-          placeholder="搜尋有興趣職位、公司或是想精進的領域"
-          className="h-5 min-w-[200px] flex-auto text-base outline-none"
-        />
+      <input
+        {...sharedInputProps}
+        placeholder={mobilePlaceholder ?? placeholder}
+        className={`${inputClass} md:hidden`}
+      />
+      <input
+        {...sharedInputProps}
+        placeholder={tabletPlaceholder ?? placeholder}
+        className={`${inputClass} hidden md:inline-block xl:hidden`}
+      />
+      <input
+        {...sharedInputProps}
+        placeholder={placeholder}
+        className={`${inputClass} hidden xl:inline-block`}
+      />
 
-        <Button
-          onClick={handleSearch}
-          disabled={isLoading}
-          className="ml-2 cursor-pointer rounded-[24px] border-none bg-primary leading-5 md:px-6 md:py-2.5"
-        >
-          {isLoading ? <Loader2 className="h-4 w-4 animate-spin" /> : '搜尋'}
-        </Button>
-      </div>
-    </>
+      <Button
+        onClick={handleSearch}
+        disabled={isLoading}
+        aria-label="搜尋"
+        className="ml-2 h-10 w-10 shrink-0 cursor-pointer rounded-full border-none bg-primary p-0 leading-5 md:h-auto md:w-auto md:rounded-[24px] md:px-6 md:py-2.5"
+      >
+        {isLoading ? (
+          <Loader2 className="h-4 w-4 animate-spin" />
+        ) : (
+          <>
+            <SearchIcon className="h-5 w-5 md:hidden" />
+            <span className="hidden md:inline">搜尋</span>
+          </>
+        )}
+      </Button>
+    </div>
   );
 };
 


### PR DESCRIPTION
## What Does This PR Do?

- Add `placeholder` / `mobilePlaceholder` / `tabletPlaceholder` props to `SearchBar`; render three CSS-swapped inputs sharing state so each breakpoint shows a length-appropriate hint
- Add `truncate min-w-0` to inputs as a safety net so future copy still ends with `…` instead of being clipped mid-character
- Switch the mobile search button to an icon-only round button with `aria-label="搜尋"` to free up horizontal space; keep the text button on `md+`
- Pass mentor-pool-specific shorter copy: mobile `搜尋職位、公司或領域`, tablet `搜尋職位、公司或想精進的領域`, desktop keeps the original

Closes Xchange-Taiwan/X-Talent-Tracker#159

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Three inputs share React state; CSS-only breakpoint swap avoids hydration mismatch and keeps the value when resizing.
- `SearchBar` is currently only consumed by mentor-pool, so the new optional props are backward-compatible.
