### PR TITLE
perf(mentor-schedule): cache month fetches with stale-while-revalidate

### DIFF
--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import isSameOrBefore from 'dayjs/plugin/isSameOrBefore';
 dayjs.extend(isSameOrBefore);
 
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
   BookingSlot,
@@ -18,8 +18,10 @@ import {
   RawMentorTimeslot,
 } from '@/lib/profile/scheduleHelpers';
 import { TimeSlotDTO } from '@/services/mentor-schedule/schedule';
+import { clearAllScheduleCache } from '@/services/mentor-schedule/scheduleCache';
 import {
-  loadMonthSchedule,
+  loadMonthScheduleCached,
+  loadMonthScheduleFresh,
   syncMonthSchedule,
 } from '@/services/mentor-schedule/sync';
 
@@ -107,29 +109,52 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     [persistedIdSet]
   );
 
+  const prevUserIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (
+      prevUserIdRef.current !== null &&
+      prevUserIdRef.current !== backend.userId
+    ) {
+      clearAllScheduleCache();
+    }
+    prevUserIdRef.current = backend.userId;
+  }, [backend.userId]);
+
+  const dirtyRef = useRef(false);
+
   useEffect(() => {
     if (!backend.userId || !backend.year || !backend.month) return;
     let ignore = false;
-    (async () => {
-      try {
-        const raws = await loadMonthSchedule(backend);
-        if (ignore) return;
-        setSaved(raws);
-        setDraft(raws);
-        setLoaded(true);
-        setPendingDeleteIds([]);
-        // Derive meeting duration from the first ALLOW slot's sub-slot size
-        const firstAllow = raws.find((r) => r.type === 'ALLOW');
-        if (firstAllow) {
-          const derived = Math.round(
-            (firstAllow.dtend - firstAllow.dtstart) / 60
-          );
-          if (derived > 0) setMeetingDurationMinutes(derived);
-        }
-      } catch {
-        if (!ignore) setLoaded(true);
+
+    const apply = (raws: RawMentorTimeslot[]) => {
+      setSaved(raws);
+      setDraft(raws);
+      setLoaded(true);
+      setPendingDeleteIds([]);
+      const firstAllow = raws.find((r) => r.type === 'ALLOW');
+      if (firstAllow) {
+        const derived = Math.round(
+          (firstAllow.dtend - firstAllow.dtstart) / 60
+        );
+        if (derived > 0) setMeetingDurationMinutes(derived);
       }
-    })();
+    };
+
+    const { cached, revalidate } = loadMonthScheduleCached(backend);
+    if (cached) apply(cached);
+
+    revalidate
+      .then((raws) => {
+        if (ignore) return;
+        // Don't clobber unsaved edits when fresh data arrives in the background.
+        if (dirtyRef.current) return;
+        if (cached && JSON.stringify(cached) === JSON.stringify(raws)) return;
+        apply(raws);
+      })
+      .catch(() => {
+        if (!ignore && !cached) setLoaded(true);
+      });
+
     return () => {
       ignore = true;
     };
@@ -330,6 +355,10 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     JSON.stringify(saved) !== JSON.stringify(draft) ||
     pendingDeleteIds.length > 0;
 
+  useEffect(() => {
+    dirtyRef.current = dirty;
+  }, [dirty]);
+
   const confirmChanges = useCallback(async () => {
     if (!dirty) return;
     if (!backend.userId) return;
@@ -370,7 +399,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const resetChanges = useCallback(() => {
     if (!backend.userId || !backend.year || !backend.month) return;
     (async () => {
-      const raws = await loadMonthSchedule(backend);
+      const raws = await loadMonthScheduleFresh(backend);
       setDraft(raws);
       setSaved(raws);
       setPendingDeleteIds([]);

--- a/src/services/mentor-schedule/scheduleCache.ts
+++ b/src/services/mentor-schedule/scheduleCache.ts
@@ -1,0 +1,40 @@
+import { RawMentorTimeslot } from '@/lib/profile/scheduleHelpers';
+
+import type { ScheduleMonthRef } from './sync';
+
+const cache = new Map<string, RawMentorTimeslot[]>();
+const inflight = new Map<string, Promise<RawMentorTimeslot[]>>();
+
+export function cacheKey(ref: ScheduleMonthRef): string {
+  return `${ref.userId}:${ref.year}-${ref.month}`;
+}
+
+export function readCache(key: string): RawMentorTimeslot[] | undefined {
+  return cache.get(key);
+}
+
+export function writeCache(key: string, raws: RawMentorTimeslot[]): void {
+  cache.set(key, raws);
+}
+
+export function readInflight(
+  key: string
+): Promise<RawMentorTimeslot[]> | undefined {
+  return inflight.get(key);
+}
+
+export function trackInflight(
+  key: string,
+  promise: Promise<RawMentorTimeslot[]>
+): Promise<RawMentorTimeslot[]> {
+  inflight.set(key, promise);
+  promise.finally(() => {
+    if (inflight.get(key) === promise) inflight.delete(key);
+  });
+  return promise;
+}
+
+export function clearAllScheduleCache(): void {
+  cache.clear();
+  inflight.clear();
+}

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -8,6 +8,13 @@ import {
   saveMentorSchedule,
   TimeSlotDTO,
 } from './schedule';
+import {
+  cacheKey,
+  readCache,
+  readInflight,
+  trackInflight,
+  writeCache,
+} from './scheduleCache';
 
 export interface ScheduleMonthRef {
   userId: string;
@@ -24,6 +31,41 @@ export async function loadMonthSchedule(
     const d = dayjs(r.dtstart * 1000);
     return d.year() === ref.year && d.month() + 1 === ref.month;
   });
+}
+
+/**
+ * Returns the cached value (sync, may be undefined) and a deduped promise
+ * that resolves to fresh data and writes it to cache. Callers should hydrate
+ * with `cached` immediately and update from `revalidate` when it differs.
+ */
+export function loadMonthScheduleCached(ref: ScheduleMonthRef): {
+  cached: RawMentorTimeslot[] | undefined;
+  revalidate: Promise<RawMentorTimeslot[]>;
+} {
+  const key = cacheKey(ref);
+  const cached = readCache(key);
+
+  let revalidate = readInflight(key);
+  if (!revalidate) {
+    revalidate = trackInflight(
+      key,
+      loadMonthSchedule(ref).then((raws) => {
+        writeCache(key, raws);
+        return raws;
+      })
+    );
+  }
+
+  return { cached, revalidate };
+}
+
+/** Force a network fetch and write the result to cache, bypassing any cache hit. */
+export async function loadMonthScheduleFresh(
+  ref: ScheduleMonthRef
+): Promise<RawMentorTimeslot[]> {
+  const raws = await loadMonthSchedule(ref);
+  writeCache(cacheKey(ref), raws);
+  return raws;
 }
 
 /**
@@ -69,7 +111,7 @@ export async function syncMonthSchedule(params: {
       );
     }
 
-    return await loadMonthSchedule(ref);
+    return await loadMonthScheduleFresh(ref);
   } catch (e) {
     console.error('[MentorSchedule] sync failed:', e);
     return null;


### PR DESCRIPTION
## What Does This PR Do?

- Add module-scope cache + inflight maps in `scheduleCache.ts` so previously-viewed months hydrate instantly when revisited (closes #215)
- Add `loadMonthScheduleCached` (sync cache hit + deduped revalidate) and `loadMonthScheduleFresh` (force fetch + write cache) in `sync.ts`
- `syncMonthSchedule` now writes the post-mutation result back to cache via `loadMonthScheduleFresh`
- `useMentorSchedule` switches to a stale-while-revalidate flow: hydrates from cache immediately, revalidates in the background, and skips the apply when the user has unsaved edits or the data is unchanged
- Clear the entire schedule cache when `backend.userId` changes so a different mentor profile never sees the previous user's data
- `resetChanges` now uses the fresh path so users always pull the server-of-truth on reset

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

- StrictMode-safe: same `[userId, year, month]` key reuses the inflight promise instead of double-fetching
- Background revalidate uses a `dirtyRef` guard so it never clobbers in-progress edits
- Cross-tab sync is intentionally out of scope per the ticket; B-tab still revalidates on month change

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
