### PR TITLE
perf(reservation): scope fetches by role, lazy history, precise refetch

### DIFF
--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -6,36 +6,35 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { NextTokens } from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
 
+import { ReservationListSkeleton } from '../skeleton';
+
 export type ReservationTabsProps = {
-  upcomingMentee: Reservation[];
-  pendingMentee: Reservation[];
-  upcomingMentor: Reservation[];
-  pendingMentor: Reservation[];
-  mentorHistory: Reservation[];
-  menteeHistory: Reservation[];
+  upcoming: Reservation[];
+  pending: Reservation[];
+  history: Reservation[];
   nextTokens: NextTokens;
   isLoadingMore: boolean;
+  isLoadingHistory: boolean;
+  isHistoryLoaded: boolean;
+  myUserId: string;
   onLoadMore: (state: ReservationState) => void;
-  onMutationSuccess?: (id: string) => void;
+  onLoadHistory: () => void;
+  onMutationSuccess?: (id: string, affectedStates: ReservationState[]) => void;
 };
 
 export default function ReservationTabs({
-  upcomingMentee,
-  pendingMentee,
-  upcomingMentor,
-  pendingMentor,
-  mentorHistory,
-  menteeHistory,
+  upcoming,
+  pending,
+  history,
   nextTokens,
   isLoadingMore,
+  isLoadingHistory,
+  isHistoryLoaded,
+  myUserId,
   onLoadMore,
+  onLoadHistory,
   onMutationSuccess,
 }: ReservationTabsProps) {
-  // This file is for mentee UI; keep mentor props to match type and avoid lint issues.
-  void upcomingMentor;
-  void pendingMentor;
-  void mentorHistory;
-
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
     'bg-transparent text-foreground ' +
@@ -44,10 +43,20 @@ export default function ReservationTabs({
   const countClass =
     'ml-1 text-xs text-muted-foreground group-data-[state=active]:text-white/80';
 
+  const handleValueChange = (value: string) => {
+    if (value === 'history' && !isHistoryLoaded && !isLoadingHistory) {
+      onLoadHistory();
+    }
+  };
+
   return (
     <div className="mx-auto w-full max-w-3xl px-0 sm:px-4 lg:px-6">
       {/* IMPORTANT: defaultValue must match an existing TabsTrigger value */}
-      <Tabs defaultValue="upcoming-mentee" className="w-full">
+      <Tabs
+        defaultValue="upcoming-mentee"
+        className="w-full"
+        onValueChange={handleValueChange}
+      >
         <div className="bg-white sticky top-0 z-10 pb-2">
           <div className="-mx-3 sm:mx-0">
             <div
@@ -64,17 +73,19 @@ export default function ReservationTabs({
                 <TabsList className="bg-transparent inline-flex w-max items-center gap-2 px-0">
                   <TabsTrigger value="upcoming-mentee" className={triggerClass}>
                     即將到來
-                    <span className={countClass}>{upcomingMentee.length}</span>
+                    <span className={countClass}>{upcoming.length}</span>
                   </TabsTrigger>
 
                   <TabsTrigger value="pending-mentee" className={triggerClass}>
                     等待回復
-                    <span className={countClass}>{pendingMentee.length}</span>
+                    <span className={countClass}>{pending.length}</span>
                   </TabsTrigger>
 
                   <TabsTrigger value="history" className={triggerClass}>
                     歷史紀錄
-                    <span className={countClass}>{menteeHistory.length}</span>
+                    {isHistoryLoaded ? (
+                      <span className={countClass}>{history.length}</span>
+                    ) : null}
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -85,10 +96,11 @@ export default function ReservationTabs({
         <div className="px-3 pt-2 sm:px-0">
           <TabsContent value="upcoming-mentee" className="mt-4 sm:mt-6">
             <ReservationList
-              items={upcomingMentee}
+              items={upcoming}
               variant="upcoming"
               sourceRole="mentee"
-              hasMore={nextTokens.menteeUpcoming !== 0}
+              myUserId={myUserId}
+              hasMore={nextTokens.upcoming !== 0}
               onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
@@ -97,10 +109,11 @@ export default function ReservationTabs({
 
           <TabsContent value="pending-mentee" className="mt-4 sm:mt-6">
             <ReservationList
-              items={pendingMentee}
+              items={pending}
               variant="pending-mentee"
               sourceRole="mentee"
-              hasMore={nextTokens.menteePending !== 0}
+              myUserId={myUserId}
+              hasMore={nextTokens.pending !== 0}
               onLoadMore={() => onLoadMore('MENTEE_PENDING')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
@@ -108,15 +121,20 @@ export default function ReservationTabs({
           </TabsContent>
 
           <TabsContent value="history" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={menteeHistory}
-              variant="history"
-              sourceRole="mentee"
-              hasMore={nextTokens.menteeHistory !== 0}
-              onLoadMore={() => onLoadMore('MENTEE_HISTORY')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {isLoadingHistory && !isHistoryLoaded ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={history}
+                variant="history"
+                sourceRole="mentee"
+                myUserId={myUserId}
+                hasMore={nextTokens.history !== 0}
+                onLoadMore={() => onLoadMore('MENTEE_HISTORY')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
         </div>
       </Tabs>

--- a/src/app/reservation/mentee/container.tsx
+++ b/src/app/reservation/mentee/container.tsx
@@ -9,15 +9,28 @@ import { ReservationSkeleton } from '../skeleton';
 const ReservationPresentation = dynamic(() => import('./ui'));
 
 export default function ReservationContainer() {
-  const { data, isLoading, isLoadingMore, loadMore, onMutationSuccess } =
-    useReservationData();
+  const {
+    data,
+    isLoading,
+    isLoadingMore,
+    isLoadingHistory,
+    isHistoryLoaded,
+    myUserId,
+    loadMore,
+    loadHistory,
+    onMutationSuccess,
+  } = useReservationData({ role: 'mentee' });
 
   if (isLoading || !data) return <ReservationSkeleton />;
   return (
     <ReservationPresentation
       {...data}
       isLoadingMore={isLoadingMore}
+      isLoadingHistory={isLoadingHistory}
+      isHistoryLoaded={isHistoryLoaded}
+      myUserId={myUserId}
       onLoadMore={loadMore}
+      onLoadHistory={loadHistory}
       onMutationSuccess={onMutationSuccess}
     />
   );

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -6,35 +6,35 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type { NextTokens } from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
 
+import { ReservationListSkeleton } from '../skeleton';
+
 export type ReservationTabsProps = {
-  upcomingMentee: Reservation[];
-  pendingMentee: Reservation[];
-  upcomingMentor: Reservation[];
-  pendingMentor: Reservation[];
-  mentorHistory: Reservation[];
-  menteeHistory: Reservation[];
+  upcoming: Reservation[];
+  pending: Reservation[];
+  history: Reservation[];
   nextTokens: NextTokens;
   isLoadingMore: boolean;
+  isLoadingHistory: boolean;
+  isHistoryLoaded: boolean;
+  myUserId: string;
   onLoadMore: (state: ReservationState) => void;
-  onMutationSuccess?: (id: string) => void;
+  onLoadHistory: () => void;
+  onMutationSuccess?: (id: string, affectedStates: ReservationState[]) => void;
 };
 
 export default function ReservationTabs({
-  upcomingMentee,
-  pendingMentee,
-  upcomingMentor,
-  pendingMentor,
-  mentorHistory,
-  menteeHistory,
+  upcoming,
+  pending,
+  history,
   nextTokens,
   isLoadingMore,
+  isLoadingHistory,
+  isHistoryLoaded,
+  myUserId,
   onLoadMore,
+  onLoadHistory,
   onMutationSuccess,
 }: ReservationTabsProps) {
-  void upcomingMentee;
-  void pendingMentee;
-  void menteeHistory;
-
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
     'bg-transparent text-foreground ' +
@@ -43,10 +43,20 @@ export default function ReservationTabs({
   const countClass =
     'ml-1 text-xs text-muted-foreground group-data-[state=active]:text-white/80';
 
+  const handleValueChange = (value: string) => {
+    if (value === 'history' && !isHistoryLoaded && !isLoadingHistory) {
+      onLoadHistory();
+    }
+  };
+
   return (
     <div className="mx-auto w-full max-w-3xl px-0 sm:px-4 lg:px-6">
       {/* IMPORTANT: defaultValue must match an existing TabsTrigger value */}
-      <Tabs defaultValue="upcoming-mentor" className="w-full">
+      <Tabs
+        defaultValue="upcoming-mentor"
+        className="w-full"
+        onValueChange={handleValueChange}
+      >
         <div className="bg-white sticky top-0 z-10 pb-2">
           <div className="-mx-3 sm:mx-0">
             <div
@@ -63,17 +73,19 @@ export default function ReservationTabs({
                 <TabsList className="bg-transparent inline-flex w-max items-center gap-2 px-0">
                   <TabsTrigger value="upcoming-mentor" className={triggerClass}>
                     即將到來
-                    <span className={countClass}>{upcomingMentor.length}</span>
+                    <span className={countClass}>{upcoming.length}</span>
                   </TabsTrigger>
 
                   <TabsTrigger value="pending-mentor" className={triggerClass}>
                     待您回復
-                    <span className={countClass}>{pendingMentor.length}</span>
+                    <span className={countClass}>{pending.length}</span>
                   </TabsTrigger>
 
                   <TabsTrigger value="history" className={triggerClass}>
                     歷史紀錄
-                    <span className={countClass}>{mentorHistory.length}</span>
+                    {isHistoryLoaded ? (
+                      <span className={countClass}>{history.length}</span>
+                    ) : null}
                   </TabsTrigger>
                 </TabsList>
               </div>
@@ -84,10 +96,11 @@ export default function ReservationTabs({
         <div className="px-3 pt-2 sm:px-0">
           <TabsContent value="upcoming-mentor" className="mt-4 sm:mt-6">
             <ReservationList
-              items={upcomingMentor}
+              items={upcoming}
               variant="upcoming"
               sourceRole="mentor"
-              hasMore={nextTokens.mentorUpcoming !== 0}
+              myUserId={myUserId}
+              hasMore={nextTokens.upcoming !== 0}
               onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
@@ -96,10 +109,11 @@ export default function ReservationTabs({
 
           <TabsContent value="pending-mentor" className="mt-4 sm:mt-6">
             <ReservationList
-              items={pendingMentor}
+              items={pending}
               variant="pending-mentor"
               sourceRole="mentor"
-              hasMore={nextTokens.mentorPending !== 0}
+              myUserId={myUserId}
+              hasMore={nextTokens.pending !== 0}
               onLoadMore={() => onLoadMore('MENTOR_PENDING')}
               isLoadingMore={isLoadingMore}
               onMutationSuccess={onMutationSuccess}
@@ -107,15 +121,20 @@ export default function ReservationTabs({
           </TabsContent>
 
           <TabsContent value="history" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={mentorHistory}
-              variant="history"
-              sourceRole="mentor"
-              hasMore={nextTokens.mentorHistory !== 0}
-              onLoadMore={() => onLoadMore('MENTOR_HISTORY')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {isLoadingHistory && !isHistoryLoaded ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={history}
+                variant="history"
+                sourceRole="mentor"
+                myUserId={myUserId}
+                hasMore={nextTokens.history !== 0}
+                onLoadMore={() => onLoadMore('MENTOR_HISTORY')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
         </div>
       </Tabs>

--- a/src/app/reservation/mentor/container.tsx
+++ b/src/app/reservation/mentor/container.tsx
@@ -9,15 +9,28 @@ import { ReservationSkeleton } from '../skeleton';
 const ReservationPresentation = dynamic(() => import('./ui'));
 
 export default function ReservationContainer() {
-  const { data, isLoading, isLoadingMore, loadMore, onMutationSuccess } =
-    useReservationData();
+  const {
+    data,
+    isLoading,
+    isLoadingMore,
+    isLoadingHistory,
+    isHistoryLoaded,
+    myUserId,
+    loadMore,
+    loadHistory,
+    onMutationSuccess,
+  } = useReservationData({ role: 'mentor' });
 
   if (isLoading || !data) return <ReservationSkeleton />;
   return (
     <ReservationPresentation
       {...data}
       isLoadingMore={isLoadingMore}
+      isLoadingHistory={isLoadingHistory}
+      isHistoryLoaded={isHistoryLoaded}
+      myUserId={myUserId}
       onLoadMore={loadMore}
+      onLoadHistory={loadHistory}
       onMutationSuccess={onMutationSuccess}
     />
   );

--- a/src/app/reservation/skeleton.tsx
+++ b/src/app/reservation/skeleton.tsx
@@ -1,5 +1,22 @@
 import { Skeleton } from '@/components/ui/skeleton';
 
+export function ReservationListSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div className="flex flex-col gap-4 px-3 pt-4 sm:px-0">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-4 rounded-2xl border p-4">
+          <Skeleton className="h-12 w-12 flex-shrink-0 rounded-full" />
+          <div className="flex flex-1 flex-col gap-2">
+            <Skeleton className="h-4 w-32" />
+            <Skeleton className="h-3 w-48" />
+          </div>
+          <Skeleton className="h-8 w-20 rounded-full" />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export function ReservationSkeleton() {
   return (
     <div className="flex min-h-[calc(100vh-70px)] justify-center">
@@ -17,22 +34,7 @@ export function ReservationSkeleton() {
             ))}
           </div>
 
-          {/* list rows */}
-          <div className="flex flex-col gap-4 px-3 pt-4 sm:px-0">
-            {Array.from({ length: 4 }).map((_, i) => (
-              <div
-                key={i}
-                className="flex items-center gap-4 rounded-2xl border p-4"
-              >
-                <Skeleton className="h-12 w-12 flex-shrink-0 rounded-full" />
-                <div className="flex flex-1 flex-col gap-2">
-                  <Skeleton className="h-4 w-32" />
-                  <Skeleton className="h-3 w-48" />
-                </div>
-                <Skeleton className="h-8 w-20 rounded-full" />
-              </div>
-            ))}
-          </div>
+          <ReservationListSkeleton rows={4} />
         </div>
       </div>
     </div>

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import { getSession, useSession } from 'next-auth/react';
-
 import AcceptReservationDialog from '@/components/reservation/AcceptReservationDialog';
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
 import ReservationConversationDialog from '@/components/reservation/ReservationConversationDialog';
@@ -10,7 +8,10 @@ import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
-import { updateReservationStatus } from '@/services/reservations';
+import {
+  ReservationState,
+  updateReservationStatus,
+} from '@/services/reservations';
 
 import { ReservationCard } from './ReservationCard';
 import type { Reservation } from './types';
@@ -22,6 +23,7 @@ export function ReservationList({
   items,
   variant,
   sourceRole,
+  myUserId,
   hasMore = false,
   onLoadMore,
   isLoadingMore = false,
@@ -30,16 +32,34 @@ export function ReservationList({
   items: Reservation[];
   variant: Variant;
   sourceRole: SourceRole;
+  myUserId: string;
   hasMore?: boolean;
   onLoadMore?: () => void;
   isLoadingMore?: boolean;
   // Called after a successful accept / reject / cancel so the parent hook can
-  // optimistically remove the operated item and refetch in the background.
-  onMutationSuccess?: (id: string) => void;
+  // optimistically remove the operated item and refetch only the affected
+  // states in the background.
+  onMutationSuccess?: (id: string, affectedStates: ReservationState[]) => void;
 }) {
   const { toast } = useToast();
-  const { data: session } = useSession();
-  const myId = session?.user?.id ? String(session.user.id) : '';
+
+  // Accept on pending-mentor: pending-mentor → upcoming-mentor.
+  const ACCEPT_AFFECTED_STATES: ReservationState[] = [
+    'MENTOR_PENDING',
+    'MENTOR_UPCOMING',
+  ];
+
+  // Reject / cancel always lands the reservation in the role's HISTORY list.
+  // The source state depends on the variant.
+  const buildRejectOrCancelAffectedStates = (): ReservationState[] => {
+    const upper = sourceRole === 'mentor' ? 'MENTOR' : 'MENTEE';
+    const history = `${upper}_HISTORY` as ReservationState;
+    if (variant === 'upcoming')
+      return [`${upper}_UPCOMING` as ReservationState, history];
+    if (variant === 'pending-mentor') return ['MENTOR_PENDING', history];
+    if (variant === 'pending-mentee') return ['MENTEE_PENDING', history];
+    return [];
+  };
 
   const findItem = (id: string): Reservation => {
     const found = items.find((x) => x.id === id);
@@ -49,24 +69,23 @@ export function ReservationList({
   };
 
   // Resolve the other party's user_id based on who is currently logged in
-  const resolveOtherId = (myId: string, it: Reservation): string | number =>
-    String(it.senderUserId) === myId ? it.participantUserId : it.senderUserId;
+  const resolveOtherId = (it: Reservation): string | number =>
+    String(it.senderUserId) === myUserId
+      ? it.participantUserId
+      : it.senderUserId;
 
   // Accept a booking request (mentor side, pending-mentor variant)
   const accept = async ({ id, message }: { id: string; message: string }) => {
     try {
-      const session = await getSession();
-      const sessionId = session?.user?.id;
-      if (!sessionId)
+      if (!myUserId)
         throw new Error('[ReservationList] missing current user id');
-      const myIdStr = String(sessionId);
-      const myIdNum = Number(sessionId);
+      const myIdNum = Number(myUserId);
 
       const it = findItem(id);
-      const otherIdNum = Number(resolveOtherId(myIdStr, it));
+      const otherIdNum = Number(resolveOtherId(it));
 
       await updateReservationStatus({
-        userId: myIdStr,
+        userId: myUserId,
         reservationId: id,
         body: {
           my_user_id: myIdNum,
@@ -87,7 +106,7 @@ export function ReservationList({
       // or once GET schedule returns booked_slots so the frontend can filter them.
 
       toast({ description: '已接受預約' });
-      onMutationSuccess?.(id);
+      onMutationSuccess?.(id, ACCEPT_AFFECTED_STATES);
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_accept',
@@ -106,18 +125,15 @@ export function ReservationList({
     successMessage: string
   ) => {
     try {
-      const session = await getSession();
-      const sessionId = session?.user?.id;
-      if (!sessionId)
+      if (!myUserId)
         throw new Error('[ReservationList] missing current user id');
-      const myIdStr = String(sessionId);
-      const myIdNum = Number(sessionId);
+      const myIdNum = Number(myUserId);
 
       const it = findItem(id);
-      const otherIdNum = Number(resolveOtherId(myIdStr, it));
+      const otherIdNum = Number(resolveOtherId(it));
 
       await updateReservationStatus({
-        userId: myIdStr,
+        userId: myUserId,
         reservationId: id,
         body: {
           my_user_id: myIdNum,
@@ -137,7 +153,7 @@ export function ReservationList({
 
       trackEvent({ name: 'reservation_rejected', feature: 'reservation' });
       toast({ description: successMessage });
-      onMutationSuccess?.(id);
+      onMutationSuccess?.(id, buildRejectOrCancelAffectedStates());
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_reject',
@@ -155,9 +171,9 @@ export function ReservationList({
   // a logged-in user (link would be ambiguous) or when the other id would
   // resolve to the current user (defensive — shouldn't happen in practice).
   const buildProfileHref = (it: Reservation): string | undefined => {
-    if (!myId) return undefined;
-    const otherId = resolveOtherId(myId, it);
-    if (!otherId || String(otherId) === myId) return undefined;
+    if (!myUserId) return undefined;
+    const otherId = resolveOtherId(it);
+    if (!otherId || String(otherId) === myUserId) return undefined;
     return `/profile/${otherId}`;
   };
 

--- a/src/hooks/user/reservation/useReservationData.test.ts
+++ b/src/hooks/user/reservation/useReservationData.test.ts
@@ -1,4 +1,4 @@
-import { act, renderHook } from '@testing-library/react';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next-auth/react', async () => {
@@ -6,18 +6,28 @@ vi.mock('next-auth/react', async () => {
   return nextAuthMockFactory();
 });
 
-vi.mock('@/services/reservations', () => ({
-  fetchAllReservationLists: vi.fn(),
-}));
+vi.mock('@/services/reservations', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/reservations')
+  >('@/services/reservations');
+  return {
+    ...actual,
+    fetchReservations: vi.fn(),
+  };
+});
 
 vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
+vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
 
-import { fetchAllReservationLists } from '@/services/reservations';
+import {
+  fetchReservations,
+  type ReservationState,
+} from '@/services/reservations';
 import { mockSession, mockUseSession } from '@/test/mocks/nextAuth';
 
 import { useReservationData } from './useReservationData';
 
-const mockFetch = vi.mocked(fetchAllReservationLists);
+const mockFetch = vi.mocked(fetchReservations);
 
 const makeReservation = (id: string) => ({
   id,
@@ -33,38 +43,27 @@ const makeReservation = (id: string) => ({
   participantUserId: 'participant-1',
 });
 
-const mockLists = {
-  upcomingMentee: [makeReservation('1')],
-  pendingMentee: [makeReservation('2')],
-  upcomingMentor: [makeReservation('3')],
-  pendingMentor: [makeReservation('4')],
-  mentorHistory: [makeReservation('5')],
-  menteeHistory: [makeReservation('6')],
-  nextTokens: {
-    menteeUpcoming: 0,
-    menteePending: 0,
-    mentorUpcoming: 0,
-    mentorPending: 0,
-    mentorHistory: 0,
-    menteeHistory: 0,
-  },
-};
-
-describe('useReservationData', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockUseSession.mockReturnValue({
-      data: mockSession,
-      status: 'authenticated',
-    });
-    mockFetch.mockResolvedValue(mockLists);
+const stubFor = (state: ReservationState) =>
+  Promise.resolve({
+    items: [makeReservation(state)],
+    next_dtend: 0,
   });
 
-  it('no session → fetchAllReservationLists is NOT called, isLoading becomes false', async () => {
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockUseSession.mockReturnValue({
+    data: mockSession,
+    status: 'authenticated',
+  });
+  mockFetch.mockImplementation(({ state }) => stubFor(state));
+});
+
+describe('useReservationData (mentee)', () => {
+  it('no session → fetchReservations is NOT called, isLoading becomes false', async () => {
     mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
 
     const { result } = await act(async () =>
-      renderHook(() => useReservationData())
+      renderHook(() => useReservationData({ role: 'mentee' }))
     );
 
     expect(mockFetch).not.toHaveBeenCalled();
@@ -72,29 +71,122 @@ describe('useReservationData', () => {
     expect(result.current.data).toBeNull();
   });
 
-  it('has session + fetch succeeds → data contains all six reservation lists correctly mapped', async () => {
+  it('initial mount fetches only mentee UPCOMING + PENDING (no history)', async () => {
     const { result } = await act(async () =>
-      renderHook(() => useReservationData())
+      renderHook(() => useReservationData({ role: 'mentee' }))
     );
 
-    expect(mockFetch).toHaveBeenCalledWith({ userId: mockSession.user.id });
-    expect(result.current.data).toEqual({
-      upcomingMentee: mockLists.upcomingMentee,
-      pendingMentee: mockLists.pendingMentee,
-      upcomingMentor: mockLists.upcomingMentor,
-      pendingMentor: mockLists.pendingMentor,
-      mentorHistory: mockLists.mentorHistory,
-      menteeHistory: mockLists.menteeHistory,
-      nextTokens: mockLists.nextTokens,
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_UPCOMING',
     });
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_PENDING',
+    });
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'MENTEE_HISTORY' })
+    );
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'MENTOR_UPCOMING' })
+    );
+
     expect(result.current.isLoading).toBe(false);
+    expect(result.current.isHistoryLoaded).toBe(false);
+    expect(result.current.myUserId).toBe(mockSession.user.id);
+    expect(result.current.data?.upcoming).toHaveLength(1);
+    expect(result.current.data?.pending).toHaveLength(1);
+    expect(result.current.data?.history).toEqual([]);
   });
 
-  it('has session + fetch throws → data remains null, isLoading becomes false', async () => {
-    mockFetch.mockRejectedValueOnce(new Error('Network error'));
+  it('loadHistory fetches MENTEE_HISTORY exactly once across multiple calls', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockFetch.mockClear();
+
+    await act(async () => {
+      await result.current.loadHistory();
+    });
+    await act(async () => {
+      await result.current.loadHistory();
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_HISTORY',
+    });
+    expect(result.current.isHistoryLoaded).toBe(true);
+    expect(result.current.data?.history).toHaveLength(1);
+  });
+
+  it('onMutationSuccess refetches only the affected states (history skipped when not loaded)', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockFetch.mockClear();
+
+    await act(async () => {
+      result.current.onMutationSuccess('any-id', [
+        'MENTEE_PENDING',
+        'MENTEE_HISTORY',
+      ]);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_PENDING',
+    });
+  });
+
+  it('onMutationSuccess refetches history when it has been loaded', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    await act(async () => {
+      await result.current.loadHistory();
+    });
+    mockFetch.mockClear();
+
+    await act(async () => {
+      result.current.onMutationSuccess('any-id', [
+        'MENTEE_PENDING',
+        'MENTEE_HISTORY',
+      ]);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_PENDING',
+    });
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTEE_HISTORY',
+    });
+  });
+
+  it('onMutationSuccess ignores affectedStates that belong to the other role', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockFetch.mockClear();
+
+    await act(async () => {
+      result.current.onMutationSuccess('any-id', [
+        'MENTOR_PENDING',
+        'MENTOR_UPCOMING',
+      ]);
+    });
+
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('initial fetch failure → data stays null, isLoading becomes false', async () => {
+    mockFetch.mockReset();
+    mockFetch.mockRejectedValue(new Error('Network error'));
 
     const { result } = await act(async () =>
-      renderHook(() => useReservationData())
+      renderHook(() => useReservationData({ role: 'mentee' }))
     );
 
     expect(result.current.data).toBeNull();
@@ -102,21 +194,92 @@ describe('useReservationData', () => {
   });
 
   it('component unmounts before fetch resolves → state is NOT updated', async () => {
-    let resolveFetch!: (value: typeof mockLists) => void;
-    mockFetch.mockReturnValueOnce(
-      new Promise((resolve) => {
-        resolveFetch = resolve;
-      })
+    let resolveFetch!: () => void;
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveFetch = () =>
+            resolve({ items: [makeReservation('1')], next_dtend: 0 });
+        })
     );
 
-    const { result, unmount } = renderHook(() => useReservationData());
+    const { result, unmount } = renderHook(() =>
+      useReservationData({ role: 'mentee' })
+    );
 
     unmount();
 
     await act(async () => {
-      resolveFetch(mockLists);
+      resolveFetch();
     });
 
     expect(result.current.data).toBeNull();
+  });
+});
+
+describe('useReservationData (mentor)', () => {
+  it('initial mount fetches only mentor UPCOMING + PENDING (no history)', async () => {
+    const { result } = await act(async () =>
+      renderHook(() => useReservationData({ role: 'mentor' }))
+    );
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTOR_UPCOMING',
+    });
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTOR_PENDING',
+    });
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'MENTOR_HISTORY' })
+    );
+    expect(mockFetch).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'MENTEE_UPCOMING' })
+    );
+
+    expect(result.current.isLoading).toBe(false);
+  });
+
+  it('accept-flow refetch only triggers MENTOR_PENDING + MENTOR_UPCOMING', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentor' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockFetch.mockClear();
+
+    await act(async () => {
+      result.current.onMutationSuccess('any-id', [
+        'MENTOR_PENDING',
+        'MENTOR_UPCOMING',
+      ]);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTOR_PENDING',
+    });
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTOR_UPCOMING',
+    });
+  });
+
+  it('refetch never sends batch param so backend uses default page size', async () => {
+    const { result } = renderHook(() => useReservationData({ role: 'mentor' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    mockFetch.mockClear();
+
+    await act(async () => {
+      result.current.onMutationSuccess('any-id', ['MENTOR_PENDING']);
+    });
+
+    expect(mockFetch).toHaveBeenCalledWith({
+      userId: mockSession.user.id,
+      state: 'MENTOR_PENDING',
+    });
+    const lastCall = mockFetch.mock.calls.at(-1)?.[0];
+    expect(lastCall).not.toHaveProperty('batch');
   });
 });

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -4,71 +4,81 @@ import { useCallback, useEffect, useState } from 'react';
 import { Reservation } from '@/components/reservation/types';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
-import {
-  fetchAllReservationLists,
-  fetchReservations,
-  ReservationState,
-} from '@/services/reservations';
+import { fetchReservations, ReservationState } from '@/services/reservations';
+
+export type ReservationRole = 'mentee' | 'mentor';
 
 export interface NextTokens {
-  menteeUpcoming: number;
-  menteePending: number;
-  mentorUpcoming: number;
-  mentorPending: number;
-  mentorHistory: number;
-  menteeHistory: number;
+  upcoming: number;
+  pending: number;
+  history: number;
 }
 
 export interface ReservationData {
-  upcomingMentee: Reservation[];
-  pendingMentee: Reservation[];
-  upcomingMentor: Reservation[];
-  pendingMentor: Reservation[];
-  mentorHistory: Reservation[];
-  menteeHistory: Reservation[];
+  upcoming: Reservation[];
+  pending: Reservation[];
+  history: Reservation[];
   nextTokens: NextTokens;
 }
 
-const STATE_TO_TOKEN_KEY: Record<ReservationState, keyof NextTokens> = {
-  MENTEE_UPCOMING: 'menteeUpcoming',
-  MENTEE_PENDING: 'menteePending',
-  MENTOR_UPCOMING: 'mentorUpcoming',
-  MENTOR_PENDING: 'mentorPending',
-  MENTOR_HISTORY: 'mentorHistory',
-  MENTEE_HISTORY: 'menteeHistory',
-};
+type ListKey = 'upcoming' | 'pending' | 'history';
 
-const STATE_TO_DATA_KEY: Record<
-  ReservationState,
-  keyof Omit<ReservationData, 'nextTokens'>
+const ROLE_STATES: Record<
+  ReservationRole,
+  Record<ListKey, ReservationState>
 > = {
-  MENTEE_UPCOMING: 'upcomingMentee',
-  MENTEE_PENDING: 'pendingMentee',
-  MENTOR_UPCOMING: 'upcomingMentor',
-  MENTOR_PENDING: 'pendingMentor',
-  MENTOR_HISTORY: 'mentorHistory',
-  MENTEE_HISTORY: 'menteeHistory',
+  mentee: {
+    upcoming: 'MENTEE_UPCOMING',
+    pending: 'MENTEE_PENDING',
+    history: 'MENTEE_HISTORY',
+  },
+  mentor: {
+    upcoming: 'MENTOR_UPCOMING',
+    pending: 'MENTOR_PENDING',
+    history: 'MENTOR_HISTORY',
+  },
 };
 
-const ALL_STATES: ReservationState[] = [
-  'MENTEE_UPCOMING',
-  'MENTEE_PENDING',
-  'MENTOR_UPCOMING',
-  'MENTOR_PENDING',
-  'MENTOR_HISTORY',
-  'MENTEE_HISTORY',
-];
+const STATE_TO_LIST_KEY: Record<ReservationState, ListKey> = {
+  MENTEE_UPCOMING: 'upcoming',
+  MENTEE_PENDING: 'pending',
+  MENTEE_HISTORY: 'history',
+  MENTOR_UPCOMING: 'upcoming',
+  MENTOR_PENDING: 'pending',
+  MENTOR_HISTORY: 'history',
+};
 
-export function useReservationData() {
+export interface UseReservationDataReturn {
+  data: ReservationData | null;
+  isLoading: boolean;
+  isLoadingMore: boolean;
+  isLoadingHistory: boolean;
+  isHistoryLoaded: boolean;
+  myUserId: string;
+  loadMore: (state: ReservationState) => Promise<void>;
+  loadHistory: () => Promise<void>;
+  onMutationSuccess: (id: string, affectedStates: ReservationState[]) => void;
+}
+
+export function useReservationData({
+  role,
+}: {
+  role: ReservationRole;
+}): UseReservationDataReturn {
   const { data: session } = useSession();
-  const loginUserId = session?.user?.id ? String(session.user.id) : '';
+  const myUserId = session?.user?.id ? String(session.user.id) : '';
+  const states = ROLE_STATES[role];
 
   const [data, setData] = useState<ReservationData | null>(null);
   const [isLoading, setIsLoading] = useState(true);
   const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [isLoadingHistory, setIsLoadingHistory] = useState(false);
+  const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
 
+  // Initial fetch covers only the role's UPCOMING + PENDING states. HISTORY is
+  // lazy and only fetched when the user opens the history tab via loadHistory.
   useEffect(() => {
-    if (!loginUserId) {
+    if (!myUserId) {
       setIsLoading(false);
       return;
     }
@@ -77,24 +87,21 @@ export function useReservationData() {
 
     (async () => {
       try {
-        const lists = await fetchAllReservationLists({ userId: loginUserId });
+        const [upcomingRes, pendingRes] = await Promise.all([
+          fetchReservations({ userId: myUserId, state: states.upcoming }),
+          fetchReservations({ userId: myUserId, state: states.pending }),
+        ]);
 
         if (cancelled) return;
 
         setData({
-          upcomingMentee: lists.upcomingMentee,
-          pendingMentee: lists.pendingMentee,
-          upcomingMentor: lists.upcomingMentor,
-          pendingMentor: lists.pendingMentor,
-          mentorHistory: lists.mentorHistory,
-          menteeHistory: lists.menteeHistory,
+          upcoming: upcomingRes.items,
+          pending: pendingRes.items,
+          history: [],
           nextTokens: {
-            menteeUpcoming: lists.nextTokens.menteeUpcoming,
-            menteePending: lists.nextTokens.menteePending,
-            mentorUpcoming: lists.nextTokens.mentorUpcoming,
-            mentorPending: lists.nextTokens.mentorPending,
-            mentorHistory: lists.nextTokens.mentorHistory,
-            menteeHistory: lists.nextTokens.menteeHistory,
+            upcoming: upcomingRes.next_dtend,
+            pending: pendingRes.next_dtend,
+            history: 0,
           },
         });
       } catch (err) {
@@ -115,106 +122,143 @@ export function useReservationData() {
     return () => {
       cancelled = true;
     };
-  }, [loginUserId]);
+  }, [myUserId, states.upcoming, states.pending]);
 
-  // Optimistic helper: drop the operated item from every list so the user
-  // doesn't see it lingering while the background refetch runs.
   const removeItem = useCallback((id: string) => {
     setData((prev) => {
       if (!prev) return prev;
       return {
         ...prev,
-        upcomingMentee: prev.upcomingMentee.filter((it) => it.id !== id),
-        pendingMentee: prev.pendingMentee.filter((it) => it.id !== id),
-        upcomingMentor: prev.upcomingMentor.filter((it) => it.id !== id),
-        pendingMentor: prev.pendingMentor.filter((it) => it.id !== id),
-        mentorHistory: prev.mentorHistory.filter((it) => it.id !== id),
-        menteeHistory: prev.menteeHistory.filter((it) => it.id !== id),
+        upcoming: prev.upcoming.filter((it) => it.id !== id),
+        pending: prev.pending.filter((it) => it.id !== id),
+        history: prev.history.filter((it) => it.id !== id),
       };
     });
   }, []);
 
-  // Refetch every state in parallel, asking the backend for at least as many
-  // rows as are currently displayed so previously load-more'd items don't
-  // disappear after a mutation.
-  const refetchAll = useCallback(async () => {
-    if (!loginUserId) return;
-    try {
-      const results = await Promise.all(
-        ALL_STATES.map((state) => {
-          const dataKey = STATE_TO_DATA_KEY[state];
-          const currentCount = (data?.[dataKey] as Reservation[] | undefined)
-            ?.length;
-          return fetchReservations({
-            userId: loginUserId,
-            state,
-            batch: Math.max(currentCount ?? 10, 10),
-          });
-        })
-      );
+  // Refetch only the affected states. States belonging to the other role are
+  // dropped (mentee page never refetches mentor data) and HISTORY is skipped
+  // when not yet loaded — loadHistory will fetch it fresh on tab open instead.
+  const refetchStates = useCallback(
+    async (targets: ReservationState[]) => {
+      if (!myUserId) return;
 
+      const ownStates = new Set<ReservationState>([
+        states.upcoming,
+        states.pending,
+        states.history,
+      ]);
+      const filtered = targets.filter((state) => {
+        if (!ownStates.has(state)) return false;
+        if (state === states.history && !isHistoryLoaded) return false;
+        return true;
+      });
+      if (filtered.length === 0) return;
+
+      try {
+        const results = await Promise.all(
+          filtered.map((state) =>
+            fetchReservations({ userId: myUserId, state })
+          )
+        );
+
+        setData((prev) => {
+          if (!prev) return prev;
+          const next: ReservationData = {
+            upcoming: prev.upcoming,
+            pending: prev.pending,
+            history: prev.history,
+            nextTokens: { ...prev.nextTokens },
+          };
+          filtered.forEach((state, idx) => {
+            const key = STATE_TO_LIST_KEY[state];
+            next[key] = results[idx].items;
+            next.nextTokens[key] = results[idx].next_dtend;
+          });
+          return next;
+        });
+      } catch (err) {
+        captureFlowFailure({
+          flow: 'reservation_refetch',
+          step: 'fetch_states',
+          message:
+            err instanceof Error
+              ? err.message
+              : 'Failed to refetch reservations',
+        });
+        console.error('[useReservationData] refetch error:', err);
+      }
+    },
+    [myUserId, states.upcoming, states.pending, states.history, isHistoryLoaded]
+  );
+
+  const onMutationSuccess = useCallback(
+    (id: string, affectedStates: ReservationState[]) => {
+      removeItem(id);
+      void refetchStates(affectedStates);
+    },
+    [removeItem, refetchStates]
+  );
+
+  const loadHistory = useCallback(async () => {
+    if (!myUserId || isHistoryLoaded || isLoadingHistory) return;
+    setIsLoadingHistory(true);
+    try {
+      const res = await fetchReservations({
+        userId: myUserId,
+        state: states.history,
+      });
       setData((prev) => {
         if (!prev) return prev;
-        const next: ReservationData = {
+        return {
           ...prev,
-          nextTokens: { ...prev.nextTokens },
+          history: res.items,
+          nextTokens: { ...prev.nextTokens, history: res.next_dtend },
         };
-        ALL_STATES.forEach((state, idx) => {
-          const dataKey = STATE_TO_DATA_KEY[state];
-          const tokenKey = STATE_TO_TOKEN_KEY[state];
-          (next as unknown as Record<string, Reservation[]>)[dataKey] =
-            results[idx].items;
-          next.nextTokens[tokenKey] = results[idx].next_dtend;
-        });
-        return next;
+      });
+      setIsHistoryLoaded(true);
+      trackEvent({
+        name: 'reservation_history_loaded',
+        feature: 'reservation',
       });
     } catch (err) {
       captureFlowFailure({
-        flow: 'reservation_refetch',
-        step: 'fetch_all',
+        flow: 'reservation_load_history',
+        step: 'fetch_history',
         message:
-          err instanceof Error ? err.message : 'Failed to refetch reservations',
+          err instanceof Error
+            ? err.message
+            : 'Failed to load reservation history',
       });
-      console.error('[useReservationData] refetch error:', err);
+      console.error('[useReservationData] loadHistory error:', err);
+    } finally {
+      setIsLoadingHistory(false);
     }
-  }, [loginUserId, data]);
-
-  // Single entry point used by mutation handlers in ReservationList: optimistic
-  // remove first (so the card disappears immediately), then refetch in the
-  // background to pick up the moved item in its destination state.
-  const onMutationSuccess = useCallback(
-    (id: string) => {
-      removeItem(id);
-      void refetchAll();
-    },
-    [removeItem, refetchAll]
-  );
+  }, [myUserId, states.history, isHistoryLoaded, isLoadingHistory]);
 
   const loadMore = useCallback(
     async (state: ReservationState): Promise<void> => {
-      if (!data || !loginUserId) return;
-
-      const tokenKey = STATE_TO_TOKEN_KEY[state];
-      const cursor = data.nextTokens[tokenKey];
+      if (!data || !myUserId) return;
+      const key = STATE_TO_LIST_KEY[state];
+      const cursor = data.nextTokens[key];
       if (cursor === 0) return;
 
       setIsLoadingMore(true);
       try {
         const result = await fetchReservations({
-          userId: loginUserId,
+          userId: myUserId,
           state,
           nextDtend: cursor,
         });
 
         setData((prev) => {
           if (!prev) return prev;
-          const dataKey = STATE_TO_DATA_KEY[state];
           return {
             ...prev,
-            [dataKey]: [...(prev[dataKey] as Reservation[]), ...result.items],
+            [key]: [...prev[key], ...result.items],
             nextTokens: {
               ...prev.nextTokens,
-              [tokenKey]: result.next_dtend,
+              [key]: result.next_dtend,
             },
           };
         });
@@ -234,14 +278,18 @@ export function useReservationData() {
         setIsLoadingMore(false);
       }
     },
-    [data, loginUserId]
+    [data, myUserId]
   );
 
   return {
     data,
     isLoading,
     isLoadingMore,
+    isLoadingHistory,
+    isHistoryLoaded,
+    myUserId,
     loadMore,
+    loadHistory,
     onMutationSuccess,
   };
 }

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -152,53 +152,6 @@ export async function fetchReservations(
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }
 
-export type FetchAllReservationListsOptions = {
-  userId: string | number;
-  batch?: number;
-  debug?: boolean;
-};
-
-export async function fetchAllReservationLists(
-  opts: FetchAllReservationListsOptions
-) {
-  const { userId, batch = 10, debug } = opts;
-
-  const commonOpts = { userId, batch, debug };
-
-  const [
-    upcomingMenteeRes,
-    pendingMenteeRes,
-    upcomingMentorRes,
-    pendingMentorRes,
-    mentorHistoryRes,
-    menteeHistoryRes,
-  ] = await Promise.all([
-    fetchReservations({ ...commonOpts, state: 'MENTEE_UPCOMING' }),
-    fetchReservations({ ...commonOpts, state: 'MENTEE_PENDING' }),
-    fetchReservations({ ...commonOpts, state: 'MENTOR_UPCOMING' }),
-    fetchReservations({ ...commonOpts, state: 'MENTOR_PENDING' }),
-    fetchReservations({ ...commonOpts, state: 'MENTOR_HISTORY' }),
-    fetchReservations({ ...commonOpts, state: 'MENTEE_HISTORY' }),
-  ]);
-
-  return {
-    upcomingMentee: upcomingMenteeRes.items,
-    pendingMentee: pendingMenteeRes.items,
-    upcomingMentor: upcomingMentorRes.items,
-    pendingMentor: pendingMentorRes.items,
-    mentorHistory: mentorHistoryRes.items,
-    menteeHistory: menteeHistoryRes.items,
-    nextTokens: {
-      menteeUpcoming: upcomingMenteeRes.next_dtend,
-      menteePending: pendingMenteeRes.next_dtend,
-      mentorUpcoming: upcomingMentorRes.next_dtend,
-      mentorPending: pendingMentorRes.next_dtend,
-      mentorHistory: mentorHistoryRes.next_dtend,
-      menteeHistory: menteeHistoryRes.next_dtend,
-    },
-  };
-}
-
 /* ================================
  * PUT: Update reservation status
  * ================================ */


### PR DESCRIPTION
## What Does This PR Do?

- Split `useReservationData` by role so mentee page only fetches MENTEE_*, mentor page only fetches MENTOR_* (was 6 → 2 on mount)
- Make HISTORY lazy: load on tab open instead of mount; show list skeleton during first load and hide count until ready
- Replace `refetchAll` with `refetchStates(targets)` so accept / reject / cancel only refetch affected lists; drop `Math.max(currentCount, 10)` batch escalation
- Remove duplicate `await getSession()` in `ReservationList`; pass `myUserId` down from the hook via container → tabs → list
- Update unit tests to mock `fetchReservations` per state and cover lazy history, cross-role filtering, and batch behavior (11/11 pass)

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Closes Xchange-Taiwan/X-Talent-Tracker#206
- History tab count is hidden until first load to avoid showing a misleading 0
- Removed unused `fetchAllReservationLists` from the service
- Cancel/reject affectedStates derive from variant + sourceRole inside `ReservationList`; if the source/target list mapping ever changes, both sides need updating

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
