### PR TITLE
fix(a11y): replace meaningless landing/about image alt with empty string

### DIFF
--- a/src/app/(landing)/about/page.tsx
+++ b/src/app/(landing)/about/page.tsx
@@ -17,7 +17,7 @@ const SectionTitle: FC<{ children: ReactNode }> = ({ children }) => (
 const FeatureItem = ({ icon, text }: { icon: string; text: string }) => {
   return (
     <div className="mb-[50px] flex items-center md:w-2/4 md:flex-col xl:mx-[60px] xl:w-auto">
-      <Image className="h-[70px] w-[70px]" src={icon} alt="1" />
+      <Image className="h-[70px] w-[70px]" src={icon} alt="" />
       <p className="ml-[20px] text-base tracking-[0.085em] md:mt-8 md:text-xl">
         {text}
       </p>
@@ -42,7 +42,7 @@ export default function Page() {
             width={500}
             height={320}
             src={aboutPage_1}
-            alt="X-Talent fleeting idea"
+            alt=""
             priority={false}
             placeholder="blur"
           />
@@ -58,15 +58,15 @@ export default function Page() {
 
         <div className="mx-auto mb-20 flex max-w-xl justify-between px-12 sm:px-0">
           <div>
-            <Image src={aboutPage_icon_1} alt="share" />
+            <Image src={aboutPage_icon_1} alt="" />
             <p className="mt-7 font-medium">交流</p>
           </div>
           <div>
-            <Image src={aboutPage_icon_2} alt="change" />
+            <Image src={aboutPage_icon_2} alt="" />
             <p className="mt-7 font-medium">改變</p>
           </div>
           <div>
-            <Image src={aboutPage_icon_3} alt="growth" />
+            <Image src={aboutPage_icon_3} alt="" />
             <p className="mt-7 font-medium ">成長</p>
           </div>
         </div>

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -37,7 +37,7 @@ import { featureData } from './data';
 const FeatureItem = ({ icon, text }: { icon: string; text: string }) => {
   return (
     <div className="mb-6 flex items-center md:mb-[50px] md:w-2/4 md:flex-col xl:mx-[60px] xl:w-auto">
-      <Image className="h-12 w-12 md:h-[70px] md:w-[70px]" src={icon} alt="1" />
+      <Image className="h-12 w-12 md:h-[70px] md:w-[70px]" src={icon} alt="" />
       <p className="ml-[20px] text-base tracking-[0.085em] md:mt-8 md:text-xl">
         {text}
       </p>
@@ -65,7 +65,7 @@ export default function Page() {
         {width > SCREEN_SIZE.lg && (
           <Image
             src={HomePageHeroImgUrl}
-            alt="Hero Section"
+            alt=""
             fill
             className="-z-10 w-[1800px] object-cover object-top"
           />
@@ -93,7 +93,7 @@ export default function Page() {
             src={landingPage_4}
             width={420}
             height={270}
-            alt="1"
+            alt=""
             className="max-w-full shrink-0 md:w-2/5"
           />
           <div className="m-auto flex flex-col py-[30px] md:m-0 md:flex-1 md:py-0 xl:pl-[62px]">
@@ -118,7 +118,7 @@ export default function Page() {
           <Image
             src={landingPage_5}
             className="max-w-full shrink-0 md:w-2/5"
-            alt="1"
+            alt=""
           />
         </div>
       </section>
@@ -162,7 +162,7 @@ export default function Page() {
             <Image
               src={landingPage_6}
               className="hidden w-[363px] xl:block"
-              alt="1"
+              alt=""
             />
             <div className="xl:ml-[78px]">
               <p className="text-midnight-blue mt-1 text-center text-xl font-bold md:text-2xl xl:text-start">
@@ -173,7 +173,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_1}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[30px] flex flex-col md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">分享經驗</p>
@@ -184,7 +184,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_2}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[30px] flex h-[43px] flex-col justify-center md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">建立專屬人脈網絡</p>
@@ -194,7 +194,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_3}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[30px] flex flex-col md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">增加社會影響力</p>
@@ -208,7 +208,7 @@ export default function Page() {
             <Image
               src={landingPage_7}
               className="hidden w-[363px] xl:block"
-              alt="1"
+              alt=""
             />
             <div className="xl:ml-[78px]">
               <p className="text-midnight-blue mt-1 text-center text-xl font-bold md:text-2xl xl:text-start">
@@ -219,7 +219,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_4}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[30px] flex flex-col md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">探索產業與</p>
@@ -230,7 +230,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_5}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[35px] flex flex-col justify-center md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">
@@ -245,7 +245,7 @@ export default function Page() {
                   <Image
                     className="ml-4 md:m-0"
                     src={landingPage_icon_6}
-                    alt="1"
+                    alt=""
                   />
                   <div className="ml-[30px] flex flex-col md:ml-0 md:mt-[34px] md:items-center">
                     <p className="text-black font-medium">


### PR DESCRIPTION
## What Does This PR Do?

- Replace 12 instances of `alt="1"` and the placeholder `alt="Hero Section"` in `src/app/(landing)/page.tsx` with `alt=""`
- Replace `alt="1"`, `alt="X-Talent fleeting idea"`, and the three icon labels (`share`/`change`/`growth`) in `src/app/(landing)/about/page.tsx` with `alt=""`
- All affected images sit next to a heading or descriptive text, so they qualify as decorative under WCAG; an empty alt prevents screen readers from announcing duplicate or meaningless content
- Closes Xchange-Taiwan/X-Talent-Tracker#170

## Demo

http://localhost:3000/ and http://localhost:3000/about

## Screenshot

N/A

## Anything to Note?

- No layout, styling, or logic changes — only `alt` attribute values
- `pnpm exec eslint` (changed files), `pnpm type-check`, and `pnpm build` all pass
- Other a11y audit items (Critical #2+) intentionally left for separate tickets

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
