### PR TITLE
fix(a11y): add skip link, spinner status role, and dropdown aria-current

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -35,6 +35,12 @@ export default async function RootLayout({
   return (
     <html lang="zh-TW" className={notoSans.className}>
       <body id="app">
+        <a
+          href="#main-content"
+          className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+        >
+          跳至主要內容
+        </a>
         {/* Google Analytics 4 — only loads when NEXT_PUBLIC_GA_ID is set.
             strategy="afterInteractive" ensures it never blocks page render.
             Page views are tracked by PageViewTracker on route changes. */}
@@ -78,7 +84,13 @@ export default async function RootLayout({
         <Providers session={session}>
           <div className="flex min-h-screen flex-col">
             <Header />
-            <main className="grow pt-[70px]">{children}</main>
+            <main
+              id="main-content"
+              tabIndex={-1}
+              className="grow pt-[70px] focus:outline-none"
+            >
+              {children}
+            </main>
             <Footer />
           </div>
           <Toaster />

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 import type { Session } from 'next-auth';
 import { signOut } from 'next-auth/react';
 import * as React from 'react';
@@ -27,6 +27,7 @@ export const UserDropdown = React.memo(function UserDropdown({
   user,
 }: UserDropdownProps): JSX.Element {
   const router = useRouter();
+  const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
   const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
   const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
@@ -50,6 +51,11 @@ export const UserDropdown = React.memo(function UserDropdown({
   const personalLinks = user.personalLinks ?? [];
 
   const profilePath = userId ? `/profile/${userId}` : '/';
+  const isOnProfile = Boolean(userId) && pathname === profilePath;
+  const isOnMentorReservation =
+    pathname?.startsWith('/reservation/mentor') ?? false;
+  const isOnMenteeReservation =
+    pathname?.startsWith('/reservation/mentee') ?? false;
   const profileUrl =
     typeof window !== 'undefined'
       ? `${window.location.origin}${profilePath}`
@@ -129,6 +135,7 @@ export const UserDropdown = React.memo(function UserDropdown({
           <button
             type="button"
             onClick={handleGoProfile}
+            aria-current={isOnProfile ? 'page' : undefined}
             className="flex w-full items-center gap-4 px-6 pb-4 pt-6 text-left"
           >
             <Image
@@ -164,6 +171,9 @@ export const UserDropdown = React.memo(function UserDropdown({
               className="px-4 py-3 text-2xl"
               onClick={handleAsMentor}
               disabled={!userId}
+              aria-current={
+                isMentor && isOnMentorReservation ? 'page' : undefined
+              }
             >
               {isMentor ? '導師預約管理' : '成為導師'}
             </DropdownMenuItem>
@@ -171,6 +181,7 @@ export const UserDropdown = React.memo(function UserDropdown({
             <DropdownMenuItem
               className="px-4 py-3 text-2xl"
               onClick={handleMyReservation}
+              aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
             </DropdownMenuItem>

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 interface LoadingSpinnerProps {
   className?: string;
   size?: 'sm' | 'md' | 'lg';
+  label?: string;
 }
 
 const sizeClasses = {
@@ -16,15 +17,20 @@ const sizeClasses = {
 export function LoadingSpinner({
   className,
   size = 'md',
+  label = '載入中',
 }: LoadingSpinnerProps) {
   return (
-    <Loader2
-      className={cn(
-        'animate-spin text-muted-foreground',
-        sizeClasses[size],
-        className
-      )}
-    />
+    <span role="status" className="inline-flex">
+      <Loader2
+        aria-hidden="true"
+        className={cn(
+          'animate-spin text-muted-foreground',
+          sizeClasses[size],
+          className
+        )}
+      />
+      <span className="sr-only">{label}</span>
+    </span>
   );
 }
 


### PR DESCRIPTION
## What Does This PR Do?

- Add a "跳至主要內容" skip link in the root layout so keyboard users can bypass header / nav, and mark `<main>` with `id="main-content"` + `tabIndex={-1}` so focus actually lands on it
- Wrap `LoadingSpinner` in `role="status"` with an sr-only "載入中" label (overridable via `label` prop) and `aria-hidden` the visual icon, so screen readers announce loading states
- Add `aria-current="page"` to the profile button, "導師預約管理", and "我的預約" entries in `UserDropdown` based on `usePathname()` so the active page is announced

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

Closes #176 partially — covers items #1 (skip link), #3 (spinner accessible name), and #6 (aria-current). Items #2 (search label), #4 (onboarding fieldset/legend), and #5 (prefers-reduced-motion) are intentionally deferred to separate tickets to keep this PR scoped.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
