### PR TITLE
fix: revalidate profile ISR cache after account deletion (#247)

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -4,6 +4,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { getSession, signIn, signOut } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
+import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
 import { useToast } from '@/components/ui/use-toast';
 import { googleCallback } from '@/lib/actions/googleCallback';
@@ -117,6 +118,9 @@ export default function GoogleOAuthRedirectPage() {
 
     if (result.status === 'success') {
       trackEvent({ name: 'delete_account_succeeded', feature: 'auth' });
+      if (user?.user_id) {
+        await revalidateProfilePath(String(user.user_id));
+      }
       await signOut({ callbackUrl: '/' });
       return;
     }

--- a/src/hooks/auth/useDeleteAccountForm.ts
+++ b/src/hooks/auth/useDeleteAccountForm.ts
@@ -5,6 +5,7 @@ import { useState } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
+import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
 import { useToast } from '@/components/ui/use-toast';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
@@ -51,6 +52,9 @@ export default function useDeleteAccountForm(): UseDeleteAccountFormReturn {
 
       if (result.status === 'success') {
         trackEvent({ name: 'delete_account_succeeded', feature: 'auth' });
+        if (session?.user?.id) {
+          await revalidateProfilePath(String(session.user.id));
+        }
         await signOut({ callbackUrl: '/' });
         return;
       }


### PR DESCRIPTION
## What Does This PR Do?

- 在 XC 密碼刪除帳號流程成功分支、`signOut` 之前，呼叫 `revalidateProfilePath(session.user.id)`
- 在 Google 重新驗證刪除帳號流程成功分支、`signOut` 之前，呼叫 `revalidateProfilePath(user.user_id)`
- 復用既有 server action `src/app/profile/[pageUserId]/actions.ts:revalidateProfilePath`，無需新增 API
- 修正前：刪除帳號後其他訪客在 ISR 60s 視窗內仍看得到舊 profile，且 BFF 回 404 時 regen 失敗會卡住舊頁直到重新部署

## Demo

http://localhost:3000/profile/{your-user-id}

## Screenshot

N/A

## Anything to Note?

- Google flow 的使用者 ID 欄位是 `user_id`（snake_case），跟 XC flow 用的 `session.user.id`（camelCase）不對稱，沿用各自既有型別
- 兩處皆有 `if (...)` 守衛，session/user 缺欄位時 skip revalidate，不阻斷 `signOut`
- 次要的「BFF transient error 不污染 ISR」強化未納入本 PR，留給後續 ticket

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
