### PR TITLE
feat(mentor-pool): rework filters + add popular position chips

### DIFF
--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { useTransition } from 'react';
+
+import { POPULAR_POSITIONS } from './data';
+import { buildHref, setSearchPattern } from './searchParams';
+
+export default function PopularPositionChips() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const [, startTransition] = useTransition();
+
+  const handleClick = (position: string) => {
+    const next = setSearchPattern(params, position);
+    startTransition(() => {
+      router.push(buildHref(next));
+    });
+  };
+
+  return (
+    <div
+      className="-mx-5 mb-5 flex gap-2 overflow-x-auto px-5 [scrollbar-width:none] md:-mx-10 md:flex-wrap md:overflow-visible md:px-10 xl:-mx-20 xl:px-20 [&::-webkit-scrollbar]:hidden"
+      aria-label="熱門職位"
+    >
+      {POPULAR_POSITIONS.map((position) => (
+        <button
+          key={position}
+          type="button"
+          onClick={() => handleClick(position)}
+          className="shrink-0 rounded-full border border-[#E6E8EA] bg-background-white px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-[#F7F2FB] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+        >
+          {position}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -20,7 +20,7 @@ export default function PopularPositionChips() {
 
   return (
     <div
-      className="-mx-5 flex gap-2 overflow-x-auto px-5 [scrollbar-width:none] md:-mx-10 md:flex-wrap md:overflow-visible md:px-10 xl:-mx-20 xl:px-20 [&::-webkit-scrollbar]:hidden"
+      className="mx-auto flex w-[338px] flex-wrap justify-center gap-2 md:w-[688px] xl:w-[846px]"
       aria-label="熱門職位"
     >
       {POPULAR_POSITIONS.map((position) => (

--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -1,15 +1,36 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useTransition } from 'react';
+import { useEffect, useRef, useState, useTransition } from 'react';
 
 import { POPULAR_POSITIONS } from './data';
 import { buildHref, setSearchPattern } from './searchParams';
+
+// Desktop SearchBar width is the source of truth. We measure each chip on
+// mount, decide how many fit in this width, then render that same set on
+// every viewport. Tablet/mobile may wrap; desktop stays single-row.
+const DESKTOP_WIDTH = 846;
+const GAP_PX = 8;
 
 export default function PopularPositionChips() {
   const router = useRouter();
   const params = useSearchParams();
   const [, startTransition] = useTransition();
+  const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [visibleCount, setVisibleCount] = useState(POPULAR_POSITIONS.length);
+
+  useEffect(() => {
+    const widths = buttonRefs.current.map((b) => b?.offsetWidth ?? 0);
+    let total = 0;
+    let count = 0;
+    for (let i = 0; i < widths.length; i++) {
+      const next = total + widths[i] + (count > 0 ? GAP_PX : 0);
+      if (next > DESKTOP_WIDTH) break;
+      total = next;
+      count++;
+    }
+    setVisibleCount(count);
+  }, []);
 
   const handleClick = (position: string) => {
     const next = setSearchPattern(params, position);
@@ -20,15 +41,20 @@ export default function PopularPositionChips() {
 
   return (
     <div
-      className="mx-auto flex w-[338px] justify-center gap-2 overflow-hidden md:w-[688px] xl:w-[846px]"
+      className="mx-auto flex w-[338px] flex-wrap justify-center gap-2 md:w-[688px] xl:w-[846px] xl:flex-nowrap"
       aria-label="熱門職位"
     >
-      {POPULAR_POSITIONS.map((position) => (
+      {POPULAR_POSITIONS.map((position, i) => (
         <button
           key={position}
+          ref={(el) => {
+            buttonRefs.current[i] = el;
+          }}
           type="button"
           onClick={() => handleClick(position)}
-          className="shrink-0 rounded-full border border-[#E6E8EA] bg-background-white px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-[#F7F2FB] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          className={`shrink-0 rounded-full border border-[#E6E8EA] bg-background-white px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-[#F7F2FB] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+            i >= visibleCount ? 'hidden' : ''
+          }`}
         >
           {position}
         </button>

--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -20,7 +20,7 @@ export default function PopularPositionChips() {
 
   return (
     <div
-      className="mx-auto flex w-[338px] flex-wrap justify-center gap-2 md:w-[688px] xl:w-[846px]"
+      className="mx-auto flex w-[338px] justify-center gap-2 overflow-hidden md:w-[688px] xl:w-[846px]"
       aria-label="熱門職位"
     >
       {POPULAR_POSITIONS.map((position) => (

--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -20,7 +20,7 @@ export default function PopularPositionChips() {
 
   return (
     <div
-      className="-mx-5 mb-5 flex gap-2 overflow-x-auto px-5 [scrollbar-width:none] md:-mx-10 md:flex-wrap md:overflow-visible md:px-10 xl:-mx-20 xl:px-20 [&::-webkit-scrollbar]:hidden"
+      className="-mx-5 flex gap-2 overflow-x-auto px-5 [scrollbar-width:none] md:-mx-10 md:flex-wrap md:overflow-visible md:px-10 xl:-mx-20 xl:px-20 [&::-webkit-scrollbar]:hidden"
       aria-label="熱門職位"
     >
       {POPULAR_POSITIONS.map((position) => (

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -8,8 +8,8 @@ import type {
   FilterOptions,
   SelectFilters,
 } from '@/components/filter/MentorFilterDropdown';
+import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests from '@/hooks/user/interests/useInterests';
-import type { InterestVO } from '@/services/profile/interests';
 import {
   fetchMentorsEnriched,
   MentorType,
@@ -26,8 +26,8 @@ import {
 } from './searchParams';
 import MentorPoolUI from './ui';
 
-function interestsToOptions(
-  items: InterestVO[]
+function subjectsToOptions(
+  items: ReadonlyArray<{ subject?: string | null }>
 ): { label: string; value: string }[] {
   return items
     .map((i) => ({ label: i.subject ?? '', value: i.subject ?? '' }))
@@ -50,20 +50,25 @@ export default function MentorPoolContainer({
   const [isPending, startTransition] = useTransition();
   const selectedFilters = parseFiltersFromParams(params);
   const { expertises, whatIOffers } = useInterests('zh_TW');
+  const { industries } = useIndustries('zh_TW');
 
   const dynamicFilterOptions = useMemo<FilterOptions>(
     () => ({
       ...filterOptions,
       filter_skills: {
         ...filterOptions.filter_skills,
-        options: interestsToOptions(expertises),
+        options: subjectsToOptions(expertises),
       },
       filter_topics: {
         ...filterOptions.filter_topics,
-        options: interestsToOptions(whatIOffers),
+        options: subjectsToOptions(whatIOffers),
+      },
+      filter_industries: {
+        ...filterOptions.filter_industries,
+        options: subjectsToOptions(industries),
       },
     }),
-    [expertises, whatIOffers]
+    [expertises, whatIOffers, industries]
   );
 
   const [mentorCount, setMentorCount] = useState<number>(initialMentorCount);

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -1,10 +1,15 @@
 'use client';
 
 import { useRouter, useSearchParams } from 'next/navigation';
-import { useCallback, useRef, useState, useTransition } from 'react';
+import { useCallback, useMemo, useRef, useState, useTransition } from 'react';
 
 import avatarImage from '@/assets/default-avatar.png';
-import type { SelectFilters } from '@/components/filter/MentorFilterDropdown';
+import type {
+  FilterOptions,
+  SelectFilters,
+} from '@/components/filter/MentorFilterDropdown';
+import useInterests from '@/hooks/user/interests/useInterests';
+import type { InterestVO } from '@/services/profile/interests';
 import {
   fetchMentorsEnriched,
   MentorType,
@@ -21,6 +26,14 @@ import {
 } from './searchParams';
 import MentorPoolUI from './ui';
 
+function interestsToOptions(
+  items: InterestVO[]
+): { label: string; value: string }[] {
+  return items
+    .map((i) => ({ label: i.subject ?? '', value: i.subject ?? '' }))
+    .filter((o) => o.value);
+}
+
 interface Props {
   initialMentors: MentorType[];
   initialCursor: string;
@@ -36,6 +49,22 @@ export default function MentorPoolContainer({
   const params = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const selectedFilters = parseFiltersFromParams(params);
+  const { expertises, whatIOffers } = useInterests('zh_TW');
+
+  const dynamicFilterOptions = useMemo<FilterOptions>(
+    () => ({
+      ...filterOptions,
+      filter_skills: {
+        ...filterOptions.filter_skills,
+        options: interestsToOptions(expertises),
+      },
+      filter_topics: {
+        ...filterOptions.filter_topics,
+        options: interestsToOptions(whatIOffers),
+      },
+    }),
+    [expertises, whatIOffers]
+  );
 
   const [mentorCount, setMentorCount] = useState<number>(initialMentorCount);
   const [mentors, setMentors] = useState<MentorType[]>(initialMentors);
@@ -123,7 +152,7 @@ export default function MentorPoolContainer({
       isReplacing={isPending}
       isNoResults={isNoResults}
       selectedFilters={selectedFilters}
-      filterOptions={filterOptions}
+      filterOptions={dynamicFilterOptions}
       onFilterChange={handleFilterChange}
       onRemoveFilter={handleRemoveFilter}
       onScrollToBottom={handleScrollToBottom}

--- a/src/app/mentor-pool/data.ts
+++ b/src/app/mentor-pool/data.ts
@@ -21,13 +21,14 @@ export const filterOptions: FilterOptions = {
 
 // Hardcoded fallback until the backend exposes a popular-position ranking
 // endpoint. Replacing this with a fetch is a one-line swap in container.tsx.
+// Labels follow the zh_TW INTERESTED_POSITION naming used in onboarding.
 export const POPULAR_POSITIONS: ReadonlyArray<string> = [
-  'Frontend Developer',
-  'Backend Developer',
-  'Software Engineer',
-  'Product Manager',
-  'UI/UX Designer',
-  'Data Engineer',
-  'DevOps Engineer',
-  'Mobile Developer',
+  '前端工程師',
+  '後端工程師',
+  '全端工程師',
+  '產品經理',
+  'UIUX 設計師',
+  '資料工程師',
+  'AI 工程師',
+  'iOS 工程師',
 ];

--- a/src/app/mentor-pool/data.ts
+++ b/src/app/mentor-pool/data.ts
@@ -1,24 +1,21 @@
 import { FilterOptions } from '@/components/filter/MentorFilterDropdown';
 
-// Skill / Topic option lists are populated at runtime from useInterests in
-// container.tsx. We keep the keys + display name here so server-side
-// searchParams parsing has a stable shape without touching the client cache.
+// Option lists are populated at runtime in container.tsx
+// (useInterests for skills/topics, useIndustries for industries).
+// We keep the keys + display name here so server-side searchParams
+// parsing has a stable shape without touching the client caches.
 export const filterOptions: FilterOptions = {
   filter_skills: {
-    name: 'Skill',
+    name: '技能',
     options: [],
   },
   filter_topics: {
-    name: 'Topic',
+    name: '主題',
     options: [],
   },
   filter_industries: {
-    name: 'Industry',
-    options: [
-      { label: 'Technology', value: 'Technology' },
-      { label: 'Healthcare', value: 'Healthcare' },
-      { label: 'Finance', value: 'Finance' },
-    ],
+    name: '產業',
+    options: [],
   },
 };
 

--- a/src/app/mentor-pool/data.ts
+++ b/src/app/mentor-pool/data.ts
@@ -1,43 +1,16 @@
 import { FilterOptions } from '@/components/filter/MentorFilterDropdown';
 
+// Skill / Topic option lists are populated at runtime from useInterests in
+// container.tsx. We keep the keys + display name here so server-side
+// searchParams parsing has a stable shape without touching the client cache.
 export const filterOptions: FilterOptions = {
-  filter_positions: {
-    name: 'Position',
-    options: [
-      { label: 'Frontend Developer', value: 'Frontend Developer' },
-      { label: 'Software Engineer', value: 'Software Engineer' },
-      { label: 'Bioinformatics Analyst', value: 'Bioinformatics Analyst' },
-      { label: 'Infrastructure Engineer', value: 'Infrastructure Engineer' },
-    ],
-  },
   filter_skills: {
     name: 'Skill',
-    options: [
-      { label: 'Kubernetes', value: 'Kubernetes' },
-      { label: 'Agile', value: 'Agile' },
-      { label: 'Go', value: 'Go' },
-      { label: 'Kafka', value: 'Kafka' },
-      { label: 'Financial Modeling', value: 'Financial Modeling' },
-      { label: 'Java', value: 'Java' },
-    ],
+    options: [],
   },
   filter_topics: {
     name: 'Topic',
-    options: [
-      { label: 'Microservices', value: 'Microservices' },
-      { label: 'User Research', value: 'User Research' },
-      { label: 'System Design', value: 'System Design' },
-      { label: 'DevOps', value: 'DevOps' },
-    ],
-  },
-  filter_expertises: {
-    name: 'Expertise',
-    options: [
-      { label: 'DevOps', value: 'DevOps' },
-      { label: 'Full Stack Development', value: 'Full Stack Development' },
-      { label: 'DevStart', value: 'DevStart' },
-      { label: 'Backend Development', value: 'Backend Development' },
-    ],
+    options: [],
   },
   filter_industries: {
     name: 'Industry',
@@ -48,3 +21,16 @@ export const filterOptions: FilterOptions = {
     ],
   },
 };
+
+// Hardcoded fallback until the backend exposes a popular-position ranking
+// endpoint. Replacing this with a fetch is a one-line swap in container.tsx.
+export const POPULAR_POSITIONS: ReadonlyArray<string> = [
+  'Frontend Developer',
+  'Backend Developer',
+  'Software Engineer',
+  'Product Manager',
+  'UI/UX Designer',
+  'Data Engineer',
+  'DevOps Engineer',
+  'Mobile Developer',
+];

--- a/src/app/mentor-pool/searchParams.ts
+++ b/src/app/mentor-pool/searchParams.ts
@@ -14,10 +14,8 @@ type AnyParams = URLSearchParams | ReadonlyURLSearchParams;
 
 export interface MentorPoolFetchConditions {
   searchPattern: string;
-  filter_positions?: string;
   filter_skills?: string;
   filter_topics?: string;
-  filter_expertises?: string;
   filter_industries?: string;
 }
 

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -45,10 +45,10 @@ export default function MentorPoolUI({
   const showLoadMoreSpinner = hasMentors && isLoading && !isReplacing;
   const showNoResults = !hasMentors && !isLoading && isNoResults;
   return (
-    <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
+    <section className="mt-[80px] px-5 pb-10 md:px-10 xl:px-20">
       <div className="mx-auto w-full max-w-[1280px] ">
         <PopularPositionChips />
-        <div className="item-center mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
+        <div className="item-center mb-5 mt-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
           <div
             className={`text-base transition-opacity ${isReplacing ? 'opacity-50' : ''}`}
           >

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -12,6 +12,8 @@ import { Badge } from '@/components/ui/badge';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { MentorType } from '@/services/search-mentor/mentors';
 
+import PopularPositionChips from './PopularPositionChips';
+
 interface Props {
   mentors: MentorType[];
   mentorCount: number;
@@ -45,6 +47,7 @@ export default function MentorPoolUI({
   return (
     <section className="mt-[132px] px-5 pb-10 md:px-10 xl:px-20">
       <div className="mx-auto w-full max-w-[1280px] ">
+        <PopularPositionChips />
         <div className="item-center mb-5 flex flex-col gap-4 md:flex-row md:items-center md:justify-between md:gap-0">
           <div
             className={`text-base transition-opacity ${isReplacing ? 'opacity-50' : ''}`}

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -43,10 +43,8 @@ export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
 
 export interface MentorRequest {
   searchPattern?: string;
-  filter_positions?: string;
   filter_skills?: string;
   filter_topics?: string;
-  filter_expertises?: string;
   filter_industries?: string;
   limit: number;
   cursor?: string;

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -32,10 +32,8 @@ function buildUrl(
 function hasMentorRequestConditions(param: MentorRequest): boolean {
   return Boolean(
     param.searchPattern ||
-    param.filter_positions ||
     param.filter_skills ||
     param.filter_topics ||
-    param.filter_expertises ||
     param.filter_industries
   );
 }


### PR DESCRIPTION
## What Does This PR Do?

- Drop `Position` and `Expertise` filter categories from `/mentor-pool` filter dropdown (hardcoded options were drifting from real interest taxonomy)
- `Skill` filter options now come from `useInterests().expertises` (mentor SKILL interests); `Topic` from `useInterests().whatIOffers` (mentor TOPIC interests)
- `filter_industries` stays hardcoded as before
- New `PopularPositionChips` rendered above the result list — clicking a chip sets `q` via `setSearchPattern` + `router.push`, preserving any active filter selections
- Popular position list is hardcoded fallback (8 common positions) until backend ranking endpoint exists; swap point is one line in `data.ts`
- Type cleanup: `MentorPoolFetchConditions` and `MentorRequest` drop the two deprecated keys; `hasMentorRequestConditions` updated accordingly
- Old URLs containing `?filter_positions=` / `?filter_expertises=` are silently ignored (parser only reads keys present in `filterOptions`)

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Filter values use `subject` for both label and value, matching the previous hardcoded format — keeps the BFF filter contract unchanged
- `useInterests` is a client hook so dropdown options populate after hydration; loading state shows empty options to avoid layout flash (per ticket guidance)
- Chip click only updates `q`; existing selected filters stay applied (explicit decision per ticket risk note)
- Mobile chips use horizontal scroll with hidden scrollbar; desktop wraps
- No analytics changes — `/mentor-pool` does not currently emit GA4 events
- Final chip visual is a placeholder pending design; functional behaviour is locked in

Closes Xchange-Taiwan/X-Talent-Tracker#193

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
