### PR TITLE
fix(profile/edit): tighten title spacing under header

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -161,7 +161,7 @@ export default function Page({
   };
 
   return (
-    <div className="mx-auto w-11/12 max-w-[1064px] pb-20 pt-10">
+    <div className="mx-auto w-11/12 max-w-[1064px] pb-20">
       <EditPageHeader
         isSaving={isSaving}
         onBack={handleGoToPrev}


### PR DESCRIPTION
## What Does This PR Do?

- Remove redundant `pt-10` on the edit page container so the "編輯個人頁面" title sits flush below the fixed site header
- The EditPageHeader is already `sticky top-[70px]` with `py-4` for breathing room, so initial render now matches the sticky position

## Demo

http://localhost:3000/profile/<id>/edit

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
