### PR TITLE
test(e2e): stabilize suite against Lambda cold start and dev server load

### DIFF
--- a/e2e/fixtures/auth.setup.ts
+++ b/e2e/fixtures/auth.setup.ts
@@ -13,14 +13,27 @@ setup('authenticate', async ({ page }) => {
     );
   }
 
-  await page.goto('/auth/signin');
-  await page.fill('input[name="email"]', email);
-  await page.fill('input[name="password"]', password);
-  await page.click('button[type="submit"]');
+  // The auth Lambda can cold-start; the first sign-in occasionally times out
+  // even though the second one succeeds quickly. Retry per-attempt with a
+  // shorter timeout instead of relying on a single long wait.
+  const MAX_ATTEMPTS = 3;
+  let lastError: unknown;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      await page.goto('/auth/signin');
+      await page.fill('input[name="email"]', email);
+      await page.fill('input[name="password"]', password);
+      await page.click('button[type="submit"]');
 
-  await page.waitForURL((url) => !url.pathname.includes('/auth/signin'), {
-    timeout: 60_000,
-  });
+      await page.waitForURL((url) => !url.pathname.includes('/auth/signin'), {
+        timeout: 25_000,
+      });
 
-  await page.context().storageState({ path: AUTH_FILE });
+      await page.context().storageState({ path: AUTH_FILE });
+      return;
+    } catch (err) {
+      lastError = err;
+    }
+  }
+  throw lastError;
 });

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -11,8 +11,15 @@
  */
 
 import { request } from '@playwright/test';
+import { config } from 'dotenv';
+import path from 'path';
 
 const BASE_URL = 'http://localhost:3000';
+
+// playwright.config.ts loads .env / .env.local / .env.e2e.local but not
+// .env.development.local, where NEXT_PUBLIC_API_URL lives in local dev. Load it
+// here so we can pre-warm the backend Lambda below.
+config({ path: path.resolve(__dirname, '../.env.development.local') });
 
 /**
  * Every page route exercised by at least one spec file.
@@ -34,7 +41,11 @@ const PAGES_TO_WARM = [
   '/auth/onboarding',
   '/auth/password-forgot',
   '/auth/password-reset',
+  '/auth/password-forgot-success',
+  '/auth/password-reset-success',
+  '/auth/email-verify',
   '/profile/1/edit',
+  '/profile/card',
   '/reservation/mentee',
   '/reservation/mentor',
 ];
@@ -42,13 +53,35 @@ const PAGES_TO_WARM = [
 export default async function globalSetup(): Promise<void> {
   const context = await request.newContext({ baseURL: BASE_URL });
 
-  await Promise.allSettled(
-    PAGES_TO_WARM.map((path) =>
+  await Promise.allSettled([
+    ...PAGES_TO_WARM.map((path) =>
       context.get(path, { timeout: 60_000 }).catch(() => {
         // Ignore errors (e.g. redirect, 401) — we only need compilation to start.
       })
-    )
-  );
+    ),
+    // Wake the X-Career-Auth Lambda so auth.setup.ts doesn't pay cold-start
+    // latency. Bogus credentials are intentional — a 400/401 still spins up the
+    // function, which is all we need.
+    warmAuthLambda(),
+  ]);
 
   await context.dispose();
+}
+
+async function warmAuthLambda(): Promise<void> {
+  const apiUrl = process.env.NEXT_PUBLIC_API_URL;
+  if (!apiUrl) return;
+
+  const ctx = await request.newContext();
+  try {
+    await ctx.post(`${apiUrl}/v1/auth/login`, {
+      data: { email: 'warmup@warmup.invalid', password: 'warmup' },
+      timeout: 30_000,
+      failOnStatusCode: false,
+    });
+  } catch {
+    // Cold start may exceed our timeout — that's fine, the Lambda is now warming.
+  } finally {
+    await ctx.dispose();
+  }
 }

--- a/e2e/tests/reservation/reservation-mentor.spec.ts
+++ b/e2e/tests/reservation/reservation-mentor.spec.ts
@@ -248,11 +248,12 @@ test('點擊接受並確認 → 卡片移至即將到來 Tab', async ({ page }) 
 
   await page.getByRole('button', { name: /接受/ }).click();
 
-  // Dialog opens at step 'check'; confirm by clicking 接收
-  await expect(page.getByRole('button', { name: /接收/ })).toBeVisible({
+  // Dialog opens at step 'check'; confirm by clicking 接受 inside the dialog
+  const dialog = page.getByRole('dialog');
+  await expect(dialog.getByRole('button', { name: '接受' })).toBeVisible({
     timeout: 5_000,
   });
-  await page.getByRole('button', { name: /接收/ }).click();
+  await dialog.getByRole('button', { name: '接受' }).click();
 
   // Page reloads; wait for tabs to re-render
   await expect(page.getByRole('tab', { name: /即將到來/ })).toBeVisible({

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 1 : undefined,
+  // Local: cap parallelism so the Next.js dev server isn't overwhelmed by
+  // simultaneous on-demand compilation, which causes redirect-target tests to
+  // time out under load. CI stays single-worker for stability.
+  workers: process.env.CI ? 1 : 6,
   reporter: 'html',
   timeout: 90_000,
 


### PR DESCRIPTION
## What Does This PR Do?

- Wake the X-Career-Auth Lambda in `global-setup.ts` (POST bogus credentials to /v1/auth/login) so `auth.setup.ts` doesn't pay cold-start latency on the first real sign-in
- Retry the sign-in in `auth.setup.ts` up to 3 times with a 25s per-attempt timeout, so a single Lambda hiccup no longer fails the whole authenticated test project
- Cap local Playwright workers at 6 to prevent the Next.js dev server from being overwhelmed by simultaneous on-demand compilation, which was timing out redirect-target tests under load
- Expand `PAGES_TO_WARM` to include `/profile/card`, `/auth/password-forgot-success`, `/auth/password-reset-success`, `/auth/email-verify`, so redirect destinations are pre-compiled before tests navigate to them
- Fix `reservation-mentor.spec.ts` accept-flow locator: `/接收/` → `/接受/` (PR #441 renamed the dialog confirm button) and scope to `getByRole('dialog')` to disambiguate from the trigger button of the same name

## Demo

N/A — `pnpm test:e2e` (35 passed in ~1 min)

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
