### PR TITLE
fix(e2e): drop pre-fill assertion in onboarding empty-name test

### DIFF
--- a/e2e/tests/onboarding/onboarding.spec.ts
+++ b/e2e/tests/onboarding/onboarding.spec.ts
@@ -164,10 +164,14 @@ test('submit Step 1 with empty name → inline validation error shown, does NOT 
 }) => {
   await gotoOnboarding(page);
 
-  // The session mock pre-fills the name field with 'Test User' via useEffect.
-  // Wait for that reset to settle, then clear the field so validation fires.
-  await expect(page.locator('input[name="name"]')).toHaveValue('Test User');
-  await page.fill('input[name="name"]', '');
+  // Clear the name field so validation fires on submit. Whether the session-
+  // driven useEffect has already pre-filled it (local) or never fires because
+  // the SessionProvider sees a null server-side session and skips the
+  // refetch (remote SSR with the intentionally-invalid fake cookie),
+  // fill('') normalises both cases.
+  const nameInput = page.locator('input[name="name"]');
+  await expect(nameInput).toBeVisible();
+  await nameInput.fill('');
   await page.getByRole('button', { name: '下一步' }).click();
 
   await expect(page.getByText('請輸入姓名')).toBeVisible();


### PR DESCRIPTION
## What Does This PR Do?

Relates to Xchange-Taiwan/X-Talent-Tracker#72.

The "submit Step 1 with empty name" onboarding test waited for the name field to be pre-filled with 'Test User' from the mocked session before clearing it. This worked locally but failed against the remote Vercel deployment because:

- The forged session cookie is intentionally invalid (`'e2e-fake-session-token'`) so the middleware existence check passes but `getServerSession()` returns null.
- Vercel SSR renders the page with `session={null}`. NextAuth's `SessionProvider` sees the explicit null initial session and does not auto-refetch `/api/auth/session`, so the mocked endpoint is never hit and the form's session-driven `useEffect` never pre-fills the name.
- Locally the dev server happens to trigger the refetch and the test passes — divergent behaviour between environments.

The pre-fill assertion was just a synchronisation point, not the test's actual concern (which is "empty name → validation error"). Replacing it with a plain visibility check + `fill('')` works in both environments without changing what the test actually validates.

Local `pnpm test:e2e --project=chromium-onboarding`: 3 passed.

## Demo

Re-run "E2E (manual)" workflow against the dev URL.

## Screenshot

N/A

## Anything to Note?

Other onboarding tests (lines 224, 257) explicitly fill the name field, so they are unaffected by this change.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
