### PR TITLE
fix(profile): keep avatar cache-buster after logout

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
@@ -64,9 +64,18 @@ export default function ProfilePageContainer({ pageUserId }: Props) {
   const isOwnProfile = loginUserId === pageUserId;
   const resolvedAvatar =
     userData?.avatar ?? (isOwnProfile ? session?.user?.avatar : undefined);
+  // Remember the latest avatar version we saw for this profile. The S3 avatar
+  // URL is a stable key (re-uploads overwrite in place), so the `?v=` query is
+  // the only cache buster. If we drop it on logout, the bare URL hits a stale
+  // browser/Image-Optimizer cache entry from before the upload.
+  const lastAvatarVersionRef = useRef<number | undefined>(undefined);
+  if (isOwnProfile && session?.user?.avatarUpdatedAt) {
+    lastAvatarVersionRef.current = session.user.avatarUpdatedAt;
+  }
+  const avatarVersion = lastAvatarVersionRef.current;
   const avatarSrc = resolvedAvatar
-    ? isOwnProfile && session?.user?.avatarUpdatedAt
-      ? `${resolvedAvatar}?v=${session.user.avatarUpdatedAt}`
+    ? avatarVersion
+      ? `${resolvedAvatar}?v=${avatarVersion}`
       : resolvedAvatar
     : DefaultAvatarImgUrl;
 


### PR DESCRIPTION
## What Does This PR Do?

- Persist the latest `avatarUpdatedAt` in a ref on the profile page so the `?v=...` query stays attached after the session clears.
- Previously, on logout `isOwnProfile` flipped to false and the cache-buster was dropped, switching the `<Image>` src to a bare S3 URL whose browser / Next.js Image Optimizer cache could still hold the pre-upload binary — making the avatar appear to revert to old data.

## Demo

http://localhost:3000/profile/<your-id> (update avatar, then log out — avatar should stay current)

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
