### PR TITLE
refactor: use generated DTOs for reservation and timeslot services

### DIFF
--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -25,10 +25,7 @@ import { UserType } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { captureFlowFailure } from '@/lib/monitoring';
-import {
-  createReservation,
-  CreateReservationPayload,
-} from '@/services/reservations';
+import { createReservation } from '@/services/reservations';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
 
@@ -117,22 +114,19 @@ export default function MenteeReservationDialog({
       if (!session?.user?.id) {
         throw new Error('You must be logged in to make a reservation.');
       }
-      const menteeId = session.user.id;
-
-      const payload: CreateReservationPayload = {
-        my_user_id: menteeId,
-        my_status: 'PENDING',
-        user_id: userData.user_id,
-        schedule_id: selectedSlot.scheduleId,
-        dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
-        dtend: Math.floor(selectedSlot.end.getTime() / 1000),
-        messages: [{ user_id: menteeId, content: bookingQuestion }],
-        previous_reserve: {},
-      };
+      const menteeId = Number(session.user.id);
 
       await createReservation({
         userId: menteeId,
-        body: payload,
+        body: {
+          my_user_id: menteeId,
+          my_status: 'PENDING',
+          user_id: userData.user_id,
+          schedule_id: selectedSlot.scheduleId,
+          dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
+          dtend: Math.floor(selectedSlot.end.getTime() / 1000),
+          messages: [{ user_id: menteeId, content: bookingQuestion }],
+        },
         debug: process.env.NODE_ENV === 'development',
       });
 

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -55,26 +55,28 @@ export function ReservationList({
   const accept = async ({ id, message }: { id: string; message: string }) => {
     try {
       const session = await getSession();
-      const myId = String(session?.user?.id ?? '');
-      if (!myId) throw new Error('[ReservationList] missing current user id');
+      const sessionId = session?.user?.id;
+      if (!sessionId)
+        throw new Error('[ReservationList] missing current user id');
+      const myIdStr = String(sessionId);
+      const myIdNum = Number(sessionId);
 
       const it = findItem(id);
-      const otherId = resolveOtherId(myId, it);
+      const otherIdNum = Number(resolveOtherId(myIdStr, it));
 
       await updateReservationStatus({
-        userId: myId,
+        userId: myIdStr,
         reservationId: id,
         body: {
-          my_user_id: myId,
-          user_id: otherId,
+          my_user_id: myIdNum,
+          user_id: otherIdNum,
           my_status: 'ACCEPT',
           schedule_id: it.scheduleId,
           dtstart: it.dtstart,
           dtend: it.dtend,
           messages: message.trim()
-            ? [{ user_id: myId, content: message.trim() }]
+            ? [{ user_id: myIdNum, content: message.trim() }]
             : [],
-          previous_reserve: {},
         },
       });
 
@@ -104,26 +106,28 @@ export function ReservationList({
   ) => {
     try {
       const session = await getSession();
-      const myId = String(session?.user?.id ?? '');
-      if (!myId) throw new Error('[ReservationList] missing current user id');
+      const sessionId = session?.user?.id;
+      if (!sessionId)
+        throw new Error('[ReservationList] missing current user id');
+      const myIdStr = String(sessionId);
+      const myIdNum = Number(sessionId);
 
       const it = findItem(id);
-      const otherId = resolveOtherId(myId, it);
+      const otherIdNum = Number(resolveOtherId(myIdStr, it));
 
       await updateReservationStatus({
-        userId: myId,
+        userId: myIdStr,
         reservationId: id,
         body: {
-          my_user_id: myId,
-          user_id: otherId,
+          my_user_id: myIdNum,
+          user_id: otherIdNum,
           my_status: 'REJECT',
           schedule_id: it.scheduleId,
           dtstart: it.dtstart,
           dtend: it.dtend,
           messages: text.trim()
-            ? [{ user_id: myId, content: text.trim() }]
+            ? [{ user_id: myIdNum, content: text.trim() }]
             : [],
-          previous_reserve: {},
         },
       });
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -17,7 +17,7 @@ import {
   ParsedMentorTimeslot,
   RawMentorTimeslot,
 } from '@/lib/profile/scheduleHelpers';
-import { UpsertTimeslotBackend } from '@/services/mentor-schedule/schedule';
+import { TimeSlotDTO } from '@/services/mentor-schedule/schedule';
 import {
   loadMonthSchedule,
   syncMonthSchedule,
@@ -89,12 +89,16 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   );
 
   const toServiceSlot = useCallback(
-    (r: RawMentorTimeslot): UpsertTimeslotBackend => {
-      const slot: UpsertTimeslotBackend = {
+    (r: RawMentorTimeslot): TimeSlotDTO => {
+      // user_id and timezone are normalized in saveMentorSchedule (path param +
+      // hardcoded UTC), so the values supplied here are placeholders.
+      const slot: TimeSlotDTO = {
+        user_id: 0,
         dt_type: 'ALLOW',
         dtstart: r.dtstart,
         dtend: r.dtend,
         rrule: r.rrule,
+        timezone: 'UTC',
         exdate: r.exdate,
       };
       if (r.id > 0 && persistedIdSet.has(r.id)) slot.id = r.id;
@@ -337,7 +341,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     // Dedupe by (dtstart, dtend); when two slots collide on the same key,
     // keep the first and queue any persisted duplicate for deletion.
     const seenKeys = new Map<string, number>();
-    const upsertPayload: UpsertTimeslotBackend[] = [];
+    const upsertPayload: TimeSlotDTO[] = [];
     const extraDeleteIds: number[] = [];
     for (const slot of rawUpsert) {
       const key = `${slot.dtstart}_${slot.dtend}`;

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -10,7 +10,7 @@ export interface ScheduleRequest {
 export type SegmentVO = components['schemas']['MentorScheduleSegmentVO'];
 export type ScheduleData = components['schemas']['MentorScheduleQueryVO'];
 
-type TimeSlotDTO = components['schemas']['TimeSlotDTO'];
+export type TimeSlotDTO = components['schemas']['TimeSlotDTO'];
 
 interface ScheduleApiResponse {
   code: string;
@@ -33,15 +33,6 @@ export async function fetchMentorSchedule(
   }
 }
 
-export type UpsertTimeslotBackend = Pick<
-  TimeSlotDTO,
-  'dtstart' | 'dtend' | 'rrule'
-> & {
-  id?: number;
-  dt_type: 'ALLOW';
-  exdate: number[]; // nulls excluded from TimeSlotDTO.exdate
-};
-
 interface SaveScheduleResponse {
   code: string;
   msg: string;
@@ -52,7 +43,7 @@ type CleanObject = Record<string, unknown>;
 /** PUT /v1/mentors/:userId/schedule */
 export async function saveMentorSchedule(params: {
   userId: string;
-  timeslots: UpsertTimeslotBackend[];
+  timeslots: TimeSlotDTO[];
   until?: number | null;
 }): Promise<boolean> {
   const cleanOptional = (obj: CleanObject): CleanObject =>

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -6,7 +6,7 @@ import {
   deleteMentorSchedule,
   fetchMentorSchedule,
   saveMentorSchedule,
-  UpsertTimeslotBackend,
+  TimeSlotDTO,
 } from './schedule';
 
 export interface ScheduleMonthRef {
@@ -32,7 +32,7 @@ export async function loadMonthSchedule(
  */
 export async function syncMonthSchedule(params: {
   ref: ScheduleMonthRef;
-  upsertPayload: UpsertTimeslotBackend[];
+  upsertPayload: TimeSlotDTO[];
   deleteIds: number[];
 }): Promise<RawMentorTimeslot[] | null> {
   const { ref, upsertPayload, deleteIds } = params;

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -190,21 +190,10 @@ export async function fetchAllReservationLists(
  * PUT: Update reservation status
  * ================================ */
 
-export type UpdateReservationPayload = {
-  my_user_id: number | string;
-  my_status: 'ACCEPT' | 'PENDING' | 'REJECT';
-  user_id: number | string;
-  schedule_id: number;
-  dtstart: number; // epoch seconds
-  dtend: number; // epoch seconds
-  messages?: Array<{ user_id: number | string; content: string }>;
-  previous_reserve?: Record<string, unknown> | null;
-};
-
 export async function updateReservationStatus(opts: {
   userId: string | number;
   reservationId: string | number;
-  body: UpdateReservationPayload;
+  body: components['schemas']['UpdateReservationDTO'];
   debug?: boolean;
 }): Promise<components['schemas']['ReservationVO']> {
   const { userId, reservationId, body, debug } = opts;
@@ -234,25 +223,15 @@ export async function updateReservationStatus(opts: {
  * POST: Create new reservation
  * ================================ */
 
-export type CreateReservationPayload = {
-  my_user_id: number | string;
-  my_status: 'ACCEPT' | 'PENDING' | 'REJECT';
-  user_id: number | string;
-  schedule_id: number;
-  dtstart: number; // epoch seconds
-  dtend: number; // epoch seconds
-  messages: Array<{ user_id: number | string; content: string }>;
-  previous_reserve: { reserve_id: number } | Record<string, never>;
-};
-
 /**
  * 新增預約（POST /v1/users/:user_id/reservations）
  *
- * @param opts.body.previous_reserve - 傳入 `{}` 表示新預約；傳入 `{ reserve_id: number }` 表示修改預約
+ * @param opts.body.previous_reserve - 修改預約時傳入 `{ reserve_id: number }`；
+ *   一般新預約可省略此欄位。
  */
 export async function createReservation(opts: {
   userId: string | number;
-  body: CreateReservationPayload;
+  body: components['schemas']['ReservationDTO'];
   debug?: boolean;
 }): Promise<components['schemas']['ReservationVO']> {
   const { userId, body, debug } = opts;

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -224,10 +224,10 @@ export async function updateReservationStatus(opts: {
  * ================================ */
 
 /**
- * 新增預約（POST /v1/users/:user_id/reservations）
+ * Create a reservation (POST /v1/users/:user_id/reservations)
  *
- * @param opts.body.previous_reserve - 修改預約時傳入 `{ reserve_id: number }`；
- *   一般新預約可省略此欄位。
+ * @param opts.body.previous_reserve - Pass `{ reserve_id: number }` when
+ *   rescheduling an existing booking; omit for a fresh reservation.
  */
 export async function createReservation(opts: {
   userId: string | number;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-26T04:35:57.666240Z
+       * @default 2026-04-27T15:54:40.580416Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-26T04:35:57.666249Z
+       * @default 2026-04-27T15:54:40.580424Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1541,11 +1541,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['ScheduleType'];
       /**
        * Dtstart
        * @example 1717203600
@@ -1606,6 +1603,14 @@ export interface components {
       desc?: string | null;
       /** Icon */
       icon?: string | null;
+    };
+    /** PreviousReserveRef */
+    PreviousReserveRef: {
+      /**
+       * Reserve Id
+       * @example 0
+       */
+      reserve_id?: number | null;
     };
     /**
      * ProfessionCategory
@@ -1824,9 +1829,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
     };
     /** ReservationInfoListVO */
     ReservationInfoListVO: {
@@ -1862,13 +1866,25 @@ export interface components {
        * @default 0
        */
       dtend: number;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
       /**
        * Messages
        * @default []
        */
       messages: components['schemas']['ReservationMessageVO'][] | null;
+    };
+    /** ReservationMessageDTO */
+    ReservationMessageDTO: {
+      /**
+       * User Id
+       * @example 0
+       */
+      user_id: number;
+      /**
+       * Content
+       * @example
+       */
+      content: string;
     };
     /** ReservationMessageVO */
     ReservationMessageVO: {
@@ -1921,9 +1937,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
-      /** Previous Reserve */
-      previous_reserve?: Record<string, never> | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
       /** Id */
       id?: number | null;
       /** @example PENDING */
@@ -1943,6 +1958,11 @@ export interface components {
       /** Confirm Password */
       confirm_password: string;
     };
+    /**
+     * ScheduleType
+     * @enum {string}
+     */
+    ScheduleType: 'ALLOW' | 'FORBIDDEN' | 'BOOKED' | 'PENDING';
     /** SearchMentorProfileListVO */
     SearchMentorProfileListVO: {
       /** Mentors */
@@ -2069,11 +2089,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['TimeSlotType'];
       /**
        * Dt Year
        * @example 2024
@@ -2115,6 +2132,11 @@ export interface components {
        */
       exdate: (number | null)[];
     };
+    /**
+     * TimeSlotType
+     * @enum {string}
+     */
+    TimeSlotType: 'ALLOW' | 'FORBIDDEN';
     /** TimeSlotVO */
     TimeSlotVO: {
       /**
@@ -2127,11 +2149,8 @@ export interface components {
        * @example 1
        */
       user_id: number;
-      /**
-       * Dt Type
-       * @example ALLOW
-       */
-      dt_type: string;
+      /** @example ALLOW */
+      dt_type: components['schemas']['TimeSlotType'];
       /**
        * Dt Year
        * @example 2024
@@ -2250,7 +2269,8 @@ export interface components {
        * Messages
        * @default []
        */
-      messages: Record<string, never>[] | null;
+      messages: components['schemas']['ReservationMessageDTO'][] | null;
+      previous_reserve?: components['schemas']['PreviousReserveRef'] | null;
     };
     /** ValidationError */
     ValidationError: {


### PR DESCRIPTION
## What Does This PR Do?

- Regenerate `src/types/api.ts` against the dev BFF spec (Xchange-Taiwan/X-Career-BFF#105) so the FE picks up `PreviousReserveRef`, `ReservationMessageDTO`, and the `TimeSlotType` / `ScheduleType` enums.
- Drop the hand-written `UpsertTimeslotBackend`; `saveMentorSchedule` and `syncMonthSchedule` now take the generated `TimeSlotDTO` directly. `user_id` and `timezone` are still normalized inside the service (path param + UTC), so callers pass placeholders that the service overwrites.
- Drop the hand-written `UpdateReservationPayload` / `CreateReservationPayload`; `updateReservationStatus` and `createReservation` now use the generated `UpdateReservationDTO` / `ReservationDTO`. Session user IDs are coerced to `number` at call sites because the generated DTOs no longer accept `string`.
- Remove the dead `previous_reserve: {}` sentinel from the three POST/PUT reservation call sites — the generated DTOs make the field optional, and there is no reschedule UI populating a real `reserve_id` yet.

Closes Xchange-Taiwan/X-Talent-Tracker#161 (partial — see "Anything to Note?").

## Demo

- http://localhost:3000/reservation/mentor
- http://localhost:3000/reservation/mentee

Mentee creates a reservation from a mentor's profile dialog; mentor accepts / rejects / cancels from the reservation list.

## Screenshot

N/A

## Anything to Note?

- **`ExperienceDTO` replacement is held back.** The regenerated spec types `mentor_experiences_metadata` as `Record<string, never>` (empty object, no keys allowed), which would break every existing FE call site that sends real metadata fields. Tracked as BFF follow-up Xchange-Taiwan/X-Career-BFF#107; once that spec fix is deployed to dev, a small follow-up FE PR will swap `MentorExperiencePayload` for `ExperienceDTO`.
- **Manual smoke test:** mentor + mentee flows on dev — create / accept / reject / cancel — please re-run before merging.
- **BFF spec follow-up (already noted in #161):** after this ships, BFF can tighten `PreviousReserveRef.reserve_id` from `Optional[int]` to required, since the FE no longer sends `previous_reserve: {}`.