### PR TITLE
perf(onboarding): background avatar upload to skip S3 wait at submit

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -47,6 +47,18 @@ export default function OnboardingContainer() {
 
   const stableOnboardingCacheBust = useRef(Date.now()).current;
 
+  // Tracks the in-flight background avatar upload kicked off after Step 1.
+  // The promise is consumed at Step 5 submit so the user doesn't wait for S3
+  // round-trip; replaced (with abort) when the user picks a new file.
+  const avatarUploadRef = useRef<{
+    file: File;
+    controller: AbortController;
+    promise: Promise<string | undefined>;
+  } | null>(null);
+  const [avatarUploadError, setAvatarUploadError] = useState<string | null>(
+    null
+  );
+
   const step1Form = useForm<z.infer<typeof step1Schema>>({
     resolver: zodResolver(step1Schema),
     defaultValues: {
@@ -83,8 +95,41 @@ export default function OnboardingContainer() {
     });
   }, [currentStep]);
 
+  const watchedAvatarFile = step1Form.watch('avatarFile');
+  useEffect(() => {
+    if (watchedAvatarFile) setAvatarUploadError(null);
+  }, [watchedAvatarFile]);
+
+  useEffect(() => {
+    return () => {
+      avatarUploadRef.current?.controller.abort();
+    };
+  }, []);
+
   const onSubmitStep1 = (data: z.infer<typeof step1Schema>) => {
     setTempData((prev) => ({ ...prev, step1: data }));
+
+    const file = data.avatarFile;
+    const currentJob = avatarUploadRef.current;
+
+    if (file) {
+      // Same File ref (user advanced without re-cropping) — keep existing job
+      if (currentJob?.file !== file) {
+        currentJob?.controller.abort();
+        const controller = new AbortController();
+        const promise = updateAvatar(file, controller.signal).catch((err) => {
+          // Aborts are expected when the user picks a new file or unmounts —
+          // swallow so they don't show up as upload failures at Step 5
+          if (controller.signal.aborted) return undefined;
+          throw err;
+        });
+        avatarUploadRef.current = { file, controller, promise };
+      }
+    } else if (currentJob) {
+      currentJob.controller.abort();
+      avatarUploadRef.current = null;
+    }
+
     trackEvent({ name: 'onboarding_step_1_completed', feature: 'onboarding' });
     setCurrentStep(2);
   };
@@ -147,9 +192,10 @@ export default function OnboardingContainer() {
     try {
       setIsSubmitting(true);
 
-      if (allData.avatarFile) {
+      const job = avatarUploadRef.current;
+      if (job) {
         try {
-          const newUrl = await updateAvatar(allData.avatarFile);
+          const newUrl = await job.promise;
           allData.avatar = newUrl ?? allData.avatar;
           allData.avatarFile = undefined;
         } catch (err) {
@@ -159,7 +205,12 @@ export default function OnboardingContainer() {
             message:
               err instanceof Error ? err.message : 'Avatar upload failed',
           });
-          throw err;
+          // Drop the failed job so the next Step 1 submit starts a fresh upload
+          avatarUploadRef.current = null;
+          setAvatarUploadError('頭像上傳失敗，請重新選擇。');
+          setCurrentStep(1);
+          setIsSubmitting(false);
+          return;
         }
       }
 
@@ -214,6 +265,7 @@ export default function OnboardingContainer() {
       stepsTotal={STEPS_TOTAL}
       stepTitle={STEP_TITLE}
       avatarDisplayUrl={avatarDisplayUrl}
+      avatarError={avatarUploadError}
       step1Form={step1Form}
       step2Form={step2Form}
       step3Form={step3Form}

--- a/src/app/auth/(sign)/onboarding/ui.tsx
+++ b/src/app/auth/(sign)/onboarding/ui.tsx
@@ -48,6 +48,7 @@ interface Props {
   stepsTotal: number;
   stepTitle: readonly string[];
   avatarDisplayUrl: string;
+  avatarError: string | null;
   step1Form: UseFormReturn<z.infer<typeof step1Schema>>;
   step2Form: UseFormReturn<z.infer<typeof step2Schema>>;
   step3Form: UseFormReturn<z.infer<typeof step3Schema>>;
@@ -103,6 +104,7 @@ export default function OnboardingUI({
   stepsTotal,
   stepTitle,
   avatarDisplayUrl,
+  avatarError,
   step1Form,
   step2Form,
   step3Form,
@@ -137,7 +139,11 @@ export default function OnboardingUI({
                 showBack={false}
                 onGoToPrev={onGoToPrev}
               />
-              <WhoAreYou form={step1Form} avatarUrl={avatarDisplayUrl} />
+              <WhoAreYou
+                form={step1Form}
+                avatarUrl={avatarDisplayUrl}
+                avatarError={avatarError}
+              />
               <Button className="rounded-xl px-12" type="submit">
                 下一步
               </Button>

--- a/src/components/onboarding/steps/WhoAreYou.tsx
+++ b/src/components/onboarding/steps/WhoAreYou.tsx
@@ -19,9 +19,10 @@ import { step1Schema } from './index';
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step1Schema>>>;
   avatarUrl: string;
+  avatarError?: string | null;
 }
 
-export const WhoAreYou: FC<Props> = ({ form, avatarUrl }) => {
+export const WhoAreYou: FC<Props> = ({ form, avatarUrl, avatarError }) => {
   return (
     <>
       <AvatarUpload
@@ -29,6 +30,11 @@ export const WhoAreYou: FC<Props> = ({ form, avatarUrl }) => {
         name="avatarFile"
         avatarUrl={avatarUrl}
       />
+      {avatarError && (
+        <p className="-mt-6 text-center text-sm font-medium text-destructive lg:text-left">
+          {avatarError}
+        </p>
+      )}
 
       <FormField
         control={form.control}

--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -20,7 +20,8 @@ interface PresignedUrlData {
 // 所以 file.type 必須是 image/*
 async function uploadToS3WithPresignedPost(
   presigned: PresignedUrlData,
-  avatarFile: File
+  avatarFile: File,
+  signal?: AbortSignal
 ): Promise<void> {
   const formData = new FormData();
 
@@ -39,6 +40,7 @@ async function uploadToS3WithPresignedPost(
   const res = await fetch(presigned.url, {
     method: 'POST',
     body: formData,
+    signal,
   });
 
   if (!res.ok) {
@@ -60,7 +62,8 @@ function buildS3ObjectUrl(bucketUrl: string, key: string): string {
  * 3) 回傳檔案的公開 URL（bucketUrl + key）
  */
 export async function updateAvatar(
-  avatarFile: File
+  avatarFile: File,
+  signal?: AbortSignal
 ): Promise<string | undefined> {
   try {
     const session = await getSession();
@@ -79,10 +82,19 @@ export async function updateAvatar(
       throw new Error('取得 presigned url 失敗或回傳格式不完整');
     }
 
-    await uploadToS3WithPresignedPost(presigned, avatarFile);
+    if (signal?.aborted) {
+      throw new DOMException('Aborted', 'AbortError');
+    }
+
+    await uploadToS3WithPresignedPost(presigned, avatarFile, signal);
 
     return buildS3ObjectUrl(presigned.url, presigned.fields.key);
   } catch (error) {
+    // Let abort propagate as-is so callers can detect cancellation
+    if (error instanceof DOMException && error.name === 'AbortError') {
+      throw error;
+    }
+
     if (error instanceof TypeError && error.message === 'Failed to fetch') {
       throw new Error('無法連接到伺服器。請檢查您的網絡連接。');
     }


### PR DESCRIPTION
## What Does This PR Do?

- Kick off avatar upload in the background as soon as Step 1 is submitted, instead of waiting until the final Step 5 submit
- Step 5 now awaits the in-flight promise (or its already-resolved value) so users no longer pay the S3 round-trip after pressing finish
- Track the upload as `{file, controller, promise}` in a ref; aborts and restarts when the user picks a new file, cancels on unmount
- On upload failure, jump back to Step 1 with an inline error and let the user re-pick the avatar without redoing Steps 2-5
- `updateAvatar` now accepts an optional `AbortSignal` and re-throws `AbortError` as-is so callers can detect cancellation

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

N/A

## Anything to Note?

- Sentry event naming preserved (`flow=onboarding_submit, step=avatar_upload`) — no analytics break
- Resolves Xchange-Taiwan/X-Talent-Tracker#198
