### PR TITLE
fix(mentor-schedule): widen schedule dialog on mobile to ease cramping

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -369,7 +369,7 @@ export default function MentorScheduleDialog({
       >
         <SelectValue />
       </SelectTrigger>
-      <SelectContent>
+      <SelectContent className="min-w-[10rem]">
         {options.map((opt) => (
           <SelectItem key={opt} value={opt}>
             {opt}

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -462,7 +462,7 @@ export default function MentorScheduleDialog({
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
-        <DialogContent className="max-h-[85dvh] w-[calc(100vw-2rem)] overflow-y-auto sm:max-w-[440px] lg:max-w-[560px]">
+        <DialogContent className="max-h-[85dvh] w-[calc(100vw-1rem)] overflow-y-auto sm:max-w-[440px] lg:max-w-[560px]">
           <DialogHeader>
             <DialogTitle>排程設定</DialogTitle>
           </DialogHeader>


### PR DESCRIPTION
## What Does This PR Do?

- Mentor 排程設定 dialog 在手機下時段編輯列(4 個 select + 兩個 icon button)視覺上過於擠迫,buffer 僅約 32px
- 將 `DialogContent` 手機寬度從 `w-[calc(100vw-2rem)]`(16px 邊距)放寬為 `w-[calc(100vw-1rem)]`(8px 邊距),buffer 拉到 ~48px
- `sm:max-w-[440px]` / `lg:max-w-[560px]` 不變,僅影響手機 viewport
- 維持 `flex-nowrap` 不換行,不動共用 `dialog.tsx`,不動 prompt sub-dialog

Closes Xchange-Taiwan/X-Talent-Tracker#223

## Demo

http://localhost:3000/profile/<mentorUserId> → 開啟「設定可預約時段」dialog(手機 viewport)

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
