### PR TITLE
chore(api-client): log every request and response to console

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -98,6 +98,7 @@ async function request<T>(
   const authHeader = auth ? await getAuthHeader() : {};
 
   const startTime = Date.now();
+  console.log('[api →]', method, path, { params, body });
   let response: Response;
 
   try {
@@ -116,6 +117,13 @@ async function request<T>(
     if (isAbortError(networkError)) {
       throw networkError;
     }
+    console.log(
+      '[api ✗]',
+      method,
+      path,
+      `${Date.now() - startTime}ms`,
+      networkError
+    );
     // fetch() itself threw — DNS failure, connection refused, timeout, etc.
     captureApiFailure({
       endpoint: path,
@@ -141,6 +149,14 @@ async function request<T>(
       (errorBody as Record<string, string>).msg ||
       (errorBody as Record<string, string>).message ||
       `Request failed with status ${response.status}`;
+    console.log(
+      '[api ✗]',
+      method,
+      path,
+      response.status,
+      `${Date.now() - startTime}ms`,
+      { message, body: errorBody }
+    );
     captureApiFailure({
       endpoint: path,
       method,
@@ -153,8 +169,27 @@ async function request<T>(
 
   // Handle 204 No Content and other empty responses
   const text = await response.text();
-  if (!text) return undefined as T;
-  return JSON.parse(text) as T;
+  if (!text) {
+    console.log(
+      '[api ←]',
+      method,
+      path,
+      response.status,
+      `${Date.now() - startTime}ms`,
+      '(empty)'
+    );
+    return undefined as T;
+  }
+  const parsed = JSON.parse(text) as T;
+  console.log(
+    '[api ←]',
+    method,
+    path,
+    response.status,
+    `${Date.now() - startTime}ms`,
+    parsed
+  );
+  return parsed;
 }
 
 // ─── Public API ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## What Does This PR Do?

- Add `console.log` for every API request, response, and error in `apiClient.ts`
- `[api →]` on dispatch (method, path, params, body)
- `[api ←]` on success (status, duration, parsed body)
- `[api ✗]` on HTTP failure or network error (status/error, duration)
- Centralized in `request()` so every domain service is covered without per-file changes

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

- Logs run unconditionally (no `NODE_ENV` guard), so they will also appear in the production console
- Payloads include user-supplied content (reservation messages, schedule data); no PII like tokens or passwords is added beyond what was already in the request bodies

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
