### PR TITLE
perf(profile): let Image Optimizer cache avatar across navigations

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -3,8 +3,9 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
+import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import useUserData from '@/hooks/user/user-data/useUserData';
 
@@ -40,21 +41,9 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded]);
 
-  // Stable per-session fallback for other users' profiles — allows browser
-  // caching across navigations. Resets only on full page refresh.
-  const stableCacheBust = useRef(Date.now()).current;
-
   const { data: session } = useSession();
   const isLogging = Boolean(session?.user?.id);
   const loginUserId = session?.user?.id ? String(session.user.id) : '';
-
-  // For the logged-in user's own profile, use the session's avatarUpdatedAt so
-  // the latest avatar appears immediately after a profile update without a full
-  // page reload. For other users' profiles the stable fallback is sufficient.
-  const avatarCacheBust =
-    loginUserId === pageUserId
-      ? (session?.user?.avatarUpdatedAt ?? stableCacheBust)
-      : stableCacheBust;
 
   const [openReservationDialog, setOpenReservationDialog] = useState(false);
   const [openMenteeReservationDialog, setOpenMenteeReservationDialog] =
@@ -65,6 +54,15 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
     pageUserIdNumber,
     'zh_TW'
   );
+
+  // Only attach a versioning param for the logged-in user's own profile; the
+  // stable URL for other users lets the Next.js Image Optimizer hit its cache
+  // across navigations.
+  const avatarSrc = userData?.avatar
+    ? loginUserId === pageUserId && session?.user?.avatarUpdatedAt
+      ? `${userData.avatar}?v=${session.user.avatarUpdatedAt}`
+      : userData.avatar
+    : DefaultAvatarImgUrl;
 
   // Show skeleton only while user profile data loads.
   // Schedule data (calendar) renders progressively once the profile appears.
@@ -101,7 +99,7 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
       scheduleLoaded={loaded}
       loginUserId={loginUserId}
       isLogging={isLogging}
-      avatarCacheBust={avatarCacheBust}
+      avatarSrc={avatarSrc}
       allowedDates={allowedDates}
       openReservationDialog={openReservationDialog}
       setOpenReservationDialog={setOpenReservationDialog}

--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import Image from 'next/image';
+import Image, { type StaticImageData } from 'next/image';
 
-import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import {
   EducationSection,
   WorkExperienceSection,
@@ -30,7 +29,7 @@ interface Props {
   scheduleLoaded: boolean;
   loginUserId: string;
   isLogging: boolean;
-  avatarCacheBust: number;
+  avatarSrc: string | StaticImageData;
   allowedDates: string[];
   openReservationDialog: boolean;
   setOpenReservationDialog: (open: boolean) => void;
@@ -49,7 +48,7 @@ export default function ProfilePageUI({
   scheduleLoaded,
   loginUserId,
   isLogging,
-  avatarCacheBust,
+  avatarSrc,
   allowedDates,
   openReservationDialog,
   setOpenReservationDialog,
@@ -70,15 +69,12 @@ export default function ProfilePageUI({
         <div className="flex h-auto -translate-y-10 flex-col sm:flex-row sm:items-start">
           <div className="relative mx-auto h-[160px] w-[160px] flex-shrink-0 overflow-hidden rounded-full bg-background-white sm:mx-0">
             <Image
-              src={
-                userData?.avatar
-                  ? `${userData.avatar}?cb=${avatarCacheBust}`
-                  : DefaultAvatarImgUrl
-              }
+              src={avatarSrc}
               alt={'Avatar of ' + userData?.name}
               fill
               sizes="160px"
               style={{ objectFit: 'contain' }}
+              priority
             />
           </div>
 


### PR DESCRIPTION
## What Does This PR Do?

- Stop appending a per-mount `?cb=Date.now()` to the profile avatar URL — it broke the Next.js Image Optimizer's 30-day cache because the cache key is the full URL
- Keep a stable `?v=avatarUpdatedAt` only for the logged-in user's own avatar so a self-upload still busts the cache exactly once
- Add `priority` to the avatar `<Image>` so the LCP element preloads instead of waiting for hydration
- Lift `avatarSrc` assembly from `ui.tsx` into `container.tsx` and drop the now-unused `stableCacheBust` ref / `DefaultAvatarImgUrl` import in the UI

## Demo

http://localhost:3000/profile/<userId>

## Screenshot

N/A

## Anything to Note?

Closes Xchange-Taiwan/X-Talent-Tracker#177. PR 1 of 2 in the profile-page perf series; PR 2 will tackle `useUserData` caching separately.
