### PR TITLE
feat: two-level CategoryMultiSelect with cap 10 across onboarding + profile edit

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -94,7 +94,7 @@ export default function OnboardingContainer() {
     defaultValues: {
       location: 'TWN',
       years_of_experience: '',
-      industry: '',
+      industry: [],
     },
   });
   const onSubmitStep2 = (data: z.infer<typeof step2Schema>) => {

--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -270,14 +270,7 @@ export default function Page({
             />
           </Section>
 
-          <Section
-            id="industry"
-            title={
-              <>
-                <span className="text-status-200">* </span>產業
-              </>
-            }
-          >
+          <Section id="industry" title="產業 (選填)">
             <CategoryMultiSelectField
               form={form}
               name="industry"

--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -9,13 +9,13 @@ import { FieldErrors, useForm } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
+import { CategoryMultiSelectField } from '@/components/profile/edit/CategoryMultiSelectField';
 import { EditPageHeader } from '@/components/profile/edit/EditPageHeader';
 import {
   SelectField,
   TextareaField,
   TextField,
 } from '@/components/profile/edit/Fields';
-import { MultiSelectField } from '@/components/profile/edit/MultiSelectField';
 import {
   createProfileFormSchema,
   defaultValues,
@@ -30,8 +30,11 @@ import useExpertises from '@/hooks/user/expertises/useExpertises';
 import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests from '@/hooks/user/interests/useInterests';
 import { useEditProfileData } from '@/hooks/user/profile/useEditProfileData';
-import { useProfileSelectOptions } from '@/hooks/user/profile/useProfileSelectOptions';
 import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
+import {
+  flattenAsSingleCategory,
+  groupAsPlaceholderCategories,
+} from '@/lib/profile/categoryGrouping';
 
 const JobExperienceSection = dynamic(async () => {
   const m = await import('@/components/profile/edit/JobExperienceSection');
@@ -94,18 +97,13 @@ export default function Page({
     setIsPageLoading,
   });
 
-  const {
-    whatIOfferTopicsList,
-    expertisedList,
-    interestedPositionList,
-    interestedSkillsList,
-    interestedTopicsList,
-  } = useProfileSelectOptions({
-    topics,
-    expertises,
-    interestedPositions,
-    skills,
-  });
+  const industryCategories = flattenAsSingleCategory(industries);
+  const whatIOfferCategories = groupAsPlaceholderCategories(topics);
+  const expertisesCategories = groupAsPlaceholderCategories(expertises);
+  const interestedPositionCategories =
+    groupAsPlaceholderCategories(interestedPositions);
+  const skillsCategories = groupAsPlaceholderCategories(skills);
+  const topicsCategories = groupAsPlaceholderCategories(topics);
 
   const scrollToField = (fieldId: string) => {
     document
@@ -208,14 +206,12 @@ export default function Page({
                 </>
               }
             >
-              <MultiSelectField
+              <CategoryMultiSelectField
                 form={form}
                 name="what_i_offer"
-                options={whatIOfferTopicsList}
-                placeholder="我能提供的服務"
-                variant="primaryAlt"
-                animation={2}
-                maxCount={3}
+                categories={whatIOfferCategories}
+                maxSelected={10}
+                searchPlaceholder="搜尋服務"
               />
             </Section>
           )}
@@ -229,14 +225,12 @@ export default function Page({
                 </>
               }
             >
-              <MultiSelectField
+              <CategoryMultiSelectField
                 form={form}
                 name="expertises"
-                options={expertisedList}
-                placeholder="專業能力"
-                variant="primaryAlt"
-                animation={2}
-                maxCount={3}
+                categories={expertisesCategories}
+                maxSelected={10}
+                searchPlaceholder="搜尋專業能力"
               />
             </Section>
           )}
@@ -284,14 +278,13 @@ export default function Page({
               </>
             }
           >
-            <SelectField
+            <CategoryMultiSelectField
               form={form}
               name="industry"
-              placeholder="請選擇產業"
-              options={industries.map((loc) => ({
-                value: loc.subject_group,
-                label: loc.subject,
-              }))}
+              categories={industryCategories}
+              flat
+              maxSelected={10}
+              searchPlaceholder="搜尋產業"
             />
           </Section>
 
@@ -303,14 +296,12 @@ export default function Page({
               </>
             }
           >
-            <MultiSelectField
+            <CategoryMultiSelectField
               form={form}
               name="interested_positions"
-              options={interestedPositionList}
-              placeholder="有興趣多了解的職位"
-              variant="primaryAlt"
-              animation={2}
-              maxCount={3}
+              categories={interestedPositionCategories}
+              maxSelected={10}
+              searchPlaceholder="搜尋職位"
             />
           </Section>
 
@@ -322,14 +313,12 @@ export default function Page({
               </>
             }
           >
-            <MultiSelectField
+            <CategoryMultiSelectField
               form={form}
               name="skills"
-              options={interestedSkillsList}
-              placeholder="想多了解、加強的技能"
-              variant="primaryAlt"
-              animation={2}
-              maxCount={3}
+              categories={skillsCategories}
+              maxSelected={10}
+              searchPlaceholder="搜尋技能"
             />
           </Section>
 
@@ -341,14 +330,12 @@ export default function Page({
               </>
             }
           >
-            <MultiSelectField
+            <CategoryMultiSelectField
               form={form}
               name="topics"
-              options={interestedTopicsList}
-              placeholder="想多了解的主題"
-              variant="primaryAlt"
-              animation={2}
-              maxCount={3}
+              categories={topicsCategories}
+              maxSelected={10}
+              searchPlaceholder="搜尋主題"
             />
           </Section>
 

--- a/src/components/onboarding/steps/GroupedSelections.tsx
+++ b/src/components/onboarding/steps/GroupedSelections.tsx
@@ -1,0 +1,137 @@
+'use client';
+
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import * as React from 'react';
+
+import type {
+  Category,
+  CategoryOption,
+} from '@/components/ui/category-multi-select';
+import { cn } from '@/lib/utils';
+
+interface RenderItemArgs {
+  checked: boolean;
+  disabled: boolean;
+  onToggle: () => void;
+}
+
+export interface GroupedSelectionsProps {
+  categories: Category[];
+  value: string[];
+  onChange: (next: string[]) => void;
+  maxSelected?: number;
+  layoutClass: string;
+  renderItem: (opt: CategoryOption, args: RenderItemArgs) => React.ReactNode;
+}
+
+export const GroupedSelections: React.FC<GroupedSelectionsProps> = ({
+  categories,
+  value,
+  onChange,
+  maxSelected = 10,
+  layoutClass,
+  renderItem,
+}) => {
+  const [openMap, setOpenMap] = React.useState<Record<string, boolean>>(() =>
+    Object.fromEntries(categories.map((c) => [c.key, true]))
+  );
+
+  React.useEffect(() => {
+    setOpenMap((prev) => {
+      const next = { ...prev };
+      categories.forEach((c) => {
+        if (next[c.key] === undefined) next[c.key] = true;
+      });
+      return next;
+    });
+  }, [categories]);
+
+  const selectedSet = React.useMemo(() => new Set(value), [value]);
+  const limitReached = value.length >= maxSelected;
+
+  const toggleOption = (optionValue: string): void => {
+    if (selectedSet.has(optionValue)) {
+      onChange(value.filter((v) => v !== optionValue));
+      return;
+    }
+    if (limitReached) return;
+    onChange([...value, optionValue]);
+  };
+
+  const toggleSection = (key: string): void => {
+    setOpenMap((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  return (
+    <div className="space-y-6">
+      <p
+        className={cn(
+          'text-sm tabular-nums',
+          limitReached ? 'text-status-200' : 'text-text-tertiary'
+        )}
+        aria-live="polite"
+      >
+        已選 {value.length} / {maxSelected}
+        {limitReached ? ' — 取消其他項目以繼續選擇' : ''}
+      </p>
+
+      {categories.map((cat) => {
+        const open = Boolean(openMap[cat.key]);
+        const selectedInCat = cat.options.reduce(
+          (acc, o) => acc + (selectedSet.has(o.value) ? 1 : 0),
+          0
+        );
+
+        return (
+          <section key={cat.key} className="space-y-3">
+            <button
+              type="button"
+              onClick={() => toggleSection(cat.key)}
+              className="flex w-full items-center justify-between"
+              aria-expanded={open}
+            >
+              <span className="flex items-center gap-2">
+                {open ? (
+                  <ChevronDown className="h-5 w-5 text-text-secondary" />
+                ) : (
+                  <ChevronRight className="h-5 w-5 text-text-secondary" />
+                )}
+                <h3 className="text-base font-semibold text-text-primary">
+                  {cat.label}
+                </h3>
+              </span>
+              <span
+                className={cn(
+                  'rounded-full px-2.5 py-0.5 text-sm tabular-nums',
+                  selectedInCat > 0
+                    ? 'bg-brand-100 text-brand-700'
+                    : 'text-text-tertiary'
+                )}
+              >
+                {selectedInCat} / {cat.options.length}
+              </span>
+            </button>
+
+            {open && (
+              <div className={layoutClass}>
+                {cat.options.map((opt) => {
+                  const checked = selectedSet.has(opt.value);
+                  const disabled = !checked && limitReached;
+                  return (
+                    <React.Fragment key={opt.value}>
+                      {renderItem(opt, {
+                        checked,
+                        disabled,
+                        onToggle: () => toggleOption(opt.value),
+                      })}
+                    </React.Fragment>
+                  );
+                })}
+              </div>
+            )}
+          </section>
+        );
+      })}
+    </div>
+  );
+};

--- a/src/components/onboarding/steps/InterestedPosition.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.tsx
@@ -4,17 +4,17 @@ import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { Checkbox } from '@/components/ui/checkbox';
 import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { groupAsPlaceholderCategories } from '@/lib/profile/categoryGrouping';
 import { cn } from '@/lib/utils';
 import { InterestVO } from '@/services/profile/interests';
 
+import { GroupedSelections } from './GroupedSelections';
 import { step3Schema } from './index';
 
 interface Props {
@@ -26,68 +26,43 @@ export const InterestedPosition: FC<Props> = ({
   form,
   interestedPositionOptions,
 }) => {
+  const categories = groupAsPlaceholderCategories(interestedPositionOptions);
+
   return (
-    <>
-      <div className="flex flex-wrap gap-3">
-        {interestedPositionOptions.map((option) => (
-          <FormField
-            key={option.subject_group}
-            control={form.control}
-            name="interested_positions"
-            render={({ field }) => {
-              return (
-                <FormItem
-                  key={option.subject_group}
-                  className="flex flex-row items-start space-y-0"
+    <FormField
+      control={form.control}
+      name="interested_positions"
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <GroupedSelections
+              categories={categories}
+              value={field.value ?? []}
+              onChange={field.onChange}
+              maxSelected={10}
+              layoutClass="flex flex-wrap gap-3"
+              renderItem={(opt, { checked, disabled, onToggle }) => (
+                <button
+                  type="button"
+                  onClick={onToggle}
+                  disabled={disabled}
+                  className={cn(
+                    'rounded-xl border px-3 py-2 text-sm transition',
+                    checked
+                      ? 'border-primary bg-secondary text-text-primary'
+                      : 'border-gray-200 text-text-primary hover:border-primary',
+                    disabled &&
+                      'cursor-not-allowed opacity-50 hover:border-gray-200'
+                  )}
                 >
-                  <FormControl className="hidden">
-                    <Checkbox
-                      checked={field.value?.includes(option.subject_group)}
-                      onCheckedChange={(checked) => {
-                        return checked
-                          ? field.onChange([
-                              ...field.value,
-                              option.subject_group,
-                            ])
-                          : field.onChange(
-                              field.value?.filter(
-                                (value) => value !== option.subject_group
-                              )
-                            );
-                      }}
-                    />
-                  </FormControl>
-                  <FormLabel className="text-sm font-normal">
-                    <div
-                      key={`interestedRole ${option.subject_group}`}
-                      className={cn(
-                        'cursor-pointer rounded-xl border border-gray-200 px-3 py-2',
-                        field.value.includes(option.subject_group) &&
-                          'border-primary bg-secondary'
-                      )}
-                    >
-                      {option.subject ?? ''}
-                    </div>
-                  </FormLabel>
-                </FormItem>
-              );
-            }}
-          />
-        ))}
-      </div>
-      <div className="ml-1 mt-3">
-        <FormField
-          control={form.control}
-          name="interested_positions"
-          render={() => {
-            return (
-              <FormItem>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
-      </div>
-    </>
+                  {opt.label}
+                </button>
+              )}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };

--- a/src/components/onboarding/steps/PersonalInfo.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.tsx
@@ -103,7 +103,7 @@ export const PersonalInfo: FC<Props> = ({
           name="industry"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>產業</FormLabel>
+              <FormLabel>產業 (選填)</FormLabel>
               <FormControl>
                 <CategoryMultiSelect
                   flat

--- a/src/components/onboarding/steps/PersonalInfo.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.tsx
@@ -4,6 +4,7 @@ import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
+import { CategoryMultiSelect } from '@/components/ui/category-multi-select';
 import {
   FormControl,
   FormField,
@@ -18,6 +19,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { flattenAsSingleCategory } from '@/lib/profile/categoryGrouping';
 import { LocationType } from '@/services/profile/countries';
 import { ProfessionVO } from '@/services/profile/industries';
 
@@ -35,6 +37,8 @@ export const PersonalInfo: FC<Props> = ({
   locationOptions,
   industryOptions,
 }) => {
+  const industryCategories = flattenAsSingleCategory(industryOptions);
+
   return (
     <>
       <div className="flex flex-col gap-4">
@@ -99,24 +103,17 @@ export const PersonalInfo: FC<Props> = ({
           name="industry"
           render={({ field }) => (
             <FormItem>
-              <FormLabel>產業 (選填)</FormLabel>
-              <Select onValueChange={field.onChange} defaultValue={field.value}>
-                <FormControl>
-                  <SelectTrigger>
-                    <SelectValue placeholder="請選擇您的產業類別" />
-                  </SelectTrigger>
-                </FormControl>
-                <SelectContent>
-                  {industryOptions.map((option) => (
-                    <SelectItem
-                      key={`industry ${option.subject_group}`}
-                      value={option.subject_group}
-                    >
-                      {option.subject}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <FormLabel>產業</FormLabel>
+              <FormControl>
+                <CategoryMultiSelect
+                  flat
+                  categories={industryCategories}
+                  value={field.value ?? []}
+                  onChange={field.onChange}
+                  maxSelected={10}
+                  searchPlaceholder="搜尋產業"
+                />
+              </FormControl>
               <FormMessage />
             </FormItem>
           )}

--- a/src/components/onboarding/steps/SkillsToImprove.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.tsx
@@ -9,12 +9,13 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { groupAsPlaceholderCategories } from '@/lib/profile/categoryGrouping';
 import { cn } from '@/lib/utils';
 import { InterestVO } from '@/services/profile/interests';
 
+import { GroupedSelections } from './GroupedSelections';
 import { step4Schema } from './index';
 
 interface Props {
@@ -23,63 +24,44 @@ interface Props {
 }
 
 export const SkillsToImprove: FC<Props> = ({ form, skillOptions }) => {
+  const categories = groupAsPlaceholderCategories(skillOptions);
+
   return (
-    <>
-      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
-        {skillOptions.map((option) => (
-          <FormField
-            key={option.subject_group}
-            control={form.control}
-            name="skills"
-            render={({ field }) => {
-              return (
-                <FormItem
-                  key={option.subject_group}
+    <FormField
+      control={form.control}
+      name="skills"
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <GroupedSelections
+              categories={categories}
+              value={field.value ?? []}
+              onChange={field.onChange}
+              maxSelected={10}
+              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
+              renderItem={(opt, { checked, disabled, onToggle }) => (
+                <label
                   className={cn(
-                    'flex items-center space-y-0 rounded-xl border border-gray-200 pl-3',
-                    field.value.includes(option.subject_group) &&
-                      'border-primary bg-secondary'
+                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
+                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
+                    disabled && 'cursor-not-allowed opacity-50'
                   )}
                 >
-                  <FormControl>
-                    <Checkbox
-                      checked={field.value?.includes(option.subject_group)}
-                      onCheckedChange={(checked) => {
-                        return checked
-                          ? field.onChange([
-                              ...field.value,
-                              option.subject_group,
-                            ])
-                          : field.onChange(
-                              field.value?.filter(
-                                (value) => value !== option.subject_group
-                              )
-                            );
-                      }}
-                    />
-                  </FormControl>
-                  <FormLabel className="grow cursor-pointer px-4 py-3 text-base font-normal">
-                    {option.subject ?? ''}
-                  </FormLabel>
-                </FormItem>
-              );
-            }}
-          />
-        ))}
-      </div>
-      <div className="ml-1 mt-3">
-        <FormField
-          control={form.control}
-          name="skills"
-          render={() => {
-            return (
-              <FormItem>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
-      </div>
-    </>
+                  <Checkbox
+                    checked={checked}
+                    disabled={disabled}
+                    onCheckedChange={onToggle}
+                  />
+                  <span className="text-base text-text-primary">
+                    {opt.label}
+                  </span>
+                </label>
+              )}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -1,7 +1,6 @@
 'use client';
 
-import Image from 'next/image';
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -26,11 +25,6 @@ interface Props {
 
 export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
   const categories = groupAsPlaceholderCategories(topicOptions);
-  const optionMap = useMemo(() => {
-    const map = new Map<string, InterestVO>();
-    topicOptions.forEach((t) => map.set(t.subject_group, t));
-    return map;
-  }, [topicOptions]);
 
   return (
     <FormField
@@ -44,50 +38,25 @@ export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
               value={field.value ?? []}
               onChange={field.onChange}
               maxSelected={10}
-              layoutClass="grid grid-cols-1 gap-4"
-              renderItem={(opt, { checked, disabled, onToggle }) => {
-                const meta = optionMap.get(opt.value);
-                const icon = meta?.desc?.icon;
-                const desc = meta?.desc?.desc;
-                return (
-                  <label
-                    className={cn(
-                      'flex cursor-pointer items-start gap-4 rounded-xl border px-4 py-3',
-                      checked
-                        ? 'border-primary bg-secondary'
-                        : 'border-gray-200',
-                      disabled && 'cursor-not-allowed opacity-50'
-                    )}
-                  >
-                    <div className="rounded-full bg-[#EBFBFB] p-3">
-                      {icon && (
-                        <Image
-                          src={icon}
-                          alt={desc ?? '主題圖示'}
-                          width={24}
-                          height={24}
-                          sizes="24px"
-                          className="object-contain"
-                        />
-                      )}
-                    </div>
-                    <div className="grow">
-                      <p className="text-base font-normal text-text-primary">
-                        {opt.label}
-                      </p>
-                      {desc && (
-                        <p className="text-sm text-text-tertiary">{desc}</p>
-                      )}
-                    </div>
-                    <Checkbox
-                      checked={checked}
-                      disabled={disabled}
-                      onCheckedChange={onToggle}
-                      className="mt-1"
-                    />
-                  </label>
-                );
-              }}
+              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
+              renderItem={(opt, { checked, disabled, onToggle }) => (
+                <label
+                  className={cn(
+                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
+                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
+                    disabled && 'cursor-not-allowed opacity-50'
+                  )}
+                >
+                  <Checkbox
+                    checked={checked}
+                    disabled={disabled}
+                    onCheckedChange={onToggle}
+                  />
+                  <span className="text-base text-text-primary">
+                    {opt.label}
+                  </span>
+                </label>
+              )}
             />
           </FormControl>
           <FormMessage />

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -10,12 +10,13 @@ import {
   FormControl,
   FormField,
   FormItem,
-  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
+import { groupAsPlaceholderCategories } from '@/lib/profile/categoryGrouping';
 import { cn } from '@/lib/utils';
 import { InterestVO } from '@/services/profile/interests';
 
+import { GroupedSelections } from './GroupedSelections';
 import { step5Schema } from './index';
 
 interface Props {
@@ -24,30 +25,45 @@ interface Props {
 }
 
 export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
+  const categories = groupAsPlaceholderCategories(topicOptions);
+  const optionMap = useMemo(() => {
+    const map = new Map<string, InterestVO>();
+    topicOptions.forEach((t) => map.set(t.subject_group, t));
+    return map;
+  }, [topicOptions]);
+
   return (
-    <>
-      <div className="grid grid-cols-1 gap-4">
-        {topicOptions.map((option) => (
-          <FormField
-            key={option.subject_group}
-            control={form.control}
-            name="topics"
-            render={({ field }) => {
-              return (
-                <FormItem
-                  key={option.subject_group}
-                  className={cn(
-                    'flex items-start gap-2 rounded-xl border border-gray-200 px-4 py-3',
-                    field.value.includes(option.subject_group) &&
-                      'border-primary bg-secondary'
-                  )}
-                >
-                  <FormLabel className="flex grow cursor-pointer gap-4 ">
+    <FormField
+      control={form.control}
+      name="topics"
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <GroupedSelections
+              categories={categories}
+              value={field.value ?? []}
+              onChange={field.onChange}
+              maxSelected={10}
+              layoutClass="grid grid-cols-1 gap-4"
+              renderItem={(opt, { checked, disabled, onToggle }) => {
+                const meta = optionMap.get(opt.value);
+                const icon = meta?.desc?.icon;
+                const desc = meta?.desc?.desc;
+                return (
+                  <label
+                    className={cn(
+                      'flex cursor-pointer items-start gap-4 rounded-xl border px-4 py-3',
+                      checked
+                        ? 'border-primary bg-secondary'
+                        : 'border-gray-200',
+                      disabled && 'cursor-not-allowed opacity-50'
+                    )}
+                  >
                     <div className="rounded-full bg-[#EBFBFB] p-3">
-                      {option.desc?.icon && (
+                      {icon && (
                         <Image
-                          src={option.desc.icon ?? ''}
-                          alt={option.desc?.desc ?? '主題圖示'}
+                          src={icon}
+                          alt={desc ?? '主題圖示'}
                           width={24}
                           height={24}
                           sizes="24px"
@@ -55,52 +71,28 @@ export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
                         />
                       )}
                     </div>
-
-                    <div>
+                    <div className="grow">
                       <p className="text-base font-normal text-text-primary">
-                        {option.subject ?? ''}
+                        {opt.label}
                       </p>
-                      <p className=" text-sm text-text-tertiary">
-                        {option.desc?.desc}
-                      </p>
+                      {desc && (
+                        <p className="text-sm text-text-tertiary">{desc}</p>
+                      )}
                     </div>
-                  </FormLabel>
-                  <FormControl>
                     <Checkbox
-                      checked={field.value?.includes(option.subject_group)}
-                      onCheckedChange={(checked) => {
-                        return checked
-                          ? field.onChange([
-                              ...field.value,
-                              option.subject_group,
-                            ])
-                          : field.onChange(
-                              field.value?.filter(
-                                (value) => value !== option.subject_group
-                              )
-                            );
-                      }}
+                      checked={checked}
+                      disabled={disabled}
+                      onCheckedChange={onToggle}
+                      className="mt-1"
                     />
-                  </FormControl>
-                </FormItem>
-              );
-            }}
-          />
-        ))}
-      </div>
-      <div className="ml-1 mt-3">
-        <FormField
-          control={form.control}
-          name="topics"
-          render={() => {
-            return (
-              <FormItem>
-                <FormMessage />
-              </FormItem>
-            );
-          }}
-        />
-      </div>
-    </>
+                  </label>
+                );
+              }}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
   );
 };

--- a/src/components/onboarding/steps/index.ts
+++ b/src/components/onboarding/steps/index.ts
@@ -16,10 +16,7 @@ export const step1Schema = z.object({
 export const step2Schema = z.object({
   location: z.string({ required_error: '請選擇地區' }),
   years_of_experience: z.string().min(1, '請選擇您的年資區間'),
-  industry: z
-    .array(z.string())
-    .min(1, '請選擇您的產業類別')
-    .max(10, '最多選 10 個'),
+  industry: z.array(z.string()).max(10, '最多選 10 個'),
 });
 
 export const step3Schema = z.object({

--- a/src/components/onboarding/steps/index.ts
+++ b/src/components/onboarding/steps/index.ts
@@ -16,19 +16,31 @@ export const step1Schema = z.object({
 export const step2Schema = z.object({
   location: z.string({ required_error: '請選擇地區' }),
   years_of_experience: z.string().min(1, '請選擇您的年資區間'),
-  industry: z.string({ required_error: '請選擇您的產業類別' }),
+  industry: z
+    .array(z.string())
+    .min(1, '請選擇您的產業類別')
+    .max(10, '最多選 10 個'),
 });
 
 export const step3Schema = z.object({
-  interested_positions: z.array(z.string()).min(1, '請至少選擇一個職位'),
+  interested_positions: z
+    .array(z.string())
+    .min(1, '請至少選擇一個職位')
+    .max(10, '最多選 10 個'),
 });
 
 export const step4Schema = z.object({
-  skills: z.array(z.string()).min(1, '請至少選擇一個技能'),
+  skills: z
+    .array(z.string())
+    .min(1, '請至少選擇一個技能')
+    .max(10, '最多選 10 個'),
 });
 
 export const step5Schema = z.object({
-  topics: z.array(z.string()).min(1, '請至少選擇一個主題'),
+  topics: z
+    .array(z.string())
+    .min(1, '請至少選擇一個主題')
+    .max(10, '最多選 10 個'),
 });
 
 export const formSchema = step1Schema

--- a/src/components/profile/edit/CategoryMultiSelectField.tsx
+++ b/src/components/profile/edit/CategoryMultiSelectField.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { FieldPath, FieldValues, UseFormReturn } from 'react-hook-form';
+
+import {
+  type Category,
+  CategoryMultiSelect,
+} from '@/components/ui/category-multi-select';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@/components/ui/form';
+
+interface CategoryMultiSelectFieldProps<T extends FieldValues> {
+  form: UseFormReturn<T>;
+  name: FieldPath<T>;
+  categories: Category[];
+  flat?: boolean;
+  maxSelected?: number;
+  searchPlaceholder?: string;
+}
+
+export function CategoryMultiSelectField<T extends FieldValues>({
+  form,
+  name,
+  categories,
+  flat = false,
+  maxSelected = 10,
+  searchPlaceholder,
+}: CategoryMultiSelectFieldProps<T>) {
+  return (
+    <FormField
+      control={form.control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <CategoryMultiSelect
+              flat={flat}
+              categories={categories}
+              value={(field.value as string[]) ?? []}
+              onChange={field.onChange}
+              maxSelected={maxSelected}
+              searchPlaceholder={searchPlaceholder ?? '搜尋'}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/components/profile/edit/profileSchema.ts
+++ b/src/components/profile/edit/profileSchema.ts
@@ -94,10 +94,7 @@ export const createProfileFormSchema = (isMentor: boolean) =>
       about: isMentor
         ? z.string().min(1, '請填寫關於我')
         : z.string().optional(),
-      industry: z
-        .array(z.string())
-        .min(1, '請選擇您的產業類別')
-        .max(10, '最多選 10 個'),
+      industry: z.array(z.string()).max(10, '最多選 10 個'),
       years_of_experience: z.string({ required_error: '請選擇經驗' }),
       work_experiences: z.array(jobSchema),
       educations: z.array(educationSchema),

--- a/src/components/profile/edit/profileSchema.ts
+++ b/src/components/profile/edit/profileSchema.ts
@@ -94,7 +94,10 @@ export const createProfileFormSchema = (isMentor: boolean) =>
       about: isMentor
         ? z.string().min(1, '請填寫關於我')
         : z.string().optional(),
-      industry: z.string(),
+      industry: z
+        .array(z.string())
+        .min(1, '請選擇您的產業類別')
+        .max(10, '最多選 10 個'),
       years_of_experience: z.string({ required_error: '請選擇經驗' }),
       work_experiences: z.array(jobSchema),
       educations: z.array(educationSchema),
@@ -105,14 +108,29 @@ export const createProfileFormSchema = (isMentor: boolean) =>
       youtube: youtubeLinkSchema,
       website: websiteLinkSchema,
       what_i_offer: isMentor
-        ? z.array(z.string()).min(1, '請至少選擇一個主題')
-        : z.array(z.string()),
+        ? z
+            .array(z.string())
+            .min(1, '請至少選擇一個主題')
+            .max(10, '最多選 10 個')
+        : z.array(z.string()).max(10, '最多選 10 個'),
       expertises: isMentor
-        ? z.array(z.string()).min(1, '請至少選擇一個技能')
-        : z.array(z.string()),
-      interested_positions: z.array(z.string()).min(1, '請至少選擇一個職位'),
-      skills: z.array(z.string()).min(1, '請至少選擇一個技能'),
-      topics: z.array(z.string()).min(1, '請至少選擇一個主題'),
+        ? z
+            .array(z.string())
+            .min(1, '請至少選擇一個技能')
+            .max(10, '最多選 10 個')
+        : z.array(z.string()).max(10, '最多選 10 個'),
+      interested_positions: z
+        .array(z.string())
+        .min(1, '請至少選擇一個職位')
+        .max(10, '最多選 10 個'),
+      skills: z
+        .array(z.string())
+        .min(1, '請至少選擇一個技能')
+        .max(10, '最多選 10 個'),
+      topics: z
+        .array(z.string())
+        .min(1, '請至少選擇一個主題')
+        .max(10, '最多選 10 個'),
     })
     .superRefine((data, ctx) => {
       if (isMentor) {
@@ -145,7 +163,7 @@ export const defaultValues: ProfileFormValues = {
   location: '',
   statement: '',
   about: '',
-  industry: '',
+  industry: [],
   years_of_experience: '',
   work_experiences: [],
   educations: [],

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -55,7 +55,9 @@ export function useEditProfileData({
           location: data.location || '',
           statement: data.personal_statement || '',
           about: data.about || '',
-          industry: data.industry?.subject_group || '',
+          industry: data.industry?.subject_group
+            ? [data.industry.subject_group]
+            : [],
           years_of_experience: data.years_of_experience || '',
           linkedin: parsedLinks.linkedin || defaultValues.linkedin,
           facebook: parsedLinks.facebook || defaultValues.facebook,

--- a/src/lib/profile/categoryGrouping.ts
+++ b/src/lib/profile/categoryGrouping.ts
@@ -1,0 +1,53 @@
+import type { Category } from '@/components/ui/category-multi-select';
+
+interface SubjectItem {
+  subject: string | null;
+  subject_group: string;
+}
+
+const PLACEHOLDER_BUCKET_LABELS = ['分類 A', '分類 B', '分類 C'] as const;
+
+function bucketIndex(key: string, total: number): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i += 1) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return hash % total;
+}
+
+/**
+ * Bucket flat option data into placeholder categories so the two-level UI
+ * works while the backend doesn't yet return grouped data. Hash-based bucket
+ * keeps each item in a stable section across renders.
+ */
+export function groupAsPlaceholderCategories(items: SubjectItem[]): Category[] {
+  const buckets = PLACEHOLDER_BUCKET_LABELS.map((label, idx) => ({
+    key: `placeholder-${idx}`,
+    label,
+    options: [] as Category['options'],
+  }));
+
+  items.forEach((item) => {
+    const idx = bucketIndex(item.subject_group, buckets.length);
+    buckets[idx].options.push({
+      value: item.subject_group,
+      label: item.subject ?? '',
+    });
+  });
+
+  return buckets.filter((b) => b.options.length > 0);
+}
+
+/** Flat single category — used for menus that intentionally have no grouping (e.g. industry). */
+export function flattenAsSingleCategory(items: SubjectItem[]): Category[] {
+  return [
+    {
+      key: 'all',
+      label: '全部',
+      options: items.map((i) => ({
+        value: i.subject_group,
+        label: i.subject ?? '',
+      })),
+    },
+  ];
+}

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -13,8 +13,10 @@ function isProfileSynced(
   if ((latest.about ?? '') !== (values.about ?? '')) return false;
   if ((latest.years_of_experience ?? '') !== (values.years_of_experience ?? ''))
     return false;
-  if ((latest.industry?.subject_group ?? '') !== (values.industry ?? ''))
-    return false;
+  const industryFirst = Array.isArray(values.industry)
+    ? (values.industry[0] ?? '')
+    : (values.industry ?? '');
+  if ((latest.industry?.subject_group ?? '') !== industryFirst) return false;
   if (avatar && latest.avatar !== avatar) return false;
   return true;
 }

--- a/src/services/profile/updateProfile.ts
+++ b/src/services/profile/updateProfile.ts
@@ -20,9 +20,18 @@ export async function updateProfile(
     throw new Error('未找到使用者 ID。請重新登入。');
   }
 
+  // Backend currently accepts a single industry string; the frontend models
+  // it as string[] (cap 10) for UI consistency with the other category menus.
+  // Drop the array down to its first element until the BFF accepts an array.
+  const { industry, ...rest } = profileData;
+  const industryPayload = Array.isArray(industry)
+    ? (industry[0] ?? '')
+    : industry;
+
   try {
     await apiClient.put(`/v1/mentors/${userId}/profile`, {
-      ...profileData,
+      ...rest,
+      industry: industryPayload,
       user_id: userId,
     });
   } catch (error) {


### PR DESCRIPTION
## What Does This PR Do?

- Onboarding steps 2-5 now use the two-level grouped picker pattern (option D from #459) with a 10-selection cap. Step 2 industry switches from single-select dropdown to flat multi-select; steps 3/4/5 keep their original chip / 2-col card / icon-card item styles inside collapsible category sections.
- Profile edit applies the same picker to industry, interested_positions, skills, topics, expertises, what_i_offer with cap 10 (was 3 via MultiSelectField).
- Adds shared `GroupedSelections` (RHF-friendly section accordion + count + max enforcement, with custom `renderItem`) and a `CategoryMultiSelectField` wrapper for profile edit.
- Adds `categoryGrouping` helper: `groupAsPlaceholderCategories` distributes flat option data into 3 placeholder buckets (分類 A/B/C) so the two-level UI works while the BFF doesn't yet return grouped data; `flattenAsSingleCategory` for industry's flat list.
- Schema: industry becomes `string[]` (min 1, max 10) in onboarding step2 and profile edit; .max(10) added to interested_positions / skills / topics / expertises / what_i_offer.
- Backend bridge: `updateProfile` collapses `industry: string[]` to its first element since the BFF still expects a single string. `pollUntilSynced` and `useEditProfileData` updated accordingly.
- Implements [X-Talent-Tracker issue #108](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/108).

## Demo

- http://localhost:3000/auth/onboarding (steps 2-5)
- http://localhost:3000/profile/<userId>/edit

## Screenshot

N/A

## Anything to Note?

- Category groupings are placeholders (hash-bucketed into 3 generic labels) until the BFF returns grouped data; replacing `groupAsPlaceholderCategories` will swap in real categories without further UI changes.
- Industry payload still ships as a single string. Once BFF accepts an array, the array→first-element conversion in `updateProfile` can be removed.
- Mentor profile edit `expertises` and `what_i_offer` were also bumped from cap 3 to cap 10 to stay consistent with the spec across roles.
- `MultiSelectField`, `useProfileSelectOptions`, and the underlying `multi-select.tsx` are now orphaned in this codebase but left in place to keep the diff focused; recommend a follow-up cleanup PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
