### PR TITLE
fix(avatar): ping touch endpoint after S3 upload

### DIFF
--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -1,5 +1,6 @@
 import { getSession } from 'next-auth/react';
 
+import { apiClient } from '@/lib/apiClient';
 import {
   fetchPresignedUrlByUserId,
   PresignedUrlData,
@@ -104,6 +105,30 @@ function buildS3ObjectUrl(bucketUrl: string, key: string): string {
   return bucketUrl.endsWith('/') ? `${bucketUrl}${key}` : `${bucketUrl}/${key}`;
 }
 
+interface TouchAvatarResponse {
+  code: string;
+  msg: string;
+  data?: { avatar_updated_at: number };
+}
+
+// The presigned-URL flow re-uses a stable per-user S3 key, so profile.avatar
+// doesn't change on re-upload and the standard profile upsert can't detect
+// the bytes have changed. Pinging this endpoint after the S3 upload tells
+// the User service to refresh avatar_updated_at — without it, every viewer
+// keeps seeing the old image until a different cache buster fires.
+async function touchAvatar(userId: number): Promise<void> {
+  try {
+    await apiClient.post<TouchAvatarResponse>(
+      `/v1/storage/avatar/touch/${userId}`,
+      {}
+    );
+  } catch (error) {
+    // Log but don't fail the upload — the file is already in S3 and the user
+    // shouldn't see a hard error if only the cache buster refresh failed.
+    console.error('touchAvatar failed:', error);
+  }
+}
+
 /**
  * updateAvatar
  * 1) Get a presigned URL (consumes the prefetched cache when available)
@@ -136,6 +161,8 @@ export async function updateAvatar(
     }
 
     await uploadToS3WithPresignedPost(presigned, avatarFile, signal);
+
+    await touchAvatar(Number(userId));
 
     return buildS3ObjectUrl(presigned.url, presigned.fields.key);
   } catch (error) {


### PR DESCRIPTION
## Summary

Presigned-URL avatar 上傳流程使用 per-user 固定的 S3 key（`files/{user_id}/avatar`），re-upload 直接 overwrite in place、`profile.avatar` 的 URL 維持不變。因為 User service 的 `assign_avatar_updated_at` 用「新 URL vs 舊 URL」當作 bump `avatar_updated_at` 的依據，這個比較對 stable key 永遠相等 — cache buster 永遠不更新，每個觀看者持續看到舊圖（Image Optimizer 最多快取 30 天）。

這個 PR 在 `updateAvatar` 裡 S3 POST 成功後立刻打新的 BFF touch endpoint。失敗只 log 不丟錯 — 檔案已經在 S3、不該因為 cache buster refresh 失敗就讓使用者看到 hard error。

### Changes

- **`src/services/profile/updateAvatar.ts`** — `uploadToS3WithPresignedPost` 成功後打 `POST /v1/storage/avatar/touch/{userId}`。包在 try/catch 裡 log 但 swallow 錯誤（best-effort refresh）。

### Coordinated PRs

- User：Xchange-Taiwan/X-Career-User — `POST /v1/users/{user_id}/avatar/touch`，bump `avatar_updated_at` 並對 mentor 重新 publish 給 Search。
- BFF：Xchange-Taiwan/X-Career-BFF — `POST /v1/storage/avatar/touch/{user_id}` proxy。

Merge / 部署順序：User → BFF → Frontend（本 PR）。

### 不在 scope 內

- 上傳成功後立刻刷新 NextAuth session 裡的 avatar version — 下次 fetch profile 就會從 DTO 拿到新的 `avatar_updated_at`，那是 container / profile-card 在用的；session 那個欄位主要給 header / dropdown 用，比較不關鍵。如果之後實際上看到 staleness 再加一個 `session.update()` follow-up。
- 補 legacy users DB 裡 `avatar_updated_at` 是 null 的資料 — 之前討論過、這次延後；他們下次上傳就會被填上。

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test`（21 files / 146 tests）
- [x] `pnpm build`
- [ ] 三個 PR 都部署完後：上傳新 avatar，確認 reservation cards / mentor-pool cards 不用 hard refresh 就會顯示新圖
- [ ] DevTools Network：確認每次上傳後 `POST /v1/storage/avatar/touch/{user_id}` 觸發一次、回 200 帶 `{ avatar_updated_at: <int> }`
- [ ] Touch 失敗（中途砍掉 BFF）：使用者仍能透過回傳的 URL 看到新檔案；只是 cache buster 沒更新 — 不會有 hard error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
