### PR TITLE
fix(mentor-pool): show what_i_offer on card tags instead of topics

### DIFF
--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -50,7 +50,7 @@ const MentorCardListBase = ({
             job_title={mentor.job_title}
             company={mentor.company}
             personalStatment={mentor.personal_statement}
-            whatIOffers={mentor.topics}
+            whatIOffers={mentor.what_i_offers}
           />
         ))}
       </div>

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -33,6 +33,7 @@ export interface MentorType {
   interested_positions: string[];
   skills: string[];
   topics: string[];
+  what_i_offers: string[];
   industry: string | null;
   expertises: string[];
   experiences: MentorExperienceBlock[];
@@ -48,6 +49,22 @@ function readInterestGroups(raw: unknown): string[] {
   return (raw as InterestEntry[])
     .map((i) => i.subject_group)
     .filter((g): g is string => Boolean(g));
+}
+
+type WhatIOfferDataItem = { subject_group?: string | null };
+function readWhatIOfferGroups(raw: RawMentor['experiences']): string[] {
+  if (!raw) return [];
+  const subjectGroups = raw
+    .filter((e) => e.category === 'WHAT_I_OFFER')
+    .flatMap((e) => {
+      const metadata = e.mentor_experiences_metadata as
+        | { data?: WhatIOfferDataItem[] }
+        | undefined;
+      return metadata?.data ?? [];
+    })
+    .map((item) => item.subject_group)
+    .filter((g): g is string => Boolean(g));
+  return Array.from(new Set(subjectGroups));
 }
 
 export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
@@ -83,6 +100,7 @@ export function mapMentor(raw: RawMentor): MentorType {
     interested_positions: readInterestGroups(raw.interested_positions),
     skills: readInterestGroups(raw.skills),
     topics: readInterestGroups(raw.topics),
+    what_i_offers: readWhatIOfferGroups(raw.experiences),
     industry: raw.industry?.subject ?? null,
     expertises: raw.expertises?.professions?.map((p) => p.subject) ?? [],
     experiences: (raw.experiences ?? []).map((e) => ({

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -107,6 +107,10 @@ export async function fetchMentorsEnrichedServer(
 
   if (searchResults.length === 0) return [];
 
+  // what_i_offer shares the topics interest vocabulary (see useInterests.ts
+  // `whatIOffers: topics` alias), so we reuse topicLabelMap here.
+  const whatIOfferLabelMap = topicLabelMap;
+
   return searchResults.map((mentor) => ({
     ...mentor,
     skills: mentor.skills
@@ -114,6 +118,9 @@ export async function fetchMentorsEnrichedServer(
       .filter(Boolean),
     topics: mentor.topics
       .map((subjectGroup) => topicLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+    what_i_offers: mentor.what_i_offers
+      .map((subjectGroup) => whatIOfferLabelMap[subjectGroup] ?? subjectGroup)
       .filter(Boolean),
   }));
 }

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -60,6 +60,11 @@ export async function fetchMentorsEnriched(
     topicLabelMap[t.subject_group] = t.subject ?? '';
   });
 
+  const whatIOfferLabelMap: Record<string, string> = {};
+  interests.whatIOffers.forEach((w) => {
+    whatIOfferLabelMap[w.subject_group] = w.subject ?? '';
+  });
+
   return searchResults.map((mentor) => ({
     ...mentor,
     skills: mentor.skills
@@ -67,6 +72,9 @@ export async function fetchMentorsEnriched(
       .filter(Boolean),
     topics: mentor.topics
       .map((subjectGroup) => topicLabelMap[subjectGroup] ?? subjectGroup)
+      .filter(Boolean),
+    what_i_offers: mentor.what_i_offers
+      .map((subjectGroup) => whatIOfferLabelMap[subjectGroup] ?? subjectGroup)
       .filter(Boolean),
   }));
 }


### PR DESCRIPTION
## What Does This PR Do?

- Add `what_i_offers: string[]` to `MentorType` and derive it from `experiences[category=WHAT_I_OFFER]` in `mapMentor`, mirroring profile page's `buildWhatIOffers` (flatMap all WHAT_I_OFFER blocks, dedupe subject_groups).
- Translate `what_i_offers` subject_groups to labels in both `fetchMentorsEnriched` (client) and `fetchMentorsEnrichedServer` (SSR); server reuses `topicLabelMap` since `useInterests.ts` aliases `whatIOffers: topics`.
- Switch `MentorCardList` to pass `mentor.what_i_offers` (was `mentor.topics`) into the card prop that was already named `whatIOffers`.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

Related: Xchange-Taiwan/X-Talent-Tracker#214 (cross-repo, won't auto-close).

Root cause: PR #526 fixed the wire-format bug for tag rendering but wired `topics` into a prop named `whatIOffers`. Card UI/prop names were already correct — only the upstream data source was wrong.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
