### PR TITLE
fix(a11y): enforce 44px touch target on schedule calendar day cells

### DIFF
--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -28,7 +28,8 @@ const scheduleCalendarSizeClassNames: Record<ScheduleCalendarSize, string> = {
     'lg:[--calendar-width:28rem]',
 
     // Dialog / modal cell size
-    '[--cell-size:1.75rem]',
+    // Mobile base meets WCAG AA 44px touch target.
+    '[--cell-size:max(1.75rem,44px)]',
     'sm:[--cell-size:2rem]',
     'md:[--cell-size:2rem]',
     'lg:[--cell-size:2.5rem]',
@@ -62,7 +63,8 @@ const scheduleCalendarSizeClassNames: Record<ScheduleCalendarSize, string> = {
     '[--calendar-width:100%]',
 
     // Profile page cell size
-    '[--cell-size:2rem]',
+    // Mobile base meets WCAG AA 44px touch target.
+    '[--cell-size:max(2rem,44px)]',
     'min-[700px]:[--cell-size:3.75rem]',
     'min-[900px]:[--cell-size:4rem]',
     '2xl:[--cell-size:3.5rem]',


### PR DESCRIPTION
## What Does This PR Do?

- Raise `ScheduleCalendar` mobile `--cell-size` to `max(1.75rem,44px)` (compact) and `max(2rem,44px)` (profile) so day cells meet the WCAG AA 44×44px touch target
- Mobile-only impact: `sm`/`min-[700px]` and larger breakpoints retain existing sizes, so desktop appearance is unchanged
- Closes #174

## Demo

http://localhost:3000/profile/[pageUserId] (Mentor schedule dialog · Mentee reservation dialog)

## Screenshot

N/A

## Anything to Note?

- Verify on iPhone SE width that the 7-column week still fits one row (no regression to #163 / #471)
- Month nav arrows share `--cell-size` and will scale with the cell; out of scope for this ticket — split into a follow-up if undesired

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
