### PR TITLE
perf(mentor-pool): replace dynamic import of MentorPoolUI with static

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import avatarImage from '@/assets/default-avatar.png';
@@ -11,8 +10,7 @@ import {
 } from '@/services/search-mentor/mentors';
 
 import { filterOptions } from './data';
-
-const MentorPoolUI = dynamic(() => import('./ui'));
+import MentorPoolUI from './ui';
 
 const PAGE_LIMIT = 9;
 const SESSION_KEY_PATTERN = 'mentor-pool:searchPattern';


### PR DESCRIPTION
## What Does This PR Do?

- Replace `dynamic(() => import('./ui'))` with a static `import MentorPoolUI from './ui';` in `src/app/mentor-pool/container.tsx`
- Both `MentorPoolContainer` and `MentorPoolUI` are already client components, so the dynamic split adds an extra chunk fetch + parse delay without any SSR-skip or bundle-split benefit
- Removes the unused `next/dynamic` import

Closes Xchange-Taiwan/X-Talent-Tracker#185

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A
