### PR TITLE
fix(profile): use DTO avatar_updated_at to bust avatar cache

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,13 +60,15 @@ export default async function RootLayout({
   // imageSrcSet + imageSizes lets the browser pick the same width that
   // <Image sizes="150-160px" /> will request (w=256 at 1x DPR, w=384 at 2x),
   // avoiding the cache-miss caused by a fixed-width preload.
+  // Skip preload entirely when no `avatarUpdatedAt` is available — preloading a
+  // bare URL would write it into the optimizer's 30-day cache and lock in stale
+  // bytes for every future viewer.
   const sessionAvatar = session?.user?.avatar;
   const avatarVersion = session?.user?.avatarUpdatedAt;
-  const avatarSrc = sessionAvatar
-    ? avatarVersion
+  const avatarSrc =
+    sessionAvatar && avatarVersion
       ? `${sessionAvatar}?v=${avatarVersion}`
-      : sessionAvatar
-    : null;
+      : null;
   const buildOptimizerUrl = (w: number) =>
     `/_next/image?url=${encodeURIComponent(avatarSrc ?? '')}&w=${w}&q=75`;
   const avatarSrcSet = avatarSrc

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -3,12 +3,15 @@
 import dynamic from 'next/dynamic';
 import { useRouter } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import useUserData from '@/hooks/user/user-data/useUserData';
-import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
+import {
+  primeUserProfileDtoCacheIfEmpty,
+  useUserProfileDto,
+} from '@/hooks/user/user-data/useUserProfileDto';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 import { ProfilePageSkeleton } from './skeleton';
@@ -21,14 +24,12 @@ interface Props {
   pageUserId: string;
   initialDto: MentorProfileVO;
   initialLoginUserId: string;
-  initialAvatarVersion: number;
 }
 
 export default function ProfilePageContainer({
   pageUserId,
   initialDto,
   initialLoginUserId,
-  initialAvatarVersion,
 }: Props) {
   const router = useRouter();
 
@@ -100,27 +101,22 @@ export default function ProfilePageContainer({
     pageUserIdNumber,
     'zh_TW'
   );
+  const { userDto } = useUserProfileDto(pageUserIdNumber, 'zh_TW');
 
   // The S3 avatar URL is a stable key (re-uploads overwrite in place), so a
   // `?v=` query is the only way to bust the Image Optimizer / browser cache.
-  // - Default version comes from the SSR render (`Date.now()` per ISR cycle),
-  //   so when an edit triggers `revalidatePath`, the next render hands every
-  //   visitor a fresh version and the optimizer re-fetches from S3.
-  // - On the user's own profile we override with `session.user.avatarUpdatedAt`
-  //   since the optimistic session update lands before the ISR refresh has a
-  //   chance to propagate.
-  // While the DTO is still loading on the user's own profile, fall back to the
-  // session avatar so the page does not flash blank.
+  // Use `avatar_updated_at` from the DTO so every viewer — including logged-out
+  // visitors and other users — sees the latest version after the backend bumps
+  // it on upload. While the DTO is still loading on the user's own profile,
+  // fall back to the session avatar so the page does not flash blank.
   const isOwnProfile = loginUserId === pageUserId;
   const resolvedAvatar =
     userData?.avatar ?? (isOwnProfile ? session?.user?.avatar : undefined);
-  const lastAvatarVersionRef = useRef<number>(initialAvatarVersion);
-  if (isOwnProfile && session?.user?.avatarUpdatedAt) {
-    lastAvatarVersionRef.current = session.user.avatarUpdatedAt;
-  }
-  const avatarVersion = lastAvatarVersionRef.current;
+  const avatarVersion = userDto?.avatar_updated_at ?? null;
   const avatarSrc = resolvedAvatar
-    ? `${resolvedAvatar}?v=${avatarVersion}`
+    ? avatarVersion
+      ? `${resolvedAvatar}?v=${avatarVersion}`
+      : resolvedAvatar
     : DefaultAvatarImgUrl;
 
   if (!userLoading && !userData) {

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -53,19 +53,11 @@ export default async function Page({ params: { pageUserId } }: PageProps) {
 
   const initialLoginUserId = session?.user?.id ? String(session.user.id) : '';
 
-  // Cache-bust the avatar URL per ISR render so the Image Optimizer treats
-  // each revalidation cycle as a new entry. Edit submit calls revalidatePath
-  // → next render generates a fresh value → optimizer re-fetches from S3.
-  // Stopgap until the backend exposes an `avatar_updated_at` we can use as a
-  // precise version.
-  const initialAvatarVersion = Date.now();
-
   return (
     <ProfilePageContainer
       pageUserId={pageUserId}
       initialDto={initialDto}
       initialLoginUserId={initialLoginUserId}
-      initialAvatarVersion={initialAvatarVersion}
     />
   );
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-27T15:54:40.580416Z
+       * @default 2026-04-29T13:59:26.811995Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-27T15:54:40.580424Z
+       * @default 2026-04-29T13:59:26.812011Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1384,6 +1384,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1448,6 +1450,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1662,6 +1666,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1718,6 +1724,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1984,6 +1992,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default


### PR DESCRIPTION
## What Does This PR Do?

- 重新生成 OpenAPI types，`MentorProfileVO` 新增 `avatar_updated_at` 欄位
- `/profile/[id]` container 改吃 `userDto.avatar_updated_at` 作為 `?v=` cache buster，所有 viewer（含登出與他人）永遠看到最新頭像
- 移除 #517 留下的 `useRef<number>` hack 與 `isOwnProfile` 版本分支
- `page.tsx` 拿掉 `initialAvatarVersion = Date.now()` stopgap 與相關 prop
- `layout.tsx` 沒有 `avatarUpdatedAt` 時跳過 `<link rel="preload">`，避免 bare URL 被寫進 optimizer 30 天 cache

## Demo

http://localhost:3000/profile/[id]

## Screenshot

N/A

## Anything to Note?

- Closes #210
- 後端依賴：Xchange-Taiwan/X-Career-User#74、Xchange-Taiwan/X-Career-BFF#109（皆已合併並部署 dev）
- Owner-side surfaces（Header / AvatarSection / WhoAreYou）依 ticket 設計維持 session-based，保留 optimistic update 的即時更新體驗
- mentor-pool / search-mentor / reservation 卡片仍會 stale，由後續 ticket #242（Search）、#243（Reservation 後端）、#244（Frontend）處理
