### PR TITLE
feat(mentor-pool): show what_i_offer instead of skills on card

### DIFF
--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -50,7 +50,7 @@ const MentorCardListBase = ({
             job_title={mentor.job_title}
             company={mentor.company}
             personalStatment={mentor.personal_statement}
-            skills={mentor.skills}
+            topics={mentor.topics}
           />
         ))}
       </div>

--- a/src/components/mentor-pool/mentor-card/Information.tsx
+++ b/src/components/mentor-pool/mentor-card/Information.tsx
@@ -1,16 +1,16 @@
 import { useLayoutEffect, useRef, useState } from 'react';
 
-import { Skill } from './Skill';
+import { Tag } from './Tag';
 
 interface InformationProps {
   name: string;
   job_title: string;
   company: string;
   personalStatment: string;
-  skills: string[];
+  topics: string[];
 }
 
-const SKILL_GAP_PX = 8;
+const TAG_GAP_PX = 8;
 const EXTRA_BADGE_RESERVE_PX = 52;
 
 export const Information = ({
@@ -18,12 +18,12 @@ export const Information = ({
   job_title,
   company,
   personalStatment,
-  skills = [],
+  topics = [],
 }: InformationProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const measureRef = useRef<HTMLDivElement>(null);
   const widthsRef = useRef<number[]>([]);
-  const [visibleSkillsCount, setVisibleSkillsCount] = useState(skills.length);
+  const [visibleTagsCount, setVisibleTagsCount] = useState(topics.length);
 
   useLayoutEffect(() => {
     if (!measureRef.current || !containerRef.current) return;
@@ -37,16 +37,14 @@ export const Information = ({
       let total = EXTRA_BADGE_RESERVE_PX;
       let lastIndex = widths.length - 1;
       for (let i = 0; i < widths.length; i++) {
-        const gap = i > 0 ? SKILL_GAP_PX : 0;
+        const gap = i > 0 ? TAG_GAP_PX : 0;
         total += widths[i] + gap;
         if (total > containerWidth) {
           lastIndex = i - 1;
           break;
         }
       }
-      setVisibleSkillsCount(
-        Math.max(0, Math.min(lastIndex + 1, skills.length))
-      );
+      setVisibleTagsCount(Math.max(0, Math.min(lastIndex + 1, topics.length)));
     };
 
     computeVisible(containerRef.current.getBoundingClientRect().width);
@@ -59,10 +57,10 @@ export const Information = ({
     observer.observe(containerRef.current);
 
     return () => observer.disconnect();
-  }, [skills]);
+  }, [topics]);
 
-  const visibleSkills = skills.slice(0, visibleSkillsCount);
-  const extraSkillsCount = skills.length - visibleSkillsCount;
+  const visibleTopics = topics.slice(0, visibleTagsCount);
+  const extraTopicsCount = topics.length - visibleTagsCount;
 
   return (
     <div className="flex h-full flex-col gap-4">
@@ -85,16 +83,16 @@ export const Information = ({
           aria-hidden
           className="pointer-events-none invisible absolute left-0 top-0 flex flex-wrap gap-2"
         >
-          {skills.map((skill) => (
-            <Skill skill={skill} key={`measure-${skill}`} />
+          {topics.map((topic) => (
+            <Tag label={topic} key={`measure-${topic}`} />
           ))}
         </div>
         <div ref={containerRef} className="flex flex-wrap gap-2">
-          {visibleSkills.map((skill) => (
-            <Skill skill={skill} key={skill} />
+          {visibleTopics.map((topic) => (
+            <Tag label={topic} key={topic} />
           ))}
-          {extraSkillsCount > 0 && (
-            <Skill skill={`+${extraSkillsCount}`} key="extra" />
+          {extraTopicsCount > 0 && (
+            <Tag label={`+${extraTopicsCount}`} key="extra" />
           )}
         </div>
       </div>

--- a/src/components/mentor-pool/mentor-card/Tag.tsx
+++ b/src/components/mentor-pool/mentor-card/Tag.tsx
@@ -1,11 +1,11 @@
-interface SkillProps {
-  skill: string;
+interface TagProps {
+  label: string;
 }
 
-export const Skill = ({ skill }: SkillProps) => {
+export const Tag = ({ label }: TagProps) => {
   return (
     <div className="rounded-md border border-[#E6E8EA] px-3 py-1.5 text-sm font-medium tracking-wide">
-      {skill}
+      {label}
     </div>
   );
 };

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -13,7 +13,7 @@ export interface MentorCardProps {
   job_title: string;
   company: string;
   personalStatment: string;
-  skills: string[];
+  topics: string[];
 }
 
 const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
@@ -26,7 +26,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
       job_title,
       company,
       personalStatment,
-      skills,
+      topics,
     }: MentorCardProps,
     ref
   ) => {
@@ -47,7 +47,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
             job_title={job_title}
             company={company}
             personalStatment={personalStatment}
-            skills={skills}
+            topics={topics}
           />
         </div>
       </article>

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -73,13 +73,14 @@ export async function fetchMentorsServer(
   }
 }
 
-async function fetchSkillLabelMapServer(
-  language: string
+async function fetchInterestLabelMapServer(
+  language: string,
+  interest: 'SKILL' | 'TOPIC'
 ): Promise<Record<string, string>> {
   if (!BASE_URL) return {};
   try {
     const res = await fetch(
-      buildUrl(`/v1/users/${language}/interests`, { interest: 'SKILL' }),
+      buildUrl(`/v1/users/${language}/interests`, { interest }),
       { next: { revalidate: REVALIDATE_SECONDS } }
     );
     if (!res.ok) return {};
@@ -90,7 +91,7 @@ async function fetchSkillLabelMapServer(
     });
     return map;
   } catch (error) {
-    console.error('SSR fetchSkillLabelMap error:', error);
+    console.error('SSR fetchInterestLabelMap error:', error);
     return {};
   }
 }
@@ -98,9 +99,10 @@ async function fetchSkillLabelMapServer(
 export async function fetchMentorsEnrichedServer(
   param: MentorRequest
 ): Promise<MentorType[]> {
-  const [searchResults, skillLabelMap] = await Promise.all([
+  const [searchResults, skillLabelMap, topicLabelMap] = await Promise.all([
     fetchMentorsServer(param),
-    fetchSkillLabelMapServer('zh_TW'),
+    fetchInterestLabelMapServer('zh_TW', 'SKILL'),
+    fetchInterestLabelMapServer('zh_TW', 'TOPIC'),
   ]);
 
   if (searchResults.length === 0) return [];
@@ -109,6 +111,9 @@ export async function fetchMentorsEnrichedServer(
     ...mentor,
     skills: mentor.skills
       .map((subjectGroup) => skillLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+    topics: mentor.topics
+      .map((subjectGroup) => topicLabelMap[subjectGroup] ?? subjectGroup)
       .filter(Boolean),
   }));
 }

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -55,10 +55,18 @@ export async function fetchMentorsEnriched(
     skillLabelMap[s.subject_group] = s.subject ?? '';
   });
 
+  const topicLabelMap: Record<string, string> = {};
+  interests.topics.forEach((t) => {
+    topicLabelMap[t.subject_group] = t.subject ?? '';
+  });
+
   return searchResults.map((mentor) => ({
     ...mentor,
     skills: mentor.skills
       .map((subjectGroup) => skillLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+    topics: mentor.topics
+      .map((subjectGroup) => topicLabelMap[subjectGroup] ?? subjectGroup)
       .filter(Boolean),
   }));
 }


### PR DESCRIPTION
## What Does This PR Do?

- Switch Mentor Pool card tags from `skills` (擅長領域) to `topics` (我能提供的服務 / what_i_offer) per PM decision in tracker #138
- Enrich `topics` subject_group → label in both client (`fetchMentorsEnriched`) and SSR (`fetchMentorsEnrichedServer`) paths, parallel-fetched alongside skills
- Rename `MentorCard` / `Information` prop `skills` → `topics` and the inner `Skill` component to a generic `Tag` (`label` prop) to match the new semantics
- Filter behaviour (`filter_skills`, `filter_topics`) untouched — only the card display source changes

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

Closes Xchange-Taiwan/X-Talent-Tracker#138.

`+N` overflow logic is unchanged but what_i_offer labels are typically longer than skills — worth a quick visual check on desktop and mobile for cards with many topics.
