### PR TITLE
perf(profile/edit): parallelize user fetch with auth to break waterfall

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -32,12 +32,10 @@ export function useEditProfileData({
   setIsMentor,
   setIsPageLoading,
 }: Options) {
-  // Pass userId only after auth resolves so we don't fetch a profile that
-  // the page would otherwise refuse to render.
-  const { userDto, error } = useUserProfileDto(
-    isAuthorized ? userId : 0,
-    'zh_TW'
-  );
+  // Fire the user fetch in parallel with auth resolution. The form.reset
+  // effect below still gates on `isAuthorized`, so unauthorized callers
+  // (redirected by useProfileAuth) never see the data populated.
+  const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
   useEffect(() => {
     if (!isAuthorized || !userDto) return;


### PR DESCRIPTION
## What Does This PR Do?

- Drop the `isAuthorized ? userId : 0` gate in `useEditProfileData` so the user-profile fetch starts in the same mount tick as the four dictionary hooks (locations / industries / interests / expertises) and `useProfileAuth`, instead of waiting one render for auth to resolve.
- The `form.reset` effect still gates on `isAuthorized && userDto`, so unauthorized callers (redirected by `useProfileAuth`) never get their data populated even if the response arrives first.
- Resolves #195.

## Demo

http://localhost:3000/profile/<userId>/edit

## Screenshot

N/A

## Anything to Note?

- Tradeoff: an unauthorized visitor will now fire one user-profile request before being redirected. The path is rare and BFF returns 403 (not Sentry noise), so the first-paint win is worth it.
- Intentionally skipped issue proposal #3 (preempt `isMentor` from session): the page is still gated by `if (isPageLoading) return <PageLoading />`, and `setIsMentor` + `setIsPageLoading` batch in the same effect today, so there is no visible flash to fix. Worth revisiting only if a future change removes the `PageLoading` gate.

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>
