### PR TITLE
perf(mentor-schedule): prefetch next month for instant forward nav

### DIFF
--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -22,6 +22,7 @@ import { clearAllScheduleCache } from '@/services/mentor-schedule/scheduleCache'
 import {
   loadMonthScheduleCached,
   loadMonthScheduleFresh,
+  prefetchMonthSchedule,
   syncMonthSchedule,
 } from '@/services/mentor-schedule/sync';
 
@@ -160,6 +161,21 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [backend.userId, backend.year, backend.month]);
+
+  // Prefetch the next month after the current month finishes loading, so
+  // forward navigation hits cache. Past months are intentionally skipped.
+  useEffect(() => {
+    if (!loaded || !backend.userId) return;
+    const next = dayjs(`${backend.year}-${backend.month}-01`).add(1, 'month');
+    const handle = setTimeout(() => {
+      prefetchMonthSchedule({
+        userId: backend.userId,
+        year: next.year(),
+        month: next.month() + 1,
+      });
+    }, 0);
+    return () => clearTimeout(handle);
+  }, [loaded, backend.userId, backend.year, backend.month]);
 
   const parsedDraft = useMemo(
     () =>

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -69,6 +69,27 @@ export async function loadMonthScheduleFresh(
 }
 
 /**
+ * Fire-and-forget background fetch that populates cache for a month.
+ * No-op when the month is already cached or a request is in flight.
+ * Failures are silenced — prefetch must never disrupt the user.
+ */
+export function prefetchMonthSchedule(ref: ScheduleMonthRef): void {
+  const key = cacheKey(ref);
+  if (readCache(key) !== undefined) return;
+  if (readInflight(key) !== undefined) return;
+
+  trackInflight(
+    key,
+    loadMonthSchedule(ref).then((raws) => {
+      writeCache(key, raws);
+      return raws;
+    })
+  ).catch(() => {
+    // Silent: prefetch failures shouldn't surface to the user.
+  });
+}
+
+/**
  * PUT all upsert slots, DELETE all removed ids, then reload the month.
  * Returns the freshly loaded slots, or null if any sync request failed.
  */


### PR DESCRIPTION
## What Does This PR Do?

- Add `prefetchMonthSchedule(ref)` in `sync.ts`: fire-and-forget background fetch that no-ops on cache hit or inflight match, silences errors (closes #216)
- Add a prefetch effect in `useMentorSchedule` that runs after the current month finishes loading and primes cache for the next month via `setTimeout(0)`
- dayjs handles year crossing (Dec → next Jan) automatically
- Past months are intentionally skipped — slots are immutable and unbookable, so prefetching them would waste API quota

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

- Depends on #215 (cache + inflight dedupe) which is already in develop
- Connecting users in the mentee reservation dialog also benefit since the same hook is shared
- Schedule API is known to be slow; this roughly doubles per-view load, but the previous-month skip keeps the increase modest. Backend warm-up / BFF cache is tracked separately

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
