### PR TITLE
fix(avatar): bake ?v= into upload URL + rollback S3 on cancel

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -60,15 +60,12 @@ export default async function RootLayout({
   // imageSrcSet + imageSizes lets the browser pick the same width that
   // <Image sizes="150-160px" /> will request (w=256 at 1x DPR, w=384 at 2x),
   // avoiding the cache-miss caused by a fixed-width preload.
-  // Skip preload entirely when no `avatarUpdatedAt` is available — preloading a
-  // bare URL would write it into the optimizer's 30-day cache and lock in stale
-  // bytes for every future viewer.
-  const sessionAvatar = session?.user?.avatar;
-  const avatarVersion = session?.user?.avatarUpdatedAt;
+  // Skip preload entirely when the avatar URL carries no `?v=` query — the
+  // upload pipeline always bakes in a cache buster, so a bare URL means
+  // legacy data we'd rather refetch live than cache for 30 days.
+  const sessionAvatar = session?.user?.avatar ?? null;
   const avatarSrc =
-    sessionAvatar && avatarVersion
-      ? `${sessionAvatar}?v=${avatarVersion}`
-      : null;
+    sessionAvatar && sessionAvatar.includes('?v=') ? sessionAvatar : null;
   const buildOptimizerUrl = (w: number) =>
     `/_next/image?url=${encodeURIComponent(avatarSrc ?? '')}&w=${w}&q=75`;
   const avatarSrcSet = avatarSrc

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -8,10 +8,7 @@ import { useEffect, useState } from 'react';
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import useUserData from '@/hooks/user/user-data/useUserData';
-import {
-  primeUserProfileDtoCacheIfEmpty,
-  useUserProfileDto,
-} from '@/hooks/user/user-data/useUserProfileDto';
+import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 import { ProfilePageSkeleton } from './skeleton';
@@ -101,23 +98,17 @@ export default function ProfilePageContainer({
     pageUserIdNumber,
     'zh_TW'
   );
-  const { userDto } = useUserProfileDto(pageUserIdNumber, 'zh_TW');
 
   // The S3 avatar URL is a stable key (re-uploads overwrite in place), so a
   // `?v=` query is the only way to bust the Image Optimizer / browser cache.
-  // Use `avatar_updated_at` from the DTO so every viewer — including logged-out
-  // visitors and other users — sees the latest version after the backend bumps
-  // it on upload. While the DTO is still loading on the user's own profile,
-  // fall back to the session avatar so the page does not flash blank.
+  // updateAvatar bakes the cache buster into the URL it returns at upload
+  // time, so we render whatever the backend stored (or the session value on
+  // your own profile while the live DTO is loading) without any post-hoc
+  // version stitching.
   const isOwnProfile = loginUserId === pageUserId;
   const resolvedAvatar =
     userData?.avatar ?? (isOwnProfile ? session?.user?.avatar : undefined);
-  const avatarVersion = userDto?.avatar_updated_at ?? null;
-  const avatarSrc = resolvedAvatar
-    ? avatarVersion
-      ? `${resolvedAvatar}?v=${avatarVersion}`
-      : resolvedAvatar
-    : DefaultAvatarImgUrl;
+  const avatarSrc = resolvedAvatar || DefaultAvatarImgUrl;
 
   if (!userLoading && !userData) {
     return (

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -209,7 +209,9 @@ export default function EditProfileContainer({
           <AvatarSection
             control={form.control}
             name="avatarFile"
-            onFileChange={avatarUpload.kickOff}
+            onFileChange={(file) =>
+              avatarUpload.kickOff(file, form.getValues('avatar'))
+            }
           />
 
           <Section
@@ -417,7 +419,18 @@ export default function EditProfileContainer({
             <Button variant="outline" onClick={unsaved.cancelLeave}>
               繼續編輯
             </Button>
-            <Button variant="destructive" onClick={unsaved.confirmLeave}>
+            <Button
+              variant="destructive"
+              onClick={() => {
+                // Restore the pre-edit avatar in S3 before navigating. Fire
+                // and forget — re-uploading the snapshot can take a couple of
+                // seconds, and the user shouldn't have to wait while leaving
+                // a page they explicitly cancelled. The hook drops the job
+                // ref synchronously so unmount cleanup can't double-abort.
+                void avatarUpload.rollback();
+                unsaved.confirmLeave();
+              }}
+            >
               離開頁面
             </Button>
           </DialogFooter>

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -40,9 +40,8 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
     'testing_mentor@xchange.com.tw',
   ].includes(user.email ?? '');
   const name = user.name ?? '';
-  const avatarSrc = user.avatar
-    ? `${user.avatar}?v=${user.avatarUpdatedAt ?? 0}`
-    : '';
+  // Avatar URL already carries its own `?v=` cache buster from upload time.
+  const avatarSrc = user.avatar ?? '';
   const jobTitle = user.jobTitle ?? '';
   const company = user.company ?? '';
   const personalLinks = user.personalLinks ?? [];

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -39,12 +39,10 @@ export const UserDropdown = React.memo(function UserDropdown({
     'testing_mentor@xchange.com.tw',
   ].includes(user.email ?? '');
   const name = user.name ?? '';
-  // Use the original avatar URL with ?v= so header / dropdown / share dialog
-  // share the same Image Optimizer + browser cache entry as the profile view
-  // and edit pages, and the layout preload is reused.
-  const avatarSrc = user.avatar
-    ? `${user.avatar}?v=${user.avatarUpdatedAt ?? 0}`
-    : '';
+  // Avatar URLs already carry their own `?v=<upload-timestamp>` cache buster
+  // (set by updateAvatar at upload time), so render the URL as-is — header /
+  // dropdown / share dialog / profile pages all share one cache entry.
+  const avatarSrc = user.avatar ?? '';
   const jobTitle = user.jobTitle ?? '';
   const company = user.company ?? '';
 

--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -45,7 +45,6 @@ const MentorCardListBase = ({
             key={mentor.user_id}
             id={mentor.user_id}
             avatar={mentor.avatar}
-            avatarVersion={mentor.avatar_updated_at}
             years={mentor.years_of_experience}
             name={mentor.name}
             job_title={mentor.job_title}

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -5,32 +5,22 @@ import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 
 interface AvatarWithBadgeProps {
   avatar: string | StaticImageData;
-  // Bumped when the user uploads a new avatar; used as a `?v=` cache buster on
-  // the stable S3 URL. Skipped when null/undefined to keep `?v=null` out of the
-  // Image Optimizer cache key.
-  avatarVersion?: number | null;
   years: string;
   name: string;
 }
 
 export const AvatarWithBadge = ({
   avatar,
-  avatarVersion,
   years,
   name,
 }: AvatarWithBadgeProps) => {
   const displayYears =
     TotalWorkSpanEnum[years as keyof typeof TotalWorkSpanEnum] ?? years;
 
-  const avatarSrc =
-    typeof avatar === 'string' && avatarVersion != null
-      ? `${avatar}?v=${avatarVersion}`
-      : avatar;
-
   return (
     <figure className="relative h-[348px] w-full overflow-hidden xl:h-[292px]">
       <Image
-        src={avatarSrc}
+        src={avatar}
         alt={`${name} 的頭像`}
         fill
         sizes="(max-width: 768px) 334px, 413px"

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -8,7 +8,6 @@ import { Information } from './Information';
 export interface MentorCardProps {
   id: number;
   avatar: string | StaticImageData;
-  avatarVersion?: number | null;
   years: string;
   name: string;
   job_title: string;
@@ -22,7 +21,6 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
     {
       id,
       avatar,
-      avatarVersion,
       years,
       name,
       job_title,
@@ -42,12 +40,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
           aria-label={`前往 ${name} 的個人頁面`}
           className="absolute bottom-0 left-0 right-0 top-0 z-10"
         ></Link>
-        <AvatarWithBadge
-          avatar={avatar}
-          avatarVersion={avatarVersion}
-          years={years}
-          name={name}
-        />
+        <AvatarWithBadge avatar={avatar} years={years} name={name} />
         <div className="px-4 pb-6 pt-4">
           <Information
             name={name}

--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useSession } from 'next-auth/react';
-import React, { useRef } from 'react';
+import React from 'react';
 import { Control, FieldValues, Path } from 'react-hook-form';
 
 import AvatarUpload from '@/components/ui/avatar-upload';
@@ -20,17 +20,9 @@ export const AvatarSection = <T extends FieldValues>({
   onFileChange,
 }: AvatarSectionProps<T>) => {
   const { data: session } = useSession();
-  // Stable fallback used when avatarUpdatedAt is absent (e.g. fresh login
-  // before any update). Ensures the browser fetches the current image on
-  // first load rather than serving a previously-cached ?v=0 stale copy.
-  const stableCacheBust = useRef(Date.now()).current;
-
-  // Use ?v= (matches the layout preload + profile view page) so the optimizer
-  // cache key is identical across surfaces and the preloaded image is reused.
-  const sessionAvatar = session?.user?.avatar ?? '';
-  const avatarUrl = sessionAvatar
-    ? `${sessionAvatar}?v=${session?.user?.avatarUpdatedAt ?? stableCacheBust}`
-    : '';
+  // Avatar URLs already carry their own `?v=` cache buster from upload time,
+  // so render the session value as-is — no post-hoc version stitching.
+  const avatarUrl = session?.user?.avatar ?? '';
 
   return (
     <Section title="個人頭像">

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -104,11 +104,7 @@ export default function AcceptReservationDialog({
                 <AvatarImage
                   src={
                     reservation.avatar
-                      ? getAvatarThumbUrl(
-                          reservation.avatar_updated_at != null
-                            ? `${reservation.avatar}?v=${reservation.avatar_updated_at}`
-                            : reservation.avatar
-                        )
+                      ? getAvatarThumbUrl(reservation.avatar)
                       : undefined
                   }
                   alt={reservation.name}

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -35,19 +35,11 @@ export function ReservationCard({
 
   const [imageFailed, setImageFailed] = React.useState(false);
 
-  // `getAvatarThumbUrl` preserves any query string, so we append `?v=` first
-  // and then swap to the thumb path. Skip when the version is null so we don't
-  // poison the Image Optimizer cache key with `?v=null`.
-  const versionedAvatar =
-    item.avatar && item.avatar_updated_at != null
-      ? `${item.avatar}?v=${item.avatar_updated_at}`
-      : item.avatar;
-
   const avatar = (
     <Avatar className="h-10 w-10 sm:h-12 sm:w-12">
-      {versionedAvatar && !imageFailed ? (
+      {item.avatar && !imageFailed ? (
         <Image
-          src={getAvatarThumbUrl(versionedAvatar)}
+          src={getAvatarThumbUrl(item.avatar)}
           alt={item.name}
           fill
           sizes="(min-width: 640px) 48px, 40px"

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -81,11 +81,7 @@ export default function ReservationConversationDialog({
             <Avatar className="h-10 w-10 shrink-0">
               {reservation.avatar ? (
                 <AvatarImage
-                  src={getAvatarThumbUrl(
-                    reservation.avatar_updated_at != null
-                      ? `${reservation.avatar}?v=${reservation.avatar_updated_at}`
-                      : reservation.avatar
-                  )}
+                  src={getAvatarThumbUrl(reservation.avatar)}
                   alt={reservation.name}
                 />
               ) : null}

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -11,10 +11,6 @@ export type Reservation = {
   id: string;
   name: string;
   avatar?: string;
-  // Bumped when the counterparty uploads a new avatar; used as a `?v=` cache
-  // buster on the stable S3 URL. Skipped when null/undefined to keep
-  // `?v=null` out of the Image Optimizer cache key.
-  avatar_updated_at?: number | null;
   roleLine: string;
   date: string;
   time: string;

--- a/src/hooks/user/profile/useBackgroundAvatarUpload.ts
+++ b/src/hooks/user/profile/useBackgroundAvatarUpload.ts
@@ -8,11 +8,31 @@ interface AvatarUploadJob {
   file: File;
   controller: AbortController;
   promise: Promise<string | undefined>;
+  // Snapshot of the avatar bytes that were live when the user FIRST started
+  // an upload in this session. Preserved across re-uploads (re-crops) so a
+  // later rollback restores the state from before the user touched the
+  // avatar at all, not from the most recent intermediate file.
+  oldBytesPromise: Promise<Blob | null>;
+  status: 'uploading' | 'completed' | 'failed';
 }
 
 export interface UseBackgroundAvatarUpload {
-  kickOff: (file: File) => void;
+  kickOff: (file: File, currentAvatarUrl: string | null | undefined) => void;
   consume: (file: File | undefined) => Promise<string | undefined>;
+  rollback: () => Promise<void>;
+}
+
+async function snapshotAvatarBytes(
+  url: string | null | undefined
+): Promise<Blob | null> {
+  if (!url) return null;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    return await res.blob();
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -20,6 +40,12 @@ export interface UseBackgroundAvatarUpload {
  * the submit flow can `consume` an already-resolved URL instead of waiting
  * for a fresh round trip. Mirrors the onboarding pattern but triggers from
  * the field's onChange rather than a step transition.
+ *
+ * Also exposes `rollback` for the form's discard-changes path: re-uploads
+ * the pre-edit avatar bytes so a cancelled session leaves S3 in the state
+ * the user had before they picked any file. The S3 key is per-user and
+ * stable, so re-uploading the snapshot puts the original image back in the
+ * exact same object the new bytes overwrote.
  */
 export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
   const jobRef = useRef<AvatarUploadJob | null>(null);
@@ -31,21 +57,50 @@ export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
     };
   }, []);
 
-  const kickOff = useCallback((file: File) => {
-    const current = jobRef.current;
-    if (current?.file === file) return;
+  const kickOff = useCallback(
+    (file: File, currentAvatarUrl: string | null | undefined) => {
+      const current = jobRef.current;
+      if (current?.file === file) return;
 
-    current?.controller.abort();
+      // Preserve the original snapshot across multiple file picks within the
+      // same session. We only fetch on the FIRST kickOff so a rollback restores
+      // the truly-pre-edit image, not whichever intermediate crop the user
+      // briefly tried.
+      const oldBytesPromise =
+        current?.oldBytesPromise ?? snapshotAvatarBytes(currentAvatarUrl);
 
-    const controller = new AbortController();
-    const promise = updateAvatar(file, controller.signal).catch((err) => {
-      // Aborts are expected when the user re-crops or unmounts — swallow so
-      // they don't surface as upload failures at submit time.
-      if (controller.signal.aborted) return undefined;
-      throw err;
-    });
-    jobRef.current = { file, controller, promise };
-  }, []);
+      current?.controller.abort();
+
+      const controller = new AbortController();
+      const job: AvatarUploadJob = {
+        file,
+        controller,
+        promise: Promise.resolve(undefined),
+        oldBytesPromise,
+        status: 'uploading',
+      };
+
+      job.promise = updateAvatar(file, controller.signal).then(
+        (url) => {
+          job.status = 'completed';
+          return url;
+        },
+        (err) => {
+          // Aborts are expected when the user re-crops or unmounts — swallow
+          // so they don't surface as upload failures at submit time.
+          if (controller.signal.aborted) {
+            job.status = 'failed';
+            return undefined;
+          }
+          job.status = 'failed';
+          throw err;
+        }
+      );
+
+      jobRef.current = job;
+    },
+    []
+  );
 
   const consume = useCallback(
     async (file: File | undefined): Promise<string | undefined> => {
@@ -62,5 +117,48 @@ export function useBackgroundAvatarUpload(): UseBackgroundAvatarUpload {
     []
   );
 
-  return { kickOff, consume };
+  const rollback = useCallback(async (): Promise<void> => {
+    const job = jobRef.current;
+    if (!job) return;
+    jobRef.current = null;
+
+    // Wait for the upload to settle so we know the final S3 state. If it's
+    // still in flight we can just abort — S3 commits atomically on POST so
+    // an aborted upload leaves the original bytes intact.
+    if (job.status === 'uploading') {
+      job.controller.abort();
+      try {
+        await job.promise;
+      } catch {
+        // expected on abort
+      }
+    }
+
+    if (job.status !== 'completed') {
+      // Either aborted before commit or upload failed — S3 still has the
+      // pre-edit bytes, no restore needed.
+      return;
+    }
+
+    // Upload landed in S3. Re-upload the snapshot so the stable per-user
+    // key holds the original bytes again. Skipped when there was no prior
+    // avatar (first-ever upload); the new file stays in S3, but since the
+    // user's profile.avatar wasn't updated we never render the cancelled
+    // image anyway.
+    const oldBytes = await job.oldBytesPromise;
+    if (!oldBytes) return;
+
+    try {
+      const restoreFile = new File([oldBytes], 'avatar', {
+        type: oldBytes.type || 'image/jpeg',
+      });
+      await updateAvatar(restoreFile);
+    } catch (err) {
+      // Best-effort: the form is already navigating away on cancel, surfacing
+      // a hard error here would be confusing. Log for monitoring instead.
+      console.error('avatar rollback failed:', err);
+    }
+  }, []);
+
+  return { kickOff, consume, rollback };
 }

--- a/src/services/profile/updateAvatar.ts
+++ b/src/services/profile/updateAvatar.ts
@@ -100,8 +100,16 @@ async function uploadToS3WithPresignedPost(
   }
 }
 
+// The S3 avatar key is per-user and stable, so the bare URL doesn't change
+// when the user re-uploads. Bake `?v=<timestamp>` into the URL we hand back
+// so the Image Optimizer / browser cache key changes on every upload —
+// downstream consumers can render the URL directly without combining it
+// with a separate version field.
 function buildS3ObjectUrl(bucketUrl: string, key: string): string {
-  return bucketUrl.endsWith('/') ? `${bucketUrl}${key}` : `${bucketUrl}/${key}`;
+  const base = bucketUrl.endsWith('/')
+    ? `${bucketUrl}${key}`
+    : `${bucketUrl}/${key}`;
+  return `${base}?v=${Date.now()}`;
 }
 
 /**

--- a/src/services/reservations/index.ts
+++ b/src/services/reservations/index.ts
@@ -64,19 +64,11 @@ function classifyMessageRole(
   return undefined;
 }
 
-// Forward-compat overlay: BFF #111 adds `avatar_updated_at` to RUserInfoVO,
-// but the OpenAPI types here are regenerated only after BFF dev redeploys.
-// Once `pnpm generate:types` runs against the new spec this overlay becomes a
-// no-op and can be dropped.
-type RUserInfoVOWithAvatarVersion = components['schemas']['RUserInfoVO'] & {
-  avatar_updated_at?: number | null;
-};
-
 export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO']
 ): Reservation {
   // API 固定結構：sender = 當前使用者，participant = 對方
-  const counterparty = reservation.participant as RUserInfoVOWithAvatarVersion;
+  const counterparty = reservation.participant;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -134,7 +126,6 @@ export function mapToReservation(
     date,
     time,
     avatar: counterparty.avatar ?? undefined,
-    avatar_updated_at: counterparty.avatar_updated_at ?? null,
     messages,
     menteeMessage,
     mentorMessage,

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -23,10 +23,6 @@ export interface MentorType {
   user_id: number;
   name: string;
   avatar: string | StaticImageData;
-  // Bumped only when the avatar changes; used to bust the Image Optimizer /
-  // browser cache on the stable S3 avatar URL. Null until X-Career-Search
-  // populates it on the mentor index (Xchange-Taiwan/X-Talent-Tracker#242).
-  avatar_updated_at: number | null;
   job_title: string;
   company: string;
   years_of_experience: string;
@@ -94,7 +90,6 @@ export function mapMentor(raw: RawMentor): MentorType {
     user_id: raw.user_id,
     name: raw.name ?? '',
     avatar: raw.avatar ?? '',
-    avatar_updated_at: raw.avatar_updated_at ?? null,
     job_title,
     company,
     years_of_experience: raw.years_of_experience ?? '',


### PR DESCRIPTION
## 這個 PR 在解什麼

換頭像之後別人看到的還是舊圖（最多 30 天瀏覽器快取）。

S3 avatar key 是 per-user 固定的（`files/{user_id}/avatar`），re-upload 直接 overwrite、URL 不變。每個 surface 為了破壞快取都要把 `profile.avatar` 跟 `avatar_updated_at` 拼起來變成 `${avatar}?v=${avatar_updated_at}` —— FE 散在 5+ 處要組、後端要 bump 那個欄位、兩邊還要協調訊號什麼時候送。

這個 PR 把版本戳**直接 bake 進 avatar URL**，從根源拿掉「兩個欄位協調」這個複雜度。

## 新流程

```
上傳完成 → updateAvatar 回傳 ".../files/{user_id}/avatar?v=1745920000"
            ↓ PUT mentor body avatar = 整個 URL（含 ?v=）
Backend：profile.avatar 整個存進 DB（後端不用改）
            ↓
所有 surface：<img src={profile.avatar} />     ← 直接 render，不用拼湊
```

每次上傳 `Date.now()` 都不同，URL 自然就變、Image Optimizer / 瀏覽器自動 cache miss、看到新圖。

## 改了什麼

### 1. Versioning 來源（單一來源）

- **`services/profile/updateAvatar.ts`** — `buildS3ObjectUrl` 在組完整 URL 後接 `?v=${Date.now()}`。整個 versioning 邏輯收斂在這 3 行。

### 2. Snapshot + Rollback（取消還原）

- **`hooks/user/profile/useBackgroundAvatarUpload.ts`**
  - `kickOff(file, currentAvatarUrl)` 多收當前 avatar URL 參數，第一次 kickOff 時 `fetch` 它把舊 bytes 暫存（後續 re-crop 不會覆蓋這份 snapshot —— 永遠是 session 開始前那張）
  - 新增 `rollback()`：上傳還在飛 → abort、上傳完了 → 用 snapshot 重傳到 S3、第一次上傳沒舊圖 → no-op、失敗 `console.error` 不丟錯

### 3. 自己這邊的 surface（render avatar 直接用）

| 檔案 | 改動 |
|---|---|
| `app/profile/[pageUserId]/container.tsx` | 移除 `userDto?.avatar_updated_at` 拼接、`useUserProfileDto` import 也順手清掉（只剩 prime function 還在用） |
| `app/layout.tsx` | preload 條件改成「URL 有 `?v=` 才 preload」（沒 `?v=` 視為 legacy 不快取） |
| `components/profile/edit/AvatarSection.tsx` | 移除 `stableCacheBust` ref、直接用 `session?.user?.avatar` |
| `components/layout/Header/UserDropdown.tsx` | 移除拼接 |
| `components/layout/Header/MobileUserMenu.tsx` | 移除拼接 |

### 4. 別人那邊的 surface（mentor-pool / reservation，#244 加的東西就地拆掉）

| 檔案 | 改動 |
|---|---|
| `services/search-mentor/mapMentor.ts` | `MentorType.avatar_updated_at` 移除 + mapping 拿掉 |
| `components/mentor-pool/mentor-card-list/index.tsx` | 不再傳 `avatarVersion` prop |
| `components/mentor-pool/mentor-card/index.tsx` | `MentorCardProps.avatarVersion` 移除 |
| `components/mentor-pool/mentor-card/AvatarWithBadge.tsx` | 不再組 `?v=`、直接 `<Image src={avatar} />` |
| `services/reservations/index.ts` | 移除 `RUserInfoVOWithAvatarVersion` overlay cast、mapping 拿掉欄位 |
| `components/reservation/types.ts` | `Reservation.avatar_updated_at` 移除 |
| `components/reservation/ReservationCard.tsx` | 不再組 `?v=` |
| `components/reservation/AcceptReservationDialog.tsx` | 不再組 `?v=` |
| `components/reservation/ReservationConversationDialog.tsx` | 不再組 `?v=` |

### 5. 取消按鈕掛 rollback

- **`app/profile/[pageUserId]/edit/container.tsx`**
  - `<AvatarSection onFileChange>` wrap 一層把當前 avatar URL 傳給 kickOff
  - 「離開頁面」按鈕的 onClick 在 `confirmLeave` 之前先 `void avatarUpload.rollback()`（fire-and-forget，不擋 navigation）

## 後端要不要改？**不用。**

之前 #74 / #109 加的 `avatar_updated_at` 欄位、`assign_avatar_updated_at` URL 比對 heuristic 全部留著當 vestigial。新流程下：
- FE 送 `avatar = ".../avatar?v=NEW_TS"`
- 後端 URL 比對發現變了 → bump `avatar_updated_at`（值更新但沒人讀）
- DB 把整個 URL 含 `?v=` 存進 `profile.avatar`
- 下次 GET 回傳 `profile.avatar` 整個帶 `?v=`，FE render 直接用

不用 migration、不用 revert 任何 commit。未來想清乾淨可另開 ticket 把 `avatar_updated_at` 欄位移除。

## 邊界情境

| 情境 | 行為 |
|---|---|
| 換頭像 + 儲存 | ✓ FE 送 URL with `?v=`、DB 存進去、別人下次 fetch 就 cache miss |
| 換頭像 + 取消 | ✓ rollback 把舊 bytes 重傳 S3、DB 沒被動、爆 cache 也對 |
| 換好幾張（A→B→C）+ 取消 | ✓ snapshot 鎖在「session 開始前」那張、還原到那張 |
| 上傳中按取消 | ✓ abort fetch、S3 沒 commit、舊 bytes 還在 |
| 第一次上傳（沒舊圖）+ 取消 | △ S3 留新檔，但 DB 沒舊 `avatar`，下次 GET 沒人會 render 那張 |
| 上傳完關掉分頁 | △ `beforeunload` 不能跑 async PUT，S3 留新 bytes —— 救不了的洞 |
| Legacy users（DB 裡 avatar 沒 `?v=`） | ✓ 直接 render bare URL，沒 cache busting，等下次他們儲存自然帶上 `?v=` |
| Session staleness | ✓ NextAuth session 的 `avatar` 在 profile 儲存後會 `updateSession`，包含新 `?v=` |

## Test plan

- [x] `pnpm type-check`
- [x] `pnpm test`（21 files / 146 tests）
- [x] `pnpm build`
- [ ] 換頭像 + 儲存：mentor-pool / reservation 卡片不重整看到新圖（不同 viewer 開新分頁也能立刻看到新版）
- [ ] 換頭像 + 取消：S3 console / API 確認 object 已被還原成舊 bytes
- [ ] 換好幾次（A→B→C）+ 取消：S3 還原到 A 之前那張
- [ ] 第一次上傳 + 取消：不會 console error
- [ ] 不換頭像、只改 about：URL 不變、瀏覽器繼續用快取（不會無謂 refetch）
- [ ] Legacy user（DB avatar 沒 `?v=`）顯示正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)
