### PR TITLE
feat(mentor-reservation): split pending entry into accept/reject buttons (#225)

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -9,7 +9,6 @@ import {
   Dialog,
   DialogClose,
   DialogContent,
-  DialogDescription,
   DialogFooter,
   DialogHeader,
   DialogTitle,
@@ -27,18 +26,14 @@ interface Props {
   reservation: Reservation;
   className?: string;
   onAccept?: (payload: { id: string; message: string }) => Promise<void> | void;
-  onReject?: (payload: { id: string; reason: string }) => Promise<void> | void;
 }
 
 export default function AcceptReservationDialog({
   reservation,
   className,
   onAccept,
-  onReject,
 }: Props) {
   const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<'check' | 'reject'>('check');
-  const [reason, setReason] = useState('');
   const [replyOpen, setReplyOpen] = useState(false);
   const [reply, setReply] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -48,8 +43,6 @@ export default function AcceptReservationDialog({
     if (isSubmitting) return;
     setOpen(next);
     if (next) {
-      setStep('check');
-      setReason('');
       setReply('');
       setReplyOpen(false);
       trackEvent({
@@ -80,24 +73,7 @@ export default function AcceptReservationDialog({
     }
   }
 
-  async function handleReject() {
-    setIsSubmitting(true);
-    try {
-      await onReject?.({ id: reservation.id, reason });
-      setIsSubmitting(false);
-      setOpen(false);
-    } catch {
-      toast({
-        variant: 'destructive',
-        description: '拒絕預約失敗,請稍後再試',
-      });
-      setIsSubmitting(false);
-    }
-  }
-
   const menteeMessage = reservation.menteeMessage?.content;
-  const trimmedReason = reason.trim();
-  const canSubmitReject = trimmedReason.length > 0 && !isSubmitting;
 
   const initials =
     reservation.name
@@ -115,162 +91,111 @@ export default function AcceptReservationDialog({
       </DialogTrigger>
 
       <DialogContent className="w-[90vw] max-w-[420px] p-0 sm:max-w-lg">
-        {step === 'check' ? (
-          <div className="p-6">
-            <DialogHeader className="mb-4">
-              <DialogTitle className="text-center sm:text-left">
-                查看我的預約
-              </DialogTitle>
-            </DialogHeader>
+        <div className="p-6">
+          <DialogHeader className="mb-4">
+            <DialogTitle className="text-center sm:text-left">
+              接受學員預約
+            </DialogTitle>
+          </DialogHeader>
 
-            <div className="rounded-2xl border p-4 sm:p-5">
-              <div className="flex items-center gap-3">
-                <Avatar className="h-10 w-10">
-                  <AvatarImage
-                    src={
-                      reservation.avatar
-                        ? getAvatarThumbUrl(reservation.avatar)
-                        : undefined
-                    }
-                    alt={reservation.name}
-                  />
-                  <AvatarFallback>{initials}</AvatarFallback>
-                </Avatar>
-                <div className="min-w-0">
-                  <div className="truncate font-medium">{reservation.name}</div>
-                  <div className="truncate text-sm text-muted-foreground">
-                    {reservation.roleLine}
-                  </div>
-                </div>
-              </div>
-
-              <div className="mt-4 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-                <div className="flex items-center gap-2">
-                  <CalendarDays className="h-4 w-4" />
-                  <span>{reservation.date}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
-                  <span>{reservation.time}</span>
+          <div className="rounded-2xl border p-4 sm:p-5">
+            <div className="flex items-center gap-3">
+              <Avatar className="h-10 w-10">
+                <AvatarImage
+                  src={
+                    reservation.avatar
+                      ? getAvatarThumbUrl(reservation.avatar)
+                      : undefined
+                  }
+                  alt={reservation.name}
+                />
+                <AvatarFallback>{initials}</AvatarFallback>
+              </Avatar>
+              <div className="min-w-0">
+                <div className="truncate font-medium">{reservation.name}</div>
+                <div className="truncate text-sm text-muted-foreground">
+                  {reservation.roleLine}
                 </div>
               </div>
             </div>
 
-            {menteeMessage ? (
-              <div className="mt-6">
-                <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
-                <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
-                  <p className="whitespace-pre-wrap text-foreground">
-                    {menteeMessage}
-                  </p>
-                </div>
+            <div className="mt-4 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
+              <div className="flex items-center gap-2">
+                <CalendarDays className="h-4 w-4" />
+                <span>{reservation.date}</span>
               </div>
-            ) : null}
+              <div className="flex items-center gap-2">
+                <Clock className="h-4 w-4" />
+                <span>{reservation.time}</span>
+              </div>
+            </div>
+          </div>
 
+          {menteeMessage ? (
             <div className="mt-6">
-              {replyOpen ? (
-                <div>
-                  <div className="mb-2 text-sm font-medium">
-                    給學員的回覆（選填）
-                  </div>
-                  <div className="rounded-2xl border p-2">
-                    <Textarea
-                      placeholder="例如：屆時於 Google Meet 見，請先準備一份履歷。"
-                      className="min-h-[96px] resize-y border-0 shadow-none focus-visible:ring-0"
-                      value={reply}
-                      onChange={(e) => setReply(e.target.value)}
-                      disabled={isSubmitting}
-                    />
-                  </div>
+              <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
+              <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
+                <p className="whitespace-pre-wrap text-foreground">
+                  {menteeMessage}
+                </p>
+              </div>
+            </div>
+          ) : null}
+
+          <div className="mt-6">
+            {replyOpen ? (
+              <div>
+                <div className="mb-2 text-sm font-medium">
+                  給學員的回覆（選填）
                 </div>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setReplyOpen(true)}
-                  className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
-                  disabled={isSubmitting}
-                >
-                  <MessageSquarePlus className="h-4 w-4" aria-hidden />
-                  附上回覆訊息（選填）
-                </button>
-              )}
-            </div>
-
-            <DialogFooter className="mt-6 gap-2">
-              <Button
+                <div className="rounded-2xl border p-2">
+                  <Textarea
+                    placeholder="例如：屆時於 Google Meet 見,請先準備一份履歷。"
+                    className="min-h-[96px] resize-y border-0 shadow-none focus-visible:ring-0"
+                    value={reply}
+                    onChange={(e) => setReply(e.target.value)}
+                    disabled={isSubmitting}
+                  />
+                </div>
+              </div>
+            ) : (
+              <button
                 type="button"
-                variant="destructive"
-                className="w-full sm:w-auto"
-                onClick={() => setStep('reject')}
+                onClick={() => setReplyOpen(true)}
+                className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
                 disabled={isSubmitting}
               >
-                拒絕
-              </Button>
-
-              <Button
-                type="button"
-                className="w-full sm:w-auto"
-                onClick={handleAccept}
-                disabled={isSubmitting}
-              >
-                {isSubmitting && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
-                接受
-              </Button>
-            </DialogFooter>
-          </div>
-        ) : (
-          <div className="p-6">
-            <DialogHeader className="mb-4">
-              <DialogTitle className="text-center sm:text-left">
-                拒絕學員預約的原因
-              </DialogTitle>
-              <DialogDescription className="text-center sm:text-left">
-                請說明無法接受此預約的原因。
-              </DialogDescription>
-            </DialogHeader>
-
-            <div className="rounded-2xl border p-2">
-              <Textarea
-                placeholder="請在此輸入原因..."
-                className="min-h-[120px] resize-y border-0 shadow-none focus-visible:ring-0"
-                value={reason}
-                onChange={(e) => setReason(e.target.value)}
-                disabled={isSubmitting}
-              />
-            </div>
-            {trimmedReason.length === 0 && (
-              <p className="mt-2 text-xs text-muted-foreground">
-                請填寫拒絕原因
-              </p>
+                <MessageSquarePlus className="h-4 w-4" aria-hidden />
+                附上回覆訊息（選填）
+              </button>
             )}
+          </div>
 
-            <DialogFooter className="mt-6 gap-2">
-              <DialogClose asChild>
-                <Button
-                  variant="outline"
-                  className="w-full sm:w-auto"
-                  disabled={isSubmitting}
-                >
-                  捨棄
-                </Button>
-              </DialogClose>
-
+          <DialogFooter className="mt-6 gap-2">
+            <DialogClose asChild>
               <Button
                 type="button"
-                className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
-                disabled={!canSubmitReject}
-                onClick={handleReject}
+                variant="outline"
+                className="w-full sm:w-auto"
+                disabled={isSubmitting}
               >
-                {isSubmitting && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
-                拒絕
+                取消
               </Button>
-            </DialogFooter>
-          </div>
-        )}
+            </DialogClose>
+
+            <Button
+              type="button"
+              className="w-full sm:w-auto"
+              onClick={handleAccept}
+              disabled={isSubmitting}
+            >
+              {isSubmitting && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              接受
+            </Button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -75,8 +75,8 @@ export default function CancelReservationDialog({
       <DialogTrigger asChild>
         <Button
           size="sm"
-          variant="outline"
-          className={cn('min-h-9 px-3 text-destructive', className)}
+          variant="destructive"
+          className={cn('min-h-9 px-3', className)}
         >
           取消預約
         </Button>

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -1,9 +1,8 @@
 'use client';
 
-import { CalendarDays, Clock, Loader2 } from 'lucide-react';
+import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 
-import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
 import {
   Dialog,
@@ -18,7 +17,6 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
-import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
 
 import type { Reservation } from './types';
@@ -38,17 +36,14 @@ export default function CancelReservationDialog({
   onConfirmCancel,
 }: Props) {
   const [open, setOpen] = useState(false);
-  const [step, setStep] = useState<'confirm' | 'reason'>('confirm');
   const [reason, setReason] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { toast } = useToast();
 
-  // Reset to the first step every time the dialog opens
   function onOpenChange(next: boolean) {
     if (isSubmitting) return;
     setOpen(next);
     if (next) {
-      setStep('confirm');
       setReason('');
       trackEvent({
         name: 'feature_opened',
@@ -73,12 +68,7 @@ export default function CancelReservationDialog({
     }
   }
 
-  const initials =
-    reservation.name
-      .split(' ')
-      .map((s) => s[0])
-      .join('')
-      .slice(0, 2) || 'U';
+  const canSubmit = reason.trim().length > 0 && !isSubmitting;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -87,110 +77,52 @@ export default function CancelReservationDialog({
           size="sm"
           variant="outline"
           className={cn('min-h-9 px-3 text-destructive', className)}
-          onClick={() => setOpen(true)}
         >
           取消預約
         </Button>
       </DialogTrigger>
 
       <DialogContent className="w-[90vw] max-w-[420px] p-0 sm:max-w-lg">
-        {step === 'confirm' ? (
-          <div className="p-6">
-            <DialogHeader className="mb-4">
-              <DialogTitle className="text-center sm:text-left">
-                取消預約
-              </DialogTitle>
-            </DialogHeader>
+        <div className="p-6">
+          <DialogHeader className="mb-4">
+            <DialogTitle className="text-center sm:text-left">
+              取消預約
+            </DialogTitle>
+            <DialogDescription className="text-center sm:text-left">
+              請說明取消預約的原因。
+            </DialogDescription>
+          </DialogHeader>
 
-            <div className="rounded-xl border p-4 sm:p-5">
-              <div className="flex items-center gap-3">
-                <Avatar className="h-10 w-10">
-                  <AvatarImage
-                    src={
-                      reservation.avatar
-                        ? getAvatarThumbUrl(reservation.avatar)
-                        : undefined
-                    }
-                    alt={reservation.name}
-                  />
-                  <AvatarFallback>{initials}</AvatarFallback>
-                </Avatar>
-                <div className="min-w-0">
-                  <div className="truncate font-medium">{reservation.name}</div>
-                  <div className="truncate text-sm text-muted-foreground">
-                    {reservation.roleLine}
-                  </div>
-                </div>
-              </div>
+          <Textarea
+            placeholder={`您好 ${reservation.name.split(' ')[0]}，...`}
+            value={reason}
+            onChange={(e) => setReason(e.target.value)}
+            className="min-h-[140px] resize-y"
+            disabled={isSubmitting}
+          />
 
-              <div className="mt-4 grid grid-cols-1 gap-2 text-sm sm:grid-cols-2">
-                <div className="flex items-center gap-2">
-                  <CalendarDays className="h-4 w-4" />
-                  <span>{reservation.date}</span>
-                </div>
-                <div className="flex items-center gap-2">
-                  <Clock className="h-4 w-4" />
-                  <span>{reservation.time}</span>
-                </div>
-              </div>
-            </div>
-
-            <DialogFooter className="mt-6 gap-2">
-              <DialogClose asChild>
-                <Button variant="outline" className="w-full sm:w-auto">
-                  維持預約
-                </Button>
-              </DialogClose>
+          <DialogFooter className="mt-6 gap-2">
+            <DialogClose asChild>
               <Button
-                className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
-                onClick={() => setStep('reason')}
+                variant="outline"
+                className="w-full sm:w-auto"
+                disabled={isSubmitting}
               >
-                取消預約
+                維持預約
               </Button>
-            </DialogFooter>
-          </div>
-        ) : (
-          <div className="p-6">
-            <DialogHeader className="mb-4">
-              <DialogTitle className="text-center sm:text-left">
-                取消原因
-              </DialogTitle>
-              <DialogDescription className="text-center sm:text-left">
-                請說明取消預約的原因。
-              </DialogDescription>
-            </DialogHeader>
-
-            <Textarea
-              placeholder={`您好 ${reservation.name.split(' ')[0]}，...`}
-              value={reason}
-              onChange={(e) => setReason(e.target.value)}
-              className="min-h-[140px] resize-y"
-              disabled={isSubmitting}
-            />
-
-            <DialogFooter className="mt-6 gap-2">
-              <DialogClose asChild>
-                <Button
-                  variant="outline"
-                  className="w-full sm:w-auto"
-                  disabled={isSubmitting}
-                >
-                  維持預約
-                </Button>
-              </DialogClose>
-              <Button
-                disabled={reason.trim().length === 0 || isSubmitting}
-                className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
-                onClick={handleConfirm}
-              >
-                {isSubmitting && (
-                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                )}
-                取消預約
-              </Button>
-            </DialogFooter>
-          </div>
-        )}
+            </DialogClose>
+            <Button
+              disabled={!canSubmit}
+              className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
+              onClick={handleConfirm}
+            >
+              {isSubmitting && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              取消預約
+            </Button>
+          </DialogFooter>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -73,8 +73,8 @@ export default function RejectReservationDialog({
       <DialogTrigger asChild>
         <Button
           size="sm"
-          variant="outline"
-          className={cn('min-h-9 px-3 text-destructive', className)}
+          variant="destructive"
+          className={cn('min-h-9 px-3', className)}
         >
           拒絕
         </Button>

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -1,0 +1,134 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+import { useState } from 'react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { useToast } from '@/components/ui/use-toast';
+import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
+
+import type { Reservation } from './types';
+
+interface Props {
+  reservation: Reservation;
+  className?: string;
+  onReject?: (payload: { id: string; reason: string }) => Promise<void> | void;
+}
+
+export default function RejectReservationDialog({
+  reservation,
+  className,
+  onReject,
+}: Props) {
+  const [open, setOpen] = useState(false);
+  const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  function onOpenChange(next: boolean) {
+    if (isSubmitting) return;
+    setOpen(next);
+    if (next) {
+      setReason('');
+      trackEvent({
+        name: 'feature_opened',
+        feature: 'reservation',
+        metadata: { dialog: 'reject_reservation' },
+      });
+    }
+  }
+
+  async function handleReject() {
+    setIsSubmitting(true);
+    try {
+      await onReject?.({ id: reservation.id, reason });
+      setIsSubmitting(false);
+      setOpen(false);
+    } catch {
+      toast({
+        variant: 'destructive',
+        description: '拒絕預約失敗,請稍後再試',
+      });
+      setIsSubmitting(false);
+    }
+  }
+
+  const trimmedReason = reason.trim();
+  const canSubmit = trimmedReason.length > 0 && !isSubmitting;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogTrigger asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          className={cn('min-h-9 px-3 text-destructive', className)}
+        >
+          拒絕
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="w-[90vw] max-w-[420px] p-0 sm:max-w-lg">
+        <div className="p-6">
+          <DialogHeader className="mb-4">
+            <DialogTitle className="text-center sm:text-left">
+              拒絕學員預約的原因
+            </DialogTitle>
+            <DialogDescription className="text-center sm:text-left">
+              請說明無法接受此預約的原因。
+            </DialogDescription>
+          </DialogHeader>
+
+          <div className="rounded-2xl border p-2">
+            <Textarea
+              placeholder="請在此輸入原因..."
+              className="min-h-[120px] resize-y border-0 shadow-none focus-visible:ring-0"
+              value={reason}
+              onChange={(e) => setReason(e.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          {trimmedReason.length === 0 && (
+            <p className="mt-2 text-xs text-muted-foreground">請填寫拒絕原因</p>
+          )}
+
+          <DialogFooter className="mt-6 gap-2">
+            <DialogClose asChild>
+              <Button
+                variant="outline"
+                className="w-full sm:w-auto"
+                disabled={isSubmitting}
+              >
+                取消
+              </Button>
+            </DialogClose>
+
+            <Button
+              type="button"
+              className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
+              disabled={!canSubmit}
+              onClick={handleReject}
+            >
+              {isSubmitting && (
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              )}
+              拒絕
+            </Button>
+          </DialogFooter>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -100,9 +100,6 @@ export default function RejectReservationDialog({
               disabled={isSubmitting}
             />
           </div>
-          {trimmedReason.length === 0 && (
-            <p className="mt-2 text-xs text-muted-foreground">請填寫拒絕原因</p>
-          )}
 
           <DialogFooter className="mt-6 gap-2">
             <DialogClose asChild>

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -2,6 +2,7 @@
 
 import AcceptReservationDialog from '@/components/reservation/AcceptReservationDialog';
 import CancelReservationDialog from '@/components/reservation/CancelReservationDialog';
+import RejectReservationDialog from '@/components/reservation/RejectReservationDialog';
 import ReservationConversationDialog from '@/components/reservation/ReservationConversationDialog';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
@@ -198,13 +199,15 @@ export function ReservationList({
           onProfileClick={handleProfileClick}
           actions={
             variant === 'history' ? null : variant === 'pending-mentor' ? (
-              <AcceptReservationDialog
-                reservation={it}
-                onAccept={accept}
-                onReject={async ({ id, reason }) =>
-                  rejectOrCancel(id, reason, '已拒絕預約')
-                }
-              />
+              <div className="flex gap-2">
+                <RejectReservationDialog
+                  reservation={it}
+                  onReject={async ({ id, reason }) =>
+                    rejectOrCancel(id, reason, '已拒絕預約')
+                  }
+                />
+                <AcceptReservationDialog reservation={it} onAccept={accept} />
+              </div>
             ) : (
               <CancelReservationDialog
                 reservation={it}


### PR DESCRIPTION
## What Does This PR Do?

- Add `RejectReservationDialog` (outline trigger + reason-only body) so mentors can reject from the list directly
- Refactor `AcceptReservationDialog` to single-purpose: drop the internal `step` state, remove `onReject`, retitle to 接受學員預約
- Render both dialogs side-by-side in the `pending-mentor` variant of `ReservationList` (reject left, accept right)

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
