### PR TITLE
feat(profile-edit): warn before leaving with unsaved changes (#237)

### DIFF
--- a/src/app/profile/[pageUserId]/edit/page.tsx
+++ b/src/app/profile/[pageUserId]/edit/page.tsx
@@ -22,6 +22,15 @@ import {
   ProfileFormValues,
 } from '@/components/profile/edit/profileSchema';
 import { Section } from '@/components/profile/edit/Section';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { PageLoading } from '@/components/ui/loading-spinner';
 import { useProfileAuth } from '@/hooks/user/auth/useProfileAuth';
@@ -32,6 +41,7 @@ import useInterests from '@/hooks/user/interests/useInterests';
 import { useBackgroundAvatarUpload } from '@/hooks/user/profile/useBackgroundAvatarUpload';
 import { useEditProfileData } from '@/hooks/user/profile/useEditProfileData';
 import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
+import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt';
 import {
   flattenAsSingleCategory,
   groupAsPlaceholderCategories,
@@ -153,11 +163,16 @@ export default function Page({
     consumeAvatarUpload: avatarUpload.consume,
   });
 
+  // Suppress the prompt while a submit is in flight so onSubmit's own
+  // router.push isn't blocked by us. isSaving stays true through the
+  // navigation (only reset on failure), so the page unmounts cleanly.
+  const unsaved = useUnsavedChangesPrompt(form.formState.isDirty && !isSaving);
+
   if (!isAuthorized) return null;
   if (isPageLoading) return <PageLoading />;
 
   const handleGoToPrev = () => {
-    router.push(`/profile/${pageUserId}`);
+    unsaved.guardNavigate(() => router.push(`/profile/${pageUserId}`));
   };
 
   return (
@@ -370,6 +385,30 @@ export default function Page({
           <LinksSection form={form} />
         </form>
       </Form>
+
+      <Dialog
+        open={unsaved.isPromptOpen}
+        onOpenChange={(open) => {
+          if (!open) unsaved.cancelLeave();
+        }}
+      >
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>尚未儲存的變更</DialogTitle>
+            <DialogDescription>
+              你的更動會直接遺失，確定要離開嗎？
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter className="gap-2 sm:justify-end">
+            <Button variant="outline" onClick={unsaved.cancelLeave}>
+              繼續編輯
+            </Button>
+            <Button variant="destructive" onClick={unsaved.confirmLeave}>
+              離開頁面
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/src/hooks/useUnsavedChangesPrompt.ts
+++ b/src/hooks/useUnsavedChangesPrompt.ts
@@ -1,0 +1,115 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+export interface UnsavedChangesPrompt {
+  isPromptOpen: boolean;
+  confirmLeave: () => void;
+  cancelLeave: () => void;
+  guardNavigate: (action: () => void) => void;
+}
+
+// Guards a long-form page against accidental navigation while `when` is true.
+// Covers three exit paths:
+//   1. Browser unload (tab close, refresh, external URL) via `beforeunload`.
+//   2. SPA <Link>/<a> clicks via document-level capture; replayed through
+//      router.push on confirm. App Router has no routeChangeStart hook, so
+//      this is the only place we can catch them.
+//   3. Browser back/forward via popstate; we re-push the current URL so the
+//      user "stays", then on confirm flip a leaving flag and call
+//      history.back() once more so the popstate fires through cleanly.
+export function useUnsavedChangesPrompt(when: boolean): UnsavedChangesPrompt {
+  const router = useRouter();
+  const [pendingAction, setPendingAction] = useState<(() => void) | null>(null);
+  const whenRef = useRef(when);
+  const isLeavingRef = useRef(false);
+
+  useEffect(() => {
+    whenRef.current = when;
+  }, [when]);
+
+  useEffect(() => {
+    if (!when) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = '';
+    };
+    window.addEventListener('beforeunload', handler);
+    return () => window.removeEventListener('beforeunload', handler);
+  }, [when]);
+
+  useEffect(() => {
+    if (!when) return;
+    const handler = (e: MouseEvent) => {
+      if (e.defaultPrevented) return;
+      if (e.button !== 0) return;
+      if (e.metaKey || e.ctrlKey || e.shiftKey || e.altKey) return;
+      const anchor = (e.target as HTMLElement | null)?.closest?.('a');
+      if (!anchor) return;
+      const target = anchor.getAttribute('target');
+      if (target && target !== '_self') return;
+      if (anchor.hasAttribute('download')) return;
+      const href = anchor.getAttribute('href');
+      if (!href || href.startsWith('#')) return;
+
+      let url: URL;
+      try {
+        url = new URL(href, window.location.origin);
+      } catch {
+        return;
+      }
+      // External origins fall through to beforeunload.
+      if (url.origin !== window.location.origin) return;
+
+      const dest = url.pathname + url.search + url.hash;
+      e.preventDefault();
+      e.stopPropagation();
+      setPendingAction(() => () => router.push(dest));
+    };
+    document.addEventListener('click', handler, true);
+    return () => document.removeEventListener('click', handler, true);
+  }, [when, router]);
+
+  useEffect(() => {
+    if (!when) return;
+    const handler = () => {
+      if (isLeavingRef.current) {
+        isLeavingRef.current = false;
+        return;
+      }
+      window.history.pushState(null, '', window.location.href);
+      setPendingAction(() => () => {
+        isLeavingRef.current = true;
+        window.history.back();
+      });
+    };
+    window.addEventListener('popstate', handler);
+    return () => window.removeEventListener('popstate', handler);
+  }, [when]);
+
+  const confirmLeave = useCallback(() => {
+    const action = pendingAction;
+    setPendingAction(null);
+    action?.();
+  }, [pendingAction]);
+
+  const cancelLeave = useCallback(() => {
+    setPendingAction(null);
+  }, []);
+
+  const guardNavigate = useCallback((action: () => void) => {
+    if (whenRef.current) {
+      setPendingAction(() => action);
+    } else {
+      action();
+    }
+  }, []);
+
+  return {
+    isPromptOpen: pendingAction !== null,
+    confirmLeave,
+    cancelLeave,
+    guardNavigate,
+  };
+}


### PR DESCRIPTION
## What Does This PR Do?

- Add `useUnsavedChangesPrompt` hook covering three exit paths: `beforeunload` (tab close / refresh / external nav), document-level capture for `<Link>` / `<a>` clicks, and `popstate` for browser back / forward
- Wire the hook into `/profile/[pageUserId]/edit` with a controlled ConfirmDialog ("繼續編輯" / "離開頁面")
- Suppress the prompt while a submit is in flight (`isDirty && !isSaving`) so the post-save `router.push` from `useProfileSubmit` isn't blocked
- Hook is generic (`when: boolean`) so onboarding / mentor-schedule and other long forms can reuse it

## Demo

http://localhost:3000/profile/1/edit

## Screenshot

N/A

## Anything to Note?

- iOS Safari's native `beforeunload` is best-effort by platform — same caveat as everywhere else this API is used
- Manual QA still needed on the five exit paths (header link, cancel button, browser back, refresh, tab close) for both mentor and mentee roles, plus mobile back arrow

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
