### PR TITLE
feat(calendar): distinguish fetching vs empty month in schedule

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -279,6 +279,7 @@ export default function ProfilePageUI({
                       allowedDates={allowedDates}
                       showTodayStyle={false}
                       disableEmptyDates={true}
+                      isMonthLoading={!schedule.monthLoaded}
                     />
                   </div>
                   <div className="flex flex-col items-start gap-4">
@@ -287,6 +288,17 @@ export default function ProfilePageUI({
                       const slots = selectedDate
                         ? generateBookingSlots(selectedDate)
                         : [];
+                      if (!schedule.monthLoaded) {
+                        return (
+                          <div
+                            aria-busy="true"
+                            aria-live="polite"
+                            className="flex min-h-10 items-center text-gray-400"
+                          >
+                            讀取中…
+                          </div>
+                        );
+                      }
                       if (slots.length === 0) {
                         return (
                           <div className="flex min-h-10 items-center text-gray-400">

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -42,8 +42,13 @@ export default function MenteeReservationDialog({
   userData: UserType | null;
   onMonthChange?: (date: Date) => void;
 }) {
-  const { selectedDate, setSelectedDate, allowedDates, generateBookingSlots } =
-    schedule;
+  const {
+    selectedDate,
+    setSelectedDate,
+    allowedDates,
+    generateBookingSlots,
+    monthLoaded,
+  } = schedule;
   const router = useRouter();
 
   const [view, setView] = useState<
@@ -224,6 +229,7 @@ export default function MenteeReservationDialog({
             allowedDates={allowedDates}
             showTodayStyle={false}
             disableEmptyDates={true}
+            isMonthLoading={!monthLoaded}
           />
         </div>
         <div>
@@ -233,6 +239,18 @@ export default function MenteeReservationDialog({
               const slots = selectedDate
                 ? generateBookingSlots(selectedDate)
                 : [];
+
+              if (!monthLoaded) {
+                return (
+                  <div
+                    aria-busy="true"
+                    aria-live="polite"
+                    className="col-span-full text-center text-sm text-gray-500"
+                  >
+                    讀取中…
+                  </div>
+                );
+              }
 
               if (slots.length === 0) {
                 return (

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -98,7 +98,7 @@ export default function MentorScheduleDialog({
     allowedDates,
     updateDraftSlot,
     meetingDurationMinutes,
-    isFetching,
+    monthLoaded,
   } = schedule;
 
   const router = useRouter();
@@ -514,12 +514,13 @@ export default function MentorScheduleDialog({
               disableEmptyDates={false}
               disablePastDates={true}
               highlightAvailableDates={true}
+              isMonthLoading={!monthLoaded}
             />
 
             <div>
               <p className="font-semibold lg:text-lg">可預約時段</p>
 
-              {isFetching ? (
+              {!monthLoaded ? (
                 <div
                   className="mt-3 flex flex-col gap-3"
                   aria-busy="true"
@@ -624,7 +625,7 @@ export default function MentorScheduleDialog({
             <Button
               onClick={handleSave}
               disabled={
-                isSaving || hasAnyError || hasInvalidTimes || isFetching
+                isSaving || hasAnyError || hasInvalidTimes || !monthLoaded
               }
             >
               {isSaving ? '儲存中...' : '儲存'}

--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import dayjs from 'dayjs';
+import { Loader2 } from 'lucide-react';
 import { useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
 
@@ -19,6 +20,12 @@ interface ScheduleCalendarProps {
   disableEmptyDates?: boolean;
   disablePastDates?: boolean;
   highlightAvailableDates?: boolean;
+  /**
+   * Show a loading overlay over the grid so the user can tell the displayed
+   * month is still being fetched (vs. settled-empty). Swiping/clicking still
+   * works; this only adds a visual cue.
+   */
+  isMonthLoading?: boolean;
   size?: ScheduleCalendarSize;
   className?: string;
 }
@@ -107,6 +114,7 @@ export const ScheduleCalendar = ({
   disableEmptyDates = false,
   disablePastDates = false,
   highlightAvailableDates = false,
+  isMonthLoading = false,
   size = 'compact',
   className,
 }: ScheduleCalendarProps) => {
@@ -145,43 +153,59 @@ export const ScheduleCalendar = ({
         className
       )}
     >
-      <Calendar
-        mode="single"
-        captionLayout="dropdown"
-        month={displayMonth}
-        selected={selected}
-        onSelect={handleSelect}
-        onMonthChange={handleMonthChange}
-        modifiers={{
-          available: availableDays,
-        }}
-        modifiersClassNames={{
-          available: 'rdp-day-available',
-        }}
-        disabled={(day) => {
-          if (disablePastDates) {
-            const today = new Date();
-            today.setHours(0, 0, 0, 0);
+      <div
+        className={cn(
+          'relative transition-opacity',
+          isMonthLoading && 'opacity-60'
+        )}
+        aria-busy={isMonthLoading}
+      >
+        <Calendar
+          mode="single"
+          captionLayout="dropdown"
+          month={displayMonth}
+          selected={selected}
+          onSelect={handleSelect}
+          onMonthChange={handleMonthChange}
+          modifiers={{
+            available: availableDays,
+          }}
+          modifiersClassNames={{
+            available: 'rdp-day-available',
+          }}
+          disabled={(day) => {
+            if (disablePastDates) {
+              const today = new Date();
+              today.setHours(0, 0, 0, 0);
 
-            if (day < today) {
-              return true;
+              if (day < today) {
+                return true;
+              }
             }
-          }
 
-          if (disableEmptyDates) {
-            const dateStr = dayjs(day).format('YYYY-MM-DD');
+            if (disableEmptyDates) {
+              const dateStr = dayjs(day).format('YYYY-MM-DD');
 
-            if (allowedDates.length === 0) {
-              return true;
+              if (allowedDates.length === 0) {
+                return true;
+              }
+
+              return !allowedDates.includes(dateStr);
             }
 
-            return !allowedDates.includes(dateStr);
-          }
-
-          return false;
-        }}
-        showTodayStyle={showTodayStyle}
-      />
+            return false;
+          }}
+          showTodayStyle={showTodayStyle}
+        />
+        {isMonthLoading && (
+          <div
+            aria-live="polite"
+            className="pointer-events-none absolute inset-0 flex items-center justify-center"
+          >
+            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+          </div>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -39,7 +39,10 @@ type Options = {
 };
 
 export type UseMentorScheduleReturn = {
+  /** Sticky: true once any month has resolved. Use this for first-paint skeletons. */
   loaded: boolean;
+  /** Per-month: false while the *current* (year, month) is being fetched after a cache miss. */
+  monthLoaded: boolean;
   isFetching: boolean;
   selectedDate: string | null;
   setSelectedDate: (dateStr: string | null) => void;
@@ -81,6 +84,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const [saved, setSaved] = useState<RawMentorTimeslot[]>([]);
   const [draft, setDraft] = useState<RawMentorTimeslot[]>([]);
   const [loaded, setLoaded] = useState(false);
+  const [monthLoaded, setMonthLoaded] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(
     dayjs().format('YYYY-MM-DD')
@@ -134,6 +138,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       setSaved(raws);
       setDraft(raws);
       setLoaded(true);
+      setMonthLoaded(true);
       setPendingDeleteIds([]);
       const firstAllow = raws.find((r) => r.type === 'ALLOW');
       if (firstAllow) {
@@ -150,9 +155,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     } else if (!dirtyRef.current) {
       // Cache miss: clear stale month data so the calendar doesn't show
       // last month's allowed dots / time slots while the fetch is in flight.
+      // monthLoaded -> false so consumers can distinguish "fetching" from
+      // "settled empty"; sticky `loaded` is left untouched.
       setSaved([]);
       setDraft([]);
       setPendingDeleteIds([]);
+      setMonthLoaded(false);
       setIsFetching(true);
     }
 
@@ -165,7 +173,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         apply(raws);
       })
       .catch(() => {
-        if (!ignore && !cached) setLoaded(true);
+        // Treat fetch failure as "settled" so the UI doesn't hang on a
+        // skeleton; the user will see the empty state instead.
+        if (!ignore && !cached) {
+          setLoaded(true);
+          setMonthLoaded(true);
+        }
       })
       .finally(() => {
         if (!ignore) setIsFetching(false);
@@ -443,6 +456,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   return {
     loaded,
+    monthLoaded,
     isFetching,
     selectedDate,
     setSelectedDate,


### PR DESCRIPTION
## What Does This PR Do?

- Add per-month `monthLoaded` flag to `useMentorSchedule` so consumers can tell "still fetching this month after a cache miss" apart from "settled empty month". The existing sticky `loaded` flag is preserved for first-paint skeletons and the auto-select-first-slot effect.
- `ScheduleCalendar` accepts `isMonthLoading`; while true, dim the grid and overlay a centered spinner (pointer-events-none, so swipe / click still work).
- `MentorScheduleDialog`: slot-list skeleton and Save-disabled now key off `!monthLoaded` instead of `isFetching`; calendar gets `isMonthLoading={!monthLoaded}`.
- `MenteeReservationDialog`: calendar gets `isMonthLoading`; show "讀取中…" while the month is loading and only fall back to "此日期暫無可預約時段" once `monthLoaded`.
- Profile page `ui.tsx`: same treatment — calendar gets `isMonthLoading`, the right-side slot list shows "讀取中…" until the current month resolves.

## Demo

http://localhost:3000/profile/{userId} — swipe the calendar fast past prefetched months.

## Screenshot

N/A

## Anything to Note?

The hook now exposes both `loaded` (sticky) and `monthLoaded` (per-month). Sticky `loaded` is kept on purpose so the profile page's full-panel `ScheduleSkeleton` and the first-slot auto-select fire only once, not on every month switch.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
