### PR TITLE
fix(profile): prevent save button text wrapping on mobile

### DIFF
--- a/src/components/profile/edit/EditPageHeader.tsx
+++ b/src/components/profile/edit/EditPageHeader.tsx
@@ -39,7 +39,7 @@ export function EditPageHeader({
         <Button
           type="submit"
           variant="default"
-          className="w-[88px] rounded-full py-3 sm:w-auto sm:grow-0 sm:px-6"
+          className="min-w-[88px] whitespace-nowrap rounded-full px-4 py-3 sm:w-auto sm:grow-0 sm:px-6"
           form="edit-profile-form"
           disabled={isSaving}
         >


### PR DESCRIPTION
## What Does This PR Do?

- Replace fixed `w-[88px]` with `min-w-[88px]` + `whitespace-nowrap` on the profile edit save button so the loading state (spinner + 「儲存中...」) no longer wraps onto two lines on mobile
- Add `px-4` for mobile breathing room while keeping the existing desktop `sm:w-auto sm:px-6` branch intact
- Closes Xchange-Taiwan/X-Talent-Tracker#162

## Demo

http://localhost:3000/profile/<userId>/edit

## Screenshot

N/A

## Anything to Note?

N/A
