### PR TITLE
feat(static-lists): add SSR fetchers and hook initialData support

### DIFF
--- a/src/hooks/user/expertises/useExpertises.ts
+++ b/src/hooks/user/expertises/useExpertises.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchExpertises, ProfessionVO } from '@/services/profile/expertises';
 
@@ -24,12 +24,27 @@ async function fetchExpertisesCached(
   return promise;
 }
 
-export default function useExpertises(language: string) {
-  const [expertises, setExpertises] = useState<ProfessionVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+export default function useExpertises(
+  language: string,
+  initialData?: ProfessionVO[]
+) {
+  const initialDataRef = useRef(initialData);
+
+  const [expertises, setExpertises] = useState<ProfessionVO[]>(
+    initialData ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      expertisesCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/hooks/user/industry/useIndustries.ts
+++ b/src/hooks/user/industry/useIndustries.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchIndustries, ProfessionVO } from '@/services/profile/industries';
 
@@ -24,12 +24,31 @@ async function fetchIndustriesCached(
   return promise;
 }
 
-export default function useIndustries(language: string) {
-  const [industries, setIndustries] = useState<ProfessionVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+export default function useIndustries(
+  language: string,
+  initialData?: ProfessionVO[]
+) {
+  // Snapshot at mount — once consumed, language switches go through the
+  // normal client fetch path even if the parent re-passes the same prop.
+  const initialDataRef = useRef(initialData);
+
+  const [industries, setIndustries] = useState<ProfessionVO[]>(
+    initialData ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      // Prime in-memory cache so other consumers of fetchIndustriesCached
+      // (and remounts of this hook) skip the round trip too.
+      industriesCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/hooks/user/interests/useInterests.ts
+++ b/src/hooks/user/interests/useInterests.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchInterests, InterestVO } from '@/services/profile/interests';
 
@@ -59,18 +59,34 @@ export async function getInterestsCached(
   return promise;
 }
 
-function useInterests(language: string) {
+function useInterests(language: string, initialData?: InterestsResult) {
+  const initialDataRef = useRef(initialData);
+
   const [interestedPositions, setInterestedPositions] = useState<InterestVO[]>(
-    []
+    initialData?.interestedPositions ?? []
   );
-  const [skills, setSkills] = useState<InterestVO[]>([]);
-  const [topics, setTopics] = useState<InterestVO[]>([]);
-  const [expertises, setExpertises] = useState<InterestVO[]>([]);
-  const [whatIOffers, setWhatIOffers] = useState<InterestVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [skills, setSkills] = useState<InterestVO[]>(initialData?.skills ?? []);
+  const [topics, setTopics] = useState<InterestVO[]>(initialData?.topics ?? []);
+  const [expertises, setExpertises] = useState<InterestVO[]>(
+    initialData?.expertises ?? []
+  );
+  const [whatIOffers, setWhatIOffers] = useState<InterestVO[]>(
+    initialData?.whatIOffers ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      // Prime the shared cache so getInterestsCached / *Sync consumers
+      // (e.g. mentor-pool infinite scroll, useUserData) skip the round trip.
+      interestsDataCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/services/profile/expertises.server.ts
+++ b/src/services/profile/expertises.server.ts
@@ -1,0 +1,28 @@
+import type { components } from '@/types/api';
+
+import type { ProfessionVO } from './expertises';
+
+type ApiResponse = components['schemas']['ApiResponse_ProfessionListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const REVALIDATE_SECONDS = 86400;
+
+export async function fetchExpertisesServer(
+  language: string
+): Promise<ProfessionVO[]> {
+  if (!BASE_URL) return [];
+  try {
+    const res = await fetch(`${BASE_URL}/v1/mentors/${language}/expertises`, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchExpertises failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.professions ?? [];
+  } catch (error) {
+    console.error('SSR fetchExpertises error:', error);
+    return [];
+  }
+}

--- a/src/services/profile/industries.server.ts
+++ b/src/services/profile/industries.server.ts
@@ -1,0 +1,32 @@
+import type { components } from '@/types/api';
+
+import type { ProfessionVO } from './industries';
+
+type ApiResponse = components['schemas']['ApiResponse_ProfessionListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// Industry list is near-static; lazy 24h revalidate trades worst-case
+// staleness for one shared cache entry instead of one per-user fetch.
+const REVALIDATE_SECONDS = 86400;
+
+export async function fetchIndustriesServer(
+  language: string
+): Promise<ProfessionVO[]> {
+  // BASE_URL may be unset at build time. Skip silently so prerender doesn't
+  // throw "Invalid URL"; client-side fallback in useIndustries takes over.
+  if (!BASE_URL) return [];
+  try {
+    const res = await fetch(`${BASE_URL}/v1/users/${language}/industries`, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchIndustries failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.professions ?? [];
+  } catch (error) {
+    console.error('SSR fetchIndustries error:', error);
+    return [];
+  }
+}

--- a/src/services/profile/interests.server.ts
+++ b/src/services/profile/interests.server.ts
@@ -1,0 +1,54 @@
+import type { InterestsResult } from '@/hooks/user/interests/useInterests';
+import type { components } from '@/types/api';
+
+import type { InterestVO } from './interests';
+
+type ApiResponse = components['schemas']['ApiResponse_InterestListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const REVALIDATE_SECONDS = 86400;
+
+type InterestKind = 'INTERESTED_POSITION' | 'SKILL' | 'TOPIC';
+
+async function fetchOneInterestServer(
+  language: string,
+  interest: InterestKind
+): Promise<InterestVO[]> {
+  if (!BASE_URL) return [];
+  try {
+    const url = new URL(`${BASE_URL}/v1/users/${language}/interests`);
+    url.searchParams.set('interest', interest);
+    const res = await fetch(url.toString(), {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchInterests(${interest}) failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.interests ?? [];
+  } catch (error) {
+    console.error(`SSR fetchInterests(${interest}) error:`, error);
+    return [];
+  }
+}
+
+export async function fetchInterestsServer(
+  language: string
+): Promise<InterestsResult> {
+  const [interestedPositions, skills, topics] = await Promise.all([
+    fetchOneInterestServer(language, 'INTERESTED_POSITION'),
+    fetchOneInterestServer(language, 'SKILL'),
+    fetchOneInterestServer(language, 'TOPIC'),
+  ]);
+
+  // expertises/whatIOffers are vocabulary aliases — keep parity with the
+  // client-side getInterestsCached so consumers can swap freely.
+  return {
+    interestedPositions,
+    skills,
+    topics,
+    expertises: skills,
+    whatIOffers: topics,
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-27T15:54:40.580416Z
+       * @default 2026-04-29T13:59:26.811995Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-27T15:54:40.580424Z
+       * @default 2026-04-29T13:59:26.812011Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1384,6 +1384,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1448,6 +1450,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1662,6 +1666,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1718,6 +1724,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1984,6 +1992,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default


### PR DESCRIPTION
## Summary
- Foundation for [Tracker #239](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/239) — moving industry/interest/expertise lists to a server-shared cache (24h `revalidate`) instead of one fetch per user reload.
- Adds three `*.server.ts` fetchers (`fetchIndustriesServer`, `fetchExpertisesServer`, `fetchInterestsServer`) following the existing `mentors.server.ts` pattern: `BASE_URL` build-time fallback, `next: { revalidate: 86400 }`, silent empty fallback on failure.
- Adds optional `initialData` to `useIndustries` / `useExpertises` / `useInterests`. When provided, hooks short-circuit the first fetch and prime the in-memory cache so downstream consumers (`getInterestsCached`, `useUserData`, mentor-pool infinite scroll) skip the round trip too.
- **No pages wired up yet** — behavior is unchanged on develop. Follow-up PRs will hook up mentor-pool, onboarding, and profile/edit.
- Bundles a routine `chore(types)` regen from BFF spec — adds optional `avatar_updated_at` on mentor/profile DTOs.

## Why split this from page wiring
Server fetchers + hook surface are pure additions; reviewers can evaluate the cache strategy (24h lazy revalidate vs. webhook+`revalidateTag` later) and `initialDataRef` snapshot pattern on a small surface before it gets fanned out to three pages.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm build` succeeds (26/26 static pages)
- [x] `pnpm test` — 136/136 pass (incl. existing `useUserData` tests that consume `getInterestsCached`)
- [x] No new lint errors in changed files (pre-existing warnings in `rwd-testing/*.js` and `auth/google/callback/redirect/container.tsx` unchanged)
- [ ] Reviewer: confirm 24h `revalidate` is acceptable starting point (vs. longer / shorter); webhook-driven invalidation is a separate ticket
- [ ] Reviewer: sanity check the `initialDataRef` snapshot pattern — language switches after mount still go through the normal client fetch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)