### PR TITLE
fix(a11y): give icon-only buttons and links accessible names

### DIFF
--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -38,16 +38,21 @@ export function HamburgerMenu({
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>
-        <Button variant="ghost" aria-label="Open menu">
-          <HamburgerMenuIcon className="h-6 w-6" />
+        <Button variant="ghost" aria-label="開啟導航選單">
+          <HamburgerMenuIcon className="h-6 w-6" aria-hidden="true" />
         </Button>
       </SheetTrigger>
 
       <SheetContent side="right" className="h-dvh w-screen">
         <SheetTitle className="sr-only">導航選單</SheetTitle>
         <div className="flex h-full flex-col">
-          <SheetClose asChild className="ml-auto">
-            <Cross2Icon className="text-blue-900 h-8 w-8" />
+          <SheetClose asChild>
+            <button type="button" aria-label="關閉導航選單" className="ml-auto">
+              <Cross2Icon
+                className="text-blue-900 h-8 w-8"
+                aria-hidden="true"
+              />
+            </button>
           </SheetClose>
 
           <div className="flex min-h-0 flex-1 flex-col items-center justify-center gap-8 text-2xl">

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -103,12 +103,12 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
         <SheetTrigger asChild>
           <button
             type="button"
-            aria-label="Open account menu"
+            aria-label="開啟用戶選單"
             className="flex items-center"
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt=""
               width={32}
               height={32}
               className="h-8 w-8 rounded-full object-cover"
@@ -120,8 +120,17 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
         <SheetContent side="right" className="h-screen w-screen">
           <SheetTitle className="sr-only">用戶選單</SheetTitle>
           <div className="flex h-full flex-col overflow-y-auto">
-            <SheetClose asChild className="ml-auto">
-              <Cross2Icon className="text-blue-900 h-8 w-8" />
+            <SheetClose asChild>
+              <button
+                type="button"
+                aria-label="關閉用戶選單"
+                className="ml-auto"
+              >
+                <Cross2Icon
+                  className="text-blue-900 h-8 w-8"
+                  aria-hidden="true"
+                />
+              </button>
             </SheetClose>
 
             {/* Profile header */}
@@ -132,7 +141,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
             >
               <Image
                 src={avatarSrc || DefaultAvatarImgUrl}
-                alt="avatar"
+                alt=""
                 width={56}
                 height={56}
                 className="h-14 w-14 rounded-full object-cover"

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -107,17 +107,19 @@ export const UserDropdown = React.memo(function UserDropdown({
           <button
             type="button"
             className="flex items-center gap-2"
-            aria-label="Open user menu"
+            aria-label="開啟用戶選單"
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt=""
               width={32}
               height={32}
               className="h-8 w-8 rounded-full object-cover"
               priority
             />
-            <span className="text-xl leading-none">▾</span>
+            <span className="text-xl leading-none" aria-hidden="true">
+              ▾
+            </span>
           </button>
         </DropdownMenuTrigger>
 
@@ -133,7 +135,7 @@ export const UserDropdown = React.memo(function UserDropdown({
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt=""
               width={56}
               height={56}
               className="h-14 w-14 rounded-full object-cover"

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -16,7 +16,7 @@ export const AvatarWithBadge = ({ avatar, years }: AvatarWithBadgeProps) => {
     <figure className="relative h-[348px] w-full overflow-hidden xl:h-[292px]">
       <Image
         src={avatar}
-        alt="avatar"
+        alt=""
         fill
         sizes="(max-width: 768px) 334px, 413px"
         className="h-full object-cover"

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -37,6 +37,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
       >
         <Link
           href={`/profile/${id}`}
+          aria-label={`前往 ${name} 的個人頁面`}
           className="absolute bottom-0 left-0 right-0 top-0 z-10"
         ></Link>
         <AvatarWithBadge avatar={avatar} years={years} />

--- a/src/components/sort/SortingDropdown.tsx
+++ b/src/components/sort/SortingDropdown.tsx
@@ -18,7 +18,10 @@ const SortingDropdown = ({
   return (
     <Select defaultValue="a-z" onValueChange={onSortChange}>
       <SelectTrigger>
-        <ArrowDownUp className="h-4 w-4 text-muted-foreground" />
+        <ArrowDownUp
+          className="h-4 w-4 text-muted-foreground"
+          aria-hidden="true"
+        />
         <SelectValue placeholder="排序" />
       </SelectTrigger>
       <SelectContent className="w-fit">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -45,8 +45,8 @@ const DialogContent = React.forwardRef<
     >
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <X className="h-4 w-4" aria-hidden="true" />
+        <span className="sr-only">關閉</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -53,7 +53,10 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   return (
     <div className="flex w-full max-w-[846px] items-center rounded-2xl border border-[#E6E8EA] bg-background-white px-3 py-1.5 md:px-6 md:py-4">
-      <SearchIcon className="mr-2 h-6 w-6 shrink-0 text-gray-500" />
+      <SearchIcon
+        className="mr-2 h-6 w-6 shrink-0 text-gray-500"
+        aria-hidden="true"
+      />
 
       <input
         {...sharedInputProps}
@@ -78,10 +81,10 @@ const SearchBar: React.FC<SearchBarProps> = ({
         className="ml-2 h-10 w-10 shrink-0 cursor-pointer rounded-full border-none bg-primary p-0 leading-5 md:h-auto md:w-auto md:rounded-[24px] md:px-6 md:py-2.5"
       >
         {isLoading ? (
-          <Loader2 className="h-4 w-4 animate-spin" />
+          <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
         ) : (
           <>
-            <SearchIcon className="h-5 w-5 md:hidden" />
+            <SearchIcon className="h-5 w-5 md:hidden" aria-hidden="true" />
             <span className="hidden md:inline">搜尋</span>
           </>
         )}

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -83,8 +83,8 @@ const SheetContent = React.forwardRef<
         {children}
         {showPrimitiveClose && (
           <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-            <X className="h-4 w-4" />
-            <span className="sr-only">Close</span>
+            <X className="h-4 w-4" aria-hidden="true" />
+            <span className="sr-only">關閉</span>
           </SheetPrimitive.Close>
         )}
       </SheetPrimitive.Content>


### PR DESCRIPTION
## What Does This PR Do?

- Localize Dialog/Sheet close button screen reader text to 繁中 and mark decorative X icons aria-hidden
- Localize Header UserDropdown / HamburgerMenu / MobileUserMenu aria-labels to 繁中 and mark decorative icons (chevron, hamburger, X) aria-hidden
- Wrap Sheet close icons with real <button aria-label> instead of bare icon via SheetClose asChild, so screen readers announce a button-name
- Add aria-label to the empty mentor-card overlay <Link> so screen readers announce the destination
- Drop redundant Avatar alt text where parent button/link already provides the accessible name (set alt="" for decorative use)
- Mark decorative SearchIcon / Loader2 / ArrowDownUp icons aria-hidden in search-bar and sort dropdown

Resolves Xchange-Taiwan/X-Talent-Tracker#171

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Verify with axe DevTools on /, /mentor-pool, and Header dropdown/sheet open states that button-name and link-name rules pass
- Two SheetClose elements (HamburgerMenu, MobileUserMenu) now wrap a real button instead of the bare Cross2Icon — visual placement is unchanged but worth a quick mobile sheet open/close check

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
