### PR TITLE
perf: drop fetchMentorsEnriched N+1 fan-out

### DIFF
--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -4,7 +4,6 @@ import { getInterestsCached } from '@/hooks/user/interests/useInterests';
 import { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
 import { apiClient } from '@/lib/apiClient';
 import { parseCurrentJob } from '@/lib/profile/parseUserExperiences';
-import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
 import { components } from '@/types/api';
 
 type RawMentor = components['schemas']['SearchMentorProfileVO'];
@@ -112,18 +111,6 @@ export async function fetchMentors(
   }
 }
 
-function enrichMentorWithProfile(
-  mentor: MentorType,
-  profile: MentorProfileVO | null,
-  skillLabelMap: Record<string, string>
-): MentorType {
-  const { job_title, company } = parseCurrentJob(profile?.experiences);
-  const skills = (profile?.skills?.interests ?? [])
-    .map((int) => skillLabelMap[int.subject_group] ?? int.subject_group)
-    .filter(Boolean);
-  return { ...mentor, job_title, company, skills };
-}
-
 export async function fetchMentorsEnriched(
   param: MentorRequest
 ): Promise<MentorType[]> {
@@ -139,11 +126,10 @@ export async function fetchMentorsEnriched(
     skillLabelMap[s.subject_group] = s.subject ?? '';
   });
 
-  const profiles = await Promise.all(
-    searchResults.map((m) => fetchUserById(m.user_id, 'zh_TW'))
-  );
-
-  return searchResults.map((mentor, i) =>
-    enrichMentorWithProfile(mentor, profiles[i], skillLabelMap)
-  );
+  return searchResults.map((mentor) => ({
+    ...mentor,
+    skills: mentor.skills
+      .map((subjectGroup) => skillLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+  }));
 }


### PR DESCRIPTION
## What Does This PR Do?

- Remove the 9 per-page `fetchUserById` calls in `fetchMentorsEnriched` (mentor-pool first paint and infinite scroll were 1 + 9 requests per page)
- Apply the existing skill `subject_group → label` translation directly to the search response, since `/v1/mentors` already returns `experiences`, `skills`, `job_title`, `company`, and the rest of the fields the enrichment was reading
- Drop now-unused `enrichMentorWithProfile`, `fetchUserById`, and `MentorProfileVO` imports

Resolves Xchange-Taiwan/X-Talent-Tracker#184

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- `MentorType` shape is unchanged, so `mentor-pool/container.tsx` is untouched
- Worth a quick smoke test on /mentor-pool: skill chips should still render in 繁中, scroll-to-load should still page, and DevTools Network should show 1 `/v1/mentors` request per page (no `fetchUserById` fan-out)
- If backend search response is ever found to be missing a field used by the card, fix it in backend rather than reintroducing the fan-out

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
