### PR TITLE
fix(avatar): rollback S3 on cancel + signal bump on save

### DIFF
--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -209,7 +209,9 @@ export default function EditProfileContainer({
           <AvatarSection
             control={form.control}
             name="avatarFile"
-            onFileChange={avatarUpload.kickOff}
+            onFileChange={(file) =>
+              avatarUpload.kickOff(file, form.getValues('avatar'))
+            }
           />
 
           <Section
@@ -417,7 +419,18 @@ export default function EditProfileContainer({
             <Button variant="outline" onClick={unsaved.cancelLeave}>
               繼續編輯
             </Button>
-            <Button variant="destructive" onClick={unsaved.confirmLeave}>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                // Restore the pre-edit avatar in S3 before navigating. Fire
+                // and forget — re-uploading the snapshot can take a couple of
+                // seconds, and the user shouldn't have to wait while leaving
+                // a page they explicitly cancelled. The hook drops the job
+                // ref synchronously so unmount cleanup can't double-abort.
+                void avatarUpload.rollback();
+                unsaved.confirmLeave();
+              }}
+            >
               離開頁面
             </Button>
           </DialogFooter>

--- a/src/hooks/user/profile/useBackgroundAvatarUpload.ts
+++ b/src/hooks/user/profile/useBackgroundAvatarUpload.ts
@@ -8,11 +8,31 @@ interface AvatarUploadJob {
   file: File;
   controller: AbortController;
   promise: Promise<string | undefined>;
+  // Snapshot of the avatar bytes that were live when the user FIRST started
+  // an upload in this session. Preserved across re-uploads (re-crops) so a
+  // later rollback restores the state from before the user touched the
+  // avatar at all, not from the most recent intermediate file.
+  oldBytesPromise: Promise<Blob | null>;
+  status: 'uploading' | 'completed' | 'failed';
 }
 
 export interface UseBackgroundAvatarUpload {
-  kickOff: (file: File) => void;
+  kickOff: (file: File, currentAvatarUrl: string | null | undefined) => void;
   consume: (file: File | undefined) => Promise<string | undefined>;
+  rollback: () => Promise<void>;
+}
+
+async function snapshotAvatarBytes(
+  url: string | null | undefined
+): Promise<Blob | null> {
+  if (!url) return null;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -20,6 +40,12 @@ export interface UseBackgroundAvatarUpload {
  * the submit flow can `consume` an already-resolved URL instead of waiting
  * for a fresh round trip. Mirrors the onboarding pattern but triggers from
  * the field's onChange rather than a step transition.
+ *
+ * Also exposes `rollback` for the form's discard-changes path: re-uploads
+ * the pre-edit avatar bytes so a cancelled session leaves S3 in the state
+ * the user had before they picked any file. The S3 key is per-user and
+ * stable, so re-uploading the snapshot puts the original image back in the
+ * exact same object the new bytes overwrote.
  */
 export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
   const jobRef = useRef<AvatarUploadJob | null>(null);
@@ -31,21 +57,50 @@ export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
     };
   }, []);
 
-  const kickOff = useCallback((file: File) => {
-    const current = jobRef.current;
-    if (current?.file === file) return;
+  const kickOff = useCallback(
+    (file: File, currentAvatarUrl: string | null | undefined) => {
+      const current = jobRef.current;
+      if (current?.file === file) return;
 
-    current?.controller.abort();
+      // Preserve the original snapshot across multiple file picks within the
+      // same session. We only fetch on the FIRST kickOff so a rollback restores
+      // the truly-pre-edit image, not whichever intermediate crop the user
+      // briefly tried.
+      const oldBytesPromise =
+        current?.oldBytesPromise ?? snapshotAvatarBytes(currentAvatarUrl);
 
-    const controller = new AbortController();
-    const promise = updateAvatar(file, controller.signal).catch((err) => {
-      // Aborts are expected when the user re-crops or unmounts — swallow so
-      // they don't surface as upload failures at submit time.
-      if (controller.signal.aborted) return undefined;
-      throw err;
-    });
-    jobRef.current = { file, controller, promise };
-  }, []);
+      current?.controller.abort();
+
+      const controller = new AbortController();
+      const job: AvatarUploadJob = {
+        file,
+        controller,
+        promise: Promise.resolve(undefined),
+        oldBytesPromise,
+        status: 'uploading',
+      };
+
+      job.promise = updateAvatar(file, controller.signal).then(
+        (url) => {
+          job.status = 'completed';
+          return url;
+        },
+        (err) => {
+          // Aborts are expected when the user re-crops or unmounts — swallow
+          // so they don't surface as upload failures at submit time.
+          if (controller.signal.aborted) {
+            job.status = 'failed';
+            return undefined;
+          }
+          job.status = 'failed';
+          throw err;
+        }
+      );
+
+      jobRef.current = job;
+    },
+    []
+  );
 
   const consume = useCallback(
     async (file: File | undefined): Promise<string | undefined> => {
@@ -62,5 +117,50 @@ export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
     []
   );
 
-  return { kickOff, consume };
+  const rollback = useCallback(async (): Promise<void> => {
+    const job = jobRef.current;
+    if (!job) return;
+    jobRef.current = null;
+
+    // Wait for the upload to settle so we know the final S3 state. If it's
+    // still in flight we can just abort — S3 commits atomically on POST so
+    // an aborted upload leaves the original bytes intact.
+    if (job.status === 'uploading') {
+      job.controller.abort();
+      try {
+        await job.promise;
+      } catch {
+        // expected on abort
+      }
+    }
+
+    if (job.status !== 'completed') {
+      // Either aborted before commit or upload failed — S3 still has the
+      // pre-edit bytes, no restore needed.
+      return;
+    }
+
+    // Upload landed in S3. Re-upload the snapshot so the stable per-user
+    // key holds the original bytes again.
+    const oldBytes = await job.oldBytesPromise;
+    if (!oldBytes) {
+      // No previous avatar (first upload ever) — nothing to roll back to.
+      // The new file stays in S3; without a previous avatar_updated_at on
+      // the user's profile the cache buster won't render either way.
+      return;
+    }
+
+    try {
+      const restoreFile = new File([oldBytes], 'avatar', {
+        type: oldBytes.type || 'image/jpeg',
+      });
+      await updateAvatar(restoreFile);
+    } catch (err) {
+      // Best-effort: the form is already navigating away on cancel, surfacing
+      // a hard error here would be confusing. Log for monitoring instead.
+      console.error('avatar rollback failed:', err);
+    }
+  }, []);
+
+  return { kickOff, consume, rollback };
 }

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -141,7 +141,20 @@ export function useProfileSubmit({
         isDirty('website');
       const whatIOfferDirty = isDirty('what_i_offer');
 
-      const payload = { ...values, avatar, avatarFile: undefined };
+      // The S3 avatar key is per-user and stable, so the URL doesn't change
+      // when bytes change — backend can't detect a re-upload from the URL
+      // alone. Pass an `avatar_updated_at` signal whenever this submit is
+      // committing a freshly-uploaded file; backend treats any non-null value
+      // as "bump with server clock", so the literal number we send doesn't
+      // matter.
+      const payload: ProfileFormValues & { avatar_updated_at?: number } = {
+        ...values,
+        avatar,
+        avatarFile: undefined,
+      };
+      if (values.avatarFile) {
+        payload.avatar_updated_at = Math.floor(Date.now() / 1000);
+      }
       const links = [
         values.linkedin,
         values.facebook,

--- a/src/services/profile/updateProfile.ts
+++ b/src/services/profile/updateProfile.ts
@@ -11,7 +11,13 @@ export const unionformSchema = z.union([
 ]);
 
 export async function updateProfile(
-  profileData: z.infer<typeof unionformSchema>
+  // `avatar_updated_at` is an out-of-band signal the form passes when it just
+  // uploaded a new avatar this session — see useProfileSubmit. Backend treats
+  // any non-null value as "bytes changed, please bump the cache buster" and
+  // overwrites with its own clock, so the value the FE sends is irrelevant.
+  profileData: z.infer<typeof unionformSchema> & {
+    avatar_updated_at?: number;
+  }
 ): Promise<void> {
   const session = await getSession();
   const userId = session?.user?.id;


### PR DESCRIPTION
## 這個 PR 在解什麼

換頭像之後別人看到的還是舊圖（最多 30 天瀏覽器快取）。S3 avatar key 是 per-user 固定的，re-upload 直接 overwrite、URL 不變，後端的 URL-vs-URL heuristic 因此抓不到「bytes 變了」這件事，cache buster 從來沒被更新過。

這個 PR 從前端兩個面向解：

1. **儲存時**：PUT mentor body 帶 `avatar_updated_at` 當訊號，後端拿到就用 server clock bump（搭配 X-Career-User 的 PR）。
2. **取消時**：把上傳前的舊頭像 bytes 傳回 S3，讓「使用者換了頭像、然後反悔取消」的情境，S3 真的回到原狀。

## 兩種使用情境

### 情境 A：換頭像 + 儲存

```
1. 選檔案 → useBackgroundAvatarUpload.kickOff()
   ├─ snapshot：fetch 現在的 avatar URL → 拿到舊 bytes 暫存（給未來 rollback 用）
   └─ 同時：背景上傳新檔到 S3
2. 使用者按儲存 → useProfileSubmit.onSubmit
   └─ PUT mentor body 帶 avatar_updated_at: <epoch>（server 會用自己的 clock 蓋過去）
3. ✓ S3 有新 bytes、DB 時間戳更新、別人下次看到新圖
```

### 情境 B：換頭像 + 取消（這個 PR 修的核心邊界情境）

```
1. 選檔案 → kickOff（同上，snapshot + 背景上傳）
2. 使用者按返回 → unsaved-changes prompt → 「離開頁面」
   ├─ avatarUpload.rollback() —— fire-and-forget
   │   ├─ 如果上傳還在飛 → abort（S3 沒 commit、舊 bytes 還在）
   │   └─ 如果上傳完了 → 把 snapshot 重傳回 S3
   └─ unsaved.confirmLeave() → 立刻 navigate
3. ✓ S3 回到舊 bytes、DB 時間戳沒動、別人繼續看到舊圖
```

## 改了什麼

### `useBackgroundAvatarUpload.ts`（核心改動）

- `kickOff(file, currentAvatarUrl)` 多收一個 `currentAvatarUrl` 參數，第一次 kickOff 時 `fetch` 它拿到舊 bytes 存起來（後續 re-crop 不會覆蓋這份原始 snapshot —— 永遠是「session 開始前」那張圖）。
- `rollback()` 新增。狀態機：
  - 還在上傳 → abort，S3 沒 commit，無事
  - 上傳完了 → 用 `new File([oldBytes], 'avatar')` 包一下、走 `updateAvatar` 重傳 snapshot
  - 失敗的話 `console.error` 不丟錯（使用者已經 navigate 走了，丟錯沒意義）
- `consume()` 行為不變（submit 時拿 promise 結果）。

### `useProfileSubmit.ts`

PUT mentor 的 payload 加上 `avatar_updated_at: Math.floor(Date.now() / 1000)`，**僅當這個 submit 真的有上傳新檔案時**（`values.avatarFile` 為 truthy）。值本身不重要，後端會用 server clock 蓋過去。

### `updateProfile.ts`

`updateProfile` 的型別宣告加一個 optional `avatar_updated_at?: number`，純 TS-level 改動。

### `app/profile/[pageUserId]/edit/container.tsx`

兩處 wiring：

1. `<AvatarSection onFileChange={...}>` 改成 wrap 一層 `(file) => avatarUpload.kickOff(file, form.getValues('avatar'))`，把當前的 avatar URL 傳給 hook 做 snapshot。
2. unsaved-changes Dialog 的「離開頁面」按鈕在 `confirmLeave` 之前先 `void avatarUpload.rollback()`（fire-and-forget），不擋 navigation。

## 邊界情境

| 情境 | 行為 |
|---|---|
| 第一次上傳（沒舊圖）→ 取消 | rollback 看到 `oldBytes = null`，什麼都不做。S3 留新 bytes，但 DB 沒舊 `avatar_updated_at`，不會有殘影 |
| 連選好幾張（A → B → C → 取消） | snapshot 在第一次 kickOff 就抓住「最原始」那張，rollback 還原到那張，中間的 A B 全部丟掉 |
| 上傳中按取消 | abort fetch → S3 沒 commit → 舊 bytes 還在 → rollback 不需要重傳 |
| 上傳完按取消 | rollback 用 snapshot 重傳到 S3，覆寫掉新 bytes |
| **上傳完關掉分頁**（不按取消、不按儲存） | 救不了。`beforeunload` handler 不能跑非同步 PUT。S3 留新 bytes — 跟現有行為一樣（這個 PR 不退步） |
| Rollback PUT 自己失敗（網路斷） | `console.error` 不丟錯。S3 留新 bytes，跟「關掉分頁」邊界情境收斂在同一個結果 |

## 配套 PR

| Repo | PR | 角色 |
|---|---|---|
| X-Career-User | `fix/avatar-updated-at-on-signal` | 後端把 `avatar_updated_at` 訊號變成 bump 觸發點 |
| **X-Talent-Frontend**（本 PR） | — | FE 訊號 + rollback |

部署順序：先 User、再 FE。FE 先 deploy 也只是 backend fallback 走 URL 比對（一樣不 bump），跟現況等價，不會壞。

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test`（21 files / 146 tests）
- [x] `pnpm build`
- [ ] 換頭像 + 儲存：別人下次重整看到新圖 ✓
- [ ] 換頭像 + 取消：S3 console / API 確認 object 已被還原成舊 bytes
- [ ] 換頭像（同一 session 連選 A → B → C）+ 取消：S3 還原到 A 之前的圖
- [ ] 上傳中按取消：S3 沒被覆寫
- [ ] 第一次上傳 + 取消：S3 留新檔（沒舊圖可還原），不會 console error
- [ ] 不換頭像、只改文字：`avatar_updated_at` 在 DB 沒變（瀏覽器繼續用快取）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
