### PR TITLE
fix(auth): use BFF avatar_updated_at instead of Date.now() in session

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -78,9 +78,7 @@ const authOptions = {
           isMentor: response.data.user.is_mentor,
           name: response.data.user.name,
           avatar: response.data.user.avatar,
-          // Set on every login so the browser never serves a stale cached avatar
-          // from a previous session (the S3 key never changes between uploads).
-          avatarUpdatedAt: Date.now(),
+          avatarUpdatedAt: response.data.user.avatar_updated_at ?? undefined,
           jobTitle: response.data.user.job_title ?? '',
           company: response.data.user.company ?? '',
           personalLinks,
@@ -125,7 +123,7 @@ const authOptions = {
             email: (credentials.email as string) || undefined,
             name: user.name,
             avatar: user.avatar,
-            avatarUpdatedAt: Date.now(),
+            avatarUpdatedAt: user.avatar_updated_at ?? undefined,
             isMentor: user.is_mentor,
             onBoarding: user.onboarding,
             jobTitle: user.job_title ?? '',


### PR DESCRIPTION
## What Does This PR Do?

- Replace `Date.now()` with `response.data.user.avatar_updated_at ?? undefined` in the credentials provider
- Replace `Date.now()` with `user.avatar_updated_at ?? undefined` in the custom-google-token provider (the user JSON serialised from the Google callback container already carries the field)
- Header / Edit / Onboarding now show an avatar `?v=` that matches the backend timestamp, so cross-device users see the latest avatar without re-login and Image Optimizer cache reuse improves
- Optimistic `Date.now()` in `useProfileSubmit.ts` and `onboarding/container.tsx` is intentionally preserved
- Closes Xchange-Taiwan/X-Talent-Tracker#245

## Demo

http://localhost:3000/auth/signin

## Screenshot

N/A

## Anything to Note?

N/A
