### PR TITLE
fix(profile): merge setValue calls into form.reset for accurate dirty tracking

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -48,6 +48,9 @@ export function useEditProfileData({
     const parsedEducations = parseEducations(experiences);
     const parsedLinks = parseLinks(experiences);
 
+    // Reset must include every server-driven field so RHF treats them as the
+    // new defaults; otherwise dirtyFields starts non-empty and submit-time
+    // skip optimisations cannot tell what the user actually changed.
     form.reset({
       is_mentor: mentorFlag,
       avatar: userDto.avatar || '',
@@ -60,33 +63,23 @@ export function useEditProfileData({
         ? [userDto.industry.subject_group]
         : [],
       years_of_experience: userDto.years_of_experience || '',
+      work_experiences: parsedExperiences || defaultValues.work_experiences,
+      educations: parsedEducations || defaultValues.educations,
       linkedin: parsedLinks.linkedin || defaultValues.linkedin,
       facebook: parsedLinks.facebook || defaultValues.facebook,
       instagram: parsedLinks.instagram || defaultValues.instagram,
       twitter: parsedLinks.twitter || defaultValues.twitter,
       youtube: parsedLinks.youtube || defaultValues.youtube,
       website: parsedLinks.website || defaultValues.website,
-      work_experiences: parsedExperiences || defaultValues.work_experiences,
-      educations: parsedEducations || defaultValues.educations,
+      what_i_offer: parseWhatIOffer(experiences),
+      expertises:
+        userDto.expertises?.professions?.map((i) => i.subject_group) || [],
+      interested_positions:
+        userDto.interested_positions?.interests?.map((i) => i.subject_group) ||
+        [],
+      skills: userDto.skills?.interests?.map((i) => i.subject_group) || [],
+      topics: userDto.topics?.interests?.map((i) => i.subject_group) || [],
     });
-
-    form.setValue(
-      'expertises',
-      userDto.expertises?.professions?.map((i) => i.subject_group) || []
-    );
-    form.setValue(
-      'interested_positions',
-      userDto.interested_positions?.interests?.map((i) => i.subject_group) || []
-    );
-    form.setValue(
-      'skills',
-      userDto.skills?.interests?.map((i) => i.subject_group) || []
-    );
-    form.setValue(
-      'topics',
-      userDto.topics?.interests?.map((i) => i.subject_group) || []
-    );
-    form.setValue('what_i_offer', parseWhatIOffer(experiences));
 
     setIsMentor(mentorFlag);
     setIsPageLoading(false);


### PR DESCRIPTION
## What Does This PR Do?

- Merges the five trailing `form.setValue` calls (`expertises`, `interested_positions`, `skills`, `topics`, `what_i_offer`) into the single `form.reset({...})` payload in `useEditProfileData`.
- After this change, those fields are treated as proper RHF defaults, so `formState.dirtyFields` starts empty when the form loads and only flags fields the user actually edited.
- Pure correctness fix; no user-visible behaviour change. Required prerequisite for the dirty-field-based submit skip optimisation tracked in issue #213.

## Demo

http://localhost:3000/profile/<userId>/edit

## Screenshot

N/A

## Anything to Note?

- Part 1 of issue #213. Follow-up PR will use `dirtyFields` in `useProfileSubmit` to skip unchanged PUTs and stop blocking navigation on `firstSyncedFetch`.
- Verified locally with `pnpm type-check` and `pnpm exec vitest run src/hooks/user/profile` (21/21 pass).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
