### PR TITLE
fix(auth): align signin/signup cover panel at lg breakpoint

### DIFF
--- a/src/app/auth/(sign)/layout.tsx
+++ b/src/app/auth/(sign)/layout.tsx
@@ -18,11 +18,13 @@ export default async function AuthOperationLayout({
     <div className="flex lg:min-h-[720px]">
       <div className="flex-1 basis-1/2">{children}</div>
       <div
-        className="box-border hidden flex-1	basis-1/2 bg-cover bg-center bg-no-repeat px-20 py-32 text-center lg:block"
+        className="box-border hidden flex-1 basis-1/2 flex-col items-center justify-center bg-cover bg-center bg-no-repeat px-8 py-16 text-center lg:flex xl:px-20 xl:py-32"
         style={{ backgroundImage: `url(${CoverImgUrl.src})` }}
       >
-        <div className="flex flex-col gap-8 text-text-white">
-          <p className="text-4xl font-bold">現在就加入，更加豐富你的職涯！</p>
+        <div className="flex max-w-md flex-col gap-6 text-text-white xl:gap-8">
+          <p className="text-2xl font-bold lg:text-3xl xl:text-4xl">
+            現在就加入，更加豐富你的職涯！
+          </p>
           <p className="text-base">
             加入我們，成為 X-Talent
             的一份子。一起拓展人脈、提升事業，還有機會接觸到各種資源和機會！

--- a/src/app/auth/(sign)/signin/page.tsx
+++ b/src/app/auth/(sign)/signin/page.tsx
@@ -10,7 +10,7 @@ export default function Page() {
   const signInFormProps = useSignInForm();
 
   return (
-    <div className="flex h-full flex-col items-center justify-center px-5 pb-8 sm:pb-0">
+    <div className="flex h-full flex-col items-center justify-center px-5 pb-8 lg:pb-0">
       <div className="flex w-full max-w-[400px] flex-col gap-6">
         <AuthTitle>登入 X-Talent 帳戶</AuthTitle>
         <SignInForm {...signInFormProps} />

--- a/src/app/auth/(sign)/signup/page.tsx
+++ b/src/app/auth/(sign)/signup/page.tsx
@@ -9,7 +9,7 @@ export default function Page() {
   const signUpFormProps = useSignUpForm();
 
   return (
-    <div className="flex h-full flex-col items-center justify-center px-5 pb-8 sm:pb-0">
+    <div className="flex h-full flex-col items-center justify-center px-5 pb-8 lg:pb-0">
       <div className="flex w-full max-w-[400px] flex-col gap-6">
         <AuthTitle>註冊 X-Talent 帳戶</AuthTitle>
         <SignUpForm {...signUpFormProps} />


### PR DESCRIPTION
## What Does This PR Do?

- Switch right cover panel from `lg:block` to `lg:flex` with vertical centering so text no longer sits at the top with a large empty area below
- Make padding responsive (`px-8 py-16` → `xl:px-20 xl:py-32`) to stop the heavy padding from eating into the narrow column at 1024px
- Make heading font responsive (`text-2xl lg:text-3xl xl:text-4xl`) so the 17-char Chinese title doesn't blow out the ~352px content area at the lg breakpoint
- Cap inner text wrapper at `max-w-md` to keep line length consistent across breakpoints

## Demo

http://localhost:3000/auth/signin
http://localhost:3000/auth/signup

## Screenshot

N/A

## Anything to Note?

- Closes Xchange-Taiwan/X-Talent-Tracker#227
- Same `(sign)` layout is also used by `/auth/onboarding`; verified build passes — please double-check onboarding visually since the ticket only listed signin/signup
