### PR TITLE
feat(reservation): show full conversation thread in HISTORY

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -224,7 +224,7 @@ export default function AcceptReservationDialog({
           <div className="p-6">
             <DialogHeader className="mb-4">
               <DialogTitle className="text-center sm:text-left">
-                拒絕 Mentee 預約的原因
+                拒絕學員預約的原因
               </DialogTitle>
               <DialogDescription className="text-center sm:text-left">
                 請說明無法接受此預約的原因。

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -10,11 +10,15 @@ import type { Reservation } from './types';
 export function ReservationCard({
   item,
   actions,
+  footer,
   profileHref,
   onProfileClick,
 }: {
   item: Reservation;
   actions?: React.ReactNode;
+  // Optional slot rendered below the message preview. Used by HISTORY tabs to
+  // mount the "view full conversation" entry without coupling the card to it.
+  footer?: React.ReactNode;
   profileHref?: string;
   onProfileClick?: () => void;
 }) {
@@ -127,7 +131,7 @@ export function ReservationCard({
                     />
                     <div className="min-w-0 flex-1">
                       <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
-                        Mentor 回覆
+                        導師回覆
                       </div>
                       <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
                         {mentorMessage.content}
@@ -137,6 +141,8 @@ export function ReservationCard({
                 ) : null}
               </div>
             ) : null}
+
+            {footer ? <div className="mt-3">{footer}</div> : null}
           </div>
         </div>
       </CardContent>

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { CalendarDays, Clock, MessageSquare } from 'lucide-react';
+import { useState } from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { trackEvent } from '@/lib/analytics';
+import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
+import { cn } from '@/lib/utils';
+
+import type { MessageRole, Reservation, ReservationMessage } from './types';
+
+interface Props {
+  reservation: Reservation;
+  // Which role the current user is browsing as. Used only for analytics so we
+  // can tell whether the mentor or mentee opened the thread; never sent as
+  // message content.
+  sourceRole: 'mentor' | 'mentee';
+  trigger?: React.ReactNode;
+}
+
+const ROLE_LABEL: Record<MessageRole, string> = {
+  MENTEE: '學員',
+  MENTOR: '導師',
+};
+
+export default function ReservationConversationDialog({
+  reservation,
+  sourceRole,
+  trigger,
+}: Props) {
+  const [open, setOpen] = useState(false);
+
+  function onOpenChange(next: boolean) {
+    setOpen(next);
+    if (next) {
+      trackEvent({
+        name: 'reservation_conversation_opened',
+        feature: 'reservation',
+        metadata: {
+          reservation_id: reservation.id,
+          source_role: sourceRole,
+          message_count: reservation.messages.length,
+        },
+      });
+    }
+  }
+
+  const initials =
+    reservation.name
+      .split(' ')
+      .map((s) => s[0])
+      .join('')
+      .slice(0, 2) || 'U';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        {trigger ?? (
+          <button
+            type="button"
+            className="inline-flex items-center gap-1 rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-sm"
+          >
+            <MessageSquare className="h-3.5 w-3.5" aria-hidden />
+            查看完整對話
+          </button>
+        )}
+      </DialogTrigger>
+
+      <DialogContent className="flex max-h-[85vh] w-[92vw] max-w-[480px] flex-col gap-0 p-0 sm:max-w-lg">
+        <DialogHeader className="space-y-3 border-b p-4 sm:p-6">
+          <div className="flex items-center gap-3">
+            <Avatar className="h-10 w-10 shrink-0">
+              {reservation.avatar ? (
+                <AvatarImage
+                  src={getAvatarThumbUrl(reservation.avatar)}
+                  alt={reservation.name}
+                />
+              ) : null}
+              <AvatarFallback>{initials}</AvatarFallback>
+            </Avatar>
+            <div className="min-w-0 flex-1 text-left">
+              <DialogTitle className="truncate text-base">
+                完整對話紀錄
+              </DialogTitle>
+              <DialogDescription className="truncate">
+                {reservation.name}
+                {reservation.roleLine ? ` · ${reservation.roleLine}` : ''}
+              </DialogDescription>
+            </div>
+          </div>
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground sm:text-sm">
+            <span className="inline-flex items-center gap-1.5">
+              <CalendarDays className="h-3.5 w-3.5" aria-hidden />
+              {reservation.date}
+            </span>
+            <span className="inline-flex items-center gap-1.5">
+              <Clock className="h-3.5 w-3.5" aria-hidden />
+              {reservation.time}
+            </span>
+          </div>
+        </DialogHeader>
+
+        <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-6">
+          {reservation.messages.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              尚無對話內容
+            </p>
+          ) : (
+            reservation.messages.map((message, index) => (
+              <MessageBubble
+                key={index}
+                message={message}
+                isPrevSameRole={
+                  index > 0 &&
+                  reservation.messages[index - 1].role === message.role
+                }
+              />
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function MessageBubble({
+  message,
+  isPrevSameRole,
+}: {
+  message: ReservationMessage;
+  isPrevSameRole: boolean;
+}) {
+  const isMentor = message.role === 'MENTOR';
+  const isMentee = message.role === 'MENTEE';
+  const label = message.role ? ROLE_LABEL[message.role] : '';
+
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-1',
+        isMentor ? 'items-end' : 'items-start'
+      )}
+    >
+      {label && !isPrevSameRole ? (
+        <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+          {label}
+        </div>
+      ) : null}
+      <div
+        className={cn(
+          'max-w-[85%] whitespace-pre-wrap break-words rounded-2xl px-3.5 py-2.5 text-sm',
+          isMentor && 'bg-primary text-primary-foreground',
+          isMentee && 'bg-muted text-foreground',
+          !message.role && 'bg-muted/60 text-muted-foreground'
+        )}
+      >
+        {message.content}
+      </div>
+    </div>
+  );
+}

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -4,6 +4,7 @@ import { getSession, useSession } from 'next-auth/react';
 
 import AcceptReservationDialog from '@/components/reservation/AcceptReservationDialog';
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
+import ReservationConversationDialog from '@/components/reservation/ReservationConversationDialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
@@ -193,6 +194,14 @@ export function ReservationList({
                 }
               />
             )
+          }
+          footer={
+            variant === 'history' && it.messages.length > 0 ? (
+              <ReservationConversationDialog
+                reservation={it}
+                sourceRole={sourceRole}
+              />
+            ) : null
           }
         />
       ))}

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,5 +1,10 @@
+export type MessageRole = 'MENTEE' | 'MENTOR';
+
 export type ReservationMessage = {
   content: string;
+  // Resolved party for this message. Undefined when neither the message's own
+  // role nor the sender/participant fallback could classify it.
+  role?: MessageRole;
 };
 
 export type Reservation = {
@@ -9,8 +14,10 @@ export type Reservation = {
   roleLine: string;
   date: string;
   time: string;
-  // Latest message authored by each party. Either side may be undefined when
-  // that party hasn't written anything yet.
+  // Full conversation in the order returned by the API. Empty when no messages.
+  messages: ReservationMessage[];
+  // Latest message authored by each party — derived from `messages` for the
+  // card preview. Either side may be undefined when that party hasn't written.
   menteeMessage?: ReservationMessage;
   mentorMessage?: ReservationMessage;
 

--- a/src/hooks/user/reservation/useReservationData.test.ts
+++ b/src/hooks/user/reservation/useReservationData.test.ts
@@ -25,6 +25,7 @@ const makeReservation = (id: string) => ({
   roleLine: 'Engineer',
   date: 'Mon, Jan 01, 2024',
   time: '10:00 am – 11:00 am',
+  messages: [],
   scheduleId: 1,
   dtstart: 1700000000,
   dtend: 1700003600,

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -83,8 +83,14 @@ describe('mapToReservation', () => {
       messages: [{ user_id: 20, role: 'MENTEE', content: 'Hello mentor!' }],
     });
     const result = mapToReservation(reservation);
-    expect(result.menteeMessage).toEqual({ content: 'Hello mentor!' });
+    expect(result.menteeMessage).toEqual({
+      content: 'Hello mentor!',
+      role: 'MENTEE',
+    });
     expect(result.mentorMessage).toBeUndefined();
+    expect(result.messages).toEqual([
+      { content: 'Hello mentor!', role: 'MENTEE' },
+    ]);
   });
 
   it('both sides have messages → menteeMessage and mentorMessage both populated', () => {
@@ -113,13 +119,21 @@ describe('mapToReservation', () => {
       ],
     });
     const result = mapToReservation(reservation);
-    expect(result.menteeMessage).toEqual({ content: 'Looking forward!' });
+    expect(result.menteeMessage).toEqual({
+      content: 'Looking forward!',
+      role: 'MENTEE',
+    });
     expect(result.mentorMessage).toEqual({
       content: 'See you on Google Meet.',
+      role: 'MENTOR',
     });
+    expect(result.messages).toEqual([
+      { content: 'Looking forward!', role: 'MENTEE' },
+      { content: 'See you on Google Meet.', role: 'MENTOR' },
+    ]);
   });
 
-  it('multiple mentee messages → menteeMessage uses the latest one', () => {
+  it('multiple mentee messages → menteeMessage uses the latest, but messages keeps every entry in API order', () => {
     const reservation = makeReservation({
       messages: [
         { user_id: 20, role: 'MENTEE', content: 'First note' },
@@ -127,17 +141,45 @@ describe('mapToReservation', () => {
       ],
     });
     const result = mapToReservation(reservation);
-    expect(result.menteeMessage).toEqual({ content: 'Updated note' });
+    expect(result.menteeMessage).toEqual({
+      content: 'Updated note',
+      role: 'MENTEE',
+    });
     expect(result.mentorMessage).toBeUndefined();
+    expect(result.messages).toEqual([
+      { content: 'First note', role: 'MENTEE' },
+      { content: 'Updated note', role: 'MENTEE' },
+    ]);
   });
 
-  it('blank message content → message is undefined', () => {
+  it('multi-turn conversation → messages preserves every turn in order', () => {
+    const reservation = makeReservation({
+      messages: [
+        { user_id: 20, role: 'MENTEE', content: 'Initial question' },
+        { user_id: 10, role: 'MENTOR', content: 'First reply' },
+        { user_id: 20, role: 'MENTEE', content: 'Follow-up question' },
+        { user_id: 10, role: 'MENTOR', content: 'Final reply' },
+      ],
+    });
+    const result = mapToReservation(reservation);
+    expect(result.messages.map((m) => m.content)).toEqual([
+      'Initial question',
+      'First reply',
+      'Follow-up question',
+      'Final reply',
+    ]);
+    expect(result.menteeMessage?.content).toBe('Follow-up question');
+    expect(result.mentorMessage?.content).toBe('Final reply');
+  });
+
+  it('blank message content → message is undefined and messages array is empty', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 20, role: 'MENTEE', content: '   ' }],
     });
     const result = mapToReservation(reservation);
     expect(result.menteeMessage).toBeUndefined();
     expect(result.mentorMessage).toBeUndefined();
+    expect(result.messages).toEqual([]);
   });
 
   it('message role missing → falls back to user_id → sender/participant role lookup', () => {
@@ -148,17 +190,24 @@ describe('mapToReservation', () => {
       ],
     });
     const result = mapToReservation(reservation);
-    expect(result.mentorMessage).toEqual({ content: 'From the mentor side' });
-    expect(result.menteeMessage).toEqual({ content: 'From the mentee side' });
+    expect(result.mentorMessage).toEqual({
+      content: 'From the mentor side',
+      role: 'MENTOR',
+    });
+    expect(result.menteeMessage).toEqual({
+      content: 'From the mentee side',
+      role: 'MENTEE',
+    });
   });
 
-  it('message from unknown user with unknown role → ignored', () => {
+  it('message from unknown user with unknown role → kept in messages but no role attached', () => {
     const reservation = makeReservation({
       messages: [{ user_id: 999, role: 'OTHER', content: 'Wrong user' }],
     });
     const result = mapToReservation(reservation);
     expect(result.menteeMessage).toBeUndefined();
     expect(result.mentorMessage).toBeUndefined();
+    expect(result.messages).toEqual([{ content: 'Wrong user' }]);
   });
 
   it('job_title present, years_of_experience empty → roleLine has no trailing comma', () => {

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -77,8 +77,10 @@ export function mapToReservation(
     .filter(Boolean)
     .join(', ');
 
-  // Pick the latest non-blank message from each side so the UI can show both
-  // the mentee's question and the mentor's reply / cancellation reason at once.
+  // Preserve the full conversation in API order so the detail view can render
+  // the entire thread, while also tracking the latest message per side for the
+  // card preview (which still wants both the mentee's question and the
+  // mentor's reply / cancellation reason at a glance).
   const userIdToRole = new Map<string, string | null | undefined>([
     [String(reservation.sender.user_id ?? ''), reservation.sender.role],
     [
@@ -87,6 +89,7 @@ export function mapToReservation(
     ],
   ]);
 
+  const messages: ReservationMessage[] = [];
   let menteeMessage: ReservationMessage | undefined;
   let mentorMessage: ReservationMessage | undefined;
   for (const message of reservation.messages ?? []) {
@@ -94,8 +97,12 @@ export function mapToReservation(
     const trimmed = message.content.trim();
     if (trimmed.length === 0) continue;
     const role = classifyMessageRole(message, userIdToRole);
-    if (role === 'MENTEE') menteeMessage = { content: trimmed };
-    else if (role === 'MENTOR') mentorMessage = { content: trimmed };
+    const item: ReservationMessage = role
+      ? { content: trimmed, role }
+      : { content: trimmed };
+    messages.push(item);
+    if (role === 'MENTEE') menteeMessage = item;
+    else if (role === 'MENTOR') mentorMessage = item;
   }
 
   return {
@@ -105,6 +112,7 @@ export function mapToReservation(
     date,
     time,
     avatar: counterparty.avatar ?? undefined,
+    messages,
     menteeMessage,
     mentorMessage,
     scheduleId: reservation.schedule_id,


### PR DESCRIPTION
## What Does This PR Do?

- Service `mapToReservation` now keeps the entire `messages` array (in API order) instead of overwriting earlier turns; latest mentee/mentor messages are still derived for the card preview.
- Add `ReservationConversationDialog`: responsive modal that renders the full conversation as chat bubbles (mentee left, mentor right) with role labels grouped by run.
- HISTORY tab cards expose a "查看完整對話" entry when messages exist; Active / Pending tabs unchanged.
- Fix mixed Chinese / English labels: `Mentor 回覆` → `導師回覆`, `拒絕 Mentee 預約的原因` → `拒絕學員預約的原因`.
- Track `reservation_conversation_opened` in GA4 / Clarity with reservation id, source role, and message count — no message content sent.
- Update unit tests for the new `messages` field and add coverage for multi-turn conversations and unknown-role messages.

## Demo

http://localhost:3000/reservation/mentor (HISTORY tab)
http://localhost:3000/reservation/mentee (HISTORY tab)

## Screenshot

N/A

## Anything to Note?

- Backend contract for `/v1/users/{userId}/reservations` `messages` is assumed to be the full conversation in chronological order. If the backend truncates to last N, BFF / X-Career-User needs a follow-up.
- `ReservationMessageVO` has no timestamp; ordering relies on the API array order.
- The "view full conversation" CTA is intentionally limited to HISTORY for this PR; service layer is ready to enable it on Active / Pending later.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
