### PR TITLE
chore(ci): pass --archive=tgz to vercel deploy to bypass upload limit

### DIFF
--- a/.github/workflows/deploy-dev.yml
+++ b/.github/workflows/deploy-dev.yml
@@ -46,7 +46,7 @@ jobs:
         id: deploy
         run: |
           echo "🚀 Deploying to Vercel Production (develop)..."
-          url=$(vercel deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }} | tail -n 1)
+          url=$(vercel deploy --prebuilt --prod --archive=tgz --token=${{ env.VERCEL_TOKEN }} | tail -n 1)
           echo "vercel_url=${url}" >> $GITHUB_OUTPUT
 
       - name: Comment on commit with deploy URL

--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           set -euo pipefail
           echo "🚀 Deploying PR preview..."
-          out="$(vercel deploy --prebuilt --token="${{ env.VERCEL_TOKEN }}")"
+          out="$(vercel deploy --prebuilt --archive=tgz --token="${{ env.VERCEL_TOKEN }}")"
           echo "$out"
           url="$(printf '%s\n' "$out" | tail -n 1)"
           echo "url=$url" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -40,4 +40,4 @@ jobs:
         run: vercel build --prod --token=${{ env.VERCEL_TOKEN }}
 
       - name: Deploy to production
-        run: vercel deploy --prebuilt --prod --token=${{ env.VERCEL_TOKEN }}
+        run: vercel deploy --prebuilt --prod --archive=tgz --token=${{ env.VERCEL_TOKEN }}


### PR DESCRIPTION
## What Does This PR Do?

- Add `--archive=tgz` to all three `vercel deploy` invocations (deploy-pr, deploy-dev, deploy-prod). The CLI now uploads a single tarball per deploy instead of thousands of individual files, so we stop hitting Vercel free tier's 5000-file/24h upload cap.

## Demo

N/A (CI-only change)

## Screenshot

N/A

## Anything to Note?

Triggered by today's PR preview failure: `Too many requests - try again in 24 hours (more than 5000, code: "api-upload-free")`. `--archive=tgz` is Vercel's own recommended workaround in that error message. Behaviour of the deployed site is unchanged — only the upload transport differs.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
