### PR TITLE
perf(profile/edit): optimistic save + presigned URL prefetch

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -4,7 +4,7 @@ import { zodResolver } from '@hookform/resolvers/zod';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { FieldErrors, useForm } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
@@ -35,6 +35,7 @@ import {
   flattenAsSingleCategory,
   groupAsPlaceholderCategories,
 } from '@/lib/profile/categoryGrouping';
+import { prefetchPresignedUrl } from '@/services/profile/updateAvatar';
 
 const JobExperienceSection = dynamic(async () => {
   const m = await import('@/components/profile/edit/JobExperienceSection');
@@ -92,6 +93,15 @@ export default function Page({
     setIsMentor,
     setIsPageLoading,
   });
+
+  // Warm up the avatar presigned URL once authorized. Saves a serial round
+  // trip from the submit waterfall when the user uploads a new avatar.
+  useEffect(() => {
+    if (!isAuthorized) return;
+    const userId = Number(pageUserId);
+    if (!Number.isFinite(userId)) return;
+    prefetchPresignedUrl(userId);
+  }, [isAuthorized, pageUserId]);
 
   const industryCategories = flattenAsSingleCategory(industries);
   const whatIOfferCategories = groupAsPlaceholderCategories(topics);

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -129,6 +129,7 @@ describe('useProfileSubmit', () => {
     expect(mockUpdateProfile).not.toHaveBeenCalled();
     expect(mockUpsertMentorExperience).not.toHaveBeenCalled();
     expect(mockPollUntilSynced).not.toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
   });
 
   it('educationSectionError: true → returns early, no service is called', async () => {
@@ -143,6 +144,7 @@ describe('useProfileSubmit', () => {
     expect(mockUpdateProfile).not.toHaveBeenCalled();
     expect(mockUpsertMentorExperience).not.toHaveBeenCalled();
     expect(mockPollUntilSynced).not.toHaveBeenCalled();
+    expect(mockRouter.push).not.toHaveBeenCalled();
   });
 
   // ── Avatar upload ──────────────────────────────────────────────────────────
@@ -285,6 +287,103 @@ describe('useProfileSubmit', () => {
     });
 
     expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
+  });
+
+  // ── Optimistic flow: poll runs in the background ───────────────────────────
+
+  it('navigation does not wait for pollUntilSynced to resolve', async () => {
+    // Never-resolving promise simulates a slow backend sync. The user must
+    // still be navigated away within a single tick.
+    let resolvePoll: (value: MentorProfileVO | null) => void = () => {};
+    mockPollUntilSynced.mockReturnValueOnce(
+      new Promise<MentorProfileVO | null>((resolve) => {
+        resolvePoll = resolve;
+      })
+    );
+
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(mockRouter.push).toHaveBeenCalledWith('/profile/test-user-id');
+    // Cleanly settle the dangling promise to avoid leaking into later tests.
+    resolvePoll(null);
+  });
+
+  it('optimistic session update preserves current isMentor / onBoarding (does not flicker from latest=null)', async () => {
+    // Background poll resolves to null (e.g. backend never synced) — the
+    // session update made BEFORE the navigation must still reflect the
+    // pre-submit isMentor/onBoarding values.
+    mockPollUntilSynced.mockResolvedValueOnce(null);
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ updateSession }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(updateSession).toHaveBeenCalled();
+    const firstCallArg = updateSession.mock.calls[0][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(firstCallArg.user.isMentor).toBe(true);
+    expect(firstCallArg.user.onBoarding).toBe(true);
+  });
+
+  it('background reconcile patches session when latest disagrees with optimistic role', async () => {
+    // Optimistic session: isMentor=true. Backend poll says isMentor=false.
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: false,
+      onboarding: true,
+    });
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ updateSession }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      // Flush microtasks so the .then() reconcile callback runs.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // First call: optimistic. Second call: reconcile.
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    const reconcileArg = updateSession.mock.calls[1][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(reconcileArg.user.isMentor).toBe(false);
+    expect(reconcileArg.user.onBoarding).toBe(true);
+  });
+
+  it('background reconcile is a no-op when latest matches optimistic session', async () => {
+    // Backend agrees with optimistic state — no second updateSession call.
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: true,
+      onboarding: true,
+    });
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ updateSession }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(updateSession).toHaveBeenCalledTimes(1);
   });
 
   // ── Primary job persistence ────────────────────────────────────────────────

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -159,42 +159,64 @@ export function useProfileSubmit({
         throw err;
       }
 
-      // 4) poll until backend reflects all updated fields (up to 1 min, every 5s)
-      const latest = await pollUntilSynced(values, avatar ?? '');
-
-      // 5) invalidate in-memory user data cache so the profile page fetches
-      //    fresh data on next mount instead of a potentially stale promise
+      // 4) optimistic session update — keep role/onboarding from current
+      //    session so we never flicker mentor → mentee while the backend
+      //    catches up. The background reconcile in step 6 corrects them
+      //    if the user actually transitioned during this submit.
       if (session?.user?.id) {
         clearUserDataCache(Number(session.user.id), 'zh_TW');
       }
-
-      // 6) update next-auth session (requires jwt trigger update handler!)
+      const sessionUser = session?.user;
+      const personalLinks = links.map((link) => ({
+        platform: link.platform,
+        url: link.url,
+      }));
       await updateSession({
         user: {
-          // keep id from current session
-          id: session?.user?.id,
-          name: latest?.name ?? values.name ?? session?.user?.name,
-          avatar: latest?.avatar ?? avatar ?? session?.user?.avatar,
+          id: sessionUser?.id,
+          name: values.name ?? sessionUser?.name,
+          avatar: avatar ?? sessionUser?.avatar,
           avatarUpdatedAt: values.avatarFile
             ? Date.now()
-            : session?.user?.avatarUpdatedAt,
-          isMentor: Boolean(latest?.is_mentor),
-          onBoarding: Boolean(latest?.onboarding),
-          msg: session?.user?.msg,
-          personalLinks: links.map((link) => ({
-            platform: link.platform,
-            url: link.url,
-          })),
+            : sessionUser?.avatarUpdatedAt,
+          isMentor: sessionUser?.isMentor,
+          onBoarding: sessionUser?.onBoarding,
+          msg: sessionUser?.msg,
+          personalLinks,
         },
       });
 
-      // 7) navigate
+      // 5) navigate immediately — user no longer waits for backend sync
       trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
       if (isMentorOnboarding) {
         router.push('/profile/card');
       } else {
         router.push(`/profile/${pageUserId}`);
       }
+
+      // 6) background reconcile — silent, never blocks the user. If the
+      //    backend ultimately reports a different is_mentor / onboarding
+      //    than the optimistic value, patch the session in the background.
+      void pollUntilSynced(values, avatar ?? '').then((latest) => {
+        if (!latest) return;
+        const optimisticIsMentor = sessionUser?.isMentor ?? false;
+        const optimisticOnBoarding = sessionUser?.onBoarding ?? false;
+        const latestIsMentor = Boolean(latest.is_mentor);
+        const latestOnBoarding = Boolean(latest.onboarding);
+        if (
+          optimisticIsMentor === latestIsMentor &&
+          optimisticOnBoarding === latestOnBoarding
+        ) {
+          return;
+        }
+        void updateSession({
+          user: {
+            ...sessionUser,
+            isMentor: latestIsMentor,
+            onBoarding: latestOnBoarding,
+          },
+        });
+      });
     } catch (err) {
       captureFlowFailure({
         flow: 'profile_update',

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,4 +1,5 @@
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
+import { captureFlowFailure } from '@/lib/monitoring';
 import { fetchUser, MentorProfileVO } from '@/services/profile/user';
 
 function isProfileSynced(
@@ -21,20 +22,44 @@ function isProfileSynced(
   return true;
 }
 
+/**
+ * Polls fetchUser until the backend reflects the submitted values, or the
+ * retry budget is exhausted. Designed for fire-and-forget background use:
+ * never throws, and reports a Sentry breadcrumb if max retries elapse
+ * without sync.
+ */
 export async function pollUntilSynced(
   values: ProfileFormValues,
   avatar: string,
   maxRetries = 12,
   intervalMs = 5000
 ): Promise<MentorProfileVO | null> {
-  let latest = await fetchUser('zh_TW');
-  for (
-    let i = 1;
-    i < maxRetries && !(latest && isProfileSynced(values, latest, avatar));
-    i++
-  ) {
-    await new Promise((resolve) => setTimeout(resolve, intervalMs));
-    latest = await fetchUser('zh_TW');
+  let latest: MentorProfileVO | null = null;
+  let synced = false;
+
+  for (let i = 0; i < maxRetries; i++) {
+    if (i > 0) {
+      await new Promise((resolve) => setTimeout(resolve, intervalMs));
+    }
+    try {
+      latest = await fetchUser('zh_TW');
+    } catch {
+      latest = null;
+      continue;
+    }
+    if (latest && isProfileSynced(values, latest, avatar)) {
+      synced = true;
+      break;
+    }
   }
+
+  if (!synced) {
+    captureFlowFailure({
+      flow: 'profile_update',
+      step: 'background_sync',
+      message: 'pollUntilSynced exhausted retries without sync',
+    });
+  }
+
   return latest;
 }

--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -106,9 +106,9 @@ function buildS3ObjectUrl(bucketUrl: string, key: string): string {
 
 /**
  * updateAvatar
- * 1) 呼叫後端拿 presigned url（若有預抓 cache 命中則直接消費）
- * 2) 用 presigned POST 直接上傳到 S3
- * 3) 回傳檔案的公開 URL（bucketUrl + key）
+ * 1) Get a presigned URL (consumes the prefetched cache when available)
+ * 2) Upload the file directly to S3 via presigned POST
+ * 3) Return the public object URL (bucketUrl + key)
  */
 export async function updateAvatar(
   avatarFile: File,

--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -1,6 +1,9 @@
 import { getSession } from 'next-auth/react';
 
-import { fetchPresignedUrlByUserId } from '@/services/profile/presignedUrl';
+import {
+  fetchPresignedUrlByUserId,
+  PresignedUrlData,
+} from '@/services/profile/presignedUrl';
 
 interface PresignedUrlFields {
   key: string;
@@ -11,15 +14,61 @@ interface PresignedUrlFields {
   [key: string]: string;
 }
 
-interface PresignedUrlData {
-  url: string;
-  fields: PresignedUrlFields;
+// S3 presigned POST URLs are valid for 15 minutes; cap our cache at 10 to
+// leave headroom for the actual upload to complete before expiry.
+const PRESIGNED_TTL_MS = 10 * 60 * 1000;
+
+interface PresignedCacheEntry {
+  userId: number;
+  fetchedAt: number;
+  promise: Promise<PresignedUrlData | null>;
+}
+
+let presignedCache: PresignedCacheEntry | null = null;
+
+function isCacheUsable(
+  entry: PresignedCacheEntry | null,
+  userId: number
+): entry is PresignedCacheEntry {
+  if (!entry) return false;
+  if (entry.userId !== userId) return false;
+  if (Date.now() - entry.fetchedAt > PRESIGNED_TTL_MS) return false;
+  return true;
+}
+
+/**
+ * Fire-and-forget warm-up for the avatar presigned URL. Caller should not
+ * await — the cached promise is consumed by `updateAvatar` at submit time
+ * to remove one serial request from the upload waterfall.
+ */
+export function prefetchPresignedUrl(userId: number): void {
+  if (!Number.isFinite(userId) || userId <= 0) return;
+  if (isCacheUsable(presignedCache, userId)) return;
+  const promise = fetchPresignedUrlByUserId(userId).catch(() => null);
+  presignedCache = { userId, fetchedAt: Date.now(), promise };
+}
+
+export function clearPresignedUrlCache(): void {
+  presignedCache = null;
+}
+
+async function consumePresignedUrl(
+  userId: number
+): Promise<PresignedUrlData | null> {
+  if (isCacheUsable(presignedCache, userId)) {
+    const cached = presignedCache;
+    // Single-use: clear regardless of outcome so the next upload re-fetches.
+    presignedCache = null;
+    const result = await cached.promise;
+    if (result) return result;
+  }
+  return fetchPresignedUrlByUserId(userId);
 }
 
 // 你的後端 policy 有這條：["starts-with", "$Content-Type", "image/"]
 // 所以 file.type 必須是 image/*
 async function uploadToS3WithPresignedPost(
-  presigned: PresignedUrlData,
+  presigned: { url: string; fields: PresignedUrlFields },
   avatarFile: File,
   signal?: AbortSignal
 ): Promise<void> {
@@ -57,7 +106,7 @@ function buildS3ObjectUrl(bucketUrl: string, key: string): string {
 
 /**
  * updateAvatar
- * 1) 呼叫後端拿 presigned url (另外一支檔案)
+ * 1) 呼叫後端拿 presigned url（若有預抓 cache 命中則直接消費）
  * 2) 用 presigned POST 直接上傳到 S3
  * 3) 回傳檔案的公開 URL（bucketUrl + key）
  */
@@ -77,7 +126,7 @@ export async function updateAvatar(
       throw new Error('頭像檔案必須是圖片格式 (image/*)。');
     }
 
-    const presigned = await fetchPresignedUrlByUserId(Number(userId));
+    const presigned = await consumePresignedUrl(Number(userId));
     if (!presigned?.url || !presigned?.fields?.key) {
       throw new Error('取得 presigned url 失敗或回傳格式不完整');
     }


### PR DESCRIPTION
## What Does This PR Do?

- Drop the up-to-60s `pollUntilSynced` block from profile edit save: optimistically update next-auth session with submitted values and navigate to profile view immediately after `updateProfile` / experience upserts succeed
- Run `pollUntilSynced` as a fire-and-forget background job; reconcile session if backend reports different `is_mentor` / `onBoarding` than the optimistic value, otherwise no-op
- Move `pollUntilSynced` to never-throw and report a Sentry breadcrumb (`flow: profile_update, step: background_sync`) when retries are exhausted
- Add `prefetchPresignedUrl(userId)` in `updateAvatar.ts` with a 10-minute single-use cache (S3 URL expires at 15 min); edit page warms it on mount so the upload waterfall skips the presigned URL round trip
- Fix latent bug: optimistic session update preserves current `isMentor` / `onBoarding` instead of `Boolean(latest?.is_mentor)`, which previously flipped mentors to mentee UI when poll returned null
- Tests: add 4 cases covering optimistic navigation, role preservation, and background reconcile

## Demo

http://localhost:3000/profile/<id>/edit

## Screenshot

N/A

## Anything to Note?

Background sync failures now surface only via Sentry — no toast — to avoid noise after the user has already left the edit page.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
