### PR TITLE
fix(profile): translate profile card back button to Chinese

### DIFF
--- a/src/app/profile/card/ui.tsx
+++ b/src/app/profile/card/ui.tsx
@@ -90,7 +90,7 @@ export default function ProfileCardUI({
             className="grow rounded-full px-6 py-3 sm:grow-0"
             onClick={onBackToProfile}
           >
-            Back to my profile
+            返回我的個人頁面
           </Button>
         </div>
       )}


### PR DESCRIPTION
## Summary
- Translate the mentor "Back to my profile" button on `/profile/card` to 中文 ("返回我的個人頁面") so the page is consistent with the rest of the localized profile flow.

## Test plan
- [ ] Visit `/profile/card` as a mentor and confirm the bottom button reads "返回我的個人頁面" and still navigates back to the profile page.
- [ ] Visit `/profile/card` as a mentee and confirm the existing buttons are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)