### PR TITLE
feat(avatar): bust mentor-pool and reservation card avatar caches

### DIFF
--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -45,6 +45,7 @@ const MentorCardListBase = ({
             key={mentor.user_id}
             id={mentor.user_id}
             avatar={mentor.avatar}
+            avatarVersion={mentor.avatar_updated_at}
             years={mentor.years_of_experience}
             name={mentor.name}
             job_title={mentor.job_title}

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -5,22 +5,32 @@ import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 
 interface AvatarWithBadgeProps {
   avatar: string | StaticImageData;
+  // Bumped when the user uploads a new avatar; used as a `?v=` cache buster on
+  // the stable S3 URL. Skipped when null/undefined to keep `?v=null` out of the
+  // Image Optimizer cache key.
+  avatarVersion?: number | null;
   years: string;
   name: string;
 }
 
 export const AvatarWithBadge = ({
   avatar,
+  avatarVersion,
   years,
   name,
 }: AvatarWithBadgeProps) => {
   const displayYears =
     TotalWorkSpanEnum[years as keyof typeof TotalWorkSpanEnum] ?? years;
 
+  const avatarSrc =
+    typeof avatar === 'string' && avatarVersion != null
+      ? `${avatar}?v=${avatarVersion}`
+      : avatar;
+
   return (
     <figure className="relative h-[348px] w-full overflow-hidden xl:h-[292px]">
       <Image
-        src={avatar}
+        src={avatarSrc}
         alt={`${name} 的頭像`}
         fill
         sizes="(max-width: 768px) 334px, 413px"

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -8,6 +8,7 @@ import { Information } from './Information';
 export interface MentorCardProps {
   id: number;
   avatar: string | StaticImageData;
+  avatarVersion?: number | null;
   years: string;
   name: string;
   job_title: string;
@@ -21,6 +22,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
     {
       id,
       avatar,
+      avatarVersion,
       years,
       name,
       job_title,
@@ -40,7 +42,12 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
           aria-label={`前往 ${name} 的個人頁面`}
           className="absolute bottom-0 left-0 right-0 top-0 z-10"
         ></Link>
-        <AvatarWithBadge avatar={avatar} years={years} name={name} />
+        <AvatarWithBadge
+          avatar={avatar}
+          avatarVersion={avatarVersion}
+          years={years}
+          name={name}
+        />
         <div className="px-4 pb-6 pt-4">
           <Information
             name={name}

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -104,7 +104,11 @@ export default function AcceptReservationDialog({
                 <AvatarImage
                   src={
                     reservation.avatar
-                      ? getAvatarThumbUrl(reservation.avatar)
+                      ? getAvatarThumbUrl(
+                          reservation.avatar_updated_at != null
+                            ? `${reservation.avatar}?v=${reservation.avatar_updated_at}`
+                            : reservation.avatar
+                        )
                       : undefined
                   }
                   alt={reservation.name}

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -35,11 +35,19 @@ export function ReservationCard({
 
   const [imageFailed, setImageFailed] = React.useState(false);
 
+  // `getAvatarThumbUrl` preserves any query string, so we append `?v=` first
+  // and then swap to the thumb path. Skip when the version is null so we don't
+  // poison the Image Optimizer cache key with `?v=null`.
+  const versionedAvatar =
+    item.avatar && item.avatar_updated_at != null
+      ? `${item.avatar}?v=${item.avatar_updated_at}`
+      : item.avatar;
+
   const avatar = (
     <Avatar className="h-10 w-10 sm:h-12 sm:w-12">
-      {item.avatar && !imageFailed ? (
+      {versionedAvatar && !imageFailed ? (
         <Image
-          src={getAvatarThumbUrl(item.avatar)}
+          src={getAvatarThumbUrl(versionedAvatar)}
           alt={item.name}
           fill
           sizes="(min-width: 640px) 48px, 40px"

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -81,7 +81,11 @@ export default function ReservationConversationDialog({
             <Avatar className="h-10 w-10 shrink-0">
               {reservation.avatar ? (
                 <AvatarImage
-                  src={getAvatarThumbUrl(reservation.avatar)}
+                  src={getAvatarThumbUrl(
+                    reservation.avatar_updated_at != null
+                      ? `${reservation.avatar}?v=${reservation.avatar_updated_at}`
+                      : reservation.avatar
+                  )}
                   alt={reservation.name}
                 />
               ) : null}

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -11,6 +11,10 @@ export type Reservation = {
   id: string;
   name: string;
   avatar?: string;
+  // Bumped when the counterparty uploads a new avatar; used as a `?v=` cache
+  // buster on the stable S3 URL. Skipped when null/undefined to keep
+  // `?v=null` out of the Image Optimizer cache key.
+  avatar_updated_at?: number | null;
   roleLine: string;
   date: string;
   time: string;

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -64,11 +64,19 @@ function classifyMessageRole(
   return undefined;
 }
 
+// Forward-compat overlay: BFF #111 adds `avatar_updated_at` to RUserInfoVO,
+// but the OpenAPI types here are regenerated only after BFF dev redeploys.
+// Once `pnpm generate:types` runs against the new spec this overlay becomes a
+// no-op and can be dropped.
+type RUserInfoVOWithAvatarVersion = components['schemas']['RUserInfoVO'] & {
+  avatar_updated_at?: number | null;
+};
+
 export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO']
 ): Reservation {
   // API 固定結構：sender = 當前使用者，participant = 對方
-  const counterparty = reservation.participant;
+  const counterparty = reservation.participant as RUserInfoVOWithAvatarVersion;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -112,6 +120,7 @@ export function mapToReservation(
     date,
     time,
     avatar: counterparty.avatar ?? undefined,
+    avatar_updated_at: counterparty.avatar_updated_at ?? null,
     messages,
     menteeMessage,
     mentorMessage,

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -23,6 +23,10 @@ export interface MentorType {
   user_id: number;
   name: string;
   avatar: string | StaticImageData;
+  // Bumped only when the avatar changes; used to bust the Image Optimizer /
+  // browser cache on the stable S3 avatar URL. Null until X-Career-Search
+  // populates it on the mentor index (Xchange-Taiwan/X-Talent-Tracker#242).
+  avatar_updated_at: number | null;
   job_title: string;
   company: string;
   years_of_experience: string;
@@ -90,6 +94,7 @@ export function mapMentor(raw: RawMentor): MentorType {
     user_id: raw.user_id,
     name: raw.name ?? '',
     avatar: raw.avatar ?? '',
+    avatar_updated_at: raw.avatar_updated_at ?? null,
     job_title,
     company,
     years_of_experience: raw.years_of_experience ?? '',


### PR DESCRIPTION
## Summary

The S3 avatar URL is a stable key (re-uploads overwrite in place), so the Image Optimizer / browser cache (TTL up to 30 days) keeps serving stale images on:

- mentor-pool / search-mentor cards (`SearchMentorProfileVO`)
- reservation cards + accept/conversation dialogs (`ReservationInfoVO.sender / participant: RUserInfoVO`)

This wires `avatar_updated_at` through both flows and appends `?v=<version>` as a cache buster on those surfaces. The query is omitted when the version is null so we don't write `?v=null` into the cache key for users who never bumped their avatar.

### Changes

- **`mapMentor.ts`** — `MentorType` gains `avatar_updated_at: number | null`, populated from `SearchMentorProfileVO`.
- **`MentorCardList` → `MentorCard` → `AvatarWithBadge`** — pass `avatarVersion` through; `AvatarWithBadge` builds `${avatar}?v=${version}` only for string URLs and only when the version is set (StaticImageData fallback unchanged).
- **`services/reservations/index.ts`** — `mapToReservation` reads `participant.avatar_updated_at` and stores it on the returned `Reservation`. Uses a small forward-compat overlay on `RUserInfoVO` because the OpenAPI types regen only after BFF dev redeploys for X-Career-BFF#111 — drops cleanly once `pnpm generate:types` re-runs.
- **`Reservation` type** — adds `avatar_updated_at?: number | null`.
- **`ReservationCard` / `AcceptReservationDialog` / `ReservationConversationDialog`** — append `?v=` first, then run through `getAvatarThumbUrl` (which already preserves query strings).

### Backend dependency status

- **Mentor side** — `SearchMentorProfileVO` already exposes `avatar_updated_at` in api.ts via X-Career-BFF#109 pass-through, but X-Career-Search hasn't backfilled the OpenSearch index yet (Xchange-Taiwan/X-Talent-Tracker#242). Until that ships, the value stays null and these URLs render unchanged.
- **Reservation side** — User + BFF PRs are open (Xchange-Taiwan/X-Career-User#78, Xchange-Taiwan/X-Career-BFF#111, both for Xchange-Taiwan/X-Talent-Tracker#243). After they merge and BFF dev redeploys, run `pnpm generate:types` and the overlay in `services/reservations/index.ts` becomes redundant (but harmless).

### Out of scope

- Backend write paths (#242 / #243).
- The `getAvatarUrlWithVersion(avatar, version)` util cleanup (the optional sweep mentioned in the ticket): kept inline to keep the diff focused; happy to follow up.
- `generateMetadata` OG image bare URL (called out as separate concern in the ticket).

Closes Xchange-Taiwan/X-Talent-Tracker#244

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test` (21 files, 139 tests)
- [x] `pnpm build`
- [x] `pnpm lint` against changed files only (repo-wide lint has unrelated pre-existing failures in `rwd-testing/*`)
- [ ] After backend deploys: regenerate types, verify mentor-pool / reservation cards swap avatars after a re-upload
- [ ] Visual smoke on mobile + desktop

🤖 Generated with [Claude Code](https://claude.com/claude-code)