### PR TITLE
fix(profile-edit): eliminate mobile flicker on profile→edit nav

### DIFF
--- a/src/hooks/user/auth/useProfileAuth.test.ts
+++ b/src/hooks/user/auth/useProfileAuth.test.ts
@@ -77,4 +77,30 @@ describe('useProfileAuth', () => {
     expect(result.current.isAuthorized).toBe(true);
     expect(mockRouter.push).not.toHaveBeenCalled();
   });
+
+  it('lazy-inits isAuthorized to true on the initial render when session already matches pageUserId', () => {
+    // Asserted synchronously without awaiting effects — the lazy-init seeds
+    // the value so client-side navigation does not paint a one-frame `null`
+    // while waiting for the auth effect to flip the state.
+    const { result } = renderHook(() => useProfileAuth(PAGE_USER_ID));
+    expect(result.current.isAuthorized).toBe(true);
+  });
+
+  it('lazy-inits isAuthorized to false when session is still loading on first render', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    const { result } = renderHook(() => useProfileAuth(PAGE_USER_ID));
+    expect(result.current.isAuthorized).toBe(false);
+  });
+
+  it('lazy-inits isAuthorized to false when session is authenticated but does not match pageUserId', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        ...mockSession,
+        user: { ...mockSession.user, id: 'different-user-id' },
+      },
+      status: 'authenticated',
+    });
+    const { result } = renderHook(() => useProfileAuth(PAGE_USER_ID));
+    expect(result.current.isAuthorized).toBe(false);
+  });
 });

--- a/src/hooks/user/auth/useProfileAuth.ts
+++ b/src/hooks/user/auth/useProfileAuth.ts
@@ -6,7 +6,13 @@ import { useEffect, useState } from 'react';
 export function useProfileAuth(pageUserId: string) {
   const router = useRouter();
   const { data: session, status } = useSession();
-  const [isAuthorized, setIsAuthorized] = useState(false);
+  // Lazy-init from a cached session so client-side navigation does not flash
+  // a false isAuthorized for one frame before the effect catches up.
+  const [isAuthorized, setIsAuthorized] = useState(() => {
+    if (status === 'loading') return false;
+    const loginUserId = session?.user?.id ? String(session.user.id) : '';
+    return Boolean(loginUserId) && loginUserId === pageUserId;
+  });
 
   useEffect(() => {
     if (status === 'loading') return;

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect } from 'react';
+import { useEffect, useLayoutEffect } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 import {
@@ -37,7 +37,11 @@ export function useEditProfileData({
   // (redirected by useProfileAuth) never see the data populated.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
-  useEffect(() => {
+  // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
+  // commit before the browser paints. When the dto is already cached at mount
+  // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
+  // spinner that otherwise paints between the initial render and the effect.
+  useLayoutEffect(() => {
     if (!isAuthorized || !userDto) return;
 
     const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);


### PR DESCRIPTION
## What Does This PR Do?

- Lazy-init `isAuthorized` in `useProfileAuth` from a cached `useSession()` so client-side navigation does not flash a one-frame `null` before the auth effect catches up.
- Switch `useEditProfileData`'s reset effect from `useEffect` to `useLayoutEffect` so `form.reset` + `setIsPageLoading(false)` commit before the browser paints — when the dto is already cached (the common profile → edit nav), the spinner frame is no longer painted.
- Add lazy-init test cases for `useProfileAuth` covering matched / loading / mismatched session.

Closes Xchange-Taiwan/X-Talent-Tracker#212

## Demo

http://localhost:3000/profile/<id>/edit (navigate from /profile/<id> on mobile)

## Screenshot

N/A

## Anything to Note?

- No bundle-size or layout changes; `<PageLoading />` is still the fallback when the dto cache misses (e.g. directly opening the edit URL).
- `useLayoutEffect` is safe here because the file is `'use client'`; the SSR path is never executed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
