### PR TITLE
perf(profile/card): prime cache after mentor onboarding to skip refetch

### DIFF
--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -21,17 +21,26 @@ vi.mock('@/services/profile/upsertExperience', () => ({
 
 vi.mock('@/lib/profile/pollUntilSynced', () => ({
   pollUntilSynced: vi.fn(),
+  firstSyncedFetch: vi.fn(),
 }));
 
 vi.mock('@/hooks/user/user-data/useUserData', () => ({
   clearUserDataCache: vi.fn(),
+  primeUserDataCache: vi.fn(),
 }));
 
 vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
 vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
 
 import { defaultValues } from '@/components/profile/edit/profileSchema';
-import { pollUntilSynced } from '@/lib/profile/pollUntilSynced';
+import {
+  clearUserDataCache,
+  primeUserDataCache,
+} from '@/hooks/user/user-data/useUserData';
+import {
+  firstSyncedFetch,
+  pollUntilSynced,
+} from '@/lib/profile/pollUntilSynced';
 import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
@@ -45,6 +54,9 @@ const mockUpdateAvatar = vi.mocked(updateAvatar);
 const mockUpdateProfile = vi.mocked(updateProfile);
 const mockUpsertMentorExperience = vi.mocked(upsertMentorExperience);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
+const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
+const mockPrimeUserDataCache = vi.mocked(primeUserDataCache);
+const mockClearUserDataCache = vi.mocked(clearUserDataCache);
 
 const mockUserDTO: MentorProfileVO = {
   user_id: 1,
@@ -75,7 +87,10 @@ const mockUserDTO: MentorProfileVO = {
 
 const mockSession: Session = {
   user: {
-    id: 'test-user-id',
+    // Real sessions store user_id as a numeric string. The cache key is
+    // built via Number(id) so a non-numeric placeholder would silently
+    // become NaN and skip the cache prime path.
+    id: '1',
     name: 'Test User',
     email: 'test@example.com',
     onBoarding: true,
@@ -113,6 +128,10 @@ describe('useProfileSubmit', () => {
     mockUpdateProfile.mockResolvedValue(undefined);
     mockUpsertMentorExperience.mockResolvedValue(undefined);
     mockPollUntilSynced.mockResolvedValue(mockUserDTO);
+    // Default: backend has not synced fast enough → exercise the historical
+    // clear-cache + background-poll fallback. Tests covering the new prime
+    // path override this per-case.
+    mockFirstSyncedFetch.mockResolvedValue(null);
   });
 
   // ── Guard clauses ──────────────────────────────────────────────────────────
@@ -384,6 +403,82 @@ describe('useProfileSubmit', () => {
     });
 
     expect(updateSession).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Cache prime vs fallback ────────────────────────────────────────────────
+
+  it('firstSyncedFetch returns dto → primeUserDataCache called, pollUntilSynced NOT called', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(mockUserDTO);
+
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      // Flush microtasks so any inline reconcile after prime runs.
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockPrimeUserDataCache).toHaveBeenCalledWith(
+      Number(mockSession.user!.id),
+      'zh_TW',
+      mockUserDTO
+    );
+    expect(mockClearUserDataCache).not.toHaveBeenCalled();
+    expect(mockPollUntilSynced).not.toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
+  });
+
+  it('firstSyncedFetch returns null → falls back to clearUserDataCache + pollUntilSynced', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(null);
+
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockPrimeUserDataCache).not.toHaveBeenCalled();
+    expect(mockClearUserDataCache).toHaveBeenCalledWith(
+      Number(mockSession.user!.id),
+      'zh_TW'
+    );
+    expect(mockPollUntilSynced).toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
+  });
+
+  it('prime path: inline reconcile patches session when primed latest disagrees with optimistic role', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: false,
+      onboarding: true,
+    });
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(makeOptions({ updateSession }))
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Optimistic + inline reconcile (no background poll second call).
+    expect(mockPollUntilSynced).not.toHaveBeenCalled();
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    const reconcileArg = updateSession.mock.calls[1][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(reconcileArg.user.isMentor).toBe(false);
+    expect(reconcileArg.user.onBoarding).toBe(true);
   });
 
   // ── Primary job persistence ────────────────────────────────────────────────

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -4,14 +4,21 @@ import { Session } from 'next-auth';
 import { useState } from 'react';
 
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
-import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
+import {
+  clearUserDataCache,
+  primeUserDataCache,
+} from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
-import { pollUntilSynced } from '@/lib/profile/pollUntilSynced';
+import {
+  firstSyncedFetch,
+  pollUntilSynced,
+} from '@/lib/profile/pollUntilSynced';
 import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
+import { MentorProfileVO } from '@/services/profile/user';
 
 interface Options {
   pageUserId: string;
@@ -159,18 +166,33 @@ export function useProfileSubmit({
         throw err;
       }
 
-      // 4) optimistic session update — keep role/onboarding from current
-      //    session so we never flicker mentor → mentee while the backend
-      //    catches up. The background reconcile in step 6 corrects them
-      //    if the user actually transitioned during this submit.
-      if (session?.user?.id) {
-        clearUserDataCache(Number(session.user.id), 'zh_TW');
-      }
+      // 4) prime user-data cache before navigation — bounded by a short
+      //    timeout. If the backend has already synced (the common case
+      //    once steps 1-3 returned), the next page mount renders from
+      //    cache with zero API calls. Otherwise we fall back to the
+      //    historical clear-cache + background-poll path so the user is
+      //    never blocked on backend latency.
+      const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
       const sessionUser = session?.user;
       const personalLinks = links.map((link) => ({
         platform: link.platform,
         url: link.url,
       }));
+
+      let primedLatest: MentorProfileVO | null = null;
+      if (sessionUserId) {
+        primedLatest = await firstSyncedFetch(values, avatar ?? '');
+        if (primedLatest) {
+          primeUserDataCache(sessionUserId, 'zh_TW', primedLatest);
+        } else {
+          clearUserDataCache(sessionUserId, 'zh_TW');
+        }
+      }
+
+      // 5) optimistic session update — keep role/onboarding from current
+      //    session so we never flicker mentor → mentee while the backend
+      //    catches up. The reconcile in step 7 corrects them if the user
+      //    actually transitioned during this submit.
       await updateSession({
         user: {
           id: sessionUser?.id,
@@ -186,7 +208,7 @@ export function useProfileSubmit({
         },
       });
 
-      // 5) navigate immediately — user no longer waits for backend sync
+      // 6) navigate immediately — user no longer waits for backend sync
       trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
       if (isMentorOnboarding) {
         router.push('/profile/card');
@@ -194,10 +216,12 @@ export function useProfileSubmit({
         router.push(`/profile/${pageUserId}`);
       }
 
-      // 6) background reconcile — silent, never blocks the user. If the
-      //    backend ultimately reports a different is_mentor / onboarding
-      //    than the optimistic value, patch the session in the background.
-      void pollUntilSynced(values, avatar ?? '').then((latest) => {
+      // 7) session reconcile — if the backend ultimately reports a
+      //    different is_mentor / onboarding than the optimistic value,
+      //    patch the session. Reuses the primed result when available so
+      //    we do not double-poll; otherwise falls back to the background
+      //    pollUntilSynced for slow-sync cases.
+      const reconcileSession = (latest: MentorProfileVO | null) => {
         if (!latest) return;
         const optimisticIsMentor = sessionUser?.isMentor ?? false;
         const optimisticOnBoarding = sessionUser?.onBoarding ?? false;
@@ -216,7 +240,13 @@ export function useProfileSubmit({
             onBoarding: latestOnBoarding,
           },
         });
-      });
+      };
+
+      if (primedLatest) {
+        reconcileSession(primedLatest);
+      } else {
+        void pollUntilSynced(values, avatar ?? '').then(reconcileSession);
+      }
     } catch (err) {
       captureFlowFailure({
         flow: 'profile_update',

--- a/src/hooks/user/user-data/useUserData.test.ts
+++ b/src/hooks/user/user-data/useUserData.test.ts
@@ -14,6 +14,7 @@ import { fetchUserById, type MentorProfileVO } from '@/services/profile/user';
 
 import useUserData, {
   clearUserDataCache,
+  primeUserDataCache,
   USER_DATA_CACHE_TTL_MS as TTL_MS,
 } from './useUserData';
 
@@ -163,6 +164,56 @@ describe('useUserData caching', () => {
     await waitFor(() => expect(mockFetchUserById).toHaveBeenCalledTimes(2));
     expect(second.result.current.userData?.name).toBe('Stale 4007');
     expect(second.result.current.error).toBeNull();
+    second.unmount();
+  });
+
+  it('primeUserDataCache: next mount renders from cache without an API call', async () => {
+    const userId = 4101;
+    const primed = {
+      ...makeUserDto(userId),
+      name: 'Primed 4101',
+    } as MentorProfileVO;
+
+    primeUserDataCache(userId, 'en', primed);
+
+    const { result, unmount } = renderHook(() => useUserData(userId, 'en'));
+
+    await waitFor(() =>
+      expect(result.current.userData?.name).toBe('Primed 4101')
+    );
+    expect(mockFetchUserById).not.toHaveBeenCalled();
+    unmount();
+  });
+
+  it('primeUserDataCache: replaces a stale entry so next mount sees primed data', async () => {
+    const userId = 4102;
+    const nowSpy = vi.spyOn(Date, 'now');
+    nowSpy.mockReturnValue(50_000);
+
+    mockFetchUserById.mockResolvedValueOnce({
+      ...makeUserDto(userId),
+      name: 'Stale 4102',
+    } as MentorProfileVO);
+
+    const first = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() =>
+      expect(first.result.current.userData?.name).toBe('Stale 4102')
+    );
+    first.unmount();
+
+    nowSpy.mockReturnValue(50_000 + TTL_MS + 1);
+    primeUserDataCache(userId, 'en', {
+      ...makeUserDto(userId),
+      name: 'Primed 4102',
+    } as MentorProfileVO);
+
+    const second = renderHook(() => useUserData(userId, 'en'));
+    await waitFor(() =>
+      expect(second.result.current.userData?.name).toBe('Primed 4102')
+    );
+    // Only the original fetch was called — prime kept the second mount off
+    // the network.
+    expect(mockFetchUserById).toHaveBeenCalledTimes(1);
     second.unmount();
   });
 

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -11,6 +11,7 @@ import {
 } from '../interests/useInterests';
 import {
   clearUserProfileDtoCache,
+  primeUserProfileDtoCache,
   USER_PROFILE_DTO_CACHE_TTL_MS,
   useUserProfileDto,
 } from './useUserProfileDto';
@@ -18,6 +19,7 @@ import {
 // Re-exported under the historical names so existing callers (e.g.
 // useProfileSubmit, useUserData.test) continue to work without churn.
 export const clearUserDataCache = clearUserProfileDtoCache;
+export const primeUserDataCache = primeUserProfileDtoCache;
 export const USER_DATA_CACHE_TTL_MS = USER_PROFILE_DTO_CACHE_TTL_MS;
 
 export interface InterestType {

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -38,6 +38,28 @@ export function clearUserProfileDtoCache(
   userDtoPromiseCache.delete(key);
 }
 
+/**
+ * Writes a known-fresh dto into the in-memory cache so the next consumer of
+ * useUserProfileDto for this user renders from cache without an API call.
+ * Call this after the caller has already retrieved authoritative data (e.g.
+ * pollUntilSynced result post profile-submit) to prime the cache before
+ * navigating to a page that reads the same dto.
+ */
+export function primeUserProfileDtoCache(
+  userId: number,
+  language: string,
+  data: MentorProfileVO
+): void {
+  const key = `${userId}-${language}`;
+  userDtoDataCache.set(key, {
+    data,
+    expiresAt: Date.now() + USER_PROFILE_DTO_CACHE_TTL_MS,
+  });
+  // Drop any in-flight promise for this key so future readers see the primed
+  // entry instead of awaiting an older fetch that is about to be superseded.
+  userDtoPromiseCache.delete(key);
+}
+
 // Promise-deduped fetch: writes to the data cache on success so subsequent
 // readers (including a parallel-mounted hook) see the fresh entry. Concurrent
 // callers share the same in-flight promise to avoid duplicate network calls.

--- a/src/lib/profile/pollUntilSynced.test.ts
+++ b/src/lib/profile/pollUntilSynced.test.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/profile/user', () => ({
+  fetchUser: vi.fn(),
+}));
+
+vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
+
+import { defaultValues } from '@/components/profile/edit/profileSchema';
+import { fetchUser, type MentorProfileVO } from '@/services/profile/user';
+
+import { firstSyncedFetch } from './pollUntilSynced';
+
+const mockFetchUser = vi.mocked(fetchUser);
+
+const baseValues = {
+  ...defaultValues,
+  name: 'Sync Test',
+  location: 'Taiwan',
+  about: 'about-me',
+  statement: 'statement',
+  years_of_experience: '1_3',
+  industry: ['tech'],
+};
+
+const makeSyncedDto = (avatar = ''): MentorProfileVO =>
+  ({
+    user_id: 1,
+    name: 'Sync Test',
+    avatar,
+    location: 'Taiwan',
+    about: 'about-me',
+    personal_statement: 'statement',
+    years_of_experience: '1_3',
+    industry: { subject_group: 'tech' },
+    is_mentor: true,
+    onboarding: true,
+    experiences: [],
+  }) as unknown as MentorProfileVO;
+
+describe('firstSyncedFetch', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockFetchUser.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('returns the dto when backend already reflects submitted values', async () => {
+    mockFetchUser.mockResolvedValueOnce(makeSyncedDto());
+
+    const result = await firstSyncedFetch(baseValues, '');
+
+    expect(result).not.toBeNull();
+    expect(result?.name).toBe('Sync Test');
+  });
+
+  it('returns null when backend has not yet synced (values disagree)', async () => {
+    mockFetchUser.mockResolvedValueOnce({
+      ...makeSyncedDto(),
+      name: 'Old Name',
+    } as MentorProfileVO);
+
+    const result = await firstSyncedFetch(baseValues, '');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null on fetch error', async () => {
+    mockFetchUser.mockRejectedValueOnce(new Error('network down'));
+
+    const result = await firstSyncedFetch(baseValues, '');
+
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fetch exceeds timeout (does not block forever)', async () => {
+    mockFetchUser.mockImplementationOnce(
+      () =>
+        new Promise<MentorProfileVO | null>(() => {
+          // Never resolves — must be cut by the timeout.
+        })
+    );
+
+    const promise = firstSyncedFetch(baseValues, '', 100);
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(await promise).toBeNull();
+  });
+});

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -23,6 +23,44 @@ function isProfileSynced(
 }
 
 /**
+ * Single, fast attempt to read the latest profile and confirm it matches the
+ * just-submitted values, bounded by `timeoutMs`. Used by submit handlers to
+ * prime caches before navigation so the next page can render from cache
+ * without a fresh API call.
+ *
+ * Returns the synced MentorProfileVO on success, or null if:
+ *   - the backend has not synced yet,
+ *   - fetch failed, or
+ *   - the call did not complete within `timeoutMs`.
+ *
+ * Never throws. On null, callers fall back to the slower `pollUntilSynced`
+ * background reconcile path so the user is not blocked on backend latency.
+ */
+export async function firstSyncedFetch(
+  values: ProfileFormValues,
+  avatar: string,
+  timeoutMs = 800
+): Promise<MentorProfileVO | null> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<null>((resolve) => {
+    timer = setTimeout(() => resolve(null), timeoutMs);
+  });
+
+  const fetchPromise = fetchUser('zh_TW')
+    .then((latest) => {
+      if (latest && isProfileSynced(values, latest, avatar)) return latest;
+      return null;
+    })
+    .catch(() => null);
+
+  try {
+    return await Promise.race([fetchPromise, timeoutPromise]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+/**
  * Polls fetchUser until the backend reflects the submitted values, or the
  * retry budget is exhausted. Designed for fire-and-forget background use:
  * never throws, and reports a Sentry breadcrumb if max retries elapse


### PR DESCRIPTION
## What Does This PR Do?

- 在 `useUserProfileDto` 新增 `primeUserProfileDtoCache`，並透過 `useUserData` re-export 為 `primeUserDataCache`，命名對齊既有的 `clearUserDataCache`
- 在 `pollUntilSynced.ts` 新增 `firstSyncedFetch` helper：對 `fetchUser` 做一次性 fetch + `isProfileSynced` 檢查，搭配 800ms timeout fallback，永不 throw
- `useProfileSubmit` 改寫 step 4–7：navigate 前 `await firstSyncedFetch`，成功就 `primeUserDataCache` 並用該結果 inline 做 session reconcile，跳過後台 `pollUntilSynced`；失敗 fallback 回原本的 `clearUserDataCache` + 背景 poll
- 結果：mentor onboarding redirect 後 `/profile/card` mount 時直接命中 cache，不再對 `/v1/mentors/{userId}/zh_TW/profile` 多打一次 API
- 補測試：`pollUntilSynced.test.ts` 新檔（4 cases），`useUserData.test.ts` 加 prime 路徑 2 cases，`useProfileSubmit.test.ts` 加 prime / fallback / inline reconcile 3 cases

Refs: Xchange-Taiwan/X-Talent-Tracker#204

## Demo

http://localhost:3000/profile/card

## Screenshot

N/A

## Anything to Note?

- Test fixture: `mockSession.user.id` 從 `'test-user-id'` 改為 `'1'`。原字串透過 `Number(...)` 是 `NaN`；`clearUserDataCache(NaN, ...)` 在舊 code 是 no-op，新 code 真的要 prime 進 cache 必須用合法 numeric string，與 prod session 結構一致
- `firstSyncedFetch` timeout 預設 800ms。Mentor onboarding 場景下 step 1-3 已 await 完成，後端通常已 sync，常見路徑 < 200ms；失敗退回現況的 clear + 背景 poll，不會比現在差
- Out of scope（與原 ticket 一致）：mentee onboarding 流程、其他進入 `/profile/card` 的路徑

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
