### PR TITLE
feat(mentor-pool): add scroll chevrons to popular position chips

### DIFF
--- a/src/app/mentor-pool/PopularPositionChips.tsx
+++ b/src/app/mentor-pool/PopularPositionChips.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { ChevronLeft, ChevronRight } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useEffect, useRef, useState, useTransition } from 'react';
 
@@ -8,7 +9,8 @@ import { buildHref, setSearchPattern } from './searchParams';
 
 // Desktop SearchBar width is the source of truth. We measure each chip on
 // mount and trim to what fits in this width on xl. Below xl, all chips are
-// shown in a single horizontal-scroll row with a right-edge fade.
+// shown in a single horizontal-scroll row with edge fades + chevrons that
+// reflect remaining scrollable content on each side.
 const DESKTOP_WIDTH = 846;
 const GAP_PX = 8;
 
@@ -17,7 +19,10 @@ export default function PopularPositionChips() {
   const params = useSearchParams();
   const [, startTransition] = useTransition();
   const buttonRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const scrollRef = useRef<HTMLDivElement | null>(null);
   const [visibleCount, setVisibleCount] = useState(POPULAR_POSITIONS.length);
+  const [canScrollLeft, setCanScrollLeft] = useState(false);
+  const [canScrollRight, setCanScrollRight] = useState(true);
 
   useEffect(() => {
     const widths = buttonRefs.current.map((b) => b?.offsetWidth ?? 0);
@@ -32,6 +37,23 @@ export default function PopularPositionChips() {
     setVisibleCount(count);
   }, []);
 
+  useEffect(() => {
+    const el = scrollRef.current;
+    if (!el) return;
+    const updateScrollState = () => {
+      const { scrollLeft, scrollWidth, clientWidth } = el;
+      setCanScrollLeft(scrollLeft > 0);
+      setCanScrollRight(scrollLeft + clientWidth < scrollWidth - 1);
+    };
+    updateScrollState();
+    el.addEventListener('scroll', updateScrollState, { passive: true });
+    window.addEventListener('resize', updateScrollState);
+    return () => {
+      el.removeEventListener('scroll', updateScrollState);
+      window.removeEventListener('resize', updateScrollState);
+    };
+  }, []);
+
   const handleClick = (position: string) => {
     const next = setSearchPattern(params, position);
     startTransition(() => {
@@ -42,6 +64,7 @@ export default function PopularPositionChips() {
   return (
     <div className="relative">
       <div
+        ref={scrollRef}
         className="flex gap-2 overflow-x-auto [-ms-overflow-style:none] [scrollbar-width:none] xl:mx-auto xl:w-[846px] xl:justify-center xl:overflow-x-visible [&::-webkit-scrollbar]:hidden"
         aria-label="熱門職位"
       >
@@ -61,10 +84,22 @@ export default function PopularPositionChips() {
           </button>
         ))}
       </div>
-      <div
-        aria-hidden
-        className="to-transparent pointer-events-none absolute inset-y-0 right-0 w-10 bg-gradient-to-l from-background-white xl:hidden"
-      />
+      {canScrollLeft && (
+        <div
+          aria-hidden
+          className="to-transparent pointer-events-none absolute inset-y-0 left-0 flex w-10 items-center justify-start bg-gradient-to-r from-background-white xl:hidden"
+        >
+          <ChevronLeft className="h-4 w-4 text-foreground/60" />
+        </div>
+      )}
+      {canScrollRight && (
+        <div
+          aria-hidden
+          className="to-transparent pointer-events-none absolute inset-y-0 right-0 flex w-10 items-center justify-end bg-gradient-to-l from-background-white xl:hidden"
+        >
+          <ChevronRight className="h-4 w-4 text-foreground/60" />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## What Does This PR Do?

- Track the chip row's scroll position and toggle left/right chevron + fade indicators below `xl`
- Replace the static right-edge fade with two dynamic indicators (left appears once scrolled, right hides at end)
- Hide both indicators on `xl` where chips are centred without overflow

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A
