### PR TITLE
perf(images): add sizes prop to next/image usages (#169)

### DIFF
--- a/src/app/(landing)/about/page.tsx
+++ b/src/app/(landing)/about/page.tsx
@@ -43,6 +43,7 @@ export default function Page() {
             height={320}
             src={aboutPage_1}
             alt=""
+            sizes="500px"
             priority={false}
             placeholder="blur"
           />

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -67,6 +67,7 @@ export default function Page() {
             src={HomePageHeroImgUrl}
             alt=""
             fill
+            sizes="1800px"
             className="-z-10 w-[1800px] object-cover object-top"
           />
         )}
@@ -94,6 +95,7 @@ export default function Page() {
             width={420}
             height={270}
             alt=""
+            sizes="(min-width: 768px) 40vw, 420px"
             className="max-w-full shrink-0 md:w-2/5"
           />
           <div className="m-auto flex flex-col py-[30px] md:m-0 md:flex-1 md:py-0 xl:pl-[62px]">
@@ -117,8 +119,9 @@ export default function Page() {
           </div>
           <Image
             src={landingPage_5}
-            className="max-w-full shrink-0 md:w-2/5"
             alt=""
+            sizes="(min-width: 768px) 40vw, 100vw"
+            className="max-w-full shrink-0 md:w-2/5"
           />
         </div>
       </section>
@@ -161,8 +164,9 @@ export default function Page() {
           <div className="flex">
             <Image
               src={landingPage_6}
-              className="hidden w-[363px] xl:block"
               alt=""
+              sizes="363px"
+              className="hidden w-[363px] xl:block"
             />
             <div className="xl:ml-[78px]">
               <p className="text-midnight-blue mt-1 text-center text-xl font-bold md:text-2xl xl:text-start">
@@ -207,8 +211,9 @@ export default function Page() {
           <div className="mt-10 flex md:mt-[116px]">
             <Image
               src={landingPage_7}
-              className="hidden w-[363px] xl:block"
               alt=""
+              sizes="363px"
+              className="hidden w-[363px] xl:block"
             />
             <div className="xl:ml-[78px]">
               <p className="text-midnight-blue mt-1 text-center text-xl font-bold md:text-2xl xl:text-start">

--- a/src/components/landing/HomePageSlider.tsx
+++ b/src/components/landing/HomePageSlider.tsx
@@ -40,6 +40,7 @@ export const HomePageSlider: FC = () => {
                   fill
                   src={avatar}
                   alt={`avatar_${name}`}
+                  sizes="112px"
                   className="object-cover"
                 />
               </div>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -38,7 +38,12 @@ export const Footer: FC = () => {
   return (
     <footer className="flex h-auto w-full bg-dark pb-[50px] md:h-[290px]">
       <div className="flex w-full flex-col items-center px-5 pt-[50px] md:flex-row md:items-start md:justify-between md:px-[70px]">
-        <Image src={logoImgUrl} className="h-[39px] w-[146px]" alt="logo" />
+        <Image
+          src={logoImgUrl}
+          alt="logo"
+          sizes="146px"
+          className="h-[39px] w-[146px]"
+        />
 
         <div className="mt-8 flex flex-col gap-8 text-[#FFFFFF] md:mt-0 md:flex-row md:gap-x-16">
           <div className="flex flex-col items-center md:items-start">

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -111,6 +111,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               alt={name ? `${name} 的頭像` : '我的頭像'}
               width={32}
               height={32}
+              sizes="32px"
               className="h-8 w-8 rounded-full object-cover"
               priority
             />
@@ -135,6 +136,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
                 alt={name ? `${name} 的頭像` : '我的頭像'}
                 width={56}
                 height={56}
+                sizes="56px"
                 className="h-14 w-14 rounded-full object-cover"
               />
               <div className="min-w-0">

--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -117,6 +117,7 @@ export function ShareProfileDialog({
                     src={avatarSrc || DefaultAvatarImgUrl}
                     alt={`Avatar of ${name}`}
                     fill
+                    sizes="64px"
                     className="object-cover"
                   />
                 </div>

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -114,6 +114,7 @@ export const UserDropdown = React.memo(function UserDropdown({
               alt={name ? `${name} 的頭像` : '我的頭像'}
               width={32}
               height={32}
+              sizes="32px"
               className="h-8 w-8 rounded-full object-cover"
               priority
             />
@@ -136,6 +137,7 @@ export const UserDropdown = React.memo(function UserDropdown({
               alt={name ? `${name} 的頭像` : '我的頭像'}
               width={56}
               height={56}
+              sizes="56px"
               className="h-14 w-14 rounded-full object-cover"
             />
 

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -50,6 +50,7 @@ export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
                           alt={option.desc?.desc ?? '主題圖示'}
                           width={24}
                           height={24}
+                          sizes="24px"
                           className="object-contain"
                         />
                       )}

--- a/src/components/profile/avatar-card/AvatarCard.tsx
+++ b/src/components/profile/avatar-card/AvatarCard.tsx
@@ -36,6 +36,7 @@ export const AvatarCard: FC<Props> = ({
           src={avatarImgUrl || DefaultAvatarImgUrl}
           alt={'Avatar of ' + name}
           fill
+          sizes="120px"
           style={{
             objectFit: 'contain',
           }}

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -310,6 +310,7 @@ export default function MenteeReservationDialog({
                 }
                 alt={userData?.name || 'Mentor Avatar'}
                 fill
+                sizes="64px"
                 className="rounded-full object-cover"
               />
             </div>
@@ -381,6 +382,7 @@ export default function MenteeReservationDialog({
                 }
                 alt={userData?.name || 'Mentor Avatar'}
                 fill
+                sizes="64px"
                 className="rounded-full object-cover"
               />
             </div>

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -86,6 +86,7 @@ const AvatarUpload = <T extends FieldValues>({
             alt="Avatar Preview"
             width={50}
             height={50}
+            sizes="50px"
             className="h-full w-full rounded-full object-cover"
           />
         ) : (


### PR DESCRIPTION
## What Does This PR Do?

- Add explicit `sizes` to all rasterized `<Image>` usages so Next.js image optimizer can pick the smallest matching srcSet variant instead of defaulting to 100vw.
- Header/menu avatars (UserDropdown, MobileUserMenu): `sizes="32px"` / `"56px"` matching fixed dims.
- Fill-mode avatars (ShareProfileDialog, MenteeReservationDialog, AvatarCard, HomePageSlider): `sizes` matching the fixed-pixel container (64/120/112).
- Landing page hero & content images: `sizes` matching breakpoint behavior (`1800px` for lg-only hero, `(min-width: 768px) 40vw, ...` for `md:w-2/5` blocks, `363px` for xl-only blocks).
- About page image, footer logo, avatar upload preview, onboarding topic icon: `sizes` matching their fixed render size.
- SVG `<Image>` usages (landing page icons, header logo, auth icons) are skipped — Next.js does not optimize SVGs, so `sizes` has no effect.

Part of #169 (image + font loading perf). Avatar cache buster collapse and font FOUT improvements will land in follow-up PRs.

## Demo

http://localhost:3000/

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
