### PR TITLE
perf: add AbortSignal + TTL cache to apiClient and useUserData

### DIFF
--- a/src/hooks/user/user-data/useUserData.test.ts
+++ b/src/hooks/user/user-data/useUserData.test.ts
@@ -1,0 +1,143 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/profile/user', () => ({
+  fetchUserById: vi.fn(),
+}));
+
+vi.mock('@/hooks/user/interests/useInterests', () => ({
+  getInterestsCached: vi.fn(),
+}));
+
+import { getInterestsCached } from '@/hooks/user/interests/useInterests';
+import { fetchUserById, type MentorProfileVO } from '@/services/profile/user';
+
+import useUserData, { clearUserDataCache } from './useUserData';
+
+const mockFetchUserById = vi.mocked(fetchUserById);
+const mockGetInterestsCached = vi.mocked(getInterestsCached);
+
+const TTL_MS = 5_000;
+
+const makeUserDto = (id: number): MentorProfileVO =>
+  ({
+    user_id: id,
+    name: `User ${id}`,
+    avatar: '',
+    is_mentor: false,
+    experiences: [],
+  }) as unknown as MentorProfileVO;
+
+const emptyInterests = {
+  interestedPositions: [],
+  skills: [],
+  topics: [],
+  expertises: [],
+  whatIOffers: [],
+};
+
+describe('useUserData caching', () => {
+  beforeEach(() => {
+    mockFetchUserById.mockReset();
+    mockGetInterestsCached.mockReset();
+    mockGetInterestsCached.mockResolvedValue(emptyInterests);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('re-mount within TTL window reuses cache (no second fetch)', async () => {
+    const userId = 4001;
+    mockFetchUserById.mockResolvedValue(makeUserDto(userId));
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(mockFetchUserById).toHaveBeenCalledTimes(1);
+    first.unmount();
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(second.result.current.userData).not.toBeNull());
+    expect(mockFetchUserById).toHaveBeenCalledTimes(1);
+    second.unmount();
+  });
+
+  it('re-mount after TTL expires triggers a fresh fetch', async () => {
+    const userId = 4002;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(10_000);
+    mockFetchUserById.mockResolvedValue(makeUserDto(userId));
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    first.unmount();
+
+    nowSpy.mockReturnValue(10_000 + TTL_MS + 1);
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+    expect(mockFetchUserById).toHaveBeenCalledTimes(2);
+    second.unmount();
+  });
+
+  it('clearUserDataCache forces a refetch on next mount', async () => {
+    const userId = 4003;
+    mockFetchUserById.mockResolvedValue(makeUserDto(userId));
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    first.unmount();
+
+    clearUserDataCache(userId, 'en');
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+    expect(mockFetchUserById).toHaveBeenCalledTimes(2);
+    second.unmount();
+  });
+
+  it('failed fetch (null result) is not cached → next mount refetches', async () => {
+    const userId = 4004;
+    mockFetchUserById.mockResolvedValueOnce(null);
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    expect(first.result.current.error).toBe('User not found');
+    first.unmount();
+
+    mockFetchUserById.mockResolvedValueOnce(makeUserDto(userId));
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+    expect(mockFetchUserById).toHaveBeenCalledTimes(2);
+    expect(second.result.current.userData).not.toBeNull();
+    second.unmount();
+  });
+
+  it('concurrent mounts of same user dedupe to one network call', async () => {
+    const userId = 4005;
+    let resolveFetch: (value: MentorProfileVO) => void = () => {};
+    mockFetchUserById.mockImplementation(
+      () =>
+        new Promise<MentorProfileVO>((resolve) => {
+          resolveFetch = resolve;
+        })
+    );
+
+    const a = renderHook(() => useUserData(userId, 'en'));
+    const b = renderHook(() => useUserData(userId, 'en'));
+
+    expect(mockFetchUserById).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      resolveFetch(makeUserDto(userId));
+    });
+
+    await waitFor(() => expect(a.result.current.userData).not.toBeNull());
+    await waitFor(() => expect(b.result.current.userData).not.toBeNull());
+    expect(mockFetchUserById).toHaveBeenCalledTimes(1);
+
+    a.unmount();
+    b.unmount();
+  });
+});

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -7,16 +7,36 @@ import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
 
 import { getInterestsCached } from '../interests/useInterests';
 
+const USER_DATA_CACHE_TTL_MS = 5_000;
+
+interface CachedUserDtoEntry {
+  data: MentorProfileVO;
+  expiresAt: number;
+}
+
+const userDtoDataCache = new Map<string, CachedUserDtoEntry>();
 const userDtoPromiseCache = new Map<string, Promise<MentorProfileVO | null>>();
 
+function readFreshFromDataCache(key: string): MentorProfileVO | undefined {
+  const entry = userDtoDataCache.get(key);
+  if (!entry) return undefined;
+  if (entry.expiresAt <= Date.now()) {
+    userDtoDataCache.delete(key);
+    return undefined;
+  }
+  return entry.data;
+}
+
 /**
- * Removes a user's entry from the in-memory request cache so the next call to
+ * Removes a user's entry from the in-memory cache so the next call to
  * useUserData for that user triggers a fresh API fetch.  Call this after a
  * successful profile update to prevent any concurrent mount from receiving
  * stale data.
  */
 export function clearUserDataCache(userId: number, language: string): void {
-  userDtoPromiseCache.delete(`${userId}-${language}`);
+  const key = `${userId}-${language}`;
+  userDtoDataCache.delete(key);
+  userDtoPromiseCache.delete(key);
 }
 
 function fetchUserByIdCached(
@@ -24,12 +44,28 @@ function fetchUserByIdCached(
   language: string
 ): Promise<MentorProfileVO | null> {
   const key = `${userId}-${language}`;
+
+  const cached = readFreshFromDataCache(key);
+  if (cached !== undefined) return Promise.resolve(cached);
+
   const inflight = userDtoPromiseCache.get(key);
   if (inflight) return inflight;
 
-  const promise = fetchUserById(userId, language).finally(() => {
-    userDtoPromiseCache.delete(key);
-  });
+  // Shared in-flight promise (no signal) so concurrent component mounts
+  // dedupe to a single network call without one unmount aborting the others.
+  const promise = fetchUserById(userId, language)
+    .then((data) => {
+      if (data) {
+        userDtoDataCache.set(key, {
+          data,
+          expiresAt: Date.now() + USER_DATA_CACHE_TTL_MS,
+        });
+      }
+      return data;
+    })
+    .finally(() => {
+      userDtoPromiseCache.delete(key);
+    });
   userDtoPromiseCache.set(key, promise);
   return promise;
 }

--- a/src/lib/apiClient.test.ts
+++ b/src/lib/apiClient.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient, ApiError } from '@/lib/apiClient';
+import { captureApiFailure } from '@/lib/monitoring';
 
 vi.mock('next-auth/react', () => ({
   getSession: vi.fn().mockResolvedValue(null),
@@ -96,6 +97,54 @@ describe('apiClient', () => {
       await expect(apiClient.get('/v1/test', { auth: false })).rejects.toThrow(
         'Failed to fetch'
       );
+    });
+  });
+
+  /* ================================
+   * AbortSignal handling
+   * ================================ */
+
+  describe('AbortSignal handling', () => {
+    beforeEach(() => {
+      vi.mocked(captureApiFailure).mockClear();
+    });
+
+    it('signal is forwarded to fetch options', async () => {
+      mockFetch.mockResolvedValue(new Response('"ok"', { status: 200 }));
+      const controller = new AbortController();
+
+      await apiClient.get('/v1/test', {
+        auth: false,
+        signal: controller.signal,
+      });
+
+      expect(mockFetch.mock.calls[0][1]).toMatchObject({
+        signal: controller.signal,
+      });
+    });
+
+    it('AbortError → re-thrown without calling captureApiFailure', async () => {
+      const abortError = new DOMException('aborted', 'AbortError');
+      mockFetch.mockRejectedValue(abortError);
+      const controller = new AbortController();
+      controller.abort();
+
+      await expect(
+        apiClient.get('/v1/test', { auth: false, signal: controller.signal })
+      ).rejects.toBe(abortError);
+
+      expect(captureApiFailure).not.toHaveBeenCalled();
+    });
+
+    it('non-abort network failure → still calls captureApiFailure', async () => {
+      const realFailure = new TypeError('Failed to fetch');
+      mockFetch.mockRejectedValue(realFailure);
+
+      await expect(apiClient.get('/v1/test', { auth: false })).rejects.toBe(
+        realFailure
+      );
+
+      expect(captureApiFailure).toHaveBeenCalled();
     });
   });
 });

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -40,7 +40,13 @@ type RequestOptions = {
   headers?: Record<string, string>;
   /** Query string params — undefined/null values are omitted */
   params?: Record<string, string | number | boolean | undefined | null>;
+  /** AbortSignal forwarded to fetch — caller controls cancellation */
+  signal?: AbortSignal;
 };
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
 
 // ─── Internals ───────────────────────────────────────────────────────────────
 const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
@@ -87,7 +93,7 @@ async function request<T>(
   options: RequestOptions = {},
   isRetry = false
 ): Promise<T> {
-  const { auth = true, headers = {}, params } = options;
+  const { auth = true, headers = {}, params, signal } = options;
 
   const authHeader = auth ? await getAuthHeader() : {};
 
@@ -103,8 +109,13 @@ async function request<T>(
         ...headers,
       },
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+      ...(signal ? { signal } : {}),
     });
   } catch (networkError) {
+    // Caller-driven cancellation — not an error worth reporting.
+    if (isAbortError(networkError)) {
+      throw networkError;
+    }
     // fetch() itself threw — DNS failure, connection refused, timeout, etc.
     captureApiFailure({
       endpoint: path,

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -8,8 +8,13 @@ export type MentorProfileVO = components['schemas']['MentorProfileVO'];
 type ApiResponseMentorProfileVO =
   components['schemas']['ApiResponse_MentorProfileVO_'];
 
+function isAbortError(error: unknown): boolean {
+  return error instanceof DOMException && error.name === 'AbortError';
+}
+
 export async function fetchUser(
-  language: string
+  language: string,
+  signal?: AbortSignal
 ): Promise<MentorProfileVO | null> {
   const session = await getSession();
   const userId = session?.user?.id;
@@ -18,17 +23,18 @@ export async function fetchUser(
     throw new Error('未找到使用者 ID。請重新登入。');
   }
 
-  return fetchUserById(Number(userId), language);
+  return fetchUserById(Number(userId), language, signal);
 }
 
 export async function fetchUserById(
   userId: number,
-  language: string
+  language: string,
+  signal?: AbortSignal
 ): Promise<MentorProfileVO | null> {
   try {
     const result = await apiClient.get<ApiResponseMentorProfileVO>(
       `/v1/mentors/${userId}/${language}/profile`,
-      { auth: false }
+      { auth: false, signal }
     );
 
     if (result.code !== '0') {
@@ -38,6 +44,7 @@ export async function fetchUserById(
 
     return result.data ?? null;
   } catch (error) {
+    if (isAbortError(error)) throw error;
     console.error('Fetch User Error:', error);
     return null;
   }


### PR DESCRIPTION
## What Does This PR Do?

- `apiClient` accepts an optional `AbortSignal` and forwards it to `fetch`; `AbortError` is re-thrown without `captureApiFailure` so caller-driven cancellation does not pollute Sentry. 401 retry preserves the same signal automatically.
- `fetchUser` / `fetchUserById` accept and forward `signal`; `AbortError` is re-thrown instead of being swallowed into `null`.
- `useUserData` keeps its shared in-flight promise cache (preserves dedup across same-page components) and adds a 5s data cache (`USER_DATA_CACHE_TTL_MS`) on top, so back-button navigation within the TTL window no longer refetches. Failed/null responses are not cached. `clearUserDataCache` still invalidates both layers.
- New tests: `apiClient` signal forwarding + AbortError-not-captured; `useUserData` TTL hit, TTL expiry, `clearUserDataCache`, null-not-cached, concurrent-mount dedup.

Closes Xchange-Taiwan/X-Talent-Tracker#166

## Demo

http://localhost:3000/profile/{mentorId}

## Screenshot

N/A

## Anything to Note?

`useUserData` deliberately does not wire its own `AbortController` into the underlying fetch: the in-flight promise is shared by multiple sibling components on the profile page, so a single unmount aborting it would cause its sibling subscribers to fail. The TTL cache solves the back-button refetch concern; the new `signal` plumbing is available for non-shared hooks (search/filter, `useMentorSchedule`, etc.) to adopt in a follow-up.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
