### PR TITLE
feat(profile): swipe left/right to change month on calendar

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "react-day-picker": "^9.8.1",
     "react-dom": "18.2.0",
     "react-hook-form": "^7.49.3",
+    "react-swipeable": "^7.0.2",
     "rrule": "^2.8.1",
     "sharp": "^0.33.2",
     "swiper": "^12.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -109,6 +109,9 @@ importers:
       react-hook-form:
         specifier: ^7.49.3
         version: 7.71.1(react@18.2.0)
+      react-swipeable:
+        specifier: ^7.0.2
+        version: 7.0.2(react@18.2.0)
       rrule:
         specifier: ^2.8.1
         version: 2.8.1
@@ -4362,6 +4365,11 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
+
+  react-swipeable@7.0.2:
+    resolution: {integrity: sha512-v1Qx1l+aC2fdxKa9aKJiaU/ZxmJ5o98RMoFwUqAAzVWUcxgfHFXDDruCKXhw6zIYXm6V64JiHgP9f6mlME5l8w==}
+    peerDependencies:
+      react: ^16.8.3 || ^17 || ^18 || ^19.0.0 || ^19.0.0-rc
 
   react-transition-group@4.4.5:
     resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
@@ -9518,6 +9526,10 @@ snapshots:
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 18.2.48
+
+  react-swipeable@7.0.2(react@18.2.0):
+    dependencies:
+      react: 18.2.0
 
   react-transition-group@4.4.5(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:

--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import dayjs from 'dayjs';
+import { useState } from 'react';
+import { useSwipeable } from 'react-swipeable';
 
 import { Calendar } from '@/components/ui/calendar';
 import { cn } from '@/lib/utils';
@@ -108,53 +110,78 @@ export const ScheduleCalendar = ({
   size = 'compact',
   className,
 }: ScheduleCalendarProps) => {
+  const [displayMonth, setDisplayMonth] = useState<Date>(selected);
+
   const handleSelect = (d: Date | undefined) => {
     if (readOnly || !d) return;
     onSelect?.(d);
   };
+
+  const handleMonthChange = (date: Date) => {
+    setDisplayMonth(date);
+    onMonthChange?.(date);
+  };
+
+  const swipeHandlers = useSwipeable({
+    onSwipedLeft: () =>
+      handleMonthChange(dayjs(displayMonth).add(1, 'month').toDate()),
+    onSwipedRight: () =>
+      handleMonthChange(dayjs(displayMonth).subtract(1, 'month').toDate()),
+    delta: 50,
+    trackMouse: false,
+    preventScrollOnSwipe: false,
+  });
 
   const availableDays = highlightAvailableDates
     ? allowedDates.map((dateStr) => new Date(`${dateStr}T00:00:00`))
     : [];
 
   return (
-    <Calendar
-      mode="single"
-      captionLayout="dropdown"
-      defaultMonth={selected}
-      selected={selected}
-      onSelect={handleSelect}
-      onMonthChange={onMonthChange}
-      className={cn(scheduleCalendarSizeClassNames[size], className)}
-      modifiers={{
-        available: availableDays,
-      }}
-      modifiersClassNames={{
-        available: 'rdp-day-available',
-      }}
-      disabled={(day) => {
-        if (disablePastDates) {
-          const today = new Date();
-          today.setHours(0, 0, 0, 0);
+    <div
+      {...swipeHandlers}
+      className={cn(
+        'touch-pan-y',
+        scheduleCalendarSizeClassNames[size],
+        className
+      )}
+    >
+      <Calendar
+        mode="single"
+        captionLayout="dropdown"
+        month={displayMonth}
+        selected={selected}
+        onSelect={handleSelect}
+        onMonthChange={handleMonthChange}
+        modifiers={{
+          available: availableDays,
+        }}
+        modifiersClassNames={{
+          available: 'rdp-day-available',
+        }}
+        disabled={(day) => {
+          if (disablePastDates) {
+            const today = new Date();
+            today.setHours(0, 0, 0, 0);
 
-          if (day < today) {
-            return true;
+            if (day < today) {
+              return true;
+            }
           }
-        }
 
-        if (disableEmptyDates) {
-          const dateStr = dayjs(day).format('YYYY-MM-DD');
+          if (disableEmptyDates) {
+            const dateStr = dayjs(day).format('YYYY-MM-DD');
 
-          if (allowedDates.length === 0) {
-            return true;
+            if (allowedDates.length === 0) {
+              return true;
+            }
+
+            return !allowedDates.includes(dateStr);
           }
 
-          return !allowedDates.includes(dateStr);
-        }
-
-        return false;
-      }}
-      showTodayStyle={showTodayStyle}
-    />
+          return false;
+        }}
+        showTodayStyle={showTodayStyle}
+      />
+    </div>
   );
 };


### PR DESCRIPTION
## What Does This PR Do?

- Add left/right swipe gesture to switch months on `ScheduleCalendar`
- Switch react-day-picker from uncontrolled `defaultMonth` to controlled `month`; share one `handleMonthChange` for chevron + dropdown + swipe so the existing `onMonthChange` cache path still drives schedule loads
- Use `react-swipeable` with `delta: 50`, `trackMouse: false`, and `touch-pan-y` so desktop is unaffected and vertical page scroll is preserved
- Applies to all three call sites (profile page, mentor schedule dialog, mentee reservation dialog) without changing their APIs

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

N/A

Closes Xchange-Taiwan/X-Talent-Tracker#222

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
