### PR TITLE
perf(reservation): speed up first paint and avatar loading

### DIFF
--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -3,7 +3,10 @@
 import { ReservationList } from '@/components/reservation/ReservationList';
 import type { Reservation } from '@/components/reservation/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { NextTokens } from '@/hooks/user/reservation/useReservationData';
+import type {
+  InitialListState,
+  NextTokens,
+} from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
 
 import { ReservationListSkeleton } from '../skeleton';
@@ -13,6 +16,7 @@ export type ReservationTabsProps = {
   pending: Reservation[];
   history: Reservation[];
   nextTokens: NextTokens;
+  initialState: InitialListState;
   isLoadingMore: boolean;
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
@@ -27,6 +31,7 @@ export default function ReservationTabs({
   pending,
   history,
   nextTokens,
+  initialState,
   isLoadingMore,
   isLoadingHistory,
   isHistoryLoaded,
@@ -95,29 +100,37 @@ export default function ReservationTabs({
 
         <div className="px-3 pt-2 sm:px-0">
           <TabsContent value="upcoming-mentee" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={upcoming}
-              variant="upcoming"
-              sourceRole="mentee"
-              myUserId={myUserId}
-              hasMore={nextTokens.upcoming !== 0}
-              onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {initialState.upcoming === 'loading' ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={upcoming}
+                variant="upcoming"
+                sourceRole="mentee"
+                myUserId={myUserId}
+                hasMore={nextTokens.upcoming !== 0}
+                onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
 
           <TabsContent value="pending-mentee" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={pending}
-              variant="pending-mentee"
-              sourceRole="mentee"
-              myUserId={myUserId}
-              hasMore={nextTokens.pending !== 0}
-              onLoadMore={() => onLoadMore('MENTEE_PENDING')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {initialState.pending === 'loading' ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={pending}
+                variant="pending-mentee"
+                sourceRole="mentee"
+                myUserId={myUserId}
+                hasMore={nextTokens.pending !== 0}
+                onLoadMore={() => onLoadMore('MENTEE_PENDING')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
 
           <TabsContent value="history" className="mt-4 sm:mt-6">

--- a/src/app/reservation/mentee/container.tsx
+++ b/src/app/reservation/mentee/container.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-
 import { useReservationData } from '@/hooks/user/reservation/useReservationData';
 
-import { ReservationSkeleton } from '../skeleton';
-
-const ReservationPresentation = dynamic(() => import('./ui'));
+import ReservationPresentation from './ui';
 
 export default function ReservationContainer() {
   const {
     data,
-    isLoading,
+    initialState,
     isLoadingMore,
     isLoadingHistory,
     isHistoryLoaded,
@@ -21,10 +17,13 @@ export default function ReservationContainer() {
     onMutationSuccess,
   } = useReservationData({ role: 'mentee' });
 
-  if (isLoading || !data) return <ReservationSkeleton />;
   return (
     <ReservationPresentation
-      {...data}
+      upcoming={data?.upcoming ?? []}
+      pending={data?.pending ?? []}
+      history={data?.history ?? []}
+      nextTokens={data?.nextTokens ?? { upcoming: 0, pending: 0, history: 0 }}
+      initialState={initialState}
       isLoadingMore={isLoadingMore}
       isLoadingHistory={isLoadingHistory}
       isHistoryLoaded={isHistoryLoaded}

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -3,7 +3,10 @@
 import { ReservationList } from '@/components/reservation/ReservationList';
 import type { Reservation } from '@/components/reservation/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
-import type { NextTokens } from '@/hooks/user/reservation/useReservationData';
+import type {
+  InitialListState,
+  NextTokens,
+} from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
 
 import { ReservationListSkeleton } from '../skeleton';
@@ -13,6 +16,7 @@ export type ReservationTabsProps = {
   pending: Reservation[];
   history: Reservation[];
   nextTokens: NextTokens;
+  initialState: InitialListState;
   isLoadingMore: boolean;
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
@@ -27,6 +31,7 @@ export default function ReservationTabs({
   pending,
   history,
   nextTokens,
+  initialState,
   isLoadingMore,
   isLoadingHistory,
   isHistoryLoaded,
@@ -95,29 +100,37 @@ export default function ReservationTabs({
 
         <div className="px-3 pt-2 sm:px-0">
           <TabsContent value="upcoming-mentor" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={upcoming}
-              variant="upcoming"
-              sourceRole="mentor"
-              myUserId={myUserId}
-              hasMore={nextTokens.upcoming !== 0}
-              onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {initialState.upcoming === 'loading' ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={upcoming}
+                variant="upcoming"
+                sourceRole="mentor"
+                myUserId={myUserId}
+                hasMore={nextTokens.upcoming !== 0}
+                onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
 
           <TabsContent value="pending-mentor" className="mt-4 sm:mt-6">
-            <ReservationList
-              items={pending}
-              variant="pending-mentor"
-              sourceRole="mentor"
-              myUserId={myUserId}
-              hasMore={nextTokens.pending !== 0}
-              onLoadMore={() => onLoadMore('MENTOR_PENDING')}
-              isLoadingMore={isLoadingMore}
-              onMutationSuccess={onMutationSuccess}
-            />
+            {initialState.pending === 'loading' ? (
+              <ReservationListSkeleton />
+            ) : (
+              <ReservationList
+                items={pending}
+                variant="pending-mentor"
+                sourceRole="mentor"
+                myUserId={myUserId}
+                hasMore={nextTokens.pending !== 0}
+                onLoadMore={() => onLoadMore('MENTOR_PENDING')}
+                isLoadingMore={isLoadingMore}
+                onMutationSuccess={onMutationSuccess}
+              />
+            )}
           </TabsContent>
 
           <TabsContent value="history" className="mt-4 sm:mt-6">

--- a/src/app/reservation/mentor/container.tsx
+++ b/src/app/reservation/mentor/container.tsx
@@ -1,17 +1,13 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-
 import { useReservationData } from '@/hooks/user/reservation/useReservationData';
 
-import { ReservationSkeleton } from '../skeleton';
-
-const ReservationPresentation = dynamic(() => import('./ui'));
+import ReservationPresentation from './ui';
 
 export default function ReservationContainer() {
   const {
     data,
-    isLoading,
+    initialState,
     isLoadingMore,
     isLoadingHistory,
     isHistoryLoaded,
@@ -21,10 +17,13 @@ export default function ReservationContainer() {
     onMutationSuccess,
   } = useReservationData({ role: 'mentor' });
 
-  if (isLoading || !data) return <ReservationSkeleton />;
   return (
     <ReservationPresentation
-      {...data}
+      upcoming={data?.upcoming ?? []}
+      pending={data?.pending ?? []}
+      history={data?.history ?? []}
+      nextTokens={data?.nextTokens ?? { upcoming: 0, pending: 0, history: 0 }}
+      initialState={initialState}
       isLoadingMore={isLoadingMore}
       isLoadingHistory={isLoadingHistory}
       isHistoryLoaded={isHistoryLoaded}

--- a/src/app/reservation/skeleton.tsx
+++ b/src/app/reservation/skeleton.tsx
@@ -16,27 +16,3 @@ export function ReservationListSkeleton({ rows = 3 }: { rows?: number }) {
     </div>
   );
 }
-
-export function ReservationSkeleton() {
-  return (
-    <div className="flex min-h-[calc(100vh-70px)] justify-center">
-      <div className="w-full max-w-[90%] overflow-hidden rounded-2xl md:max-w-[800px]">
-        {/* title */}
-        <div className="mx-auto mb-6 flex h-[42px] w-[251px] items-center justify-center">
-          <Skeleton className="h-8 w-40" />
-        </div>
-
-        <div className="mx-auto w-full max-w-3xl px-0 sm:px-4 lg:px-6">
-          {/* tab pills */}
-          <div className="mb-3 flex justify-center gap-2 py-1">
-            {Array.from({ length: 3 }).map((_, i) => (
-              <Skeleton key={i} className="h-8 w-20 rounded-full" />
-            ))}
-          </div>
-
-          <ReservationListSkeleton rows={4} />
-        </div>
-      </div>
-    </div>
-  );
-}

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -1,7 +1,9 @@
 import { CalendarDays, Clock, MessageSquare } from 'lucide-react';
+import Image from 'next/image';
 import Link from 'next/link';
+import * as React from 'react';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
+import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
@@ -31,10 +33,19 @@ export function ReservationCard({
     .slice(0, 2)
     .join('');
 
+  const [imageFailed, setImageFailed] = React.useState(false);
+
   const avatar = (
     <Avatar className="h-10 w-10 sm:h-12 sm:w-12">
-      {item.avatar ? (
-        <AvatarImage src={getAvatarThumbUrl(item.avatar)} alt={item.name} />
+      {item.avatar && !imageFailed ? (
+        <Image
+          src={getAvatarThumbUrl(item.avatar)}
+          alt={item.name}
+          fill
+          sizes="(min-width: 640px) 48px, 40px"
+          className="object-cover"
+          onError={() => setImageFailed(true)}
+        />
       ) : null}
       <AvatarFallback className="font-medium">{initials}</AvatarFallback>
     </Avatar>

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -48,8 +48,20 @@ const STATE_TO_LIST_KEY: Record<ReservationState, ListKey> = {
   MENTOR_HISTORY: 'history',
 };
 
+export type ListLoadState = 'idle' | 'loading' | 'ready';
+
+export type InitialListState = Record<ListKey, ListLoadState>;
+
+const EMPTY_DATA: ReservationData = {
+  upcoming: [],
+  pending: [],
+  history: [],
+  nextTokens: { upcoming: 0, pending: 0, history: 0 },
+};
+
 export interface UseReservationDataReturn {
   data: ReservationData | null;
+  initialState: InitialListState;
   isLoading: boolean;
   isLoadingMore: boolean;
   isLoadingHistory: boolean;
@@ -70,54 +82,60 @@ export function useReservationData({
   const states = ROLE_STATES[role];
 
   const [data, setData] = useState<ReservationData | null>(null);
-  const [isLoading, setIsLoading] = useState(true);
+  const [initialUpcoming, setInitialUpcoming] =
+    useState<ListLoadState>('loading');
+  const [initialPending, setInitialPending] =
+    useState<ListLoadState>('loading');
   const [isLoadingMore, setIsLoadingMore] = useState(false);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
 
   // Initial fetch covers only the role's UPCOMING + PENDING states. HISTORY is
   // lazy and only fetched when the user opens the history tab via loadHistory.
+  // Fetches run independently so the active tab (default upcoming) can paint as
+  // soon as its own response lands instead of waiting for the slowest sibling.
   useEffect(() => {
     if (!myUserId) {
-      setIsLoading(false);
+      setInitialUpcoming('idle');
+      setInitialPending('idle');
       return;
     }
 
     let cancelled = false;
 
-    (async () => {
+    const fetchOne = async (
+      key: 'upcoming' | 'pending',
+      state: ReservationState,
+      setStatus: (s: ListLoadState) => void
+    ) => {
       try {
-        const [upcomingRes, pendingRes] = await Promise.all([
-          fetchReservations({ userId: myUserId, state: states.upcoming }),
-          fetchReservations({ userId: myUserId, state: states.pending }),
-        ]);
-
+        const res = await fetchReservations({ userId: myUserId, state });
         if (cancelled) return;
-
-        setData({
-          upcoming: upcomingRes.items,
-          pending: pendingRes.items,
-          history: [],
-          nextTokens: {
-            upcoming: upcomingRes.next_dtend,
-            pending: pendingRes.next_dtend,
-            history: 0,
-          },
+        setData((prev) => {
+          const base = prev ?? EMPTY_DATA;
+          return {
+            ...base,
+            [key]: res.items,
+            nextTokens: { ...base.nextTokens, [key]: res.next_dtend },
+          };
         });
       } catch (err) {
         captureFlowFailure({
           flow: 'reservation_fetch',
-          step: 'fetch_lists',
+          step: `fetch_${key}`,
           message:
             err instanceof Error
               ? err.message
-              : 'Failed to fetch reservation lists',
+              : `Failed to fetch reservation ${key}`,
         });
-        console.error('[useReservationData] fetch error:', err);
+        console.error(`[useReservationData] fetch ${key} error:`, err);
       } finally {
-        if (!cancelled) setIsLoading(false);
+        if (!cancelled) setStatus('ready');
       }
-    })();
+    };
+
+    void fetchOne('upcoming', states.upcoming, setInitialUpcoming);
+    void fetchOne('pending', states.pending, setInitialPending);
 
     return () => {
       cancelled = true;
@@ -281,8 +299,27 @@ export function useReservationData({
     [data, myUserId]
   );
 
+  const historyState: ListLoadState = isHistoryLoaded
+    ? 'ready'
+    : isLoadingHistory
+      ? 'loading'
+      : 'idle';
+
+  const initialState: InitialListState = {
+    upcoming: initialUpcoming,
+    pending: initialPending,
+    history: historyState,
+  };
+
+  // Derived for backward compatibility — true while either initial list is
+  // still in flight. UI no longer uses this to gate full-page rendering;
+  // per-list `initialState` is the source of truth for skeletons.
+  const isLoading =
+    initialUpcoming === 'loading' || initialPending === 'loading';
+
   return {
     data,
+    initialState,
     isLoading,
     isLoadingMore,
     isLoadingHistory,


### PR DESCRIPTION
## What Does This PR Do?

- Switch reservation containers from `dynamic(() => import('./ui'))` to static import to remove the extra chunk round-trip on first paint
- Refactor `useReservationData` to fetch upcoming and pending independently and expose per-list `initialState` (`'idle' | 'loading' | 'ready'`) so the active tab can paint as soon as its own response lands
- Each reservation tab renders its own `ReservationListSkeleton` while loading instead of blocking the whole page on the slowest BFF call
- Replace `<AvatarImage>` in `ReservationCard` with `next/image` (`fill` + `sizes` + `object-cover`, with an `onError` fallback to initials) so avatars are lazy-loaded and benefit from the Next.js Image Optimizer cache
- Remove the now-unused page-level `ReservationSkeleton`

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Partial-failure UX changed: previously if both initial fetches rejected the page stayed on a full-page skeleton; now upcoming/pending fail independently, so a partial response renders the successful list instead of an infinite skeleton
- `<AvatarFallback>` initials may briefly render before the image overlays — kept intentionally as it improves perceived first paint
- Closes Xchange-Taiwan/X-Talent-Tracker#207

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
