### PR TITLE
fix(ux): keep prev mentors during filter/search to avoid flash

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -25,9 +25,13 @@ export default function MentorPoolContainer() {
   const [selectedFilters, setSelectedFilters] = useState<SelectFilters>({});
   const [isNoResults, setIsNoResults] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
+  const [isReplacing, setIsReplacing] = useState(false);
   const [cursor, setCursor] = useState<string | undefined>('');
   const [sessionRestored, setSessionRestored] = useState(false);
   const isLoadingRef = useRef(false);
+  // Monotonic counter — every fetch claims an id. Late responses whose id no
+  // longer matches the current value are stale and must not touch state.
+  const requestIdRef = useRef(0);
 
   // Restore persisted search state before the first fetch
   useEffect(() => {
@@ -70,6 +74,7 @@ export default function MentorPoolContainer() {
   }, []);
 
   const fetchMentorsBySearch = useCallback(async () => {
+    const myRequestId = ++requestIdRef.current;
     const filters = Object.fromEntries(
       Object.entries(selectedFilters).map(([key, value]) => [key, value.value])
     );
@@ -79,9 +84,8 @@ export default function MentorPoolContainer() {
       cursor: '',
       ...filters,
     };
-    setMentors([]);
-    setMentorCount(0);
     setIsLoading(true);
+    setIsReplacing(true);
     isLoadingRef.current = true;
     let rtnList: MentorType[] = [];
     try {
@@ -93,9 +97,13 @@ export default function MentorPoolContainer() {
             : avatarImage,
       }));
     } finally {
-      setIsLoading(false);
-      isLoadingRef.current = false;
+      if (myRequestId === requestIdRef.current) {
+        setIsLoading(false);
+        setIsReplacing(false);
+        isLoadingRef.current = false;
+      }
     }
+    if (myRequestId !== requestIdRef.current) return;
     if (rtnList.length > 0) {
       setMentors(rtnList);
       setMentorCount(rtnList.length);
@@ -103,10 +111,14 @@ export default function MentorPoolContainer() {
       setIsNoResults(false);
       return;
     }
+    setMentors([]);
+    setMentorCount(0);
+    setCursor('');
     setIsNoResults(true);
   }, [searchPattern, selectedFilters]);
 
   const fetchMoreMentors = useCallback(async () => {
+    const myRequestId = ++requestIdRef.current;
     const filters = Object.fromEntries(
       Object.entries(selectedFilters).map(([key, value]) => [key, value.value])
     );
@@ -128,9 +140,12 @@ export default function MentorPoolContainer() {
             : avatarImage,
       }));
     } finally {
-      setIsLoading(false);
-      isLoadingRef.current = false;
+      if (myRequestId === requestIdRef.current) {
+        setIsLoading(false);
+        isLoadingRef.current = false;
+      }
     }
+    if (myRequestId !== requestIdRef.current) return;
     if (rtnList.length > 0) {
       setMentors((prevMentors) => {
         const newMentors = rtnList.filter(
@@ -165,6 +180,7 @@ export default function MentorPoolContainer() {
       mentors={mentors}
       mentorCount={mentorCount}
       isLoading={isLoading}
+      isReplacing={isReplacing}
       isNoResults={isNoResults}
       selectedFilters={selectedFilters}
       filterOptions={filterOptions}

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -17,6 +17,7 @@ interface Props {
   mentors: MentorType[];
   mentorCount: number;
   isLoading: boolean;
+  isReplacing: boolean;
   isNoResults: boolean;
   selectedFilters: SelectFilters;
   filterOptions: FilterOptions;
@@ -30,6 +31,7 @@ export default function MentorPoolUI({
   mentors,
   mentorCount,
   isLoading,
+  isReplacing,
   isNoResults,
   selectedFilters,
   filterOptions,
@@ -38,6 +40,11 @@ export default function MentorPoolUI({
   onRemoveFilter,
   onScrollToBottom,
 }: Props) {
+  const hasMentors = mentors.length > 0;
+  const showOverlay = hasMentors && isReplacing;
+  const showFullSpinner = !hasMentors && isLoading;
+  const showLoadMoreSpinner = hasMentors && isLoading && !isReplacing;
+  const showNoResults = !hasMentors && !isLoading && isNoResults;
   return (
     <div className="relative">
       <section className="flex h-[202px] w-full items-center justify-center bg-[linear-gradient(to_right,#FFFFEF_0%,#FFF6FF_19%,#F7F2FB_42%,#E4FFFF_100%)] px-4 text-xl font-semibold md:text-3xl xl:rounded-br-[120px]">
@@ -53,7 +60,11 @@ export default function MentorPoolUI({
       <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
         <div className="mx-auto w-full max-w-[1280px] ">
           <div className="item-center mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
-            <div className="text-base">找到 {mentorCount} 位導師</div>
+            <div
+              className={`text-base transition-opacity ${isReplacing ? 'opacity-50' : ''}`}
+            >
+              找到 {mentorCount} 位導師
+            </div>
             <div className="grid w-full grid-cols-2 gap-3 md:flex md:w-fit">
               <div className="block md:hidden"></div>
               <MentorFilterDropdown
@@ -87,23 +98,36 @@ export default function MentorPoolUI({
               </Badge>
             ))}
           </div>
-          {mentors.length === 0 && !isLoading ? (
-            <div className="mt-6 flex h-full w-full items-center justify-center">
-              {isNoResults && (
-                <span className="text-xl md:text-3xl">找不到符合的導師</span>
-              )}
-            </div>
-          ) : (
-            <div className="mb-6">
+          {hasMentors && (
+            <div className="relative mb-6">
               <MentorCardList
                 mentors={mentors}
                 onScrollToBottom={onScrollToBottom}
               />
+              {showOverlay && (
+                <div
+                  aria-busy="true"
+                  aria-live="polite"
+                  className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background-white/60"
+                >
+                  <LoadingSpinner size="lg" />
+                </div>
+              )}
             </div>
           )}
-          {isLoading && (
+          {showFullSpinner && (
             <div className="flex h-full w-full items-center justify-center">
               <LoadingSpinner size="lg" />
+            </div>
+          )}
+          {showLoadMoreSpinner && (
+            <div className="flex h-full w-full items-center justify-center">
+              <LoadingSpinner size="lg" />
+            </div>
+          )}
+          {showNoResults && (
+            <div className="mt-6 flex h-full w-full items-center justify-center">
+              <span className="text-xl md:text-3xl">找不到符合的導師</span>
             </div>
           )}
         </div>


### PR DESCRIPTION
## What Does This PR Do?

- Stop clearing the mentor list when filters or search change; the previous results stay visible until new data arrives
- Add an `isReplacing` flag to drive a semi-transparent overlay over the existing list during a fetch, leaving the bottom spinner for infinite-scroll load-more
- Guard against race conditions with a monotonic request id — late responses from a stale fetch are dropped instead of overwriting the latest state
- Dim the "找到 N 位導師" count during replacement instead of flashing it to 0

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- No service-layer changes — request id pattern keeps the fix scoped to the container; stale `fetchMentorsEnriched` calls still complete but their results are discarded
- Debounce on filter changes is intentionally deferred to a follow-up PR

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
