### PR TITLE
fix(a11y): make mentor-pool filter remove icon a real button

### DIFF
--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -73,13 +73,17 @@ export default function MentorPoolUI({
                 <span>
                   {filter.name}: {filter.value}
                 </span>
-                <XIcon
-                  className="h-4 w-4 cursor-pointer"
+                <button
+                  type="button"
                   onClick={(event) => {
                     event.stopPropagation();
                     onRemoveFilter(key);
                   }}
-                />
+                  aria-label={`移除「${filter.name}：${filter.value}」篩選`}
+                  className="bg-transparent inline-flex items-center rounded-sm p-0 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <XIcon className="h-4 w-4" aria-hidden />
+                </button>
               </Badge>
             ))}
           </div>


### PR DESCRIPTION
## What Does This PR Do?

- Wrap the filter badge XIcon in a real `<button>` with `aria-label` and a focus-visible ring so keyboard users can Tab to it and screen readers announce "移除「{name}：{value}」篩選"
- Mark the icon `aria-hidden` and reset native button styles to keep the badge layout unchanged

Resolves Xchange-Taiwan/X-Talent-Tracker#175

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
