### PR TITLE
feat(mentor-pool): add clear-all CTA to no-results state (#238)

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -12,6 +12,7 @@ import useIndustries from '@/hooks/user/industry/useIndustries';
 import useInterests, {
   type InterestsResult,
 } from '@/hooks/user/interests/useInterests';
+import { trackEvent } from '@/lib/analytics';
 import type { ProfessionVO } from '@/services/profile/industries';
 import {
   fetchMentorsEnriched,
@@ -22,6 +23,7 @@ import { PAGE_LIMIT } from './constants';
 import { filterOptions } from './data';
 import {
   buildHref,
+  clearAllConditions,
   paramsToFetchConditions,
   parseFiltersFromParams,
   removeFilterFromParams,
@@ -156,6 +158,14 @@ export default function MentorPoolContainer({
     [params, router]
   );
 
+  const handleClearAll = useCallback(() => {
+    trackEvent({ name: 'mentor_pool_clear_all_filters_click' });
+    const next = clearAllConditions(params);
+    startTransition(() => {
+      router.push(buildHref(next));
+    });
+  }, [params, router]);
+
   return (
     <MentorPoolUI
       mentors={mentors}
@@ -167,6 +177,7 @@ export default function MentorPoolContainer({
       filterOptions={dynamicFilterOptions}
       onFilterChange={handleFilterChange}
       onRemoveFilter={handleRemoveFilter}
+      onClearAll={handleClearAll}
       onScrollToBottom={handleScrollToBottom}
     />
   );

--- a/src/app/mentor-pool/searchParams.ts
+++ b/src/app/mentor-pool/searchParams.ts
@@ -109,6 +109,13 @@ export function removeFilterFromParams(
   return next;
 }
 
+export function clearAllConditions(base: AnyParams | null): URLSearchParams {
+  const next = new URLSearchParams(base?.toString() ?? '');
+  FILTER_KEYS.forEach((key) => next.delete(key));
+  next.delete(SEARCH_PARAM_KEY);
+  return next;
+}
+
 export function buildHref(params: URLSearchParams): string {
   const qs = params.toString();
   return qs ? `/mentor-pool?${qs}` : '/mentor-pool';

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { XIcon } from 'lucide-react';
+import { SearchXIcon, XIcon } from 'lucide-react';
 
 import {
   FilterOptions,
@@ -9,6 +9,7 @@ import {
 import MentorFilterDropdown from '@/components/filter/MentorFilterDropdown';
 import { MentorCardList } from '@/components/mentor-pool/mentor-card-list';
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { MentorType } from '@/services/search-mentor/mentors';
 
@@ -24,6 +25,7 @@ interface Props {
   filterOptions: FilterOptions;
   onFilterChange: (opts: SelectFilters) => void;
   onRemoveFilter: (key: string) => void;
+  onClearAll: () => void;
   onScrollToBottom: () => Promise<void>;
 }
 
@@ -37,6 +39,7 @@ export default function MentorPoolUI({
   filterOptions,
   onFilterChange,
   onRemoveFilter,
+  onClearAll,
   onScrollToBottom,
 }: Props) {
   const hasMentors = mentors.length > 0;
@@ -115,8 +118,24 @@ export default function MentorPoolUI({
           </div>
         )}
         {showNoResults && (
-          <div className="mt-6 flex h-full w-full items-center justify-center">
-            <span className="text-xl md:text-3xl">找不到符合的導師</span>
+          <div
+            role="status"
+            aria-live="polite"
+            className="mt-6 flex w-full flex-col items-center justify-center gap-4 py-12 text-center"
+          >
+            <SearchXIcon
+              className="h-12 w-12 text-muted-foreground md:h-16 md:w-16"
+              aria-hidden
+            />
+            <p className="text-xl md:text-3xl">找不到符合的導師</p>
+            <Button
+              type="button"
+              variant="outline"
+              size="lg"
+              onClick={onClearAll}
+            >
+              清除所有條件
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
## What Does This PR Do?

- Upgrade mentor-pool no-results state from a single line of text to an actionable empty state with icon, message, and a "清除所有條件" button
- Add `clearAllConditions()` helper that strips all filter keys and the search query in one call
- Wire `handleClearAll` in the container, fired through `startTransition` + `router.push` like existing filter handlers
- Track a `mentor_pool_clear_all_filters_click` analytics event when the CTA is clicked
- Add `role="status"` + `aria-live="polite"` to the empty state for screen readers

## Demo

http://localhost:3000/mentor-pool?filter_skills=does-not-exist

## Screenshot

N/A

## Anything to Note?

- No new shared `EmptyState` component yet — the only consumer is mentor-pool; revisit if a second list page needs the same treatment
- Wording kept as the original "找不到符合的導師" per design preference
- Resolves Xchange-Taiwan/X-Talent-Tracker#238
