### PR TITLE
refactor: share profile DTO cache between view and edit pages

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -87,6 +87,7 @@ export default function Page({
   });
 
   useEditProfileData({
+    userId: Number(pageUserId),
     form,
     isAuthorized,
     isMentorOnboarding,

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -6,6 +6,7 @@ import {
   defaultValues,
   ProfileFormValues,
 } from '@/components/profile/edit/profileSchema';
+import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 import {
   parseEducations,
   parseLinks,
@@ -13,9 +14,9 @@ import {
   parseWorkExperiences,
 } from '@/lib/profile/parseUserExperiences';
 import { MentorExperiencePayload } from '@/services/profile/upsertExperience';
-import { fetchUser } from '@/services/profile/user';
 
 interface Options {
+  userId: number;
   form: UseFormReturn<ProfileFormValues>;
   isAuthorized: boolean;
   isMentorOnboarding: boolean;
@@ -24,81 +25,83 @@ interface Options {
 }
 
 export function useEditProfileData({
+  userId,
   form,
   isAuthorized,
   isMentorOnboarding,
   setIsMentor,
   setIsPageLoading,
 }: Options) {
+  // Pass userId only after auth resolves so we don't fetch a profile that
+  // the page would otherwise refuse to render.
+  const { userDto, error } = useUserProfileDto(
+    isAuthorized ? userId : 0,
+    'zh_TW'
+  );
+
   useEffect(() => {
-    if (!isAuthorized) return;
-    let cancelled = false;
+    if (!isAuthorized || !userDto) return;
 
-    async function fetchUserData() {
-      try {
-        const data = await fetchUser('zh_TW');
-        if (!data || cancelled) return;
+    const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
+    const experiences =
+      userDto.experiences as unknown as MentorExperiencePayload[];
 
-        const mentorFlag = Boolean(data.is_mentor || isMentorOnboarding);
-        const experiences =
-          data.experiences as unknown as MentorExperiencePayload[];
+    const parsedExperiences = parseWorkExperiences(experiences);
+    const parsedEducations = parseEducations(experiences);
+    const parsedLinks = parseLinks(experiences);
 
-        const parsedExperiences = parseWorkExperiences(experiences);
-        const parsedEducations = parseEducations(experiences);
-        const parsedLinks = parseLinks(experiences);
+    form.reset({
+      is_mentor: mentorFlag,
+      avatar: userDto.avatar || '',
+      avatarFile: undefined,
+      name: userDto.name || '',
+      location: userDto.location || '',
+      statement: userDto.personal_statement || '',
+      about: userDto.about || '',
+      industry: userDto.industry?.subject_group || '',
+      years_of_experience: userDto.years_of_experience || '',
+      linkedin: parsedLinks.linkedin || defaultValues.linkedin,
+      facebook: parsedLinks.facebook || defaultValues.facebook,
+      instagram: parsedLinks.instagram || defaultValues.instagram,
+      twitter: parsedLinks.twitter || defaultValues.twitter,
+      youtube: parsedLinks.youtube || defaultValues.youtube,
+      website: parsedLinks.website || defaultValues.website,
+      work_experiences: parsedExperiences || defaultValues.work_experiences,
+      educations: parsedEducations || defaultValues.educations,
+    });
 
-        form.reset({
-          is_mentor: mentorFlag,
-          avatar: data.avatar || '',
-          avatarFile: undefined,
-          name: data.name || '',
-          location: data.location || '',
-          statement: data.personal_statement || '',
-          about: data.about || '',
-          industry: data.industry?.subject_group || '',
-          years_of_experience: data.years_of_experience || '',
-          linkedin: parsedLinks.linkedin || defaultValues.linkedin,
-          facebook: parsedLinks.facebook || defaultValues.facebook,
-          instagram: parsedLinks.instagram || defaultValues.instagram,
-          twitter: parsedLinks.twitter || defaultValues.twitter,
-          youtube: parsedLinks.youtube || defaultValues.youtube,
-          website: parsedLinks.website || defaultValues.website,
-          work_experiences: parsedExperiences || defaultValues.work_experiences,
-          educations: parsedEducations || defaultValues.educations,
-        });
+    form.setValue(
+      'expertises',
+      userDto.expertises?.professions?.map((i) => i.subject_group) || []
+    );
+    form.setValue(
+      'interested_positions',
+      userDto.interested_positions?.interests?.map((i) => i.subject_group) || []
+    );
+    form.setValue(
+      'skills',
+      userDto.skills?.interests?.map((i) => i.subject_group) || []
+    );
+    form.setValue(
+      'topics',
+      userDto.topics?.interests?.map((i) => i.subject_group) || []
+    );
+    form.setValue('what_i_offer', parseWhatIOffer(experiences));
 
-        form.setValue(
-          'expertises',
-          data.expertises?.professions?.map((i) => i.subject_group) || []
-        );
-        form.setValue(
-          'interested_positions',
-          data.interested_positions?.interests?.map((i) => i.subject_group) ||
-            []
-        );
-        form.setValue(
-          'skills',
-          data.skills?.interests?.map((i) => i.subject_group) || []
-        );
-        form.setValue(
-          'topics',
-          data.topics?.interests?.map((i) => i.subject_group) || []
-        );
-        form.setValue('what_i_offer', parseWhatIOffer(experiences));
+    setIsMentor(mentorFlag);
+    setIsPageLoading(false);
+  }, [
+    userDto,
+    isAuthorized,
+    isMentorOnboarding,
+    form,
+    setIsMentor,
+    setIsPageLoading,
+  ]);
 
-        setIsMentor(mentorFlag);
-        setIsPageLoading(false);
-      } catch (err) {
-        if (!cancelled) {
-          console.error('Failed to fetch user data:', err);
-          setIsPageLoading(false);
-        }
-      }
-    }
-
-    fetchUserData();
-    return () => {
-      cancelled = true;
-    };
-  }, [isAuthorized, isMentorOnboarding, form, setIsMentor, setIsPageLoading]);
+  useEffect(() => {
+    if (!error) return;
+    console.error('Failed to fetch user data:', error);
+    setIsPageLoading(false);
+  }, [error, setIsPageLoading]);
 }

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -3,74 +3,22 @@ import { useEffect, useState } from 'react';
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 import { parseCurrentJob } from '@/lib/profile/parseUserExperiences';
 import { ExperienceType } from '@/services/profile/experienceType';
-import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
+import { MentorProfileVO } from '@/services/profile/user';
 
 import {
   getInterestsCached,
   type InterestsResult,
 } from '../interests/useInterests';
+import {
+  clearUserProfileDtoCache,
+  USER_PROFILE_DTO_CACHE_TTL_MS,
+  useUserProfileDto,
+} from './useUserProfileDto';
 
-export const USER_DATA_CACHE_TTL_MS = 60_000;
-
-interface CachedUserDtoEntry {
-  data: MentorProfileVO;
-  expiresAt: number;
-}
-
-interface CachedReadResult {
-  data: MentorProfileVO;
-  isStale: boolean;
-}
-
-const userDtoDataCache = new Map<string, CachedUserDtoEntry>();
-const userDtoPromiseCache = new Map<string, Promise<MentorProfileVO | null>>();
-
-function readFromDataCache(key: string): CachedReadResult | undefined {
-  const entry = userDtoDataCache.get(key);
-  if (!entry) return undefined;
-  return { data: entry.data, isStale: entry.expiresAt <= Date.now() };
-}
-
-/**
- * Removes a user's entry from the in-memory cache so the next call to
- * useUserData for that user triggers a fresh API fetch.  Call this after a
- * successful profile update to prevent any concurrent mount from receiving
- * stale data.
- */
-export function clearUserDataCache(userId: number, language: string): void {
-  const key = `${userId}-${language}`;
-  userDtoDataCache.delete(key);
-  userDtoPromiseCache.delete(key);
-}
-
-// Promise-deduped fetch: writes to the data cache on success so subsequent
-// readers (including a parallel-mounted hook) see the fresh entry. Concurrent
-// callers share the same in-flight promise to avoid duplicate network calls.
-function startFetchUserById(
-  userId: number,
-  language: string
-): Promise<MentorProfileVO | null> {
-  const key = `${userId}-${language}`;
-
-  const inflight = userDtoPromiseCache.get(key);
-  if (inflight) return inflight;
-
-  const promise = fetchUserById(userId, language)
-    .then((data) => {
-      if (data) {
-        userDtoDataCache.set(key, {
-          data,
-          expiresAt: Date.now() + USER_DATA_CACHE_TTL_MS,
-        });
-      }
-      return data;
-    })
-    .finally(() => {
-      userDtoPromiseCache.delete(key);
-    });
-  userDtoPromiseCache.set(key, promise);
-  return promise;
-}
+// Re-exported under the historical names so existing callers (e.g.
+// useProfileSubmit, useUserData.test) continue to work without churn.
+export const clearUserDataCache = clearUserProfileDtoCache;
+export const USER_DATA_CACHE_TTL_MS = USER_PROFILE_DTO_CACHE_TTL_MS;
 
 export interface InterestType {
   subject_group: string;
@@ -242,96 +190,37 @@ function parseUserDtoToUserType(
 }
 
 function useUserData(userId: number, language: string) {
+  const { userDto, isLoading, error } = useUserProfileDto(userId, language);
   const [userData, setUserData] = useState<UserType | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
-    const isLanguageValid = Boolean(language);
-
-    if (!isUserIdValid || !isLanguageValid) {
-      setUserData(null);
-      setError(null);
-      setIsLoading(false);
+    if (!userDto || !language) {
+      if (!userDto) setUserData(null);
       return;
     }
 
     let cancelled = false;
-    const key = `${userId}-${language}`;
-    const cachedEntry = readFromDataCache(key);
-    const interestsPromise = getInterestsCached(language);
 
-    const applyData = (
-      userDto: MentorProfileVO,
-      interests: InterestsResult
-    ) => {
-      if (cancelled) return;
-      const labelByGroup = new Map(
-        interests.whatIOffers.map(
-          (item) => [item.subject_group, item.subject ?? ''] as const
-        )
-      );
-      setUserData(parseUserDtoToUserType(userDto, labelByGroup));
-      setError(null);
-    };
-
-    // Cached path: render immediately from cache, then optionally
-    // revalidate in the background. Only a missing cache entry triggers
-    // a blocking load.
-    if (cachedEntry) {
-      setIsLoading(false);
-      interestsPromise
-        .then((interests) => applyData(cachedEntry.data, interests))
-        .catch((e) => {
-          console.error('Failed to load interests for cached user:', e);
-        });
-
-      if (cachedEntry.isStale) {
-        Promise.all([startFetchUserById(userId, language), interestsPromise])
-          .then(([userDto, interests]) => {
-            if (cancelled || !userDto) return;
-            applyData(userDto, interests);
-          })
-          .catch((e) => {
-            // Background revalidation failure: keep showing stale data,
-            // surface only via console (no error state flip).
-            console.error('Background user-data refetch failed:', e);
-          });
-      }
-
-      return () => {
-        cancelled = true;
-      };
-    }
-
-    setIsLoading(true);
-    setError(null);
-
-    Promise.all([startFetchUserById(userId, language), interestsPromise])
-      .then(([userDto, interests]) => {
+    getInterestsCached(language)
+      .then((interests: InterestsResult) => {
         if (cancelled) return;
-        if (!userDto) {
-          setUserData(null);
-          setError('User not found');
-          return;
-        }
-        applyData(userDto, interests);
+        const labelByGroup = new Map(
+          interests.whatIOffers.map(
+            (item) => [item.subject_group, item.subject ?? ''] as const
+          )
+        );
+        setUserData(parseUserDtoToUserType(userDto, labelByGroup));
       })
       .catch((e) => {
-        console.error('Failed to load user:', e);
-        if (cancelled) return;
-        setUserData(null);
-        setError('Failed to load user data');
-      })
-      .finally(() => {
-        if (!cancelled) setIsLoading(false);
+        // Interests-fetch failure leaves the previously rendered userData
+        // intact; surface only via console to keep the UX stable.
+        console.error('Failed to load interests for user:', e);
       });
 
     return () => {
       cancelled = true;
     };
-  }, [userId, language]);
+  }, [userDto, language]);
 
   return { userData, isLoading, error };
 }

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -1,0 +1,160 @@
+import { useEffect, useState } from 'react';
+
+import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
+
+export const USER_PROFILE_DTO_CACHE_TTL_MS = 60_000;
+
+interface CachedUserDtoEntry {
+  data: MentorProfileVO;
+  expiresAt: number;
+}
+
+interface CachedReadResult {
+  data: MentorProfileVO;
+  isStale: boolean;
+}
+
+const userDtoDataCache = new Map<string, CachedUserDtoEntry>();
+const userDtoPromiseCache = new Map<string, Promise<MentorProfileVO | null>>();
+
+function readFromDataCache(key: string): CachedReadResult | undefined {
+  const entry = userDtoDataCache.get(key);
+  if (!entry) return undefined;
+  return { data: entry.data, isStale: entry.expiresAt <= Date.now() };
+}
+
+/**
+ * Removes a user's entry from the in-memory cache so the next call to
+ * useUserProfileDto for that user triggers a fresh API fetch. Call this after
+ * a successful profile update to prevent any concurrent mount from receiving
+ * stale data.
+ */
+export function clearUserProfileDtoCache(
+  userId: number,
+  language: string
+): void {
+  const key = `${userId}-${language}`;
+  userDtoDataCache.delete(key);
+  userDtoPromiseCache.delete(key);
+}
+
+// Promise-deduped fetch: writes to the data cache on success so subsequent
+// readers (including a parallel-mounted hook) see the fresh entry. Concurrent
+// callers share the same in-flight promise to avoid duplicate network calls.
+function startFetchUserById(
+  userId: number,
+  language: string
+): Promise<MentorProfileVO | null> {
+  const key = `${userId}-${language}`;
+
+  const inflight = userDtoPromiseCache.get(key);
+  if (inflight) return inflight;
+
+  const promise = fetchUserById(userId, language)
+    .then((data) => {
+      if (data) {
+        userDtoDataCache.set(key, {
+          data,
+          expiresAt: Date.now() + USER_PROFILE_DTO_CACHE_TTL_MS,
+        });
+      }
+      return data;
+    })
+    .finally(() => {
+      userDtoPromiseCache.delete(key);
+    });
+  userDtoPromiseCache.set(key, promise);
+  return promise;
+}
+
+export interface UseUserProfileDtoResult {
+  userDto: MentorProfileVO | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Shared cache layer for the mentor profile DTO. Both the read-only profile
+ * view (useUserData) and the edit form (useEditProfileData) consume this hook
+ * so navigating between them within the cache TTL avoids duplicate API calls.
+ */
+export function useUserProfileDto(
+  userId: number,
+  language: string
+): UseUserProfileDtoResult {
+  const [userDto, setUserDto] = useState<MentorProfileVO | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
+    const isLanguageValid = Boolean(language);
+
+    if (!isUserIdValid || !isLanguageValid) {
+      setUserDto(null);
+      setError(null);
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const key = `${userId}-${language}`;
+    const cachedEntry = readFromDataCache(key);
+
+    // Cached path: render immediately from cache, then optionally
+    // revalidate in the background. Only a missing cache entry triggers
+    // a blocking load.
+    if (cachedEntry) {
+      setUserDto(cachedEntry.data);
+      setError(null);
+      setIsLoading(false);
+
+      if (cachedEntry.isStale) {
+        startFetchUserById(userId, language)
+          .then((data) => {
+            if (cancelled || !data) return;
+            setUserDto(data);
+          })
+          .catch((e) => {
+            // Background revalidation failure: keep showing stale data,
+            // surface only via console (no error state flip).
+            console.error('Background user-profile-dto refetch failed:', e);
+          });
+      }
+
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    startFetchUserById(userId, language)
+      .then((data) => {
+        if (cancelled) return;
+        if (!data) {
+          setUserDto(null);
+          setError('User not found');
+          return;
+        }
+        setUserDto(data);
+        setError(null);
+      })
+      .catch((e) => {
+        console.error('Failed to load user profile dto:', e);
+        if (cancelled) return;
+        setUserDto(null);
+        setError('Failed to load user data');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, language]);
+
+  return { userDto, isLoading, error };
+}


### PR DESCRIPTION
## What Does This PR Do?

- Extract the in-memory profile cache (60s TTL, stale-while-revalidate, promise dedup) out of `useUserData` into a new `useUserProfileDto` hook that returns the raw `MentorProfileVO`
- Refactor `useUserData` into a thin parser wrapper around `useUserProfileDto` + `getInterestsCached`; public signature unchanged
- Switch `useEditProfileData` to consume `useUserProfileDto` instead of calling `fetchUser` directly, so profile view and edit page now share one cache entry per `(userId, lang)`
- Re-export `clearUserDataCache` and `USER_DATA_CACHE_TTL_MS` from `useUserData` for backward compat (existing callers and tests untouched)
- Result: navigating Profile ↔ Edit within 60s makes zero extra API calls; save flow + cache invalidation in `useProfileSubmit` unchanged

Closes Xchange-Taiwan/X-Talent-Tracker#191

## Demo

http://localhost:3000/profile/{your-user-id}/edit

## Screenshot

N/A

## Anything to Note?

- Cache invalidation behavior preserved — `useProfileSubmit` still calls `clearUserDataCache` after save, so post-save Profile re-fetches fresh data
- All 7 existing `useUserData` cache tests pass without modification, confirming TTL / SWR / promise-dedup behavior is unchanged
- Out of scope (could be future ticket): writing the `pollUntilSynced` result back into the cache to skip Profile's post-save refetch
