### PR TITLE
perf(mentor-pool): SSR + ISR + Suspense streaming for first paint

### DIFF
--- a/src/app/mentor-pool/MentorGridSkeleton.tsx
+++ b/src/app/mentor-pool/MentorGridSkeleton.tsx
@@ -1,0 +1,43 @@
+const SKELETON_COUNT = 9;
+
+function CardSkeleton() {
+  return (
+    <div
+      aria-hidden="true"
+      className="w-[334px] animate-pulse overflow-hidden rounded-lg border border-[#E6E8EA] bg-background-white xl:h-[480px] xl:w-[413px]"
+    >
+      <div className="h-[200px] w-full bg-[#F2F4F7] xl:h-[260px]" />
+      <div className="px-4 pb-6 pt-4">
+        <div className="mb-3 h-5 w-2/3 rounded bg-[#F2F4F7]" />
+        <div className="mb-2 h-4 w-1/2 rounded bg-[#F2F4F7]" />
+        <div className="mb-4 h-3 w-full rounded bg-[#F2F4F7]" />
+        <div className="flex gap-2">
+          <div className="h-6 w-16 rounded-full bg-[#F2F4F7]" />
+          <div className="h-6 w-20 rounded-full bg-[#F2F4F7]" />
+          <div className="h-6 w-14 rounded-full bg-[#F2F4F7]" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function MentorGridSkeleton() {
+  return (
+    <section
+      aria-busy="true"
+      aria-label="導師清單載入中"
+      className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20"
+    >
+      <div className="mx-auto w-full max-w-[1280px]">
+        <div className="mb-5 h-6 w-32 animate-pulse rounded bg-[#F2F4F7]" />
+        <div className="flex flex-col items-center gap-6">
+          <div className="grid min-w-max grid-cols-1 gap-5 md:grid-cols-2 xl:grid-cols-3">
+            {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+              <CardSkeleton key={i} />
+            ))}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/app/mentor-pool/MentorPoolHero.tsx
+++ b/src/app/mentor-pool/MentorPoolHero.tsx
@@ -1,0 +1,7 @@
+export default function MentorPoolHero() {
+  return (
+    <section className="flex h-[202px] w-full items-center justify-center bg-[linear-gradient(to_right,#FFFFEF_0%,#FFF6FF_19%,#F7F2FB_42%,#E4FFFF_100%)] px-4 text-xl font-semibold md:text-3xl xl:rounded-br-[120px]">
+      和 Mentors 一起提升你的職涯經驗吧！
+    </section>
+  );
+}

--- a/src/app/mentor-pool/MentorPoolSearchBar.tsx
+++ b/src/app/mentor-pool/MentorPoolSearchBar.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import SearchBar from '@/components/ui/search-bar';
+
+import { useMentorPoolState } from './MentorPoolStateProvider';
+
+export default function MentorPoolSearchBar() {
+  const { setSearch } = useMentorPoolState();
+
+  const handleSearch = async (query: string) => {
+    setSearch(query);
+  };
+
+  return (
+    <div className="absolute left-[calc(50%-169px)] top-[172px] h-20 w-[338px] md:left-[calc(50%-344px)] md:w-[688px] xl:left-[calc(50%-423px)] xl:w-[846px]">
+      <SearchBar
+        onSearch={handleSearch}
+        mobilePlaceholder="搜尋職位、公司或領域"
+        tabletPlaceholder="搜尋職位、公司或想精進的領域"
+      />
+    </div>
+  );
+}

--- a/src/app/mentor-pool/MentorPoolStateProvider.tsx
+++ b/src/app/mentor-pool/MentorPoolStateProvider.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useState,
+} from 'react';
+
+import { SelectFilters } from '@/components/filter/MentorFilterDropdown';
+
+import { SESSION_KEY_FILTERS, SESSION_KEY_PATTERN } from './constants';
+
+interface MentorPoolState {
+  searchPattern: string;
+  selectedFilters: SelectFilters;
+  // True after sessionStorage restore has run; container uses this to gate
+  // the first client-side fetch so it doesn't race with SSR-provided data.
+  sessionRestored: boolean;
+  // True when sessionStorage held a persisted search/filter that requires the
+  // container to refetch on mount (overriding SSR-provided initial mentors).
+  hasRestoredState: boolean;
+  setSearch: (q: string) => void;
+  setFilters: (filters: SelectFilters) => void;
+  removeFilter: (key: string) => void;
+}
+
+const MentorPoolStateContext = createContext<MentorPoolState | null>(null);
+
+export function MentorPoolStateProvider({ children }: { children: ReactNode }) {
+  const [searchPattern, setSearchPattern] = useState('');
+  const [selectedFilters, setSelectedFilters] = useState<SelectFilters>({});
+  const [sessionRestored, setSessionRestored] = useState(false);
+  const [hasRestoredState, setHasRestoredState] = useState(false);
+
+  useEffect(() => {
+    let restored = false;
+    try {
+      const savedPattern = sessionStorage.getItem(SESSION_KEY_PATTERN);
+      const savedFilters = sessionStorage.getItem(SESSION_KEY_FILTERS);
+      if (savedPattern) {
+        setSearchPattern(savedPattern);
+        restored = true;
+      }
+      if (savedFilters) {
+        setSelectedFilters(JSON.parse(savedFilters));
+        restored = true;
+      }
+    } catch {
+      // sessionStorage unavailable (private browsing) — leave defaults
+    } finally {
+      setHasRestoredState(restored);
+      setSessionRestored(true);
+    }
+  }, []);
+
+  const setSearch = useCallback((q: string) => {
+    setSearchPattern(q);
+    try {
+      sessionStorage.setItem(SESSION_KEY_PATTERN, q);
+    } catch {}
+  }, []);
+
+  const setFilters = useCallback((filters: SelectFilters) => {
+    setSelectedFilters(filters);
+    try {
+      sessionStorage.setItem(SESSION_KEY_FILTERS, JSON.stringify(filters));
+    } catch {}
+  }, []);
+
+  const removeFilter = useCallback((key: string) => {
+    setSelectedFilters((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      try {
+        sessionStorage.setItem(SESSION_KEY_FILTERS, JSON.stringify(next));
+      } catch {}
+      return next;
+    });
+  }, []);
+
+  return (
+    <MentorPoolStateContext.Provider
+      value={{
+        searchPattern,
+        selectedFilters,
+        sessionRestored,
+        hasRestoredState,
+        setSearch,
+        setFilters,
+        removeFilter,
+      }}
+    >
+      {children}
+    </MentorPoolStateContext.Provider>
+  );
+}
+
+export function useMentorPoolState(): MentorPoolState {
+  const ctx = useContext(MentorPoolStateContext);
+  if (!ctx) {
+    throw new Error(
+      'useMentorPoolState must be used inside <MentorPoolStateProvider>'
+    );
+  }
+  return ctx;
+}

--- a/src/app/mentor-pool/MentorPoolWithData.tsx
+++ b/src/app/mentor-pool/MentorPoolWithData.tsx
@@ -1,0 +1,31 @@
+import avatarImage from '@/assets/default-avatar.png';
+import type { MentorType } from '@/services/search-mentor/mentors';
+import { fetchMentorsEnrichedServer } from '@/services/search-mentor/mentors.server';
+
+import { PAGE_LIMIT } from './constants';
+import MentorPoolContainer from './container';
+
+function resolveAvatar(mentor: MentorType): MentorType {
+  return {
+    ...mentor,
+    avatar:
+      typeof mentor.avatar === 'string' && mentor.avatar
+        ? `${mentor.avatar}${mentor.updated_at ? `?cb=${mentor.updated_at}` : ''}`
+        : avatarImage,
+  };
+}
+
+export default async function MentorPoolWithData() {
+  const initialMentors = (
+    await fetchMentorsEnrichedServer({ limit: PAGE_LIMIT, cursor: '' })
+  ).map(resolveAvatar);
+  const initialCursor = initialMentors.at(-1)?.updated_at?.toString() ?? '';
+
+  return (
+    <MentorPoolContainer
+      initialMentors={initialMentors}
+      initialCursor={initialCursor}
+      initialMentorCount={initialMentors.length}
+    />
+  );
+}

--- a/src/app/mentor-pool/constants.ts
+++ b/src/app/mentor-pool/constants.ts
@@ -1,0 +1,4 @@
+export const PAGE_LIMIT = 9;
+
+export const SESSION_KEY_PATTERN = 'mentor-pool:searchPattern';
+export const SESSION_KEY_FILTERS = 'mentor-pool:selectedFilters';

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -3,73 +3,49 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 import avatarImage from '@/assets/default-avatar.png';
-import { SelectFilters } from '@/components/filter/MentorFilterDropdown';
 import {
   fetchMentorsEnriched,
   MentorType,
 } from '@/services/search-mentor/mentors';
 
+import { PAGE_LIMIT } from './constants';
 import { filterOptions } from './data';
+import { useMentorPoolState } from './MentorPoolStateProvider';
 import MentorPoolUI from './ui';
 
-const PAGE_LIMIT = 9;
-const SESSION_KEY_PATTERN = 'mentor-pool:searchPattern';
-const SESSION_KEY_FILTERS = 'mentor-pool:selectedFilters';
+interface Props {
+  initialMentors: MentorType[];
+  initialCursor: string;
+  initialMentorCount: number;
+}
 
-export default function MentorPoolContainer() {
-  const [searchPattern, setSearchPattern] = useState('');
-  const [mentorCount, setMentorCount] = useState<number>(0);
-  const [mentors, setMentors] = useState<MentorType[]>([]);
-  const [selectedFilters, setSelectedFilters] = useState<SelectFilters>({});
+export default function MentorPoolContainer({
+  initialMentors,
+  initialCursor,
+  initialMentorCount,
+}: Props) {
+  const {
+    searchPattern,
+    selectedFilters,
+    sessionRestored,
+    hasRestoredState,
+    setFilters,
+    removeFilter,
+  } = useMentorPoolState();
+
+  const [mentorCount, setMentorCount] = useState<number>(initialMentorCount);
+  const [mentors, setMentors] = useState<MentorType[]>(initialMentors);
   const [isNoResults, setIsNoResults] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [isReplacing, setIsReplacing] = useState(false);
-  const [cursor, setCursor] = useState<string | undefined>('');
-  const [sessionRestored, setSessionRestored] = useState(false);
+  const [cursor, setCursor] = useState<string | undefined>(initialCursor);
   const isLoadingRef = useRef(false);
   // Monotonic counter — every fetch claims an id. Late responses whose id no
   // longer matches the current value are stale and must not touch state.
   const requestIdRef = useRef(0);
-
-  // Restore persisted search state before the first fetch
-  useEffect(() => {
-    try {
-      const savedPattern = sessionStorage.getItem(SESSION_KEY_PATTERN);
-      if (savedPattern !== null) setSearchPattern(savedPattern);
-
-      const savedFilters = sessionStorage.getItem(SESSION_KEY_FILTERS);
-      if (savedFilters) setSelectedFilters(JSON.parse(savedFilters));
-    } catch {
-      // sessionStorage unavailable (private browsing restrictions etc.) — ignore
-    } finally {
-      setSessionRestored(true);
-    }
-  }, []);
-
-  const handleFilterChange = useCallback((options: SelectFilters) => {
-    setSelectedFilters(options);
-    try {
-      sessionStorage.setItem(SESSION_KEY_FILTERS, JSON.stringify(options));
-    } catch {}
-  }, []);
-
-  const handleSearch = useCallback(async (queryWords: string) => {
-    setSearchPattern(queryWords);
-    try {
-      sessionStorage.setItem(SESSION_KEY_PATTERN, queryWords);
-    } catch {}
-  }, []);
-
-  const removeFilter = useCallback((key: string) => {
-    setSelectedFilters((prevFilters) => {
-      const newFilters = { ...prevFilters };
-      delete newFilters[key];
-      try {
-        sessionStorage.setItem(SESSION_KEY_FILTERS, JSON.stringify(newFilters));
-      } catch {}
-      return newFilters;
-    });
-  }, []);
+  // After the first run, treat further searchPattern/filter changes as user-
+  // driven and always refetch (regardless of restored state).
+  const didInitialRunRef = useRef(false);
 
   const fetchMentorsBySearch = useCallback(async () => {
     const myRequestId = ++requestIdRef.current;
@@ -166,12 +142,18 @@ export default function MentorPoolContainer() {
     await fetchMoreMentors();
   }, [mentors.length, fetchMoreMentors]);
 
-  // Only start fetching after sessionStorage has been read — avoids a wasted
-  // request with empty state immediately followed by one with the restored state.
+  // Drives both the initial restore-and-refetch and subsequent search/filter
+  // changes. On first run, only refetch if sessionStorage held persisted state
+  // (otherwise SSR-provided initial mentors are correct). After that, any
+  // search/filter change is user-driven and always refetches.
   useEffect(() => {
     if (!sessionRestored) return;
+    if (!didInitialRunRef.current) {
+      didInitialRunRef.current = true;
+      if (!hasRestoredState) return;
+    }
     fetchMentorsBySearch();
-  }, [sessionRestored, fetchMentorsBySearch]);
+  }, [sessionRestored, hasRestoredState, fetchMentorsBySearch]);
 
   return (
     <MentorPoolUI
@@ -182,8 +164,7 @@ export default function MentorPoolContainer() {
       isNoResults={isNoResults}
       selectedFilters={selectedFilters}
       filterOptions={filterOptions}
-      onSearch={handleSearch}
-      onFilterChange={handleFilterChange}
+      onFilterChange={setFilters}
       onRemoveFilter={removeFilter}
       onScrollToBottom={handleScrollToBottom}
     />

--- a/src/app/mentor-pool/page.tsx
+++ b/src/app/mentor-pool/page.tsx
@@ -1,5 +1,21 @@
-import MentorPoolContainer from './container';
+import { Suspense } from 'react';
+
+import MentorGridSkeleton from './MentorGridSkeleton';
+import MentorPoolHero from './MentorPoolHero';
+import MentorPoolSearchBar from './MentorPoolSearchBar';
+import { MentorPoolStateProvider } from './MentorPoolStateProvider';
+import MentorPoolWithData from './MentorPoolWithData';
 
 export default function Page() {
-  return <MentorPoolContainer />;
+  return (
+    <MentorPoolStateProvider>
+      <div className="relative">
+        <MentorPoolHero />
+        <MentorPoolSearchBar />
+      </div>
+      <Suspense fallback={<MentorGridSkeleton />}>
+        <MentorPoolWithData />
+      </Suspense>
+    </MentorPoolStateProvider>
+  );
 }

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -10,7 +10,6 @@ import MentorFilterDropdown from '@/components/filter/MentorFilterDropdown';
 import { MentorCardList } from '@/components/mentor-pool/mentor-card-list';
 import { Badge } from '@/components/ui/badge';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import SearchBar from '@/components/ui/search-bar';
 import { MentorType } from '@/services/search-mentor/mentors';
 
 interface Props {
@@ -21,7 +20,6 @@ interface Props {
   isNoResults: boolean;
   selectedFilters: SelectFilters;
   filterOptions: FilterOptions;
-  onSearch: (q: string) => Promise<void>;
   onFilterChange: (opts: SelectFilters) => void;
   onRemoveFilter: (key: string) => void;
   onScrollToBottom: () => Promise<void>;
@@ -35,7 +33,6 @@ export default function MentorPoolUI({
   isNoResults,
   selectedFilters,
   filterOptions,
-  onSearch,
   onFilterChange,
   onRemoveFilter,
   onScrollToBottom,
@@ -46,92 +43,80 @@ export default function MentorPoolUI({
   const showLoadMoreSpinner = hasMentors && isLoading && !isReplacing;
   const showNoResults = !hasMentors && !isLoading && isNoResults;
   return (
-    <div className="relative">
-      <section className="flex h-[202px] w-full items-center justify-center bg-[linear-gradient(to_right,#FFFFEF_0%,#FFF6FF_19%,#F7F2FB_42%,#E4FFFF_100%)] px-4 text-xl font-semibold md:text-3xl xl:rounded-br-[120px]">
-        和 Mentors 一起提升你的職涯經驗吧！
-      </section>
-      <div className="absolute left-[calc(50%-169px)] top-[172px] h-20 w-[338px] md:left-[calc(50%-344px)] md:w-[688px] xl:left-[calc(50%-423px)] xl:w-[846px]">
-        <SearchBar
-          onSearch={onSearch}
-          mobilePlaceholder="搜尋職位、公司或領域"
-          tabletPlaceholder="搜尋職位、公司或想精進的領域"
-        />
-      </div>
-      <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
-        <div className="mx-auto w-full max-w-[1280px] ">
-          <div className="item-center mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
-            <div
-              className={`text-base transition-opacity ${isReplacing ? 'opacity-50' : ''}`}
-            >
-              找到 {mentorCount} 位導師
-            </div>
-            <div className="grid w-full grid-cols-2 gap-3 md:flex md:w-fit">
-              <div className="block md:hidden"></div>
-              <MentorFilterDropdown
-                onChange={onFilterChange}
-                filterOptions={filterOptions}
-                selectOptions={selectedFilters}
-              />
-            </div>
+    <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
+      <div className="mx-auto w-full max-w-[1280px] ">
+        <div className="item-center mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
+          <div
+            className={`text-base transition-opacity ${isReplacing ? 'opacity-50' : ''}`}
+          >
+            找到 {mentorCount} 位導師
           </div>
-          <div className="mb-5 flex flex-wrap gap-3">
-            {Object.entries(selectedFilters).map(([key, filter]) => (
-              <Badge
-                key={key}
-                variant={'filter'}
-                className="text-sm font-medium leading-5"
-              >
-                <span>
-                  {filter.name}: {filter.value}
-                </span>
-                <button
-                  type="button"
-                  onClick={(event) => {
-                    event.stopPropagation();
-                    onRemoveFilter(key);
-                  }}
-                  aria-label={`移除「${filter.name}：${filter.value}」篩選`}
-                  className="bg-transparent inline-flex items-center rounded-sm p-0 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                >
-                  <XIcon className="h-4 w-4" aria-hidden />
-                </button>
-              </Badge>
-            ))}
+          <div className="grid w-full grid-cols-2 gap-3 md:flex md:w-fit">
+            <div className="block md:hidden"></div>
+            <MentorFilterDropdown
+              onChange={onFilterChange}
+              filterOptions={filterOptions}
+              selectOptions={selectedFilters}
+            />
           </div>
-          {hasMentors && (
-            <div className="relative mb-6">
-              <MentorCardList
-                mentors={mentors}
-                onScrollToBottom={onScrollToBottom}
-              />
-              {showOverlay && (
-                <div
-                  aria-busy="true"
-                  aria-live="polite"
-                  className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background-white/60"
-                >
-                  <LoadingSpinner size="lg" />
-                </div>
-              )}
-            </div>
-          )}
-          {showFullSpinner && (
-            <div className="flex h-full w-full items-center justify-center">
-              <LoadingSpinner size="lg" />
-            </div>
-          )}
-          {showLoadMoreSpinner && (
-            <div className="flex h-full w-full items-center justify-center">
-              <LoadingSpinner size="lg" />
-            </div>
-          )}
-          {showNoResults && (
-            <div className="mt-6 flex h-full w-full items-center justify-center">
-              <span className="text-xl md:text-3xl">找不到符合的導師</span>
-            </div>
-          )}
         </div>
-      </section>
-    </div>
+        <div className="mb-5 flex flex-wrap gap-3">
+          {Object.entries(selectedFilters).map(([key, filter]) => (
+            <Badge
+              key={key}
+              variant={'filter'}
+              className="text-sm font-medium leading-5"
+            >
+              <span>
+                {filter.name}: {filter.value}
+              </span>
+              <button
+                type="button"
+                onClick={(event) => {
+                  event.stopPropagation();
+                  onRemoveFilter(key);
+                }}
+                aria-label={`移除「${filter.name}：${filter.value}」篩選`}
+                className="bg-transparent inline-flex items-center rounded-sm p-0 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                <XIcon className="h-4 w-4" aria-hidden />
+              </button>
+            </Badge>
+          ))}
+        </div>
+        {hasMentors && (
+          <div className="relative mb-6">
+            <MentorCardList
+              mentors={mentors}
+              onScrollToBottom={onScrollToBottom}
+            />
+            {showOverlay && (
+              <div
+                aria-busy="true"
+                aria-live="polite"
+                className="pointer-events-none absolute inset-0 flex items-center justify-center bg-background-white/60"
+              >
+                <LoadingSpinner size="lg" />
+              </div>
+            )}
+          </div>
+        )}
+        {showFullSpinner && (
+          <div className="flex h-full w-full items-center justify-center">
+            <LoadingSpinner size="lg" />
+          </div>
+        )}
+        {showLoadMoreSpinner && (
+          <div className="flex h-full w-full items-center justify-center">
+            <LoadingSpinner size="lg" />
+          </div>
+        )}
+        {showNoResults && (
+          <div className="mt-6 flex h-full w-full items-center justify-center">
+            <span className="text-xl md:text-3xl">找不到符合的導師</span>
+          </div>
+        )}
+      </div>
+    </section>
   );
 }

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -1,0 +1,91 @@
+import type { StaticImageData } from 'next/image';
+
+import type { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
+import { parseCurrentJob } from '@/lib/profile/parseUserExperiences';
+import type { components } from '@/types/api';
+
+type RawMentor = components['schemas']['SearchMentorProfileVO'];
+type ExperienceCategory = components['schemas']['ExperienceCategory'];
+
+export type MentorListResponse =
+  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
+
+export type { WorkExperienceMetadata };
+
+export interface MentorExperienceBlock {
+  id: number;
+  category: ExperienceCategory;
+  order: number;
+  mentor_experiences_metadata?: Record<string, unknown>;
+}
+
+export interface MentorType {
+  user_id: number;
+  name: string;
+  avatar: string | StaticImageData;
+  job_title: string;
+  company: string;
+  years_of_experience: string;
+  location: string;
+  personal_statement: string;
+  about: string;
+  seniority_level: string;
+  interested_positions: string[];
+  skills: string[];
+  topics: string[];
+  industry: string | null;
+  expertises: string[];
+  experiences: MentorExperienceBlock[];
+  updated_at: number | null;
+}
+
+export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
+
+export interface MentorRequest {
+  searchPattern?: string;
+  filter_positions?: string;
+  filter_skills?: string;
+  filter_topics?: string;
+  filter_expertises?: string;
+  filter_industries?: string;
+  limit: number;
+  cursor?: string;
+}
+
+export function mapMentor(raw: RawMentor): MentorType {
+  const { job_title, company } = parseCurrentJob(
+    raw.experiences as
+      | { category?: string | null; mentor_experiences_metadata: unknown }[]
+      | null
+      | undefined
+  );
+
+  return {
+    user_id: raw.user_id,
+    name: raw.name ?? '',
+    avatar: raw.avatar ?? '',
+    job_title,
+    company,
+    years_of_experience: raw.years_of_experience ?? '',
+    location: raw.location ?? '',
+    personal_statement: raw.personal_statement ?? '',
+    about: raw.about ?? '',
+    seniority_level: raw.seniority_level ?? '',
+    interested_positions:
+      raw.interested_positions?.interests?.map((i) => i.subject_group) ?? [],
+    skills: raw.skills?.interests?.map((i) => i.subject_group) ?? [],
+    topics: raw.topics?.interests?.map((i) => i.subject_group) ?? [],
+    industry: raw.industry?.subject ?? null,
+    expertises: raw.expertises?.professions?.map((p) => p.subject) ?? [],
+    experiences: (raw.experiences ?? []).map((e) => ({
+      id: e.id,
+      category: e.category ?? 'WORK',
+      order: e.order,
+      mentor_experiences_metadata: e.mentor_experiences_metadata as Record<
+        string,
+        unknown
+      >,
+    })),
+    updated_at: raw.updated_at ?? null,
+  };
+}

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -1,0 +1,100 @@
+import type { components } from '@/types/api';
+
+import { mapMentor, type MentorRequest, type MentorType } from './mapMentor';
+
+type MentorListResponse =
+  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
+type InterestListResponse =
+  components['schemas']['ApiResponse_InterestListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// mentor pool data is not realtime — ISR keeps LCP fast and limits BFF load
+const REVALIDATE_SECONDS = 60;
+
+function buildUrl(
+  path: string,
+  params?: Record<string, string | number | undefined | null>
+): string {
+  const url = `${BASE_URL}${path}`;
+  if (!params) return url;
+  const query = new URLSearchParams();
+  Object.entries(params).forEach(([key, value]) => {
+    if (value !== undefined && value !== null && value !== '') {
+      query.append(key, String(value));
+    }
+  });
+  const qs = query.toString();
+  return qs ? `${url}?${qs}` : url;
+}
+
+export async function fetchMentorsServer(
+  param: MentorRequest
+): Promise<MentorType[]> {
+  // BASE_URL may be unset at build time (no .env.production* / .env.local).
+  // Skip silently — the SSR-empty result lets the client take over at runtime
+  // with the proper env, instead of throwing a noisy "Invalid URL" during
+  // build prerender.
+  if (!BASE_URL) return [];
+  try {
+    const res = await fetch(
+      buildUrl(
+        '/v1/mentors',
+        param as unknown as Record<string, string | number | undefined>
+      ),
+      { next: { revalidate: REVALIDATE_SECONDS } }
+    );
+    if (!res.ok) {
+      console.error(`SSR fetchMentors failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as MentorListResponse;
+    if (result.code !== '0') {
+      console.error(`SSR fetchMentors API error: ${result.msg}`);
+      return [];
+    }
+    return (result.data?.mentors ?? []).map(mapMentor);
+  } catch (error) {
+    console.error('SSR fetchMentors error:', error);
+    return [];
+  }
+}
+
+async function fetchSkillLabelMapServer(
+  language: string
+): Promise<Record<string, string>> {
+  if (!BASE_URL) return {};
+  try {
+    const res = await fetch(
+      buildUrl(`/v1/users/${language}/interests`, { interest: 'SKILL' }),
+      { next: { revalidate: REVALIDATE_SECONDS } }
+    );
+    if (!res.ok) return {};
+    const data = (await res.json()) as InterestListResponse;
+    const map: Record<string, string> = {};
+    (data.data?.interests ?? []).forEach((s) => {
+      map[s.subject_group] = s.subject ?? '';
+    });
+    return map;
+  } catch (error) {
+    console.error('SSR fetchSkillLabelMap error:', error);
+    return {};
+  }
+}
+
+export async function fetchMentorsEnrichedServer(
+  param: MentorRequest
+): Promise<MentorType[]> {
+  const [searchResults, skillLabelMap] = await Promise.all([
+    fetchMentorsServer(param),
+    fetchSkillLabelMapServer('zh_TW'),
+  ]);
+
+  if (searchResults.length === 0) return [];
+
+  return searchResults.map((mentor) => ({
+    ...mentor,
+    skills: mentor.skills
+      .map((subjectGroup) => skillLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+  }));
+}

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,95 +1,24 @@
-import { StaticImageData } from 'next/image';
-
 import { getInterestsCached } from '@/hooks/user/interests/useInterests';
-import { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
 import { apiClient } from '@/lib/apiClient';
-import { parseCurrentJob } from '@/lib/profile/parseUserExperiences';
-import { components } from '@/types/api';
 
-type RawMentor = components['schemas']['SearchMentorProfileVO'];
-type ExperienceCategory = components['schemas']['ExperienceCategory'];
-type MentorListResponse =
-  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
+import {
+  mapMentor,
+  type MentorExperienceBlock,
+  type MentorListResponse,
+  type MentorRequest,
+  type MentorsType,
+  type MentorType,
+  type WorkExperienceMetadata,
+} from './mapMentor';
 
-export type { WorkExperienceMetadata };
-
-export interface MentorExperienceBlock {
-  id: number;
-  category: ExperienceCategory;
-  order: number;
-  mentor_experiences_metadata?: Record<string, unknown>;
-}
-
-export interface MentorType {
-  user_id: number;
-  name: string;
-  avatar: string | StaticImageData;
-  job_title: string;
-  company: string;
-  years_of_experience: string;
-  location: string;
-  personal_statement: string;
-  about: string;
-  seniority_level: string;
-  interested_positions: string[];
-  skills: string[];
-  topics: string[];
-  industry: string | null;
-  expertises: string[];
-  experiences: MentorExperienceBlock[];
-  updated_at: number | null;
-}
-
-export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
-
-export interface MentorRequest {
-  searchPattern?: string;
-  filter_positions?: string;
-  filter_skills?: string;
-  filter_topics?: string;
-  filter_expertises?: string;
-  filter_industries?: string;
-  limit: number;
-  cursor?: string;
-}
-
-function mapMentor(raw: RawMentor): MentorType {
-  const { job_title, company } = parseCurrentJob(
-    raw.experiences as
-      | { category?: string | null; mentor_experiences_metadata: unknown }[]
-      | null
-      | undefined
-  );
-
-  return {
-    user_id: raw.user_id,
-    name: raw.name ?? '',
-    avatar: raw.avatar ?? '',
-    job_title,
-    company,
-    years_of_experience: raw.years_of_experience ?? '',
-    location: raw.location ?? '',
-    personal_statement: raw.personal_statement ?? '',
-    about: raw.about ?? '',
-    seniority_level: raw.seniority_level ?? '',
-    interested_positions:
-      raw.interested_positions?.interests?.map((i) => i.subject_group) ?? [],
-    skills: raw.skills?.interests?.map((i) => i.subject_group) ?? [],
-    topics: raw.topics?.interests?.map((i) => i.subject_group) ?? [],
-    industry: raw.industry?.subject ?? null,
-    expertises: raw.expertises?.professions?.map((p) => p.subject) ?? [],
-    experiences: (raw.experiences ?? []).map((e) => ({
-      id: e.id,
-      category: e.category ?? 'WORK',
-      order: e.order,
-      mentor_experiences_metadata: e.mentor_experiences_metadata as Record<
-        string,
-        unknown
-      >,
-    })),
-    updated_at: raw.updated_at ?? null,
-  };
-}
+export type {
+  MentorExperienceBlock,
+  MentorListResponse,
+  MentorRequest,
+  MentorsType,
+  MentorType,
+  WorkExperienceMetadata,
+};
 
 export async function fetchMentors(
   param: MentorRequest


### PR DESCRIPTION
## What Does This PR Do?

- Convert `/mentor-pool` `page.tsx` from client-only to server component wrapped in `<Suspense>`, so hero + search bar enter SSR HTML immediately and no longer wait on the slow `/v1/mentors` fetch
- Add server-safe `mentors.server.ts` using plain `fetch` with `next: { revalidate: 60 }` ISR — the first request warms the cache, subsequent users hit it in milliseconds
- Extract pure `mapMentor` + types into `mapMentor.ts` so client (`mentors.ts`) and server (`mentors.server.ts`) entries can share logic without pulling the `'use client'` apiClient into the RSC tree
- Add `MentorPoolStateProvider` (client) holding searchPattern / selectedFilters / sessionStorage restore, so the SearchBar can live outside the Suspense boundary and still drive the container
- Move hero and SearchBar into `page.tsx`; `ui.tsx` now only renders the cards section
- New `MentorGridSkeleton` as Suspense fallback to avoid CLS during streaming
- Container accepts `initialMentors` / `initialCursor` / `initialMentorCount` props; only refetches on mount when sessionStorage held a persisted state, otherwise SSR data is kept

Closes #189 Phase 1. Phase 2 (URL searchParams refactor) tracked in #192.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- BFF `/v1/mentors` is currently slow (several seconds). Streaming + ISR only mitigate; the underlying API still needs a separate ticket on BFF / Search service
- `mentors.server.ts` returns empty silently when `NEXT_PUBLIC_API_URL` is unset (build-time prerender) so the build stays clean; the client takes over at runtime

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
