### PR TITLE
fix(a11y): use user name in avatar alt across header and mentor card

### DIFF
--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -108,7 +108,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt={name ? `${name} 的頭像` : '我的頭像'}
               width={32}
               height={32}
               className="h-8 w-8 rounded-full object-cover"
@@ -132,7 +132,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
             >
               <Image
                 src={avatarSrc || DefaultAvatarImgUrl}
-                alt="avatar"
+                alt={name ? `${name} 的頭像` : '我的頭像'}
                 width={56}
                 height={56}
                 className="h-14 w-14 rounded-full object-cover"

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -111,7 +111,7 @@ export const UserDropdown = React.memo(function UserDropdown({
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt={name ? `${name} 的頭像` : '我的頭像'}
               width={32}
               height={32}
               className="h-8 w-8 rounded-full object-cover"
@@ -133,7 +133,7 @@ export const UserDropdown = React.memo(function UserDropdown({
           >
             <Image
               src={avatarSrc || DefaultAvatarImgUrl}
-              alt="avatar"
+              alt={name ? `${name} 的頭像` : '我的頭像'}
               width={56}
               height={56}
               className="h-14 w-14 rounded-full object-cover"

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -6,9 +6,14 @@ import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 interface AvatarWithBadgeProps {
   avatar: string | StaticImageData;
   years: string;
+  name: string;
 }
 
-export const AvatarWithBadge = ({ avatar, years }: AvatarWithBadgeProps) => {
+export const AvatarWithBadge = ({
+  avatar,
+  years,
+  name,
+}: AvatarWithBadgeProps) => {
   const displayYears =
     TotalWorkSpanEnum[years as keyof typeof TotalWorkSpanEnum] ?? years;
 
@@ -16,7 +21,7 @@ export const AvatarWithBadge = ({ avatar, years }: AvatarWithBadgeProps) => {
     <figure className="relative h-[348px] w-full overflow-hidden xl:h-[292px]">
       <Image
         src={avatar}
-        alt="avatar"
+        alt={`${name} 的頭像`}
         fill
         sizes="(max-width: 768px) 334px, 413px"
         className="h-full object-cover"

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -39,7 +39,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
           href={`/profile/${id}`}
           className="absolute bottom-0 left-0 right-0 top-0 z-10"
         ></Link>
-        <AvatarWithBadge avatar={avatar} years={years} />
+        <AvatarWithBadge avatar={avatar} years={years} name={name} />
         <div className="px-4 pb-6 pt-4">
           <Information
             name={name}


### PR DESCRIPTION
## What Does This PR Do?

- Replace hardcoded `alt="avatar"` with the user's name so screen reader users can distinguish people in the UI
- Update `UserDropdown` and `MobileUserMenu` to use `${name} 的頭像` (with `'我的頭像'` fallback when name is empty)
- Add required `name` prop to `AvatarWithBadge` and pass it from `MentorCard`

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A

Closes Xchange-Taiwan/X-Talent-Tracker#173
