### PR TITLE
fix(e2e): use __Secure- cookie name prefix when targeting https deployments

### DIFF
--- a/e2e/helpers/session.ts
+++ b/e2e/helpers/session.ts
@@ -13,13 +13,26 @@ interface SessionPayload {
   personalLinks?: { platform: string; url: string }[];
 }
 
-// Derive cookie domain + secure flag from BASE_URL so the same helper works
-// against both http://localhost:3000 (local dev server) and remote https
-// deployments like https://xtalentdev.vercel.app.
-function getCookieTarget(): { domain: string; secure: boolean } {
+// Derive cookie domain, secure flag, and cookie *name* from BASE_URL so the
+// same helper works against both http://localhost:3000 and remote https
+// deployments. NextAuth prefixes the cookie name with `__Secure-` when the
+// deployment serves over HTTPS — forging without this prefix means the server
+// never sees the cookie and treats the user as signed-out.
+function getCookieTarget(): {
+  name: string;
+  domain: string;
+  secure: boolean;
+} {
   const baseUrl = process.env.BASE_URL ?? 'http://localhost:3000';
   const url = new URL(baseUrl);
-  return { domain: url.hostname, secure: url.protocol === 'https:' };
+  const secure = url.protocol === 'https:';
+  return {
+    name: secure
+      ? '__Secure-next-auth.session-token'
+      : 'next-auth.session-token',
+    domain: url.hostname,
+    secure,
+  };
 }
 
 /**
@@ -41,10 +54,10 @@ export async function setSignedSessionCookie(
     secret: process.env.NEXTAUTH_SECRET ?? 'secret',
   });
 
-  const { domain, secure } = getCookieTarget();
+  const { name, domain, secure } = getCookieTarget();
   await page.context().addCookies([
     {
-      name: 'next-auth.session-token',
+      name,
       value: signed,
       domain,
       path: '/',
@@ -64,10 +77,10 @@ export async function setRawSessionCookie(
   page: Page,
   value: string
 ): Promise<void> {
-  const { domain, secure } = getCookieTarget();
+  const { name, domain, secure } = getCookieTarget();
   await page.context().addCookies([
     {
-      name: 'next-auth.session-token',
+      name,
       value,
       domain,
       path: '/',


### PR DESCRIPTION
## What Does This PR Do?

Relates to Xchange-Taiwan/X-Talent-Tracker#72.

- NextAuth prefixes the session cookie name with `__Secure-` whenever the deployment serves over HTTPS — so the cookie that Vercel reads is `__Secure-next-auth.session-token`, not `next-auth.session-token`
- Our cookie-forging helpers were always setting the unprefixed name, so on https://xtalentdev.vercel.app the server never saw the forged cookie and treated every cookie-forging test as signed-out (snapshots showed the 註冊 / 登入 header in 12 failing tests)
- `getCookieTarget()` now also returns the cookie *name*, derived from the BASE_URL protocol; both `setSignedSessionCookie` and `setRawSessionCookie` use it
- HTTP / localhost path is unchanged (still uses the unprefixed name)

Local `pnpm test:e2e`: 37 passed in 1.3m.

## Demo

Re-run "E2E (manual)" from Actions UI against the default dev URL.

## Screenshot

N/A

## Anything to Note?

NextAuth uses other prefixes too (`__Host-` for csrf token, etc.) but the session cookie is the only one any forged-cookie test relies on, so only `__Secure-next-auth.session-token` needs to be handled here.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
