### PR TITLE
perf(profile): align avatar preload key + DPR-aware srcset

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,23 +56,37 @@ export default async function RootLayout({
   const session = await getServerSession(authOptions);
 
   // Preload the logged-in user's avatar through the next/image optimizer so the
-  // profile view page's first paint does not wait on a cold S3 fetch. The href
-  // must match the optimizer cache key used by <Image sizes="160px" /> on that
-  // page (w=384 covers 2x DPR; lower-DPR users get a cheap wasted hint).
+  // profile view / edit page's first paint does not wait on a cold S3 fetch.
+  // imageSrcSet + imageSizes lets the browser pick the same width that
+  // <Image sizes="150-160px" /> will request (w=256 at 1x DPR, w=384 at 2x),
+  // avoiding the cache-miss caused by a fixed-width preload.
   const sessionAvatar = session?.user?.avatar;
   const avatarVersion = session?.user?.avatarUpdatedAt;
-  const avatarPreloadHref = sessionAvatar
-    ? `/_next/image?url=${encodeURIComponent(
-        avatarVersion ? `${sessionAvatar}?v=${avatarVersion}` : sessionAvatar
-      )}&w=384&q=75`
+  const avatarSrc = sessionAvatar
+    ? avatarVersion
+      ? `${sessionAvatar}?v=${avatarVersion}`
+      : sessionAvatar
+    : null;
+  const buildOptimizerUrl = (w: number) =>
+    `/_next/image?url=${encodeURIComponent(avatarSrc ?? '')}&w=${w}&q=75`;
+  const avatarSrcSet = avatarSrc
+    ? `${buildOptimizerUrl(256)} 256w, ${buildOptimizerUrl(384)} 384w`
     : null;
 
   return (
     <html lang="zh-TW" className={notoSans.className}>
-      <body id="app">
-        {avatarPreloadHref && (
-          <link rel="preload" as="image" href={avatarPreloadHref} />
+      <head>
+        {avatarSrcSet && (
+          <link
+            rel="preload"
+            as="image"
+            imageSrcSet={avatarSrcSet}
+            imageSizes="160px"
+            fetchPriority="high"
+          />
         )}
+      </head>
+      <body id="app">
         <a
           href="#main-content"
           className="sr-only focus:not-sr-only focus:fixed focus:left-4 focus:top-4 focus:z-[100] focus:rounded-md focus:bg-primary focus:px-4 focus:py-2 focus:text-primary-foreground focus:shadow-lg focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"

--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -20,12 +20,14 @@ export const AvatarSection = <T extends FieldValues>({
   const { data: session } = useSession();
   // Stable fallback used when avatarUpdatedAt is absent (e.g. fresh login
   // before any update). Ensures the browser fetches the current image on
-  // first load rather than serving a previously-cached ?cb=0 stale copy.
+  // first load rather than serving a previously-cached ?v=0 stale copy.
   const stableCacheBust = useRef(Date.now()).current;
 
+  // Use ?v= (matches the layout preload + profile view page) so the optimizer
+  // cache key is identical across surfaces and the preloaded image is reused.
   const sessionAvatar = session?.user?.avatar ?? '';
   const avatarUrl = sessionAvatar
-    ? `${sessionAvatar}?cb=${session?.user?.avatarUpdatedAt ?? stableCacheBust}`
+    ? `${sessionAvatar}?v=${session?.user?.avatarUpdatedAt ?? stableCacheBust}`
     : '';
 
   return (

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -88,6 +88,7 @@ const AvatarUpload = <T extends FieldValues>({
             height={150}
             sizes="150px"
             className="h-full w-full rounded-full object-cover"
+            priority
           />
         ) : (
           // Show default avatar if no image is selected


### PR DESCRIPTION
## What Does This PR Do?

- Replace fixed `w=384` avatar preload with `imageSrcSet` (256w + 384w) + `imageSizes="160px"` so the browser preloads the same width `<Image>` requests at any DPR; 1x DPR users were missing the optimizer cache before.
- Move the preload `<link>` from `<body>` to `<head>` and add `fetchPriority="high"` so the preload scanner runs earlier and competes with JS bundles for bandwidth on cold paths.
- Align profile edit page avatar URL from `?cb=` to `?v=` so it matches the layout preload + profile view page — view + edit now share the same optimizer cache entry.
- Add `priority` to the edit page `<Image>` so the first-screen avatar loads eagerly instead of lazily.

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
