### PR TITLE
fix(profile): show toast when profile update fails (#236)

### DIFF
--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -7,6 +7,11 @@ vi.mock('next/navigation', async () => {
   return navigationMockFactory();
 });
 
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
 vi.mock('@/services/profile/updateAvatar', () => ({
   updateAvatar: vi.fn(),
 }));
@@ -47,6 +52,7 @@ import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
 import type { MentorProfileVO } from '@/services/profile/user';
 import { mockRouter } from '@/test/mocks/navigation';
+import { mockToast } from '@/test/mocks/useToast';
 
 import { useProfileSubmit } from './useProfileSubmit';
 
@@ -250,6 +256,50 @@ describe('useProfileSubmit', () => {
     });
 
     expect(result.current.isSaving).toBe(false);
+  });
+
+  // ── Error feedback (toast) ────────────────────────────────────────────────
+
+  it('updateProfile throws → destructive toast with generic save-failed message', async () => {
+    mockUpdateProfile.mockRejectedValueOnce(new Error('Profile update failed'));
+
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: '儲存失敗，請稍後再試',
+      })
+    );
+  });
+
+  it('avatar upload throws → destructive toast still fires (inner catch re-throws)', async () => {
+    mockUpdateAvatar.mockRejectedValueOnce(new Error('Upload failed'));
+
+    const file = new File(['c'], 'avatar.jpg', { type: 'image/jpeg' });
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit({ ...baseValues, avatarFile: file });
+    });
+
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'destructive' })
+    );
+  });
+
+  it('happy path → no toast is fired', async () => {
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(mockToast).not.toHaveBeenCalled();
   });
 
   // ── Conditional upserts ────────────────────────────────────────────────────

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -5,6 +5,7 @@ import { useState } from 'react';
 
 import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
+import { useToast } from '@/components/ui/use-toast';
 import {
   clearUserDataCache,
   primeUserDataCache,
@@ -61,6 +62,7 @@ export function useProfileSubmit({
   consumeAvatarUpload,
 }: Options) {
   const router = useRouter();
+  const { toast } = useToast();
   const [isSaving, setIsSaving] = useState(false);
 
   const onSubmit = async (
@@ -332,6 +334,11 @@ export function useProfileSubmit({
             : 'Unexpected profile update error',
       });
       console.error('Update Profile Error:', err);
+      toast({
+        variant: 'destructive',
+        description: '儲存失敗，請稍後再試',
+        duration: 5000,
+      });
       setIsSaving(false);
     }
   };


### PR DESCRIPTION
Closes Xchange-Taiwan/X-Talent-Tracker#236

## Summary
- Profile edit submit now fires a destructive toast (`儲存失敗，請稍後再試`, 5s) on failure so users get immediate feedback instead of a silent reset.
- Inner avatar / parallel-write `catch` blocks keep their re-throw behaviour — the outer `catch` is the single toast point (all-or-nothing semantics, matches today's actual flow).
- Sentry (`captureFlowFailure`) and `console.error` paths are unchanged.

## Scope notes
- Background tasks after `router.push` (`revalidateProfilePath`, `firstSyncedFetch`, `pollUntilSynced`, background `updateSession`) intentionally still surface only via Sentry — by the time they fail the user may have unmounted the toast container.
- Followed `useSignInForm` pattern (`useToast` inside the hook + `variant: 'destructive'`).
- No new analytics event added; failure funnel can be read from Sentry.

## Test plan
- [x] `pnpm test` — 31 cases on `useProfileSubmit`, including 3 new toast cases (updateProfile fails, avatar upload fails, happy path no toast)
- [x] `pnpm type-check`
- [x] `pnpm build`
- [ ] Manual: airplane-mode submit → toast shows
- [ ] Manual: backend 5xx (block update endpoint) → toast shows
- [ ] Manual: payload validation failure → toast shows
- [ ] Manual: verify both mentor onboarding flow and regular profile edit
- [ ] Manual: success path still navigates without toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)