### PR TITLE
feat(profile): preserve viewed month when opening booking dialog

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -47,7 +47,8 @@ export default function ProfilePageContainer({
   const schedule = useMentorSchedule({
     backend: { userId: pageUserId, year, month },
   });
-  const { loaded, setSelectedDate, parsedDraft, allowedDates } = schedule;
+  const { loaded, selectedDate, setSelectedDate, parsedDraft, allowedDates } =
+    schedule;
 
   const [openReservationDialog, setOpenReservationDialog] = useState(false);
   const [openMenteeReservationDialog, setOpenMenteeReservationDialog] =
@@ -134,6 +135,27 @@ export default function ProfilePageContainer({
       return;
     }
     if (!userData) return;
+    // If the user directly clicked a past day on the profile calendar
+    // (still possible when that day has saved slots), snap selectedDate
+    // forward to today so the dialog never opens on an un-editable past
+    // date with its slot editor primed.
+    if (selectedDate) {
+      const sel = new Date(selectedDate + 'T00:00:00');
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      if (sel < today) {
+        const pad = (n: number) => String(n).padStart(2, '0');
+        setSelectedDate(
+          `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`
+        );
+        const todayYear = today.getFullYear();
+        const todayMonth = today.getMonth() + 1;
+        if (todayYear !== year || todayMonth !== month) {
+          setYear(todayYear);
+          setMonth(todayMonth);
+        }
+      }
+    }
     if (userData.is_mentor && pageUserId === loginUserId) {
       setOpenReservationDialog(true);
       return;

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -61,8 +61,18 @@ export default function ProfilePageContainer({
     // Carry the viewed month into the booking dialogs by anchoring
     // selectedDate to the new month. Skip while a dialog is open so
     // in-dialog month navigation does not clobber the user's day pick.
+    // Clamp to today so a past month never anchors to an un-editable
+    // past day (which would let the dialog render its slot editor on
+    // a date the mentor cannot configure).
     if (!openReservationDialog && !openMenteeReservationDialog) {
-      setSelectedDate(`${newYear}-${String(newMonth).padStart(2, '0')}-01`);
+      const today = new Date();
+      today.setHours(0, 0, 0, 0);
+      const monthStart = new Date(newYear, newMonth - 1, 1);
+      const anchor = monthStart < today ? today : monthStart;
+      const pad = (n: number) => String(n).padStart(2, '0');
+      setSelectedDate(
+        `${anchor.getFullYear()}-${pad(anchor.getMonth() + 1)}-${pad(anchor.getDate())}`
+      );
     }
   };
 

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -44,15 +44,27 @@ export default function ProfilePageContainer({
   const [year, setYear] = useState(() => new Date().getFullYear());
   const [month, setMonth] = useState(() => new Date().getMonth() + 1);
 
-  const handleScheduleMonthChange = (date: Date) => {
-    setYear(date.getFullYear());
-    setMonth(date.getMonth() + 1);
-  };
-
   const schedule = useMentorSchedule({
     backend: { userId: pageUserId, year, month },
   });
   const { loaded, setSelectedDate, parsedDraft, allowedDates } = schedule;
+
+  const [openReservationDialog, setOpenReservationDialog] = useState(false);
+  const [openMenteeReservationDialog, setOpenMenteeReservationDialog] =
+    useState(false);
+
+  const handleScheduleMonthChange = (date: Date) => {
+    const newYear = date.getFullYear();
+    const newMonth = date.getMonth() + 1;
+    setYear(newYear);
+    setMonth(newMonth);
+    // Carry the viewed month into the booking dialogs by anchoring
+    // selectedDate to the new month. Skip while a dialog is open so
+    // in-dialog month navigation does not clobber the user's day pick.
+    if (!openReservationDialog && !openMenteeReservationDialog) {
+      setSelectedDate(`${newYear}-${String(newMonth).padStart(2, '0')}-01`);
+    }
+  };
 
   // Auto-select the first available date once schedule is loaded
   useEffect(() => {
@@ -70,10 +82,6 @@ export default function ProfilePageContainer({
     ? String(session.user.id)
     : initialLoginUserId;
   const isLogging = Boolean(loginUserId);
-
-  const [openReservationDialog, setOpenReservationDialog] = useState(false);
-  const [openMenteeReservationDialog, setOpenMenteeReservationDialog] =
-    useState(false);
 
   const { userData, isLoading: userLoading } = useUserData(
     pageUserIdNumber,


### PR DESCRIPTION
## What Does This PR Do?

- Anchor `selectedDate` to the new month when the user changes month on the profile schedule calendar so the booking dialog (mentor 預約設定 / mentee 預約時間) opens to the same month instead of jumping back to today
- Skip the anchor while a dialog is open so in-dialog month navigation does not clobber the user's day pick
- Move the dialog open-state declarations above `handleScheduleMonthChange` since the handler now reads them

Closes Xchange-Taiwan/X-Talent-Tracker#220

## Demo

http://localhost:3000/profile/<userId>

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
