### PR TITLE
feat(mentor-pool): hydrate industries and interests from SSR

### DIFF
--- a/src/app/mentor-pool/MentorPoolWithData.tsx
+++ b/src/app/mentor-pool/MentorPoolWithData.tsx
@@ -1,4 +1,6 @@
 import avatarImage from '@/assets/default-avatar.png';
+import { fetchIndustriesServer } from '@/services/profile/industries.server';
+import { fetchInterestsServer } from '@/services/profile/interests.server';
 import type { MentorType } from '@/services/search-mentor/mentors';
 import { fetchMentorsEnrichedServer } from '@/services/search-mentor/mentors.server';
 
@@ -28,13 +30,16 @@ export default async function MentorPoolWithData({ searchParams }: Props) {
   const urlParams = toURLSearchParams(searchParams);
   const conditions = paramsToFetchConditions(urlParams);
 
-  const initialMentors = (
-    await fetchMentorsEnrichedServer({
+  const [mentors, initialIndustries, initialInterests] = await Promise.all([
+    fetchMentorsEnrichedServer({
       ...conditions,
       limit: PAGE_LIMIT,
       cursor: '',
-    })
-  ).map(resolveAvatar);
+    }),
+    fetchIndustriesServer('zh_TW'),
+    fetchInterestsServer('zh_TW'),
+  ]);
+  const initialMentors = mentors.map(resolveAvatar);
   const initialCursor = initialMentors.at(-1)?.updated_at?.toString() ?? '';
 
   return (
@@ -43,6 +48,8 @@ export default async function MentorPoolWithData({ searchParams }: Props) {
       initialMentors={initialMentors}
       initialCursor={initialCursor}
       initialMentorCount={initialMentors.length}
+      initialIndustries={initialIndustries}
+      initialInterests={initialInterests}
     />
   );
 }

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -9,7 +9,10 @@ import type {
   SelectFilters,
 } from '@/components/filter/MentorFilterDropdown';
 import useIndustries from '@/hooks/user/industry/useIndustries';
-import useInterests from '@/hooks/user/interests/useInterests';
+import useInterests, {
+  type InterestsResult,
+} from '@/hooks/user/interests/useInterests';
+import type { ProfessionVO } from '@/services/profile/industries';
 import {
   fetchMentorsEnriched,
   MentorType,
@@ -38,19 +41,23 @@ interface Props {
   initialMentors: MentorType[];
   initialCursor: string;
   initialMentorCount: number;
+  initialIndustries: ProfessionVO[];
+  initialInterests: InterestsResult;
 }
 
 export default function MentorPoolContainer({
   initialMentors,
   initialCursor,
   initialMentorCount,
+  initialIndustries,
+  initialInterests,
 }: Props) {
   const router = useRouter();
   const params = useSearchParams();
   const [isPending, startTransition] = useTransition();
   const selectedFilters = parseFiltersFromParams(params);
-  const { expertises, whatIOffers } = useInterests('zh_TW');
-  const { industries } = useIndustries('zh_TW');
+  const { expertises, whatIOffers } = useInterests('zh_TW', initialInterests);
+  const { industries } = useIndustries('zh_TW', initialIndustries);
 
   const dynamicFilterOptions = useMemo<FilterOptions>(
     () => ({

--- a/src/hooks/user/expertises/useExpertises.ts
+++ b/src/hooks/user/expertises/useExpertises.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchExpertises, ProfessionVO } from '@/services/profile/expertises';
 
@@ -24,12 +24,27 @@ async function fetchExpertisesCached(
   return promise;
 }
 
-export default function useExpertises(language: string) {
-  const [expertises, setExpertises] = useState<ProfessionVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+export default function useExpertises(
+  language: string,
+  initialData?: ProfessionVO[]
+) {
+  const initialDataRef = useRef(initialData);
+
+  const [expertises, setExpertises] = useState<ProfessionVO[]>(
+    initialData ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      expertisesCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/hooks/user/industry/useIndustries.ts
+++ b/src/hooks/user/industry/useIndustries.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchIndustries, ProfessionVO } from '@/services/profile/industries';
 
@@ -24,12 +24,31 @@ async function fetchIndustriesCached(
   return promise;
 }
 
-export default function useIndustries(language: string) {
-  const [industries, setIndustries] = useState<ProfessionVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+export default function useIndustries(
+  language: string,
+  initialData?: ProfessionVO[]
+) {
+  // Snapshot at mount — once consumed, language switches go through the
+  // normal client fetch path even if the parent re-passes the same prop.
+  const initialDataRef = useRef(initialData);
+
+  const [industries, setIndustries] = useState<ProfessionVO[]>(
+    initialData ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      // Prime in-memory cache so other consumers of fetchIndustriesCached
+      // (and remounts of this hook) skip the round trip too.
+      industriesCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/hooks/user/interests/useInterests.ts
+++ b/src/hooks/user/interests/useInterests.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import { fetchInterests, InterestVO } from '@/services/profile/interests';
 
@@ -59,18 +59,34 @@ export async function getInterestsCached(
   return promise;
 }
 
-function useInterests(language: string) {
+function useInterests(language: string, initialData?: InterestsResult) {
+  const initialDataRef = useRef(initialData);
+
   const [interestedPositions, setInterestedPositions] = useState<InterestVO[]>(
-    []
+    initialData?.interestedPositions ?? []
   );
-  const [skills, setSkills] = useState<InterestVO[]>([]);
-  const [topics, setTopics] = useState<InterestVO[]>([]);
-  const [expertises, setExpertises] = useState<InterestVO[]>([]);
-  const [whatIOffers, setWhatIOffers] = useState<InterestVO[]>([]);
-  const [isLoading, setIsLoading] = useState<boolean>(false);
+  const [skills, setSkills] = useState<InterestVO[]>(initialData?.skills ?? []);
+  const [topics, setTopics] = useState<InterestVO[]>(initialData?.topics ?? []);
+  const [expertises, setExpertises] = useState<InterestVO[]>(
+    initialData?.expertises ?? []
+  );
+  const [whatIOffers, setWhatIOffers] = useState<InterestVO[]>(
+    initialData?.whatIOffers ?? []
+  );
+  const [isLoading, setIsLoading] = useState<boolean>(
+    initialData === undefined
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
+    if (initialDataRef.current !== undefined) {
+      // Prime the shared cache so getInterestsCached / *Sync consumers
+      // (e.g. mentor-pool infinite scroll, useUserData) skip the round trip.
+      interestsDataCache.set(language, initialDataRef.current);
+      initialDataRef.current = undefined;
+      return;
+    }
+
     let cancelled = false;
 
     const run = async () => {

--- a/src/services/profile/expertises.server.ts
+++ b/src/services/profile/expertises.server.ts
@@ -1,0 +1,28 @@
+import type { components } from '@/types/api';
+
+import type { ProfessionVO } from './expertises';
+
+type ApiResponse = components['schemas']['ApiResponse_ProfessionListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const REVALIDATE_SECONDS = 86400;
+
+export async function fetchExpertisesServer(
+  language: string
+): Promise<ProfessionVO[]> {
+  if (!BASE_URL) return [];
+  try {
+    const res = await fetch(`${BASE_URL}/v1/mentors/${language}/expertises`, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchExpertises failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.professions ?? [];
+  } catch (error) {
+    console.error('SSR fetchExpertises error:', error);
+    return [];
+  }
+}

--- a/src/services/profile/industries.server.ts
+++ b/src/services/profile/industries.server.ts
@@ -1,0 +1,32 @@
+import type { components } from '@/types/api';
+
+import type { ProfessionVO } from './industries';
+
+type ApiResponse = components['schemas']['ApiResponse_ProfessionListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// Industry list is near-static; lazy 24h revalidate trades worst-case
+// staleness for one shared cache entry instead of one per-user fetch.
+const REVALIDATE_SECONDS = 86400;
+
+export async function fetchIndustriesServer(
+  language: string
+): Promise<ProfessionVO[]> {
+  // BASE_URL may be unset at build time. Skip silently so prerender doesn't
+  // throw "Invalid URL"; client-side fallback in useIndustries takes over.
+  if (!BASE_URL) return [];
+  try {
+    const res = await fetch(`${BASE_URL}/v1/users/${language}/industries`, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchIndustries failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.professions ?? [];
+  } catch (error) {
+    console.error('SSR fetchIndustries error:', error);
+    return [];
+  }
+}

--- a/src/services/profile/interests.server.ts
+++ b/src/services/profile/interests.server.ts
@@ -1,0 +1,54 @@
+import type { InterestsResult } from '@/hooks/user/interests/useInterests';
+import type { components } from '@/types/api';
+
+import type { InterestVO } from './interests';
+
+type ApiResponse = components['schemas']['ApiResponse_InterestListVO_'];
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+const REVALIDATE_SECONDS = 86400;
+
+type InterestKind = 'INTERESTED_POSITION' | 'SKILL' | 'TOPIC';
+
+async function fetchOneInterestServer(
+  language: string,
+  interest: InterestKind
+): Promise<InterestVO[]> {
+  if (!BASE_URL) return [];
+  try {
+    const url = new URL(`${BASE_URL}/v1/users/${language}/interests`);
+    url.searchParams.set('interest', interest);
+    const res = await fetch(url.toString(), {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    if (!res.ok) {
+      console.error(`SSR fetchInterests(${interest}) failed: ${res.status}`);
+      return [];
+    }
+    const result = (await res.json()) as ApiResponse;
+    return result.data?.interests ?? [];
+  } catch (error) {
+    console.error(`SSR fetchInterests(${interest}) error:`, error);
+    return [];
+  }
+}
+
+export async function fetchInterestsServer(
+  language: string
+): Promise<InterestsResult> {
+  const [interestedPositions, skills, topics] = await Promise.all([
+    fetchOneInterestServer(language, 'INTERESTED_POSITION'),
+    fetchOneInterestServer(language, 'SKILL'),
+    fetchOneInterestServer(language, 'TOPIC'),
+  ]);
+
+  // expertises/whatIOffers are vocabulary aliases — keep parity with the
+  // client-side getInterestsCached so consumers can swap freely.
+  return {
+    interestedPositions,
+    skills,
+    topics,
+    expertises: skills,
+    whatIOffers: topics,
+  };
+}

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-27T15:54:40.580416Z
+       * @default 2026-04-29T13:59:26.811995Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-27T15:54:40.580424Z
+       * @default 2026-04-29T13:59:26.812011Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1384,6 +1384,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1448,6 +1450,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1662,6 +1666,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1718,6 +1724,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1984,6 +1992,8 @@ export interface components {
        * @default
        */
       avatar: string | null;
+      /** Avatar Updated At */
+      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default


### PR DESCRIPTION
## Summary
- Second slice of [Tracker #239](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/239). Wires up mentor-pool to consume the SSR fetchers + `initialData` hooks from #553.
- `MentorPoolWithData.tsx` already SSR-fetched mentors — piggyback the same `Promise.all` to also fetch industries + interests via the new server fetchers (24h `revalidate`).
- `MentorPoolContainer` accepts two new props (`initialIndustries`, `initialInterests`) and forwards them to `useIndustries` / `useInterests`. The hooks short-circuit their first fetch and prime the in-memory cache.
- **Bonus**: the infinite-scroll path (`fetchMentorsEnriched -> getInterestsCached`) hits the warm cache instead of re-fetching the interest vocabulary, since the hook primed it.

## Stacked PR
Base is **#553**, not develop. Merge #553 first; GitHub will auto-retarget this PR to develop.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm build` succeeds (mentor-pool route still 10.8 kB)
- [x] `pnpm test` — 136/136 pass
- [ ] Reviewer / author manual:
  - [ ] `pnpm dev` → load `/mentor-pool` → view source confirms industry/skill/topic options are in the SSR HTML (no client-side flash on filter dropdown)
  - [ ] Filter by industry / skill / topic — dropdown options render correctly, filter results update
  - [ ] Scroll to bottom to trigger infinite scroll — enriched mentors still show Chinese skill/topic labels (cache hit, no extra interest fetch in DevTools Network)

🤖 Generated with [Claude Code](https://claude.com/claude-code)