### PR TITLE
perf(onboarding): memo groupAsPlaceholderCategories in steps 3-5

### DIFF
--- a/src/components/onboarding/steps/InterestedPosition.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -26,7 +26,10 @@ export const InterestedPosition: FC<Props> = ({
   form,
   interestedPositionOptions,
 }) => {
-  const categories = groupAsPlaceholderCategories(interestedPositionOptions);
+  const categories = useMemo(
+    () => groupAsPlaceholderCategories(interestedPositionOptions),
+    [interestedPositionOptions]
+  );
 
   return (
     <FormField

--- a/src/components/onboarding/steps/SkillsToImprove.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -24,7 +24,10 @@ interface Props {
 }
 
 export const SkillsToImprove: FC<Props> = ({ form, skillOptions }) => {
-  const categories = groupAsPlaceholderCategories(skillOptions);
+  const categories = useMemo(
+    () => groupAsPlaceholderCategories(skillOptions),
+    [skillOptions]
+  );
 
   return (
     <FormField

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FC } from 'react';
+import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
@@ -24,7 +24,10 @@ interface Props {
 }
 
 export const TopicsToDiscuss: FC<Props> = ({ form, topicOptions }) => {
-  const categories = groupAsPlaceholderCategories(topicOptions);
+  const categories = useMemo(
+    () => groupAsPlaceholderCategories(topicOptions),
+    [topicOptions]
+  );
 
   return (
     <FormField


### PR DESCRIPTION
## What Does This PR Do?

- Wrap `groupAsPlaceholderCategories(options)` in `useMemo` for InterestedPosition / SkillsToImprove / TopicsToDiscuss so toggling a checkbox no longer re-buckets the full options array on every render.
- `useInterests` already returns a stable array reference via its module-level cache, so the memo dependency hits across renders and `categories` keeps the same reference until `options` actually changes.

## Demo

http://localhost:3000/auth/onboarding (steps 3 / 4 / 5)

## Screenshot

N/A

## Anything to Note?

N/A
