### PR TITLE
perf(onboarding): optimistic session update to skip fetchUser at submit

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -23,7 +23,6 @@ import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
-import { fetchUser } from '@/services/profile/user';
 
 import { STEP_TITLE, STEPS_TOTAL } from './data';
 import OnboardingUI from './ui';
@@ -217,21 +216,23 @@ export default function OnboardingContainer() {
       try {
         const validatedData = formSchema.parse(allData);
         await updateProfile(validatedData);
-        const latest = await fetchUser('zh_TW');
 
         if (session?.user?.id) {
           clearUserDataCache(Number(session.user.id), 'zh_TW');
         }
 
+        // Optimistic session update — server-side `is_mentor` is taken from
+        // the existing DB value (onboarding payload doesn't carry it), and
+        // server-side `onboarding` is derived from the interests we just
+        // submitted, so both values are predictable without a fetch.
         await updateSession({
           user: {
-            id: session?.user?.id,
-            name: latest?.name ?? validatedData.name ?? session?.user?.name,
-            avatar:
-              latest?.avatar ?? validatedData.avatar ?? session?.user?.avatar,
-            isMentor: Boolean(latest?.is_mentor),
-            onBoarding: Boolean(latest?.onboarding),
-            msg: session?.user?.msg,
+            ...session?.user,
+            name: validatedData.name ?? session?.user?.name,
+            avatar: validatedData.avatar ?? session?.user?.avatar,
+            isMentor: session?.user?.isMentor ?? false,
+            onBoarding: true,
+            ...(job ? { avatarUpdatedAt: Date.now() } : {}),
           },
         });
       } catch (err) {


### PR DESCRIPTION
## What Does This PR Do?

- Drop the blocking `fetchUser('zh_TW')` call after `updateProfile` on Step 5 submit (saves a full BFF round-trip — 2-3s on dev)
- Build the `updateSession` payload from `validatedData` + existing `session.user` (preserves `jobTitle`, `company`, `personalLinks`, `msg`, `provider`)
- `isMentor` reuses the session value (BFF `PUT /v1/mentors/{id}/profile` doesn't change `is_mentor`), `onBoarding: true` (server derives this from the interests we just submitted), `avatarUpdatedAt` bumped only when avatar actually changed
- Keep `clearUserDataCache` so `/profile/card` still re-fetches on entry; keep `captureFlowFailure({ step: 'submit_profile' })` error path

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

N/A

## Anything to Note?

Verified backend behavior before going optimistic: `profile_service.py` sets `is_mentor` from the DTO (onboarding payload omits it, so existing DB value is preserved) and computes `onboarding` from filled interests — both optimistic values are guaranteed to match what the server would return.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
