### PR TITLE
fix(mentor-pool): horizontal-scroll popular chips on mobile/tablet

### DIFF
--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -42,7 +42,7 @@ export default function PopularPositionChips() {
   return (
     <div className="relative">
       <div
-        className="flex gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden xl:mx-auto xl:w-[846px] xl:justify-center xl:overflow-x-visible"
+        className="flex gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] xl:mx-auto xl:w-[846px] xl:justify-center xl:overflow-x-visible [&::-webkit-scrollbar]:hidden"
         aria-label="熱門職位"
       >
         {POPULAR_POSITIONS.map((position, i) => (
@@ -63,7 +63,7 @@ export default function PopularPositionChips() {
       </div>
       <div
         aria-hidden
-        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background-white to-transparent xl:hidden"
+        className="to-transparent pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background-white xl:hidden"
       />
     </div>
   );

--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -7,8 +7,8 @@ import { POPULAR_POSITIONS } from './data';
 import { buildHref, setSearchPattern } from './searchParams';
 
 // Desktop SearchBar width is the source of truth. We measure each chip on
-// mount, decide how many fit in this width, then render that same set on
-// every viewport. Tablet/mobile may wrap; desktop stays single-row.
+// mount and trim to what fits in this width on xl. Below xl, all chips are
+// shown in a single horizontal-scroll row with a right-edge fade.
 const DESKTOP_WIDTH = 846;
 const GAP_PX = 8;
 
@@ -40,25 +40,31 @@ export default function PopularPositionChips() {
   };
 
   return (
-    <div
-      className="mx-auto flex w-[338px] flex-wrap justify-center gap-2 md:w-[688px] xl:w-[846px] xl:flex-nowrap"
-      aria-label="熱門職位"
-    >
-      {POPULAR_POSITIONS.map((position, i) => (
-        <button
-          key={position}
-          ref={(el) => {
-            buttonRefs.current[i] = el;
-          }}
-          type="button"
-          onClick={() => handleClick(position)}
-          className={`shrink-0 rounded-full border border-[#E6E8EA] bg-background-white px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-[#F7F2FB] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
-            i >= visibleCount ? 'hidden' : ''
-          }`}
-        >
-          {position}
-        </button>
-      ))}
+    <div className="relative">
+      <div
+        className="flex gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden xl:mx-auto xl:w-[846px] xl:justify-center xl:overflow-x-visible"
+        aria-label="熱門職位"
+      >
+        {POPULAR_POSITIONS.map((position, i) => (
+          <button
+            key={position}
+            ref={(el) => {
+              buttonRefs.current[i] = el;
+            }}
+            type="button"
+            onClick={() => handleClick(position)}
+            className={`shrink-0 rounded-full border border-[#E6E8EA] bg-background-white px-4 py-1.5 text-sm font-medium text-foreground transition-colors hover:bg-[#F7F2FB] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring ${
+              i >= visibleCount ? 'xl:hidden' : ''
+            }`}
+          >
+            {position}
+          </button>
+        ))}
+      </div>
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background-white to-transparent xl:hidden"
+      />
     </div>
   );
 }


### PR DESCRIPTION
## What Does This PR Do?

- Replaces the wrapping chip layout with a single horizontal-scroll row below `xl`, so popular position chips no longer break into multiple rows on mobile/tablet.
- Hides the scrollbar across browsers (`scrollbar-width: none`, `-ms-overflow-style: none`, `::-webkit-scrollbar`) and adds a right-edge fade gradient as a scrollability hint.
- Keeps the existing desktop behaviour: chips are measured against the 846px SearchBar width and trimmed to a centred single row; chips that would overflow on `xl` are now hidden via `xl:hidden` instead of `hidden`, so they remain visible (and scrollable) on smaller screens.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
