### PR TITLE
perf(profile/card): prime cache from mentee onboarding form

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -18,7 +18,11 @@ import {
 import useLocations from '@/hooks/user/country/useLocations';
 import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests from '@/hooks/user/interests/useInterests';
-import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
+import { buildOnboardingDtoStub } from '@/hooks/user/onboarding/buildOnboardingDtoStub';
+import {
+  clearUserDataCache,
+  primeUserDataCache,
+} from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { updateAvatar } from '@/services/profile/updateAvatar';
@@ -210,7 +214,21 @@ export default function OnboardingContainer() {
         const validatedData = formSchema.parse(allData);
         await updateProfile(validatedData);
 
-        if (session?.user?.id) {
+        // Prime the user-profile cache from the form values + interest
+        // pools we already have in memory, so /profile/card mounts from
+        // cache instead of refetching the same DTO. Falls back to
+        // clearUserDataCache if the userId is not a finite number, which
+        // matches the historical behaviour for unexpected session shapes.
+        const sessionUserId = session?.user?.id ? Number(session.user.id) : NaN;
+        if (Number.isFinite(sessionUserId)) {
+          const stub = buildOnboardingDtoStub({
+            userId: sessionUserId,
+            formData: validatedData,
+            pools: { interestedPositions, skills, topics },
+            isMentor: session?.user?.isMentor ?? false,
+          });
+          primeUserDataCache(sessionUserId, 'zh_TW', stub);
+        } else if (session?.user?.id) {
           clearUserDataCache(Number(session.user.id), 'zh_TW');
         }
 

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, it } from 'vitest';
+
+import { type InterestVO } from '@/services/profile/interests';
+
+import {
+  buildOnboardingDtoStub,
+  type InterestPools,
+} from './buildOnboardingDtoStub';
+
+const vo = (subject_group: string, subject: string): InterestVO => ({
+  id: 1,
+  subject_group,
+  subject,
+});
+
+const pools: InterestPools = {
+  interestedPositions: [vo('engineer', '工程師'), vo('designer', '設計師')],
+  skills: [vo('typescript', 'TypeScript'), vo('react', 'React')],
+  topics: [vo('career', '職涯規劃'), vo('frontend', '前端')],
+};
+
+const baseFormData = {
+  name: 'Mentee A',
+  avatar: 'https://cdn.example.com/a.jpg',
+  location: 'TWN',
+  years_of_experience: '1_3',
+  interested_positions: ['engineer'],
+  skills: ['typescript'],
+  topics: ['career'],
+};
+
+describe('buildOnboardingDtoStub', () => {
+  it('hydrates form ID arrays into InterestVO[] using the pool lookup', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      pools,
+    });
+
+    expect(dto.interested_positions?.interests).toEqual([
+      { id: 1, subject_group: 'engineer', subject: '工程師' },
+    ]);
+    expect(dto.skills?.interests).toEqual([
+      { id: 1, subject_group: 'typescript', subject: 'TypeScript' },
+    ]);
+    expect(dto.topics?.interests).toEqual([
+      { id: 1, subject_group: 'career', subject: '職涯規劃' },
+    ]);
+  });
+
+  it('passes through scalar form fields onto the DTO', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      pools,
+    });
+
+    expect(dto.user_id).toBe(42);
+    expect(dto.name).toBe('Mentee A');
+    expect(dto.avatar).toBe('https://cdn.example.com/a.jpg');
+    expect(dto.location).toBe('TWN');
+    expect(dto.years_of_experience).toBe('1_3');
+    expect(dto.onboarding).toBe(true);
+    expect(dto.is_mentor).toBe(false);
+    expect(dto.language).toBe('zh_TW');
+  });
+
+  it('fills unused mentee-branch fields with safe defaults', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      pools,
+    });
+
+    expect(dto.job_title).toBeNull();
+    expect(dto.company).toBeNull();
+    expect(dto.industry).toBeNull();
+    expect(dto.about).toBeNull();
+    expect(dto.personal_statement).toBeNull();
+    expect(dto.seniority_level).toBeNull();
+    expect(dto.expertises).toBeNull();
+    expect(dto.experiences).toEqual([]);
+  });
+
+  it('lookup miss → keeps the raw ID as both subject_group and subject so the chip is not silently dropped', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: { ...baseFormData, skills: ['typescript', 'unknown_skill'] },
+      pools,
+    });
+
+    expect(dto.skills?.interests).toEqual([
+      { id: 1, subject_group: 'typescript', subject: 'TypeScript' },
+      { id: 0, subject_group: 'unknown_skill', subject: 'unknown_skill' },
+    ]);
+  });
+
+  it('empty / undefined ID arrays → produce empty interest lists, no crash', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: {
+        name: 'Empty',
+        interested_positions: [],
+        skills: undefined,
+        topics: undefined,
+      },
+      pools,
+    });
+
+    expect(dto.interested_positions?.interests).toEqual([]);
+    expect(dto.skills?.interests).toEqual([]);
+    expect(dto.topics?.interests).toEqual([]);
+  });
+
+  it('isMentor=true is honoured (default false)', () => {
+    const mentorStub = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      pools,
+      isMentor: true,
+    });
+    expect(mentorStub.is_mentor).toBe(true);
+
+    const menteeStub = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      pools,
+    });
+    expect(menteeStub.is_mentor).toBe(false);
+  });
+});

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
@@ -1,0 +1,84 @@
+import { type InterestVO } from '@/services/profile/interests';
+import { type MentorProfileVO } from '@/services/profile/user';
+
+export interface InterestPools {
+  interestedPositions: InterestVO[];
+  skills: InterestVO[];
+  topics: InterestVO[];
+}
+
+export interface OnboardingStubInput {
+  name?: string | null;
+  avatar?: string | null;
+  location?: string | null;
+  years_of_experience?: string | null;
+  interested_positions?: string[];
+  skills?: string[];
+  topics?: string[];
+}
+
+function hydrate(ids: string[] | undefined, pool: InterestVO[]): InterestVO[] {
+  return (ids ?? []).map((id) => {
+    const match = pool.find((vo) => vo.subject_group === id);
+    if (match) return match;
+    // Lookup miss fallback: surface the raw ID so the next page does not
+    // silently drop a chip the user just selected. The shape mirrors
+    // InterestVO so downstream parsing (parseUserDtoToUserType) keeps
+    // working without a special branch.
+    return { id: 0, subject_group: id, subject: id };
+  });
+}
+
+/**
+ * Builds a `MentorProfileVO` stub from mentee-onboarding form data so the
+ * caller can prime the user-profile cache before navigating to
+ * `/profile/card`. ProfileCard only consumes a subset of the DTO on the
+ * mentee branch (name / avatar / interested_positions / skills / topics),
+ * so unused fields are filled with safe defaults that match the API's
+ * "empty" shape and keep `parseUserDtoToUserType` happy.
+ */
+export function buildOnboardingDtoStub({
+  userId,
+  formData,
+  pools,
+  isMentor = false,
+}: {
+  userId: number;
+  formData: OnboardingStubInput;
+  pools: InterestPools;
+  isMentor?: boolean;
+}): MentorProfileVO {
+  return {
+    user_id: userId,
+    name: formData.name ?? null,
+    avatar: formData.avatar ?? null,
+    job_title: null,
+    company: null,
+    years_of_experience: formData.years_of_experience ?? null,
+    location: formData.location ?? null,
+    interested_positions: {
+      interests: hydrate(
+        formData.interested_positions,
+        pools.interestedPositions
+      ),
+      language: 'zh_TW',
+    },
+    skills: {
+      interests: hydrate(formData.skills, pools.skills),
+      language: 'zh_TW',
+    },
+    topics: {
+      interests: hydrate(formData.topics, pools.topics),
+      language: 'zh_TW',
+    },
+    industry: null,
+    onboarding: true,
+    is_mentor: isMentor,
+    language: 'zh_TW',
+    personal_statement: null,
+    about: null,
+    seniority_level: null,
+    expertises: null,
+    experiences: [],
+  };
+}


### PR DESCRIPTION
## What Does This PR Do?

- 新增 `buildOnboardingDtoStub` helper：把 mentee onboarding form 的 string ID 陣列（`interested_positions` / `skills` / `topics`）配合 `useInterests` 在記憶體裡的 lookup 表 hydrate 成 `InterestVO[]`，組成一份 `MentorProfileVO` stub
- `onSubmitStep5` 把 `clearUserDataCache(...)` 改成 `primeUserDataCache(userId, 'zh_TW', stub)`（共用 #510 加的 API）
- `Number.isFinite(sessionUserId)` guard：non-numeric session id 會 fallback 回 `clearUserDataCache`，不會把垃圾 prime 進 cache
- lookup miss fallback：若某個 form ID 在 interests pool 找不到，stub 用 `{ subject_group: id, subject: id }` 保留，避免 ProfileCard 該格 silently 消失
- 結果：mentee onboarding redirect 後 `/profile/card` mount 時直接命中 cache，0 API call
- 補測試：`buildOnboardingDtoStub.test.ts`（6 cases，涵蓋 hydrate / scalar 欄位 / 安全 default / lookup miss / 空陣列 / mentor flag）

Refs: Xchange-Taiwan/X-Talent-Tracker#205

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

N/A

## Anything to Note?

- Stub DTO 對 mentee ProfileCard 用到的欄位（name / avatar / interested_positions / skills / topics）都有正確值；其他欄位（about / years_of_experience / industry / expertises / experiences）給 null / 空陣列，與 server 對 mentee user 回傳的「empty」shape 一致，`parseUserDtoToUserType` 不需特殊分支
- 60 秒 TTL 內若 user 離開 `/profile/card` 又回來，看到的仍是 stub。mentee 分支沒用到的欄位視覺上不會差；超過 TTL 就會自動 background revalidate
- Out of scope（與原 ticket 一致）：mentor onboarding（已在 #510）、其他進入 `/profile/card` 的路徑

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
