### PR TITLE
feat: split HISTORY into MENTOR_HISTORY / MENTEE_HISTORY

### DIFF
--- a/e2e/tests/reservation/reservation-mentee.spec.ts
+++ b/e2e/tests/reservation/reservation-mentee.spec.ts
@@ -87,7 +87,7 @@ async function mockSessionGet(page: Page): Promise<void> {
 }
 
 /**
- * Mock all 5 reservation list endpoints that useReservationData calls in
+ * Mock all 6 reservation list endpoints that useReservationData calls in
  * parallel. The `stateData` map lets each test override specific states with
  * custom payloads; any state not provided gets an empty list.
  */
@@ -100,7 +100,8 @@ async function mockReservationEndpoints(
     MENTEE_PENDING: [],
     MENTOR_UPCOMING: [],
     MENTOR_PENDING: [],
-    HISTORY: [],
+    MENTOR_HISTORY: [],
+    MENTEE_HISTORY: [],
   };
   const data = { ...defaults, ...stateData };
 

--- a/e2e/tests/reservation/reservation-mentor.spec.ts
+++ b/e2e/tests/reservation/reservation-mentor.spec.ts
@@ -103,7 +103,7 @@ async function mockSessionGet(page: Page): Promise<void> {
 }
 
 /**
- * Mock all 5 reservation list endpoints. The `stateData` map lets each test
+ * Mock all 6 reservation list endpoints. The `stateData` map lets each test
  * override specific states with custom payloads; any state not provided gets an
  * empty list.
  */
@@ -116,7 +116,8 @@ async function mockReservationListEndpoints(
     MENTEE_PENDING: [],
     MENTOR_UPCOMING: [],
     MENTOR_PENDING: [],
-    HISTORY: [],
+    MENTOR_HISTORY: [],
+    MENTEE_HISTORY: [],
   };
   const data = { ...defaults, ...stateData };
 

--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -11,7 +11,8 @@ export type ReservationTabsProps = {
   pendingMentee: Reservation[];
   upcomingMentor: Reservation[];
   pendingMentor: Reservation[];
-  history: Reservation[];
+  mentorHistory: Reservation[];
+  menteeHistory: Reservation[];
   nextTokens: NextTokens;
   isLoadingMore: boolean;
   onLoadMore: (state: ReservationState) => void;
@@ -23,7 +24,8 @@ export default function ReservationTabs({
   pendingMentee,
   upcomingMentor,
   pendingMentor,
-  history,
+  mentorHistory,
+  menteeHistory,
   nextTokens,
   isLoadingMore,
   onLoadMore,
@@ -32,6 +34,7 @@ export default function ReservationTabs({
   // This file is for mentee UI; keep mentor props to match type and avoid lint issues.
   void upcomingMentor;
   void pendingMentor;
+  void mentorHistory;
 
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
@@ -71,7 +74,7 @@ export default function ReservationTabs({
 
                   <TabsTrigger value="history" className={triggerClass}>
                     歷史紀錄
-                    <span className={countClass}>{history.length}</span>
+                    <span className={countClass}>{menteeHistory.length}</span>
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -106,11 +109,11 @@ export default function ReservationTabs({
 
           <TabsContent value="history" className="mt-4 sm:mt-6">
             <ReservationList
-              items={history}
+              items={menteeHistory}
               variant="history"
               sourceRole="mentee"
-              hasMore={nextTokens.history !== 0}
-              onLoadMore={() => onLoadMore('HISTORY')}
+              hasMore={nextTokens.menteeHistory !== 0}
+              onLoadMore={() => onLoadMore('MENTEE_HISTORY')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
             />

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -11,7 +11,8 @@ export type ReservationTabsProps = {
   pendingMentee: Reservation[];
   upcomingMentor: Reservation[];
   pendingMentor: Reservation[];
-  history: Reservation[];
+  mentorHistory: Reservation[];
+  menteeHistory: Reservation[];
   nextTokens: NextTokens;
   isLoadingMore: boolean;
   onLoadMore: (state: ReservationState) => void;
@@ -23,7 +24,8 @@ export default function ReservationTabs({
   pendingMentee,
   upcomingMentor,
   pendingMentor,
-  history,
+  mentorHistory,
+  menteeHistory,
   nextTokens,
   isLoadingMore,
   onLoadMore,
@@ -31,6 +33,7 @@ export default function ReservationTabs({
 }: ReservationTabsProps) {
   void upcomingMentee;
   void pendingMentee;
+  void menteeHistory;
 
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
@@ -70,7 +73,7 @@ export default function ReservationTabs({
 
                   <TabsTrigger value="history" className={triggerClass}>
                     歷史紀錄
-                    <span className={countClass}>{history.length}</span>
+                    <span className={countClass}>{mentorHistory.length}</span>
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -105,11 +108,11 @@ export default function ReservationTabs({
 
           <TabsContent value="history" className="mt-4 sm:mt-6">
             <ReservationList
-              items={history}
+              items={mentorHistory}
               variant="history"
               sourceRole="mentor"
-              hasMore={nextTokens.history !== 0}
-              onLoadMore={() => onLoadMore('HISTORY')}
+              hasMore={nextTokens.mentorHistory !== 0}
+              onLoadMore={() => onLoadMore('MENTOR_HISTORY')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
             />

--- a/src/hooks/user/reservation/useReservationData.test.ts
+++ b/src/hooks/user/reservation/useReservationData.test.ts
@@ -37,13 +37,15 @@ const mockLists = {
   pendingMentee: [makeReservation('2')],
   upcomingMentor: [makeReservation('3')],
   pendingMentor: [makeReservation('4')],
-  history: [makeReservation('5')],
+  mentorHistory: [makeReservation('5')],
+  menteeHistory: [makeReservation('6')],
   nextTokens: {
     menteeUpcoming: 0,
     menteePending: 0,
     mentorUpcoming: 0,
     mentorPending: 0,
-    history: 0,
+    mentorHistory: 0,
+    menteeHistory: 0,
   },
 };
 
@@ -69,7 +71,7 @@ describe('useReservationData', () => {
     expect(result.current.data).toBeNull();
   });
 
-  it('has session + fetch succeeds → data contains all five reservation lists correctly mapped', async () => {
+  it('has session + fetch succeeds → data contains all six reservation lists correctly mapped', async () => {
     const { result } = await act(async () =>
       renderHook(() => useReservationData())
     );
@@ -80,7 +82,8 @@ describe('useReservationData', () => {
       pendingMentee: mockLists.pendingMentee,
       upcomingMentor: mockLists.upcomingMentor,
       pendingMentor: mockLists.pendingMentor,
-      history: mockLists.history,
+      mentorHistory: mockLists.mentorHistory,
+      menteeHistory: mockLists.menteeHistory,
       nextTokens: mockLists.nextTokens,
     });
     expect(result.current.isLoading).toBe(false);

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -15,7 +15,8 @@ export interface NextTokens {
   menteePending: number;
   mentorUpcoming: number;
   mentorPending: number;
-  history: number;
+  mentorHistory: number;
+  menteeHistory: number;
 }
 
 export interface ReservationData {
@@ -23,7 +24,8 @@ export interface ReservationData {
   pendingMentee: Reservation[];
   upcomingMentor: Reservation[];
   pendingMentor: Reservation[];
-  history: Reservation[];
+  mentorHistory: Reservation[];
+  menteeHistory: Reservation[];
   nextTokens: NextTokens;
 }
 
@@ -32,7 +34,8 @@ const STATE_TO_TOKEN_KEY: Record<ReservationState, keyof NextTokens> = {
   MENTEE_PENDING: 'menteePending',
   MENTOR_UPCOMING: 'mentorUpcoming',
   MENTOR_PENDING: 'mentorPending',
-  HISTORY: 'history',
+  MENTOR_HISTORY: 'mentorHistory',
+  MENTEE_HISTORY: 'menteeHistory',
 };
 
 const STATE_TO_DATA_KEY: Record<
@@ -43,7 +46,8 @@ const STATE_TO_DATA_KEY: Record<
   MENTEE_PENDING: 'pendingMentee',
   MENTOR_UPCOMING: 'upcomingMentor',
   MENTOR_PENDING: 'pendingMentor',
-  HISTORY: 'history',
+  MENTOR_HISTORY: 'mentorHistory',
+  MENTEE_HISTORY: 'menteeHistory',
 };
 
 const ALL_STATES: ReservationState[] = [
@@ -51,7 +55,8 @@ const ALL_STATES: ReservationState[] = [
   'MENTEE_PENDING',
   'MENTOR_UPCOMING',
   'MENTOR_PENDING',
-  'HISTORY',
+  'MENTOR_HISTORY',
+  'MENTEE_HISTORY',
 ];
 
 export function useReservationData() {
@@ -81,13 +86,15 @@ export function useReservationData() {
           pendingMentee: lists.pendingMentee,
           upcomingMentor: lists.upcomingMentor,
           pendingMentor: lists.pendingMentor,
-          history: lists.history,
+          mentorHistory: lists.mentorHistory,
+          menteeHistory: lists.menteeHistory,
           nextTokens: {
             menteeUpcoming: lists.nextTokens.menteeUpcoming,
             menteePending: lists.nextTokens.menteePending,
             mentorUpcoming: lists.nextTokens.mentorUpcoming,
             mentorPending: lists.nextTokens.mentorPending,
-            history: lists.nextTokens.history,
+            mentorHistory: lists.nextTokens.mentorHistory,
+            menteeHistory: lists.nextTokens.menteeHistory,
           },
         });
       } catch (err) {
@@ -121,7 +128,8 @@ export function useReservationData() {
         pendingMentee: prev.pendingMentee.filter((it) => it.id !== id),
         upcomingMentor: prev.upcomingMentor.filter((it) => it.id !== id),
         pendingMentor: prev.pendingMentor.filter((it) => it.id !== id),
-        history: prev.history.filter((it) => it.id !== id),
+        mentorHistory: prev.mentorHistory.filter((it) => it.id !== id),
+        menteeHistory: prev.menteeHistory.filter((it) => it.id !== id),
       };
     });
   }, []);

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -13,7 +13,8 @@ export type ReservationState =
   | 'MENTOR_PENDING'
   | 'MENTEE_UPCOMING'
   | 'MENTEE_PENDING'
-  | 'HISTORY';
+  | 'MENTOR_HISTORY'
+  | 'MENTEE_HISTORY';
 
 export type FetchOptions = {
   userId: string | number;
@@ -161,13 +162,15 @@ export async function fetchAllReservationLists(
     pendingMenteeRes,
     upcomingMentorRes,
     pendingMentorRes,
-    historyRes,
+    mentorHistoryRes,
+    menteeHistoryRes,
   ] = await Promise.all([
     fetchReservations({ ...commonOpts, state: 'MENTEE_UPCOMING' }),
     fetchReservations({ ...commonOpts, state: 'MENTEE_PENDING' }),
     fetchReservations({ ...commonOpts, state: 'MENTOR_UPCOMING' }),
     fetchReservations({ ...commonOpts, state: 'MENTOR_PENDING' }),
-    fetchReservations({ ...commonOpts, state: 'HISTORY' }),
+    fetchReservations({ ...commonOpts, state: 'MENTOR_HISTORY' }),
+    fetchReservations({ ...commonOpts, state: 'MENTEE_HISTORY' }),
   ]);
 
   return {
@@ -175,13 +178,15 @@ export async function fetchAllReservationLists(
     pendingMentee: pendingMenteeRes.items,
     upcomingMentor: upcomingMentorRes.items,
     pendingMentor: pendingMentorRes.items,
-    history: historyRes.items,
+    mentorHistory: mentorHistoryRes.items,
+    menteeHistory: menteeHistoryRes.items,
     nextTokens: {
       menteeUpcoming: upcomingMenteeRes.next_dtend,
       menteePending: pendingMenteeRes.next_dtend,
       mentorUpcoming: upcomingMentorRes.next_dtend,
       mentorPending: pendingMentorRes.next_dtend,
-      history: historyRes.next_dtend,
+      mentorHistory: mentorHistoryRes.next_dtend,
+      menteeHistory: menteeHistoryRes.next_dtend,
     },
   };
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-26T04:35:57.666240Z
+       * @default 2026-04-27T15:42:14.728074Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-26T04:35:57.666249Z
+       * @default 2026-04-27T15:42:14.728090Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1541,11 +1541,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['ScheduleType'];
       /**
        * Dtstart
        * @example 1717203600
@@ -1606,6 +1603,14 @@ export interface components {
       desc?: string | null;
       /** Icon */
       icon?: string | null;
+    };
+    /** PreviousReserveRef */
+    PreviousReserveRef: {
+      /**
+       * Reserve Id
+       * @example 0
+       */
+      reserve_id?: number | null;
     };
     /**
      * ProfessionCategory
@@ -1824,9 +1829,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
     };
     /** ReservationInfoListVO */
     ReservationInfoListVO: {
@@ -1862,13 +1866,25 @@ export interface components {
        * @default 0
        */
       dtend: number;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
       /**
        * Messages
        * @default []
        */
       messages: components['schemas']['ReservationMessageVO'][] | null;
+    };
+    /** ReservationMessageDTO */
+    ReservationMessageDTO: {
+      /**
+       * User Id
+       * @example 0
+       */
+      user_id: number;
+      /**
+       * Content
+       * @example
+       */
+      content: string;
     };
     /** ReservationMessageVO */
     ReservationMessageVO: {
@@ -1921,9 +1937,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
       /** Id */
       id?: number | null;
       /** @example PENDING */
@@ -1943,6 +1958,11 @@ export interface components {
       /** Confirm Password */
       confirm_password: string;
     };
+    /**
+     * ScheduleType
+     * @enum {string}
+     */
+    ScheduleType: 'ALLOW' | 'FORBIDDEN' | 'BOOKED' | 'PENDING';
     /** SearchMentorProfileListVO */
     SearchMentorProfileListVO: {
       /** Mentors */
@@ -2069,11 +2089,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['TimeSlotType'];
       /**
        * Dt Year
        * @example 2024
@@ -2115,6 +2132,11 @@ export interface components {
        */
       exdate: (number | null)[];
     };
+    /**
+     * TimeSlotType
+     * @enum {string}
+     */
+    TimeSlotType: 'ALLOW' | 'FORBIDDEN';
     /** TimeSlotVO */
     TimeSlotVO: {
       /**
@@ -2127,11 +2149,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['TimeSlotType'];
       /**
        * Dt Year
        * @example 2024
@@ -2250,7 +2269,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
     };
     /** ValidationError */
     ValidationError: {


### PR DESCRIPTION
## What Does This PR Do?

- Replace `HISTORY` reservation state with `MENTOR_HISTORY` / `MENTEE_HISTORY` to match BFF (X-Career-User#71, X-Career-BFF#104) — `HISTORY` now returns 422.
- Service: extend `ReservationState` union; `fetchAllReservationLists` issues 6 parallel calls and returns separate `mentorHistory` / `menteeHistory` items + tokens.
- Hook (`useReservationData`): split `history` bucket into `mentorHistory` / `menteeHistory` across `NextTokens`, `ReservationData`, state→key maps, `ALL_STATES`, `removeItem`, and initial `setData`.
- UI: mentor `ReservationTabs` consumes `mentorHistory` + `MENTOR_HISTORY`; mentee `ReservationTabs` consumes `menteeHistory` + `MENTEE_HISTORY`. `container.tsx` / `ui.tsx` are unchanged (props spread).
- Tests: update `useReservationData.test.ts` fixtures and e2e mock defaults for both pages.
- Regenerate `src/types/api.ts` from latest BFF dev OpenAPI (BFF still types `state` as string, so the FE union remains source of truth).

## Demo

http://localhost:3000/reservation/mentor
http://localhost:3000/reservation/mentee

## Screenshot

N/A

## Anything to Note?

- Eager-fetch pattern preserved (5 → 6 parallel calls). Lazy/per-page fetching can be revisited later if perf becomes a concern.
- `pnpm type-check`, `pnpm build`, and the `useReservationData` unit tests pass. Lint on changed files is clean (944 pre-existing repo errors are unrelated).
- E2E reservation specs and manual desktop/mobile smoke still need to be run by the reviewer.
