### PR TITLE
perf: cut re-renders in mentor-pool and shared hooks

### DIFF
--- a/src/components/mentor-pool/mentor-card/Information.tsx
+++ b/src/components/mentor-pool/mentor-card/Information.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { Skill } from './Skill';
 
@@ -10,6 +10,9 @@ interface InformationProps {
   skills: string[];
 }
 
+const SKILL_GAP_PX = 8;
+const EXTRA_BADGE_RESERVE_PX = 52;
+
 export const Information = ({
   name,
   job_title,
@@ -17,36 +20,45 @@ export const Information = ({
   personalStatment,
   skills = [],
 }: InformationProps) => {
-  const skillsContainerRef = useRef<HTMLDivElement>(null);
+  const containerRef = useRef<HTMLDivElement>(null);
+  const measureRef = useRef<HTMLDivElement>(null);
+  const widthsRef = useRef<number[]>([]);
   const [visibleSkillsCount, setVisibleSkillsCount] = useState(skills.length);
 
-  useEffect(() => {
-    const checkSkillsInLine = () => {
-      if (!skillsContainerRef.current) return;
+  useLayoutEffect(() => {
+    if (!measureRef.current || !containerRef.current) return;
 
-      const container = skillsContainerRef.current;
-      const skillElements = container.children;
-      if (skillElements.length === 0) return;
+    widthsRef.current = Array.from(measureRef.current.children).map(
+      (child) => (child as HTMLElement).getBoundingClientRect().width
+    );
 
-      const containerWidth = container.offsetWidth;
-      let lastVisibleIndex = 0;
-      let totalWidth = 52;
-
-      for (let i = 0; i < skillElements.length; i++) {
-        const skillWidth = skillElements[i].getBoundingClientRect().width;
-        const gap = i > 0 ? 8 : 0;
-        totalWidth += skillWidth + gap;
-        if (totalWidth > containerWidth) {
-          lastVisibleIndex = i - 1;
+    const computeVisible = (containerWidth: number) => {
+      const widths = widthsRef.current;
+      let total = EXTRA_BADGE_RESERVE_PX;
+      let lastIndex = widths.length - 1;
+      for (let i = 0; i < widths.length; i++) {
+        const gap = i > 0 ? SKILL_GAP_PX : 0;
+        total += widths[i] + gap;
+        if (total > containerWidth) {
+          lastIndex = i - 1;
           break;
         }
-        lastVisibleIndex = i;
       }
-
-      setVisibleSkillsCount(Math.min(lastVisibleIndex + 1, skills.length));
+      setVisibleSkillsCount(
+        Math.max(0, Math.min(lastIndex + 1, skills.length))
+      );
     };
 
-    checkSkillsInLine();
+    computeVisible(containerRef.current.getBoundingClientRect().width);
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0];
+      if (!entry) return;
+      computeVisible(entry.contentRect.width);
+    });
+    observer.observe(containerRef.current);
+
+    return () => observer.disconnect();
   }, [skills]);
 
   const visibleSkills = skills.slice(0, visibleSkillsCount);
@@ -67,13 +79,24 @@ export const Information = ({
       <p className="line-clamp-2 text-sm font-normal tracking-wide text-[#9DA8B9]">
         {personalStatment}
       </p>
-      <div ref={skillsContainerRef} className="flex flex-wrap gap-2">
-        {visibleSkills.map((skill) => (
-          <Skill skill={skill} key={skill} />
-        ))}
-        {extraSkillsCount > 0 && (
-          <Skill skill={`+${extraSkillsCount}`} key="extra" />
-        )}
+      <div className="relative">
+        <div
+          ref={measureRef}
+          aria-hidden
+          className="pointer-events-none invisible absolute left-0 top-0 flex flex-wrap gap-2"
+        >
+          {skills.map((skill) => (
+            <Skill skill={skill} key={`measure-${skill}`} />
+          ))}
+        </div>
+        <div ref={containerRef} className="flex flex-wrap gap-2">
+          {visibleSkills.map((skill) => (
+            <Skill skill={skill} key={skill} />
+          ))}
+          {extraSkillsCount > 0 && (
+            <Skill skill={`+${extraSkillsCount}`} key="extra" />
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/hooks/useWindowSize.test.ts
+++ b/src/hooks/useWindowSize.test.ts
@@ -1,0 +1,70 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import useWindowSize from './useWindowSize';
+
+describe('useWindowSize', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.innerWidth = 1024;
+    window.innerHeight = 768;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the current window size on mount', () => {
+    const { result } = renderHook(() => useWindowSize());
+
+    expect(result.current).toEqual({ width: 1024, height: 768 });
+  });
+
+  it('debounces resize updates and only commits the final size', () => {
+    const { result } = renderHook(() => useWindowSize());
+
+    act(() => {
+      window.innerWidth = 800;
+      window.dispatchEvent(new Event('resize'));
+    });
+    act(() => {
+      window.innerWidth = 600;
+      window.dispatchEvent(new Event('resize'));
+    });
+    act(() => {
+      window.innerWidth = 480;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(result.current.width).toBe(1024);
+
+    act(() => {
+      vi.advanceTimersByTime(149);
+    });
+    expect(result.current.width).toBe(1024);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.width).toBe(480);
+  });
+
+  it('clears pending timeout and removes listener on unmount', () => {
+    const removeSpy = vi.spyOn(window, 'removeEventListener');
+    const { result, unmount } = renderHook(() => useWindowSize());
+
+    act(() => {
+      window.innerWidth = 500;
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    unmount();
+
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+
+    expect(result.current.width).toBe(1024);
+    expect(removeSpy).toHaveBeenCalledWith('resize', expect.any(Function));
+  });
+});

--- a/src/hooks/useWindowSize.ts
+++ b/src/hooks/useWindowSize.ts
@@ -1,21 +1,32 @@
-import { useLayoutEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
+
+const RESIZE_DEBOUNCE_MS = 150;
+
+const getSize = () => ({
+  width: typeof window === 'undefined' ? 0 : window.innerWidth,
+  height: typeof window === 'undefined' ? 0 : window.innerHeight,
+});
 
 export default function useWindowSize() {
-  const [windowSize, setWindowSize] = useState({ width: 0, height: 0 });
+  const [windowSize, setWindowSize] = useState(getSize);
 
-  const handleSize = () => {
-    setWindowSize({
-      width: window.innerWidth,
-      height: window.innerHeight,
-    });
-  };
+  useEffect(() => {
+    setWindowSize(getSize());
 
-  useLayoutEffect(() => {
-    handleSize();
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    const handleResize = () => {
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      timeoutId = setTimeout(() => {
+        setWindowSize(getSize());
+      }, RESIZE_DEBOUNCE_MS);
+    };
 
-    window.addEventListener('resize', handleSize);
+    window.addEventListener('resize', handleResize);
 
-    return () => window.removeEventListener('resize', handleSize);
+    return () => {
+      if (timeoutId !== null) clearTimeout(timeoutId);
+      window.removeEventListener('resize', handleResize);
+    };
   }, []);
 
   return windowSize;

--- a/src/hooks/user/profile/useProfileSelectOptions.ts
+++ b/src/hooks/user/profile/useProfileSelectOptions.ts
@@ -12,7 +12,7 @@ export function useProfileSelectOptions({
   interestedPositions: { subject: string | null; subject_group: string }[];
   skills: { subject: string | null; subject_group: string }[];
 }) {
-  const whatIOfferTopicsList = useMemo(
+  const topicsList = useMemo(
     () =>
       topics.map((t) => ({ value: t.subject_group, label: t.subject ?? '' })),
     [topics]
@@ -38,17 +38,12 @@ export function useProfileSelectOptions({
       skills.map((s) => ({ value: s.subject_group, label: s.subject ?? '' })),
     [skills]
   );
-  const interestedTopicsList = useMemo(
-    () =>
-      topics.map((t) => ({ value: t.subject_group, label: t.subject ?? '' })),
-    [topics]
-  );
 
   return {
-    whatIOfferTopicsList,
+    whatIOfferTopicsList: topicsList,
     expertisedList,
     interestedPositionList,
     interestedSkillsList,
-    interestedTopicsList,
+    interestedTopicsList: topicsList,
   };
 }


### PR DESCRIPTION
## What Does This PR Do?

- Debounce `useWindowSize` resize handler at 150ms, with mount-time sync read so first paint has the real size
- Add unit tests for `useWindowSize` covering initial value, debounced final commit, and unmount cleanup
- Share a single `topicsList` memo between `whatIOfferTopicsList` and `interestedTopicsList` in `useProfileSelectOptions` (public API unchanged)
- Refactor `MentorCard/Information` to a hidden measurement layer + `ResizeObserver`, so skill widths are measured once per skill set and only pure layout math runs on container resize — removes the per-render `getBoundingClientRect` loop

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

DevTools Performance verification of "no long tasks on scroll/resize" still needs manual confirmation per the issue's acceptance criteria.

Closes Xchange-Taiwan/X-Talent-Tracker#167
