### PR TITLE
feat(onboarding): hydrate industries and interests from SSR

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -17,7 +17,9 @@ import {
 } from '@/components/onboarding/steps';
 import useLocations from '@/hooks/user/country/useLocations';
 import useIndustries from '@/hooks/user/industry/useIndustries';
-import useInterests from '@/hooks/user/interests/useInterests';
+import useInterests, {
+  type InterestsResult,
+} from '@/hooks/user/interests/useInterests';
 import { buildOnboardingDtoStub } from '@/hooks/user/onboarding/buildOnboardingDtoStub';
 import {
   clearUserDataCache,
@@ -25,17 +27,29 @@ import {
 } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
+import type { ProfessionVO } from '@/services/profile/industries';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 
 import { STEP_TITLE, STEPS_TOTAL } from './data';
 import OnboardingUI from './ui';
 
-export default function OnboardingContainer() {
+interface Props {
+  initialIndustries: ProfessionVO[];
+  initialInterests: InterestsResult;
+}
+
+export default function OnboardingContainer({
+  initialIndustries,
+  initialInterests,
+}: Props) {
   const router = useRouter();
   const { locations } = useLocations('zh_TW');
-  const { industries } = useIndustries('zh_TW');
-  const { interestedPositions, skills, topics } = useInterests('zh_TW');
+  const { industries } = useIndustries('zh_TW', initialIndustries);
+  const { interestedPositions, skills, topics } = useInterests(
+    'zh_TW',
+    initialInterests
+  );
   const [currentStep, setCurrentStep] = useState(1);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const { data: session, status, update: updateSession } = useSession();

--- a/src/app/auth/(sign)/onboarding/page.tsx
+++ b/src/app/auth/(sign)/onboarding/page.tsx
@@ -1,5 +1,18 @@
+import { fetchIndustriesServer } from '@/services/profile/industries.server';
+import { fetchInterestsServer } from '@/services/profile/interests.server';
+
 import OnboardingContainer from './container';
 
-export default function Page() {
-  return <OnboardingContainer />;
+export default async function Page() {
+  const [initialIndustries, initialInterests] = await Promise.all([
+    fetchIndustriesServer('zh_TW'),
+    fetchInterestsServer('zh_TW'),
+  ]);
+
+  return (
+    <OnboardingContainer
+      initialIndustries={initialIndustries}
+      initialInterests={initialInterests}
+    />
+  );
 }


### PR DESCRIPTION
## Summary
- Third slice of [Tracker #239](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/239), following #553 (server fetchers + hook initialData) and #555 (mentor-pool wiring) which are now both merged.
- `page.tsx` becomes an async server component that fetches industries + interests via the SSR fetchers (24h `revalidate`) and passes them to `OnboardingContainer`.
- Container's `useIndustries` / `useInterests` short-circuit their first fetch and prime the shared in-memory cache, so submit-time `primeUserDataCache` (which reads the interest pools) also benefits.
- `useLocations` is intentionally untouched — it is in scope of a separate ticket.

## Test plan
- [x] `pnpm type-check` clean
- [x] `pnpm build` succeeds
- [x] `pnpm test` — 139/139 pass
- [ ] Reviewer / author manual:
  - [ ] `pnpm dev` → start onboarding flow as a fresh user → step 2 industry chips render immediately (no skeleton flash)
  - [ ] Step 3 / step 4 / step 5 — each step's options render immediately on entry
  - [ ] Submit step 5 — no extra interest fetch in DevTools Network
  - [ ] view-source on `/auth/onboarding` — industry/interest options present in initial HTML

🤖 Generated with [Claude Code](https://claude.com/claude-code)