### PR TITLE
perf(profile): persist useUserData cache with 60s TTL + SWR

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -18,6 +18,7 @@ import {
 import useLocations from '@/hooks/user/country/useLocations';
 import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests from '@/hooks/user/interests/useInterests';
+import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateAvatar } from '@/services/profile/updateAvatar';
@@ -166,6 +167,10 @@ export default function OnboardingContainer() {
         const validatedData = formSchema.parse(allData);
         await updateProfile(validatedData);
         const latest = await fetchUser('zh_TW');
+
+        if (session?.user?.id) {
+          clearUserDataCache(Number(session.user.id), 'zh_TW');
+        }
 
         await updateSession({
           user: {

--- a/src/hooks/user/user-data/useUserData.test.ts
+++ b/src/hooks/user/user-data/useUserData.test.ts
@@ -12,12 +12,13 @@ vi.mock('@/hooks/user/interests/useInterests', () => ({
 import { getInterestsCached } from '@/hooks/user/interests/useInterests';
 import { fetchUserById, type MentorProfileVO } from '@/services/profile/user';
 
-import useUserData, { clearUserDataCache } from './useUserData';
+import useUserData, {
+  clearUserDataCache,
+  USER_DATA_CACHE_TTL_MS as TTL_MS,
+} from './useUserData';
 
 const mockFetchUserById = vi.mocked(fetchUserById);
 const mockGetInterestsCached = vi.mocked(getInterestsCached);
-
-const TTL_MS = 5_000;
 
 const makeUserDto = (id: number): MentorProfileVO =>
   ({
@@ -62,21 +63,106 @@ describe('useUserData caching', () => {
     second.unmount();
   });
 
-  it('re-mount after TTL expires triggers a fresh fetch', async () => {
+  it('re-mount after TTL: shows stale data immediately and revalidates in background', async () => {
     const userId = 4002;
     const nowSpy = vi.spyOn(Date, 'now');
     nowSpy.mockReturnValue(10_000);
-    mockFetchUserById.mockResolvedValue(makeUserDto(userId));
+
+    const stale = { ...makeUserDto(userId), name: 'Stale 4002' };
+    const fresh = { ...makeUserDto(userId), name: 'Fresh 4002' };
+    mockFetchUserById.mockResolvedValueOnce(stale as MentorProfileVO);
 
     const first = renderHook(() => useUserData(userId, 'en'));
-    await waitFor(() => expect(first.result.current.isLoading).toBe(false));
+    await waitFor(() =>
+      expect(first.result.current.userData?.name).toBe('Stale 4002')
+    );
     first.unmount();
 
     nowSpy.mockReturnValue(10_000 + TTL_MS + 1);
+    let resolveFresh: (value: MentorProfileVO) => void = () => {};
+    mockFetchUserById.mockImplementationOnce(
+      () =>
+        new Promise<MentorProfileVO>((resolve) => {
+          resolveFresh = resolve;
+        })
+    );
 
     const second = renderHook(() => useUserData(userId, 'en'));
-    await waitFor(() => expect(second.result.current.isLoading).toBe(false));
+    // Stale data is shown immediately without entering loading state,
+    // before the background refetch resolves.
+    await waitFor(() =>
+      expect(second.result.current.userData?.name).toBe('Stale 4002')
+    );
+    expect(second.result.current.isLoading).toBe(false);
     expect(mockFetchUserById).toHaveBeenCalledTimes(2);
+
+    await act(async () => {
+      resolveFresh(fresh as MentorProfileVO);
+    });
+    await waitFor(() =>
+      expect(second.result.current.userData?.name).toBe('Fresh 4002')
+    );
+    second.unmount();
+  });
+
+  it('background revalidation failure keeps stale data without flipping to error', async () => {
+    const userId = 4006;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(20_000);
+    const consoleErrorSpy = vi
+      .spyOn(console, 'error')
+      .mockImplementation(() => {});
+
+    mockFetchUserById.mockResolvedValueOnce({
+      ...makeUserDto(userId),
+      name: 'Stale 4006',
+    } as MentorProfileVO);
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() =>
+      expect(first.result.current.userData?.name).toBe('Stale 4006')
+    );
+    first.unmount();
+
+    nowSpy.mockReturnValue(20_000 + TTL_MS + 1);
+    mockFetchUserById.mockRejectedValueOnce(new Error('Network down'));
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() =>
+      expect(second.result.current.userData?.name).toBe('Stale 4006')
+    );
+    // Wait for the rejected promise to settle, then assert state is intact.
+    await waitFor(() => expect(mockFetchUserById).toHaveBeenCalledTimes(2));
+    expect(second.result.current.userData?.name).toBe('Stale 4006');
+    expect(second.result.current.error).toBeNull();
+
+    consoleErrorSpy.mockRestore();
+    second.unmount();
+  });
+
+  it('background revalidation returning null keeps stale data', async () => {
+    const userId = 4007;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(30_000);
+
+    mockFetchUserById.mockResolvedValueOnce({
+      ...makeUserDto(userId),
+      name: 'Stale 4007',
+    } as MentorProfileVO);
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() =>
+      expect(first.result.current.userData?.name).toBe('Stale 4007')
+    );
+    first.unmount();
+
+    nowSpy.mockReturnValue(30_000 + TTL_MS + 1);
+    mockFetchUserById.mockResolvedValueOnce(null);
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() => expect(mockFetchUserById).toHaveBeenCalledTimes(2));
+    expect(second.result.current.userData?.name).toBe('Stale 4007');
+    expect(second.result.current.error).toBeNull();
     second.unmount();
   });
 

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -5,26 +5,30 @@ import { parseCurrentJob } from '@/lib/profile/parseUserExperiences';
 import { ExperienceType } from '@/services/profile/experienceType';
 import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
 
-import { getInterestsCached } from '../interests/useInterests';
+import {
+  getInterestsCached,
+  type InterestsResult,
+} from '../interests/useInterests';
 
-const USER_DATA_CACHE_TTL_MS = 5_000;
+export const USER_DATA_CACHE_TTL_MS = 60_000;
 
 interface CachedUserDtoEntry {
   data: MentorProfileVO;
   expiresAt: number;
 }
 
+interface CachedReadResult {
+  data: MentorProfileVO;
+  isStale: boolean;
+}
+
 const userDtoDataCache = new Map<string, CachedUserDtoEntry>();
 const userDtoPromiseCache = new Map<string, Promise<MentorProfileVO | null>>();
 
-function readFreshFromDataCache(key: string): MentorProfileVO | undefined {
+function readFromDataCache(key: string): CachedReadResult | undefined {
   const entry = userDtoDataCache.get(key);
   if (!entry) return undefined;
-  if (entry.expiresAt <= Date.now()) {
-    userDtoDataCache.delete(key);
-    return undefined;
-  }
-  return entry.data;
+  return { data: entry.data, isStale: entry.expiresAt <= Date.now() };
 }
 
 /**
@@ -39,20 +43,18 @@ export function clearUserDataCache(userId: number, language: string): void {
   userDtoPromiseCache.delete(key);
 }
 
-function fetchUserByIdCached(
+// Promise-deduped fetch: writes to the data cache on success so subsequent
+// readers (including a parallel-mounted hook) see the fresh entry. Concurrent
+// callers share the same in-flight promise to avoid duplicate network calls.
+function startFetchUserById(
   userId: number,
   language: string
 ): Promise<MentorProfileVO | null> {
   const key = `${userId}-${language}`;
 
-  const cached = readFreshFromDataCache(key);
-  if (cached !== undefined) return Promise.resolve(cached);
-
   const inflight = userDtoPromiseCache.get(key);
   if (inflight) return inflight;
 
-  // Shared in-flight promise (no signal) so concurrent component mounts
-  // dedupe to a single network call without one unmount aborting the others.
   const promise = fetchUserById(userId, language)
     .then((data) => {
       if (data) {
@@ -245,54 +247,86 @@ function useUserData(userId: number, language: string) {
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
+    const isLanguageValid = Boolean(language);
+
+    if (!isUserIdValid || !isLanguageValid) {
+      setUserData(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
     let cancelled = false;
+    const key = `${userId}-${language}`;
+    const cachedEntry = readFromDataCache(key);
+    const interestsPromise = getInterestsCached(language);
 
-    const run = async () => {
-      const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
-      const isLanguageValid = Boolean(language);
+    const applyData = (
+      userDto: MentorProfileVO,
+      interests: InterestsResult
+    ) => {
+      if (cancelled) return;
+      const labelByGroup = new Map(
+        interests.whatIOffers.map(
+          (item) => [item.subject_group, item.subject ?? ''] as const
+        )
+      );
+      setUserData(parseUserDtoToUserType(userDto, labelByGroup));
+      setError(null);
+    };
 
-      if (!isUserIdValid || !isLanguageValid) {
-        setUserData(null);
-        setError(null);
-        setIsLoading(false);
-        return;
+    // Cached path: render immediately from cache, then optionally
+    // revalidate in the background. Only a missing cache entry triggers
+    // a blocking load.
+    if (cachedEntry) {
+      setIsLoading(false);
+      interestsPromise
+        .then((interests) => applyData(cachedEntry.data, interests))
+        .catch((e) => {
+          console.error('Failed to load interests for cached user:', e);
+        });
+
+      if (cachedEntry.isStale) {
+        Promise.all([startFetchUserById(userId, language), interestsPromise])
+          .then(([userDto, interests]) => {
+            if (cancelled || !userDto) return;
+            applyData(userDto, interests);
+          })
+          .catch((e) => {
+            // Background revalidation failure: keep showing stale data,
+            // surface only via console (no error state flip).
+            console.error('Background user-data refetch failed:', e);
+          });
       }
 
-      setIsLoading(true);
-      setError(null);
+      return () => {
+        cancelled = true;
+      };
+    }
 
-      try {
-        const [userDto, interests] = await Promise.all([
-          fetchUserByIdCached(userId, language),
-          getInterestsCached(language),
-        ]);
+    setIsLoading(true);
+    setError(null);
 
+    Promise.all([startFetchUserById(userId, language), interestsPromise])
+      .then(([userDto, interests]) => {
         if (cancelled) return;
-
         if (!userDto) {
           setUserData(null);
           setError('User not found');
           return;
         }
-
-        const labelByGroup = new Map(
-          interests.whatIOffers.map(
-            (item) => [item.subject_group, item.subject ?? ''] as const
-          )
-        );
-
-        setUserData(parseUserDtoToUserType(userDto, labelByGroup));
-      } catch (e) {
+        applyData(userDto, interests);
+      })
+      .catch((e) => {
         console.error('Failed to load user:', e);
         if (cancelled) return;
         setUserData(null);
         setError('Failed to load user data');
-      } finally {
+      })
+      .finally(() => {
         if (!cancelled) setIsLoading(false);
-      }
-    };
-
-    run();
+      });
 
     return () => {
       cancelled = true;


### PR DESCRIPTION
## What Does This PR Do?

- Extend `useUserData` in-memory TTL from 5s to 60s so re-entering a profile page within a minute renders instantly without a network round-trip.
- Add stale-while-revalidate behaviour: when a cached entry is past TTL, the hook now renders the stale data immediately and revalidates in the background, swapping in fresh data once the refetch resolves. Background failures keep the stale view (no error flip).
- Plug the missing invalidation in onboarding completion: `clearUserDataCache` is now called after `updateProfile` succeeds, so the user lands on `/profile/card` with fresh data instead of a 0–60s stale window.
- Tests cover SWR (stale shown immediately then fresh), background failure keeps stale, and null revalidation keeps stale.

Closes Xchange-Taiwan/X-Talent-Tracker#178

## Demo

http://localhost:3000/profile/card

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
