### PR TITLE
perf: parallelize profile page user data and schedule loading

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -10,7 +10,9 @@ import useUserData from '@/hooks/user/user-data/useUserData';
 
 import { ProfilePageSkeleton } from './skeleton';
 
-const ProfilePageUI = dynamic(() => import('./ui'));
+const ProfilePageUI = dynamic(() => import('./ui'), {
+  loading: () => <ProfilePageSkeleton />,
+});
 
 interface Props {
   pageUserId: string;
@@ -61,16 +63,12 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
     useState(false);
 
   const pageUserIdNumber = Number(pageUserId);
-  const { userData, isLoading: loading } = useUserData(
+  const { userData, isLoading: userLoading } = useUserData(
     pageUserIdNumber,
     'zh_TW'
   );
 
-  // Show skeleton only while user profile data loads.
-  // Schedule data (calendar) renders progressively once the profile appears.
-  if (loading) return <ProfilePageSkeleton />;
-
-  if (!userData) {
+  if (!userLoading && !userData) {
     return (
       <div className="flex h-[50vh] items-center justify-center text-gray-500">
         沒有該位使用者
@@ -83,6 +81,7 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
       router.push('/auth/signin');
       return;
     }
+    if (!userData) return;
     if (userData.is_mentor && pageUserId === loginUserId) {
       setOpenReservationDialog(true);
       return;
@@ -96,6 +95,7 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
   return (
     <ProfilePageUI
       userData={userData}
+      userLoading={userLoading}
       pageUserId={pageUserId}
       schedule={schedule}
       scheduleLoaded={loaded}

--- a/src/app/profile/[pageUserId]/skeleton.tsx
+++ b/src/app/profile/[pageUserId]/skeleton.tsx
@@ -1,60 +1,48 @@
 import { Skeleton } from '@/components/ui/skeleton';
 
-export function ProfilePageSkeleton() {
+export function ProfileHeaderSkeleton() {
   return (
-    <div>
-      <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]" />
-
-      <div className="container mb-20 max-w-[1024px]">
-        <div className="flex h-auto -translate-y-10 flex-col justify-between sm:relative sm:h-[160px] sm:flex-row lg:static">
-          <div className="flex flex-col items-center gap-6 sm:flex-row">
-            <Skeleton className="h-[160px] w-[160px] flex-shrink-0 rounded-full" />
-            <div className="flex flex-col gap-3 sm:mb-6 lg:mb-0">
-              <Skeleton className="h-7 w-48" />
-              <Skeleton className="h-4 w-32" />
-            </div>
-          </div>
+    <div className="flex h-auto -translate-y-10 flex-col justify-between sm:relative sm:h-[160px] sm:flex-row lg:static">
+      <div className="flex flex-col items-center gap-6 sm:flex-row">
+        <Skeleton className="h-[160px] w-[160px] flex-shrink-0 rounded-full" />
+        <div className="flex flex-col gap-3 sm:mb-6 lg:mb-0">
+          <Skeleton className="h-7 w-48" />
+          <Skeleton className="h-4 w-32" />
         </div>
+      </div>
+    </div>
+  );
+}
 
-        <div className="flex flex-col gap-8 lg:flex-row lg:gap-12">
-          <div className="flex w-full flex-col gap-8 lg:w-3/5">
-            <div className="flex flex-col gap-3">
-              <Skeleton className="h-6 w-16" />
+export function ProfileContentSkeleton() {
+  return (
+    <div className="flex w-full flex-col gap-8">
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-6 w-16" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-full" />
+        <Skeleton className="h-4 w-3/4" />
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-6 w-24" />
+        <div className="flex flex-wrap gap-2">
+          {Array.from({ length: 5 }).map((_, i) => (
+            <Skeleton key={i} className="h-6 w-20 rounded-full" />
+          ))}
+        </div>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <Skeleton className="h-6 w-20" />
+        <div className="flex flex-col gap-4">
+          {Array.from({ length: 2 }).map((_, i) => (
+            <div key={i} className="flex flex-col gap-2">
+              <Skeleton className="h-5 w-40" />
+              <Skeleton className="h-4 w-28" />
               <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-full" />
-              <Skeleton className="h-4 w-3/4" />
             </div>
-
-            <div className="flex flex-col gap-3">
-              <Skeleton className="h-6 w-24" />
-              <div className="flex flex-wrap gap-2">
-                {Array.from({ length: 5 }).map((_, i) => (
-                  <Skeleton key={i} className="h-6 w-20 rounded-full" />
-                ))}
-              </div>
-            </div>
-
-            <div className="flex flex-col gap-3">
-              <Skeleton className="h-6 w-20" />
-              <div className="flex flex-col gap-4">
-                {Array.from({ length: 2 }).map((_, i) => (
-                  <div key={i} className="flex flex-col gap-2">
-                    <Skeleton className="h-5 w-40" />
-                    <Skeleton className="h-4 w-28" />
-                    <Skeleton className="h-4 w-full" />
-                  </div>
-                ))}
-              </div>
-            </div>
-          </div>
-
-          <div className="w-full lg:w-2/5">
-            <div className="flex flex-col gap-4">
-              <Skeleton className="h-6 w-24" />
-              <Skeleton className="h-64 w-full rounded-lg" />
-              <Skeleton className="h-10 w-full rounded-full" />
-            </div>
-          </div>
+          ))}
         </div>
       </div>
     </div>
@@ -72,6 +60,27 @@ export function ScheduleSkeleton() {
         ))}
       </div>
       <Skeleton className="h-10 w-full rounded-full" />
+    </div>
+  );
+}
+
+export function ProfilePageSkeleton() {
+  return (
+    <div>
+      <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]" />
+
+      <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
+        <ProfileHeaderSkeleton />
+
+        <div className="flex flex-col gap-8 2xl:flex-row 2xl:gap-12">
+          <div className="w-full 2xl:w-3/5">
+            <ProfileContentSkeleton />
+          </div>
+          <div className="w-full 2xl:w-2/5">
+            <ScheduleSkeleton />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -21,10 +21,15 @@ import {
   toDateKey,
 } from '@/lib/profile/scheduleFormatters';
 
-import { ScheduleSkeleton } from './skeleton';
+import {
+  ProfileContentSkeleton,
+  ProfileHeaderSkeleton,
+  ScheduleSkeleton,
+} from './skeleton';
 
 interface Props {
-  userData: UserType;
+  userData: UserType | null;
+  userLoading: boolean;
   pageUserId: string;
   schedule: UseMentorScheduleReturn;
   scheduleLoaded: boolean;
@@ -44,6 +49,7 @@ interface Props {
 
 export default function ProfilePageUI({
   userData,
+  userLoading,
   pageUserId,
   schedule,
   scheduleLoaded,
@@ -62,166 +68,191 @@ export default function ProfilePageUI({
 }: Props) {
   const { selectedDate, setSelectedDate, generateBookingSlots } = schedule;
 
+  // Render the schedule region while user data loads (most profile views are
+  // mentors) so the calendar can appear before user data resolves; collapse
+  // it once the user is confirmed as a non-mentor.
+  const showScheduleRegion = userLoading || userData?.is_mentor;
+  const isOwnMentorProfile =
+    !!userData &&
+    userData.is_mentor &&
+    loginUserId === userData.user_id.toString();
+
   return (
     <div>
       <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]" />
 
       <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
-        <div className="flex h-auto -translate-y-10 flex-col sm:flex-row sm:items-start">
-          <div className="relative mx-auto h-[160px] w-[160px] flex-shrink-0 overflow-hidden rounded-full bg-background-white sm:mx-0">
-            <Image
-              src={
-                userData?.avatar
-                  ? `${userData.avatar}?cb=${avatarCacheBust}`
-                  : DefaultAvatarImgUrl
-              }
-              alt={'Avatar of ' + userData?.name}
-              fill
-              sizes="160px"
-              style={{ objectFit: 'contain' }}
-            />
-          </div>
-
-          <div className="flex min-w-0 flex-col items-center sm:ml-6 sm:mt-10 sm:items-start">
-            <div className="mb-2 flex flex-col items-center gap-1 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
-              <p className="break-words text-2xl font-semibold">
-                {userData?.name}
-              </p>
-              {!!userData?.personalLinks?.length && (
-                <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
-                  {userData.personalLinks.map((link) => (
-                    <a
-                      key={link.platform}
-                      href={link.url}
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="hover:text-blue-600 text-gray-600"
-                      title={
-                        platformLabelMap[link.platform]?.label || link.platform
-                      }
-                    >
-                      {platformLabelMap[link.platform]?.icon}
-                    </a>
-                  ))}
-                </div>
-              )}
+        {userLoading ? (
+          <ProfileHeaderSkeleton />
+        ) : userData ? (
+          <div className="flex h-auto -translate-y-10 flex-col sm:flex-row sm:items-start">
+            <div className="relative mx-auto h-[160px] w-[160px] flex-shrink-0 overflow-hidden rounded-full bg-background-white sm:mx-0">
+              <Image
+                src={
+                  userData.avatar
+                    ? `${userData.avatar}?cb=${avatarCacheBust}`
+                    : DefaultAvatarImgUrl
+                }
+                alt={'Avatar of ' + userData.name}
+                fill
+                sizes="160px"
+                style={{ objectFit: 'contain' }}
+              />
             </div>
-            {(userData.job_title || userData.company) && (
-              <p className="text-sm">
-                {userData.job_title}
-                {userData.job_title && userData.company && (
-                  <span className="text-text-tertiary"> at </span>
-                )}
-                {userData.company}
-              </p>
-            )}
-            <div className="mt-4 flex items-center justify-center gap-4 sm:justify-start">
-              {isLogging && pageUserId === loginUserId && (
-                <Button
-                  variant="outline"
-                  className="grow rounded-full px-6 py-3 sm:grow-0"
-                  onClick={onEditProfile}
-                >
-                  編輯個人資訊
-                </Button>
-              )}
 
-              {isLogging &&
-                !userData.is_mentor &&
-                pageUserId === loginUserId && (
+            <div className="flex min-w-0 flex-col items-center sm:ml-6 sm:mt-10 sm:items-start">
+              <div className="mb-2 flex flex-col items-center gap-1 sm:flex-row sm:flex-wrap sm:items-center sm:gap-2">
+                <p className="break-words text-2xl font-semibold">
+                  {userData.name}
+                </p>
+                {!!userData.personalLinks?.length && (
+                  <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
+                    {userData.personalLinks.map((link) => (
+                      <a
+                        key={link.platform}
+                        href={link.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:text-blue-600 text-gray-600"
+                        title={
+                          platformLabelMap[link.platform]?.label ||
+                          link.platform
+                        }
+                      >
+                        {platformLabelMap[link.platform]?.icon}
+                      </a>
+                    ))}
+                  </div>
+                )}
+              </div>
+              {(userData.job_title || userData.company) && (
+                <p className="text-sm">
+                  {userData.job_title}
+                  {userData.job_title && userData.company && (
+                    <span className="text-text-tertiary"> at </span>
+                  )}
+                  {userData.company}
+                </p>
+              )}
+              <div className="mt-4 flex items-center justify-center gap-4 sm:justify-start">
+                {isLogging && pageUserId === loginUserId && (
                   <Button
-                    variant="default"
+                    variant="outline"
                     className="grow rounded-full px-6 py-3 sm:grow-0"
-                    onClick={onBecomeMentor}
+                    onClick={onEditProfile}
                   >
-                    成為導師
+                    編輯個人資訊
                   </Button>
                 )}
+
+                {isLogging &&
+                  !userData.is_mentor &&
+                  pageUserId === loginUserId && (
+                    <Button
+                      variant="default"
+                      className="grow rounded-full px-6 py-3 sm:grow-0"
+                      onClick={onBecomeMentor}
+                    >
+                      成為導師
+                    </Button>
+                  )}
+              </div>
             </div>
           </div>
-        </div>
+        ) : null}
 
         <div className="flex flex-col gap-8 2xl:flex-row 2xl:gap-12">
           <div className="w-full 2xl:w-3/5">
-            {userData?.about && (
-              <div>
-                <p className="mb-4 text-xl font-bold">關於我</p>
-                <p className="break-words text-sm text-gray-400">
-                  {userData.about}
-                </p>
-              </div>
-            )}
+            {userLoading ? (
+              <ProfileContentSkeleton />
+            ) : userData ? (
+              <>
+                {userData.about && (
+                  <div>
+                    <p className="mb-4 text-xl font-bold">關於我</p>
+                    <p className="break-words text-sm text-gray-400">
+                      {userData.about}
+                    </p>
+                  </div>
+                )}
 
-            <ProfileBadgeSection
-              title="經驗"
-              items={
-                userData?.years_of_experience
-                  ? [
-                      {
-                        subject_group: 'years_of_experience',
-                        subject: userData.years_of_experience,
-                      },
-                    ]
-                  : []
-              }
-            />
-
-            <ProfileBadgeSection
-              title="產業"
-              items={
-                userData?.industry
-                  ? [{ subject_group: 'industry', subject: userData.industry }]
-                  : []
-              }
-            />
-
-            {userData.is_mentor && (
-              <ProfileBadgeSection
-                title="專業能力"
-                items={userData?.expertises ?? []}
-              />
-            )}
-
-            {userData.is_mentor && (
-              <ProfileBadgeSection
-                title="我能提供的服務"
-                items={userData?.what_i_offers ?? []}
-              />
-            )}
-
-            <ProfileBadgeSection
-              title="有興趣多了解的職位"
-              items={userData?.interested_positions ?? []}
-            />
-
-            <ProfileBadgeSection
-              title="想多了解、加強的技能"
-              items={userData?.skills ?? []}
-            />
-
-            <ProfileBadgeSection
-              title="想多了解的主題"
-              items={userData?.topics ?? []}
-            />
-
-            {!!userData?.workExperiences?.length && (
-              <div className="mt-10">
-                <p className="mb-4 text-xl font-bold">工作經驗</p>
-                <WorkExperienceSection
-                  workExperiences={userData.workExperiences}
+                <ProfileBadgeSection
+                  title="經驗"
+                  items={
+                    userData.years_of_experience
+                      ? [
+                          {
+                            subject_group: 'years_of_experience',
+                            subject: userData.years_of_experience,
+                          },
+                        ]
+                      : []
+                  }
                 />
-              </div>
-            )}
 
-            {!!userData?.educations?.length && (
-              <div className="mt-10">
-                <p className="mb-4 text-xl font-bold">教育</p>
-                <EducationSection educations={userData.educations} />
-              </div>
-            )}
+                <ProfileBadgeSection
+                  title="產業"
+                  items={
+                    userData.industry
+                      ? [
+                          {
+                            subject_group: 'industry',
+                            subject: userData.industry,
+                          },
+                        ]
+                      : []
+                  }
+                />
+
+                {userData.is_mentor && (
+                  <ProfileBadgeSection
+                    title="專業能力"
+                    items={userData.expertises ?? []}
+                  />
+                )}
+
+                {userData.is_mentor && (
+                  <ProfileBadgeSection
+                    title="我能提供的服務"
+                    items={userData.what_i_offers ?? []}
+                  />
+                )}
+
+                <ProfileBadgeSection
+                  title="有興趣多了解的職位"
+                  items={userData.interested_positions ?? []}
+                />
+
+                <ProfileBadgeSection
+                  title="想多了解、加強的技能"
+                  items={userData.skills ?? []}
+                />
+
+                <ProfileBadgeSection
+                  title="想多了解的主題"
+                  items={userData.topics ?? []}
+                />
+
+                {!!userData.workExperiences?.length && (
+                  <div className="mt-10">
+                    <p className="mb-4 text-xl font-bold">工作經驗</p>
+                    <WorkExperienceSection
+                      workExperiences={userData.workExperiences}
+                    />
+                  </div>
+                )}
+
+                {!!userData.educations?.length && (
+                  <div className="mt-10">
+                    <p className="mb-4 text-xl font-bold">教育</p>
+                    <EducationSection educations={userData.educations} />
+                  </div>
+                )}
+              </>
+            ) : null}
           </div>
 
-          {userData.is_mentor && (
+          {showScheduleRegion && (
             <div className="w-full 2xl:w-2/5">
               {!scheduleLoaded ? (
                 <ScheduleSkeleton />
@@ -289,29 +320,27 @@ export default function ProfilePageUI({
                     variant="default"
                     className="w-full rounded-full px-6 py-3"
                     onClick={onReservation}
+                    disabled={!userData}
                   >
-                    {loginUserId && userData.is_mentor
-                      ? loginUserId === userData?.user_id.toString()
-                        ? '預約設定'
-                        : '預約時間'
-                      : '預約時間'}
+                    {isOwnMentorProfile ? '預約設定' : '預約時間'}
                   </Button>
-                  {loginUserId === pageUserId ? (
-                    <MentorScheduleDialog
-                      open={openReservationDialog}
-                      onOpenChange={setOpenReservationDialog}
-                      schedule={schedule}
-                      onMonthChange={onScheduleMonthChange}
-                    />
-                  ) : (
-                    <MenteeReservationDialog
-                      open={openMenteeReservationDialog}
-                      onOpenChange={setOpenMenteeReservationDialog}
-                      schedule={schedule}
-                      userData={userData}
-                      onMonthChange={onScheduleMonthChange}
-                    />
-                  )}
+                  {userData &&
+                    (loginUserId === pageUserId ? (
+                      <MentorScheduleDialog
+                        open={openReservationDialog}
+                        onOpenChange={setOpenReservationDialog}
+                        schedule={schedule}
+                        onMonthChange={onScheduleMonthChange}
+                      />
+                    ) : (
+                      <MenteeReservationDialog
+                        open={openMenteeReservationDialog}
+                        onOpenChange={setOpenMenteeReservationDialog}
+                        schedule={schedule}
+                        userData={userData}
+                        onMonthChange={onScheduleMonthChange}
+                      />
+                    ))}
                 </div>
               )}
             </div>


### PR DESCRIPTION
## What Does This PR Do?

- Remove the full-page loading gate in profile container so user data and mentor schedule render independently
- Split the profile UI into header / left-column / schedule regions, each with its own skeleton, so the calendar can appear before user data resolves
- Add `ProfileHeaderSkeleton` and `ProfileContentSkeleton`; align `ProfilePageSkeleton` breakpoints with the actual layout to avoid layout shift after chunk load
- Wire `ProfilePageSkeleton` as the dynamic() loading fallback so first-visit chunk fetch still shows a full-page skeleton
- Disable the reservation button until user data is ready and guard `reservationHandler` against null user data

## Demo

http://localhost:3000/profile/<mentorId>

## Screenshot

N/A

## Anything to Note?

- Mentee profiles will briefly show the schedule skeleton before the right column collapses; this is the cost of letting the calendar render before user data resolves.
- Closes Xchange-Taiwan/X-Talent-Tracker#168.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
