### PR TITLE
feat(profile/edit): require industry for mentors

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -276,7 +276,15 @@ export default function Page({
             />
           </Section>
 
-          <Section id="industry" title="產業 (選填)">
+          <Section
+            id="industry"
+            title={
+              <>
+                {isMentor && <span className="text-status-200">* </span>}
+                產業
+              </>
+            }
+          >
             <CategoryMultiSelectField
               form={form}
               name="industry"

--- a/src/components/profile/edit/profileSchema.ts
+++ b/src/components/profile/edit/profileSchema.ts
@@ -94,7 +94,12 @@ export const createProfileFormSchema = (isMentor: boolean) =>
       about: isMentor
         ? z.string().min(1, '請填寫關於我')
         : z.string().optional(),
-      industry: z.array(z.string()).max(10, '最多選 10 個'),
+      industry: isMentor
+        ? z
+            .array(z.string())
+            .min(1, '請至少選擇一個產業')
+            .max(10, '最多選 10 個')
+        : z.array(z.string()).max(10, '最多選 10 個'),
       years_of_experience: z.string({ required_error: '請選擇經驗' }),
       work_experiences: z.array(jobSchema),
       educations: z.array(educationSchema),


### PR DESCRIPTION
## What Does This PR Do?

- Industry is now required on the profile edit page when the user is a mentor (or in the mentor onboarding flow, which already feeds the same `isMentor` flag).
- Adds conditional `min(1)` to the `industry` Zod field, matching the existing pattern used for `about` / `what_i_offer` / `expertises`.
- Updates the Section title to show the red `*` marker when `isMentor` is true and drops the `(選填)` suffix, matching the `about` Section pattern.

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
