### PR TITLE
fix(onboarding): align step 3 design with steps 4 and 5

### DIFF
--- a/src/components/onboarding/steps/InterestedPosition.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.tsx
@@ -4,6 +4,7 @@ import { FC, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   FormControl,
   FormField,
@@ -43,23 +44,24 @@ export const InterestedPosition: FC<Props> = ({
               value={field.value ?? []}
               onChange={field.onChange}
               maxSelected={10}
-              layoutClass="flex flex-wrap gap-3"
+              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
               renderItem={(opt, { checked, disabled, onToggle }) => (
-                <button
-                  type="button"
-                  onClick={onToggle}
-                  disabled={disabled}
+                <label
                   className={cn(
-                    'rounded-xl border px-3 py-2 text-sm transition',
-                    checked
-                      ? 'border-primary bg-secondary text-text-primary'
-                      : 'border-gray-200 text-text-primary hover:border-primary',
-                    disabled &&
-                      'cursor-not-allowed opacity-50 hover:border-gray-200'
+                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
+                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
+                    disabled && 'cursor-not-allowed opacity-50'
                   )}
                 >
-                  {opt.label}
-                </button>
+                  <Checkbox
+                    checked={checked}
+                    disabled={disabled}
+                    onCheckedChange={onToggle}
+                  />
+                  <span className="text-base text-text-primary">
+                    {opt.label}
+                  </span>
+                </label>
               )}
             />
           </FormControl>


### PR DESCRIPTION
## What Does This PR Do?

- Switch onboarding step 3 (Interested Positions) from pill buttons to the checkbox-label layout used by steps 4 and 5
- Use the same `grid grid-cols-1 gap-4 sm:grid-cols-2` layout and selected/disabled styling for visual consistency across selection steps

## Demo

http://localhost:3000/auth/onboarding

## Screenshot

N/A

## Anything to Note?

N/A
