### PR TITLE
feat(reservation): inform mentor meeting link is sent on accept

### DIFF
--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -105,7 +105,10 @@ export function ReservationList({
       // slot overlaps an existing ALLOW slot. Re-enable once backend supports it,
       // or once GET schedule returns booked_slots so the frontend can filter them.
 
-      toast({ description: '已接受預約' });
+      toast({
+        title: '已接受預約',
+        description: '會議連結將於數分鐘內寄至雙方信箱',
+      });
       onMutationSuccess?.(id, ACCEPT_AFFECTED_STATES);
     } catch (err) {
       captureFlowFailure({


### PR DESCRIPTION
## What Does This PR Do?

- 接受預約成功後的 toast 加上副文案，告知導師會議連結將於數分鐘內寄至雙方信箱，避免使用者不確定後端是否已處理
- 由原先單行 `description` 拆成 `title` + `description` 兩行（沿用既有 toast pattern，如 GoogleButton / signUpErrorHandler）
- 僅調整 `ReservationList.tsx` 接受成功路徑的文案，不改 API、不改後端、不影響拒絕 / 取消 / 失敗路徑

Closes Xchange-Taiwan/X-Talent-Tracker#219

## Demo

http://localhost:3000/reservation

## Screenshot

N/A

## Anything to Note?

N/A
