### PR TITLE
perf(reservation): cut re-renders via stable callbacks and per-state loading

### DIFF
--- a/src/app/reservation/mentee/ReservationTabs.tsx
+++ b/src/app/reservation/mentee/ReservationTabs.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useCallback } from 'react';
+
 import { ReservationList } from '@/components/reservation/ReservationList';
 import type { Reservation } from '@/components/reservation/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type {
   InitialListState,
+  LoadingMoreStates,
   NextTokens,
 } from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
@@ -17,7 +20,7 @@ export type ReservationTabsProps = {
   history: Reservation[];
   nextTokens: NextTokens;
   initialState: InitialListState;
-  isLoadingMore: boolean;
+  loadingMoreStates: LoadingMoreStates;
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
   myUserId: string;
@@ -32,7 +35,7 @@ export default function ReservationTabs({
   history,
   nextTokens,
   initialState,
-  isLoadingMore,
+  loadingMoreStates,
   isLoadingHistory,
   isHistoryLoaded,
   myUserId,
@@ -40,6 +43,18 @@ export default function ReservationTabs({
   onLoadHistory,
   onMutationSuccess,
 }: ReservationTabsProps) {
+  const loadMoreUpcoming = useCallback(
+    () => onLoadMore('MENTEE_UPCOMING'),
+    [onLoadMore]
+  );
+  const loadMorePending = useCallback(
+    () => onLoadMore('MENTEE_PENDING'),
+    [onLoadMore]
+  );
+  const loadMoreHistory = useCallback(
+    () => onLoadMore('MENTEE_HISTORY'),
+    [onLoadMore]
+  );
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
     'bg-transparent text-foreground ' +
@@ -109,8 +124,8 @@ export default function ReservationTabs({
                 sourceRole="mentee"
                 myUserId={myUserId}
                 hasMore={nextTokens.upcoming !== 0}
-                onLoadMore={() => onLoadMore('MENTEE_UPCOMING')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMoreUpcoming}
+                isLoadingMore={loadingMoreStates.MENTEE_UPCOMING}
                 onMutationSuccess={onMutationSuccess}
               />
             )}
@@ -126,8 +141,8 @@ export default function ReservationTabs({
                 sourceRole="mentee"
                 myUserId={myUserId}
                 hasMore={nextTokens.pending !== 0}
-                onLoadMore={() => onLoadMore('MENTEE_PENDING')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMorePending}
+                isLoadingMore={loadingMoreStates.MENTEE_PENDING}
                 onMutationSuccess={onMutationSuccess}
               />
             )}
@@ -143,8 +158,8 @@ export default function ReservationTabs({
                 sourceRole="mentee"
                 myUserId={myUserId}
                 hasMore={nextTokens.history !== 0}
-                onLoadMore={() => onLoadMore('MENTEE_HISTORY')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMoreHistory}
+                isLoadingMore={loadingMoreStates.MENTEE_HISTORY}
                 onMutationSuccess={onMutationSuccess}
               />
             )}

--- a/src/app/reservation/mentee/container.tsx
+++ b/src/app/reservation/mentee/container.tsx
@@ -8,7 +8,7 @@ export default function ReservationContainer() {
   const {
     data,
     initialState,
-    isLoadingMore,
+    loadingMoreStates,
     isLoadingHistory,
     isHistoryLoaded,
     myUserId,
@@ -24,7 +24,7 @@ export default function ReservationContainer() {
       history={data?.history ?? []}
       nextTokens={data?.nextTokens ?? { upcoming: 0, pending: 0, history: 0 }}
       initialState={initialState}
-      isLoadingMore={isLoadingMore}
+      loadingMoreStates={loadingMoreStates}
       isLoadingHistory={isLoadingHistory}
       isHistoryLoaded={isHistoryLoaded}
       myUserId={myUserId}

--- a/src/app/reservation/mentor/ReservationTabs.tsx
+++ b/src/app/reservation/mentor/ReservationTabs.tsx
@@ -1,10 +1,13 @@
 'use client';
 
+import { useCallback } from 'react';
+
 import { ReservationList } from '@/components/reservation/ReservationList';
 import type { Reservation } from '@/components/reservation/types';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import type {
   InitialListState,
+  LoadingMoreStates,
   NextTokens,
 } from '@/hooks/user/reservation/useReservationData';
 import type { ReservationState } from '@/services/reservations';
@@ -17,7 +20,7 @@ export type ReservationTabsProps = {
   history: Reservation[];
   nextTokens: NextTokens;
   initialState: InitialListState;
-  isLoadingMore: boolean;
+  loadingMoreStates: LoadingMoreStates;
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
   myUserId: string;
@@ -32,7 +35,7 @@ export default function ReservationTabs({
   history,
   nextTokens,
   initialState,
-  isLoadingMore,
+  loadingMoreStates,
   isLoadingHistory,
   isHistoryLoaded,
   myUserId,
@@ -40,6 +43,18 @@ export default function ReservationTabs({
   onLoadHistory,
   onMutationSuccess,
 }: ReservationTabsProps) {
+  const loadMoreUpcoming = useCallback(
+    () => onLoadMore('MENTOR_UPCOMING'),
+    [onLoadMore]
+  );
+  const loadMorePending = useCallback(
+    () => onLoadMore('MENTOR_PENDING'),
+    [onLoadMore]
+  );
+  const loadMoreHistory = useCallback(
+    () => onLoadMore('MENTOR_HISTORY'),
+    [onLoadMore]
+  );
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
     'bg-transparent text-foreground ' +
@@ -109,8 +124,8 @@ export default function ReservationTabs({
                 sourceRole="mentor"
                 myUserId={myUserId}
                 hasMore={nextTokens.upcoming !== 0}
-                onLoadMore={() => onLoadMore('MENTOR_UPCOMING')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMoreUpcoming}
+                isLoadingMore={loadingMoreStates.MENTOR_UPCOMING}
                 onMutationSuccess={onMutationSuccess}
               />
             )}
@@ -126,8 +141,8 @@ export default function ReservationTabs({
                 sourceRole="mentor"
                 myUserId={myUserId}
                 hasMore={nextTokens.pending !== 0}
-                onLoadMore={() => onLoadMore('MENTOR_PENDING')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMorePending}
+                isLoadingMore={loadingMoreStates.MENTOR_PENDING}
                 onMutationSuccess={onMutationSuccess}
               />
             )}
@@ -143,8 +158,8 @@ export default function ReservationTabs({
                 sourceRole="mentor"
                 myUserId={myUserId}
                 hasMore={nextTokens.history !== 0}
-                onLoadMore={() => onLoadMore('MENTOR_HISTORY')}
-                isLoadingMore={isLoadingMore}
+                onLoadMore={loadMoreHistory}
+                isLoadingMore={loadingMoreStates.MENTOR_HISTORY}
                 onMutationSuccess={onMutationSuccess}
               />
             )}

--- a/src/app/reservation/mentor/container.tsx
+++ b/src/app/reservation/mentor/container.tsx
@@ -8,7 +8,7 @@ export default function ReservationContainer() {
   const {
     data,
     initialState,
-    isLoadingMore,
+    loadingMoreStates,
     isLoadingHistory,
     isHistoryLoaded,
     myUserId,
@@ -24,7 +24,7 @@ export default function ReservationContainer() {
       history={data?.history ?? []}
       nextTokens={data?.nextTokens ?? { upcoming: 0, pending: 0, history: 0 }}
       initialState={initialState}
-      isLoadingMore={isLoadingMore}
+      loadingMoreStates={loadingMoreStates}
       isLoadingHistory={isLoadingHistory}
       isHistoryLoaded={isHistoryLoaded}
       myUserId={myUserId}

--- a/src/hooks/user/reservation/useReservationData.test.ts
+++ b/src/hooks/user/reservation/useReservationData.test.ts
@@ -193,6 +193,72 @@ describe('useReservationData (mentee)', () => {
     expect(result.current.isLoading).toBe(false);
   });
 
+  it('loadingMoreStates is per-state — loading one state does not block another', async () => {
+    // Initial mount with non-zero cursors so loadMore is allowed to run
+    mockFetch.mockReset();
+    mockFetch.mockImplementation(({ state }) =>
+      Promise.resolve({
+        items: [makeReservation(state)],
+        next_dtend: 1700000000,
+      })
+    );
+
+    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    // Stage controllable responses for the two concurrent load-mores
+    let resolveUpcoming!: (v: {
+      items: ReturnType<typeof makeReservation>[];
+      next_dtend: number;
+    }) => void;
+    let resolvePending!: (v: {
+      items: ReturnType<typeof makeReservation>[];
+      next_dtend: number;
+    }) => void;
+    mockFetch.mockImplementation(({ state }) => {
+      if (state === 'MENTEE_UPCOMING') {
+        return new Promise((resolve) => {
+          resolveUpcoming = resolve;
+        });
+      }
+      if (state === 'MENTEE_PENDING') {
+        return new Promise((resolve) => {
+          resolvePending = resolve;
+        });
+      }
+      return Promise.resolve({ items: [], next_dtend: 0 });
+    });
+
+    await act(async () => {
+      void result.current.loadMore('MENTEE_UPCOMING');
+    });
+    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(true);
+    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(false);
+
+    await act(async () => {
+      void result.current.loadMore('MENTEE_PENDING');
+    });
+    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(true);
+    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(true);
+
+    await act(async () => {
+      resolveUpcoming({
+        items: [makeReservation('upcoming-extra')],
+        next_dtend: 0,
+      });
+    });
+    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(false);
+    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(true);
+
+    await act(async () => {
+      resolvePending({
+        items: [makeReservation('pending-extra')],
+        next_dtend: 0,
+      });
+    });
+    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(false);
+  });
+
   it('component unmounts before fetch resolves → state is NOT updated', async () => {
     let resolveFetch!: () => void;
     mockFetch.mockReset();

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -1,5 +1,5 @@
 import { useSession } from 'next-auth/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { Reservation } from '@/components/reservation/types';
 import { trackEvent } from '@/lib/analytics';
@@ -52,6 +52,17 @@ export type ListLoadState = 'idle' | 'loading' | 'ready';
 
 export type InitialListState = Record<ListKey, ListLoadState>;
 
+export type LoadingMoreStates = Record<ReservationState, boolean>;
+
+const EMPTY_LOADING_MORE: LoadingMoreStates = {
+  MENTEE_UPCOMING: false,
+  MENTEE_PENDING: false,
+  MENTEE_HISTORY: false,
+  MENTOR_UPCOMING: false,
+  MENTOR_PENDING: false,
+  MENTOR_HISTORY: false,
+};
+
 const EMPTY_DATA: ReservationData = {
   upcoming: [],
   pending: [],
@@ -63,7 +74,7 @@ export interface UseReservationDataReturn {
   data: ReservationData | null;
   initialState: InitialListState;
   isLoading: boolean;
-  isLoadingMore: boolean;
+  loadingMoreStates: LoadingMoreStates;
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
   myUserId: string;
@@ -82,13 +93,32 @@ export function useReservationData({
   const states = ROLE_STATES[role];
 
   const [data, setData] = useState<ReservationData | null>(null);
+  // Mirror of `data` so loadMore can read the latest cursor synchronously
+  // without listing `data` in its deps. Listing `data` rebuilt loadMore (and
+  // therefore onMutationSuccess) on every reservation change, swapping the
+  // prop identity into ReservationTabs and re-rendering the whole subtree.
+  const dataRef = useRef<ReservationData | null>(null);
   const [initialUpcoming, setInitialUpcoming] =
     useState<ListLoadState>('loading');
   const [initialPending, setInitialPending] =
     useState<ListLoadState>('loading');
-  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadingMoreStates, setLoadingMoreStates] =
+    useState<LoadingMoreStates>(EMPTY_LOADING_MORE);
   const [isLoadingHistory, setIsLoadingHistory] = useState(false);
   const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
+
+  // Wrapper that keeps dataRef and React state in lock-step. Every write to
+  // `data` must go through here so the next loadMore reads a fresh cursor.
+  const updateData = useCallback(
+    (updater: (prev: ReservationData | null) => ReservationData | null) => {
+      setData((prev) => {
+        const next = updater(prev);
+        dataRef.current = next;
+        return next;
+      });
+    },
+    []
+  );
 
   // Initial fetch covers only the role's UPCOMING + PENDING states. HISTORY is
   // lazy and only fetched when the user opens the history tab via loadHistory.
@@ -111,7 +141,7 @@ export function useReservationData({
       try {
         const res = await fetchReservations({ userId: myUserId, state });
         if (cancelled) return;
-        setData((prev) => {
+        updateData((prev) => {
           const base = prev ?? EMPTY_DATA;
           return {
             ...base,
@@ -140,19 +170,22 @@ export function useReservationData({
     return () => {
       cancelled = true;
     };
-  }, [myUserId, states.upcoming, states.pending]);
+  }, [myUserId, states.upcoming, states.pending, updateData]);
 
-  const removeItem = useCallback((id: string) => {
-    setData((prev) => {
-      if (!prev) return prev;
-      return {
-        ...prev,
-        upcoming: prev.upcoming.filter((it) => it.id !== id),
-        pending: prev.pending.filter((it) => it.id !== id),
-        history: prev.history.filter((it) => it.id !== id),
-      };
-    });
-  }, []);
+  const removeItem = useCallback(
+    (id: string) => {
+      updateData((prev) => {
+        if (!prev) return prev;
+        return {
+          ...prev,
+          upcoming: prev.upcoming.filter((it) => it.id !== id),
+          pending: prev.pending.filter((it) => it.id !== id),
+          history: prev.history.filter((it) => it.id !== id),
+        };
+      });
+    },
+    [updateData]
+  );
 
   // Refetch only the affected states. States belonging to the other role are
   // dropped (mentee page never refetches mentor data) and HISTORY is skipped
@@ -180,7 +213,7 @@ export function useReservationData({
           )
         );
 
-        setData((prev) => {
+        updateData((prev) => {
           if (!prev) return prev;
           const next: ReservationData = {
             upcoming: prev.upcoming,
@@ -207,7 +240,14 @@ export function useReservationData({
         console.error('[useReservationData] refetch error:', err);
       }
     },
-    [myUserId, states.upcoming, states.pending, states.history, isHistoryLoaded]
+    [
+      myUserId,
+      states.upcoming,
+      states.pending,
+      states.history,
+      isHistoryLoaded,
+      updateData,
+    ]
   );
 
   const onMutationSuccess = useCallback(
@@ -226,7 +266,7 @@ export function useReservationData({
         userId: myUserId,
         state: states.history,
       });
-      setData((prev) => {
+      updateData((prev) => {
         if (!prev) return prev;
         return {
           ...prev,
@@ -252,16 +292,18 @@ export function useReservationData({
     } finally {
       setIsLoadingHistory(false);
     }
-  }, [myUserId, states.history, isHistoryLoaded, isLoadingHistory]);
+  }, [myUserId, states.history, isHistoryLoaded, isLoadingHistory, updateData]);
 
   const loadMore = useCallback(
     async (state: ReservationState): Promise<void> => {
-      if (!data || !myUserId) return;
+      if (!myUserId) return;
+      const currentData = dataRef.current;
+      if (!currentData) return;
       const key = STATE_TO_LIST_KEY[state];
-      const cursor = data.nextTokens[key];
+      const cursor = currentData.nextTokens[key];
       if (cursor === 0) return;
 
-      setIsLoadingMore(true);
+      setLoadingMoreStates((prev) => ({ ...prev, [state]: true }));
       try {
         const result = await fetchReservations({
           userId: myUserId,
@@ -269,7 +311,7 @@ export function useReservationData({
           nextDtend: cursor,
         });
 
-        setData((prev) => {
+        updateData((prev) => {
           if (!prev) return prev;
           return {
             ...prev,
@@ -293,10 +335,10 @@ export function useReservationData({
         });
         console.error('[useReservationData] loadMore error:', err);
       } finally {
-        setIsLoadingMore(false);
+        setLoadingMoreStates((prev) => ({ ...prev, [state]: false }));
       }
     },
-    [data, myUserId]
+    [myUserId, updateData]
   );
 
   const historyState: ListLoadState = isHistoryLoaded
@@ -321,7 +363,7 @@ export function useReservationData({
     data,
     initialState,
     isLoading,
-    isLoadingMore,
+    loadingMoreStates,
     isLoadingHistory,
     isHistoryLoaded,
     myUserId,


### PR DESCRIPTION
## What Does This PR Do?

- `useReservationData`: mirror `data` into `dataRef` so `loadMore` can read the latest cursor without listing `data` in its deps; this stops `onMutationSuccess` from changing identity on every reservation mutation and re-rendering the whole `ReservationTabs` subtree.
- Replace global `isLoadingMore: boolean` with `loadingMoreStates: Record<ReservationState, boolean>` so loading on one tab no longer disables the load-more button on the other tabs.
- Mentee/mentor `ReservationTabs`: replace inline arrow `() => onLoadMore('XXX')` with three `useCallback`-bound handlers per file, and feed each list its own per-state loading flag. Sets up stable child props for a future `React.memo`.
- Add a unit test that asserts loading more on `MENTEE_UPCOMING` and `MENTEE_PENDING` are independent (one's loading flag does not block the other).

## Demo

http://localhost:3000/reservation/mentee
http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Closes Xchange-Taiwan/X-Talent-Tracker#208.
- `pnpm type-check`, `pnpm build`, and the full Vitest suite (126 tests, including the new per-state independence case) all pass; `pnpm lint` is clean for the touched files (only pre-existing errors in `rwd-testing/*.js`).