### PR TITLE
perf(onboarding): cohese avatar watch into step1 to skip container re-renders

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -44,8 +44,6 @@ export default function OnboardingContainer() {
     step5?: z.infer<typeof step5Schema>;
   }>({});
 
-  const stableOnboardingCacheBust = useRef(Date.now()).current;
-
   // Tracks the in-flight background avatar upload kicked off after Step 1.
   // The promise is consumed at Step 5 submit so the user doesn't wait for S3
   // round-trip; replaced (with abort) when the user picks a new file.
@@ -67,11 +65,6 @@ export default function OnboardingContainer() {
       language: 'zh_TW',
     },
   });
-
-  const watchedAvatar = step1Form.watch('avatar');
-  const avatarDisplayUrl = watchedAvatar
-    ? `${watchedAvatar}?cb=${session?.user?.avatarUpdatedAt ?? stableOnboardingCacheBust}`
-    : '';
 
   useEffect(() => {
     if (status === 'loading') return;
@@ -265,7 +258,6 @@ export default function OnboardingContainer() {
       currentStep={currentStep}
       stepsTotal={STEPS_TOTAL}
       stepTitle={STEP_TITLE}
-      avatarDisplayUrl={avatarDisplayUrl}
       avatarError={avatarUploadError}
       step1Form={step1Form}
       step2Form={step2Form}

--- a/src/app/auth/(sign)/onboarding/ui.tsx
+++ b/src/app/auth/(sign)/onboarding/ui.tsx
@@ -47,7 +47,6 @@ interface Props {
   currentStep: number;
   stepsTotal: number;
   stepTitle: readonly string[];
-  avatarDisplayUrl: string;
   avatarError: string | null;
   step1Form: UseFormReturn<z.infer<typeof step1Schema>>;
   step2Form: UseFormReturn<z.infer<typeof step2Schema>>;
@@ -103,7 +102,6 @@ export default function OnboardingUI({
   currentStep,
   stepsTotal,
   stepTitle,
-  avatarDisplayUrl,
   avatarError,
   step1Form,
   step2Form,
@@ -139,11 +137,7 @@ export default function OnboardingUI({
                 showBack={false}
                 onGoToPrev={onGoToPrev}
               />
-              <WhoAreYou
-                form={step1Form}
-                avatarUrl={avatarDisplayUrl}
-                avatarError={avatarError}
-              />
+              <WhoAreYou form={step1Form} avatarError={avatarError} />
               <Button className="rounded-xl px-12" type="submit">
                 下一步
               </Button>

--- a/src/components/onboarding/steps/WhoAreYou.tsx
+++ b/src/components/onboarding/steps/WhoAreYou.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { FC } from 'react';
-import { useForm } from 'react-hook-form';
+import { useSession } from 'next-auth/react';
+import { FC, useRef } from 'react';
+import { useForm, useWatch } from 'react-hook-form';
 import * as z from 'zod';
 
 import AvatarUpload from '@/components/ui/avatar-upload';
@@ -18,17 +19,23 @@ import { step1Schema } from './index';
 
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step1Schema>>>;
-  avatarUrl: string;
   avatarError?: string | null;
 }
 
-export const WhoAreYou: FC<Props> = ({ form, avatarUrl, avatarError }) => {
+export const WhoAreYou: FC<Props> = ({ form, avatarError }) => {
+  const watchedAvatar = useWatch({ control: form.control, name: 'avatar' });
+  const { data: session } = useSession();
+  const stableCacheBust = useRef(Date.now()).current;
+  const avatarDisplayUrl = watchedAvatar
+    ? `${watchedAvatar}?cb=${session?.user?.avatarUpdatedAt ?? stableCacheBust}`
+    : '';
+
   return (
     <>
       <AvatarUpload
         control={form.control}
         name="avatarFile"
-        avatarUrl={avatarUrl}
+        avatarUrl={avatarDisplayUrl}
       />
       {avatarError && (
         <p className="-mt-6 text-center text-sm font-medium text-destructive lg:text-left">


### PR DESCRIPTION
## What Does This PR Do?

- Move `avatar` field subscription from `OnboardingContainer` into `WhoAreYou` via `useWatch`, so changing avatar (or any step1 field) no longer re-renders steps 2-5.
- Compute `avatarDisplayUrl` (with session/stable cache-bust fallback) inside `WhoAreYou` instead of the container.
- Drop `avatarDisplayUrl` prop drilling through `OnboardingUI`; remove unused `stableOnboardingCacheBust` from the container.

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

N/A

## Anything to Note?

- Closes Xchange-Taiwan/X-Talent-Tracker#201.
- `useWatch` reacts to `step1Form.reset()` the same way the previous `watch` call did, so OAuth-session-driven avatar reset still propagates to the preview.
- Cache-bust behavior preserved: prefers `session.user.avatarUpdatedAt`, falls back to a per-mount stable ref.
- Out of scope: container still subscribes to `avatarFile` for clearing the upload error banner; that re-render is confined to step 1 and unrelated to this issue.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
