### PR TITLE
fix(ci): let e2e workflow fail loudly instead of always reporting green

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -12,9 +12,9 @@ jobs:
   e2e:
     runs-on: ubuntu-latest
     name: Playwright E2E
-    # Non-blocking: a red e2e run does not fail the workflow chain or any
-    # required-checks gate. Status still surfaces in the Actions UI.
-    continue-on-error: true
+    # Manual trigger only, never wired into branch protection — so a failure
+    # here cannot block PR merge anyway. Let the run fail loudly so the result
+    # is unambiguous in the Actions UI instead of always showing green.
     env:
       BASE_URL: ${{ inputs.base_url }}
       E2E_EMAIL: ${{ secrets.E2E_EMAIL }}
@@ -43,12 +43,7 @@ jobs:
         run: pnpm playwright install --with-deps chromium
 
       - name: Run Playwright tests
-        id: e2e
         run: pnpm test:e2e
-
-      - name: Surface failure as warning
-        if: steps.e2e.outcome == 'failure'
-        run: echo "::warning ::E2E tests failed against ${{ inputs.base_url }} — not blocking merge"
 
       - name: Upload Playwright report
         if: always()


### PR DESCRIPTION
## What Does This PR Do?

Relates to Xchange-Taiwan/X-Talent-Tracker#72.

- Drop `continue-on-error: true` from the manual e2e workflow so a real test failure surfaces as a red run in the Actions UI instead of being masked as success
- Drop the now-redundant "Surface failure as warning" step (the run itself fails when tests fail, no extra annotation needed)

The workflow is `workflow_dispatch` only and not wired into any branch-protection required check, so a red e2e run still cannot block PR merges — but it now correctly reflects whether the tests actually passed.

## Demo

GitHub → Actions → "E2E (manual)" → Run workflow

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
