### PR TITLE
fix(mentor-schedule): surface save errors via toast (#221)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -20,6 +20,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select';
+import { useToast } from '@/components/ui/use-toast';
 import {
   expandRrule,
   UseMentorScheduleReturn,
@@ -99,6 +100,7 @@ export default function MentorScheduleDialog({
   } = schedule;
 
   const router = useRouter();
+  const { toast } = useToast();
   const [isSaving, setIsSaving] = useState(false);
   const [editingSlots, setEditingSlots] = useState<EditingSlot[]>([]);
   const [slotErrors, setSlotErrors] = useState<Record<number, SlotErrors>>({});
@@ -225,8 +227,20 @@ export default function MentorScheduleDialog({
 
   const handleSave = async () => {
     setIsSaving(true);
-    await confirmChanges();
+    const result = await confirmChanges();
     setIsSaving(false);
+    if (!result.ok) {
+      // Keep the dialog open so the mentor can adjust the conflicting slot
+      // and retry. The draft state is preserved on failure.
+      toast({
+        variant: 'destructive',
+        description:
+          result.reason === 'conflict'
+            ? '此時段與既有預約衝突,請調整後再試'
+            : '儲存失敗,請稍後再試',
+      });
+      return;
+    }
     onOpenChange(false);
   };
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -24,6 +24,7 @@ import {
   loadMonthScheduleFresh,
   prefetchMonthSchedule,
   syncMonthSchedule,
+  SyncResult,
 } from '@/services/mentor-schedule/sync';
 
 export type { BookingSlot } from '@/lib/profile/scheduleHelpers';
@@ -69,7 +70,7 @@ export type UseMentorScheduleReturn = {
   /** Toggle a single sub-slot occurrence in/out of exdate for an ALLOW slot. */
   toggleOccurrence: (slotId: number, occurrenceDtstart: number) => void;
 
-  confirmChanges: () => void;
+  confirmChanges: () => Promise<SyncResult>;
   resetChanges: () => void;
 };
 
@@ -375,9 +376,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     dirtyRef.current = dirty;
   }, [dirty]);
 
-  const confirmChanges = useCallback(async () => {
-    if (!dirty) return;
-    if (!backend.userId) return;
+  const confirmChanges = useCallback(async (): Promise<SyncResult> => {
+    if (!dirty || !backend.userId) return { ok: true };
 
     const rawUpsert = draft
       .filter((r) => !pendingDeleteIds.includes(r.id) && r.type === 'ALLOW')
@@ -400,16 +400,20 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
     const idsToDelete = [...pendingDeleteIds, ...extraDeleteIds];
 
-    const raws = await syncMonthSchedule({
+    const outcome = await syncMonthSchedule({
       ref: backend,
       upsertPayload,
       deleteIds: idsToDelete,
     });
-    if (raws) {
-      setSaved(raws);
-      setDraft(raws);
-      setPendingDeleteIds([]);
+    // On failure, leave saved/draft alone so the user keeps their unsaved
+    // edits and can fix the conflict and retry.
+    if (!outcome.ok) {
+      return { ok: false, reason: outcome.reason, message: outcome.message };
     }
+    setSaved(outcome.raws);
+    setDraft(outcome.raws);
+    setPendingDeleteIds([]);
+    return { ok: true };
   }, [draft, toServiceSlot, dirty, pendingDeleteIds, backend]);
 
   const resetChanges = useCallback(() => {

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -1,4 +1,4 @@
-import { apiClient } from '@/lib/apiClient';
+import { apiClient, ApiError } from '@/lib/apiClient';
 import { components } from '@/types/api';
 
 export interface ScheduleRequest {
@@ -40,12 +40,19 @@ interface SaveScheduleResponse {
 
 type CleanObject = Record<string, unknown>;
 
-/** PUT /v1/mentors/:userId/schedule */
+/**
+ * PUT /v1/mentors/:userId/schedule
+ *
+ * Resolves on success, throws on failure. HTTP failures bubble up as ApiError
+ * (with backend `msg` in `.message`); a non-zero response `code` is rethrown
+ * as ApiError(200, msg) so callers can surface the same message regardless of
+ * transport-level vs. body-level failure.
+ */
 export async function saveMentorSchedule(params: {
   userId: string;
   timeslots: TimeSlotDTO[];
   until?: number | null;
-}): Promise<boolean> {
+}): Promise<void> {
   const cleanOptional = (obj: CleanObject): CleanObject =>
     Object.fromEntries(
       Object.entries(obj).filter(
@@ -69,37 +76,25 @@ export async function saveMentorSchedule(params: {
     ),
   });
 
-  try {
-    const result = await apiClient.put<SaveScheduleResponse>(
-      `/v1/mentors/${params.userId}/schedule`,
-      body
-    );
-    if (result.code !== '0') {
-      console.error(
-        '[saveMentorSchedule] non-zero code:',
-        result.code,
-        result.msg
-      );
-      return false;
-    }
-    return true;
-  } catch (err) {
-    console.error('[saveMentorSchedule] request failed:', err);
-    return false;
+  const result = await apiClient.put<SaveScheduleResponse>(
+    `/v1/mentors/${params.userId}/schedule`,
+    body
+  );
+  if (result.code !== '0') {
+    throw new ApiError(200, result.msg || 'Save failed', result);
   }
 }
 
-/** DELETE /v1/mentors/:userId/schedule/:scheduleId */
+/**
+ * DELETE /v1/mentors/:userId/schedule/:scheduleId
+ *
+ * Resolves on success, throws on failure (ApiError bubbles up from apiClient).
+ */
 export async function deleteMentorSchedule(params: {
   userId: string | number;
   scheduleId: string | number;
-}): Promise<boolean> {
-  try {
-    await apiClient.delete(
-      `/v1/mentors/${params.userId}/schedule/${params.scheduleId}`
-    );
-    return true;
-  } catch {
-    return false;
-  }
+}): Promise<void> {
+  await apiClient.delete(
+    `/v1/mentors/${params.userId}/schedule/${params.scheduleId}`
+  );
 }

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -1,5 +1,6 @@
 import dayjs from 'dayjs';
 
+import { ApiError } from '@/lib/apiClient';
 import { RawMentorTimeslot, segmentToRaw } from '@/lib/profile/scheduleHelpers';
 
 import {
@@ -21,6 +22,18 @@ export interface ScheduleMonthRef {
   year: number;
   month: number; // 1-12
 }
+
+export type SyncFailureReason = 'conflict' | 'unknown';
+
+/** Internal — syncMonthSchedule passes raws back to the hook on success. */
+export type SyncOutcome =
+  | { ok: true; raws: RawMentorTimeslot[] }
+  | { ok: false; reason: SyncFailureReason; message: string };
+
+/** Public — surfaced to UI; success has no payload. */
+export type SyncResult =
+  | { ok: true }
+  | { ok: false; reason: SyncFailureReason; message: string };
 
 /** Fetch + filter to slots whose dtstart falls in the requested local month. */
 export async function loadMonthSchedule(
@@ -91,13 +104,17 @@ export function prefetchMonthSchedule(ref: ScheduleMonthRef): void {
 
 /**
  * PUT all upsert slots, DELETE all removed ids, then reload the month.
- * Returns the freshly loaded slots, or null if any sync request failed.
+ *
+ * Returns SyncResult — on failure the caller can surface `message` (raw
+ * backend `msg`, e.g. "There is 1 conflict in 2026/5") and `reason` to map
+ * to user-friendly UI copy. PUT failure aborts before DELETE so we don't
+ * partially mutate the schedule.
  */
 export async function syncMonthSchedule(params: {
   ref: ScheduleMonthRef;
   upsertPayload: TimeSlotDTO[];
   deleteIds: number[];
-}): Promise<RawMentorTimeslot[] | null> {
+}): Promise<SyncOutcome> {
   const { ref, upsertPayload, deleteIds } = params;
 
   const endOfMonthUnix = dayjs(
@@ -112,29 +129,36 @@ export async function syncMonthSchedule(params: {
 
   try {
     if (upsertPayload.length > 0) {
-      const ok = await saveMentorSchedule({
+      await saveMentorSchedule({
         userId: ref.userId,
         until: endOfMonthUnix,
         timeslots: upsertPayload,
       });
-      if (!ok) throw new Error('PUT failed');
     }
 
     if (deleteIds.length > 0) {
       await Promise.all(
-        deleteIds.map(async (id) => {
-          const ok = await deleteMentorSchedule({
+        deleteIds.map((id) =>
+          deleteMentorSchedule({
             userId: ref.userId,
             scheduleId: id,
-          });
-          if (!ok) throw new Error(`DELETE failed: ${id}`);
-        })
+          })
+        )
       );
     }
 
-    return await loadMonthScheduleFresh(ref);
+    const raws = await loadMonthScheduleFresh(ref);
+    return { ok: true, raws };
   } catch (e) {
-    console.error('[MentorSchedule] sync failed:', e);
-    return null;
+    const message =
+      e instanceof ApiError
+        ? e.message
+        : e instanceof Error
+          ? e.message
+          : 'Sync failed';
+    const reason: SyncFailureReason = /conflict/i.test(message)
+      ? 'conflict'
+      : 'unknown';
+    return { ok: false, reason, message };
   }
 }


### PR DESCRIPTION
## What Does This PR Do?

- syncMonthSchedule no longer swallows errors; returns SyncOutcome with
  reason ('conflict' | 'unknown') and the raw backend message
- saveMentorSchedule / deleteMentorSchedule now resolve on success and
  let ApiError bubble up so callers can read the backend msg
- confirmChanges returns Promise<SyncResult>; on failure the draft is
  preserved so the mentor can adjust and retry
- MentorScheduleDialog handleSave keeps the dialog open on failure and
  shows a destructive toast ('此時段與既有預約衝突,請調整後再試' for
  conflicts, generic copy otherwise)
- removed debug console.logs added during the original investigation

## Demo

http://localhost:3000/profile/<own-mentor-id>

## Screenshot

N/A

## Anything to Note?

Closes #221. Behavioral change: before this PR, a failed PUT (e.g.
backend conflict) closed the dialog silently and lost the user's edits
on refresh. After this PR, the dialog stays open with a destructive
toast and the in-memory draft is preserved.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
