### PR TITLE
fix: keep calendar slot delete/add buttons inline on mobile and tablet

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -398,7 +398,7 @@ export default function MentorScheduleDialog({
                       key={slot.id}
                       className="flex flex-col gap-2 rounded-lg p-3 lg:p-4"
                     >
-                      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
+                      <div className="flex flex-row flex-wrap items-center justify-between gap-2 lg:gap-3">
                         <div className="flex flex-wrap items-center gap-1.5 lg:gap-2">
                           {renderTimeSelect(
                             slot.id,
@@ -445,7 +445,7 @@ export default function MentorScheduleDialog({
                           )}
                         </div>
 
-                        <div className="flex justify-end gap-1 lg:ml-4">
+                        <div className="flex shrink-0 justify-end gap-1 lg:ml-4">
                           <Button
                             variant="ghost"
                             size="icon"


### PR DESCRIPTION
## What Does This PR Do?

- Replaces the mentor schedule slot row's `flex-col` mobile layout with `flex-row flex-wrap` so the time selectors and the X / + buttons stay on the same line at all breakpoints
- Adds `shrink-0` to the button container so the two icon buttons stay grouped if the row needs to wrap on very narrow viewports
- Resolves Xchange-Taiwan/X-Talent-Tracker#163

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
