### PR TITLE
chore(ci): remove informational Lighthouse step from PR preview

### DIFF
--- a/.github/workflows/deploy-pr.yml
+++ b/.github/workflows/deploy-pr.yml
@@ -126,13 +126,3 @@ jobs:
                 body,
               });
             }
-
-      - name: Run Lighthouse CI (informational)
-        uses: treosh/lighthouse-ci-action@v11
-        continue-on-error: true
-        with:
-          urls: |
-            ${{ steps.vercel_preview.outputs.url }}
-            ${{ steps.vercel_preview.outputs.url }}/auth/signin
-          uploadArtifacts: true
-          temporaryPublicStorage: true


### PR DESCRIPTION
## What Does This PR Do?

- Drop the `treosh/lighthouse-ci-action` step from `deploy-pr.yml`
- Removes ~1–2 min of CI per PR and avoids leaking preview URLs via `temporaryPublicStorage`

## Demo

N/A (CI-only change)

## Screenshot

N/A

## Anything to Note?

- The step had no PR comment, no budget/assertions, and uploaded reports to public storage — effectively silent.
- Bundle size is still gated by `performance.yml`. For real-user perf, rely on Vercel Speed Insights / Sentry Performance instead of lab data per PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
