### PR TITLE
feat(mentor-schedule): per-month draft buffer for cross-month edits (#246)

### DIFF
--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -13,8 +13,12 @@ import {
   expandRrule,
   formatTimeslot,
   hasOverlapAt,
+  MonthKey,
+  monthKeyFromDateStr,
+  monthKeyFromYearMonth,
   nextTempId,
   ParsedMentorTimeslot,
+  parseMonthKey,
   RawMentorTimeslot,
 } from '@/lib/profile/scheduleHelpers';
 import { TimeSlotDTO } from '@/services/mentor-schedule/schedule';
@@ -22,8 +26,10 @@ import { clearAllScheduleCache } from '@/services/mentor-schedule/scheduleCache'
 import {
   loadMonthScheduleCached,
   loadMonthScheduleFresh,
+  MonthSyncRequest,
   prefetchMonthSchedule,
-  syncMonthSchedule,
+  ScheduleMonthRef,
+  syncMonths,
   SyncResult,
 } from '@/services/mentor-schedule/sync';
 
@@ -81,27 +87,55 @@ export type UseMentorScheduleReturn = {
 export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const { backend } = opts;
 
-  const [saved, setSaved] = useState<RawMentorTimeslot[]>([]);
-  const [draft, setDraft] = useState<RawMentorTimeslot[]>([]);
+  // Per-month buffers. Editing a slot only mutates that slot's month entry;
+  // unloaded months stay absent from these maps until the user navigates to
+  // them. Slot ids issued by the backend are globally unique so the same id
+  // never appears in two month buffers.
+  const [savedByMonth, setSavedByMonth] = useState<
+    Map<MonthKey, RawMentorTimeslot[]>
+  >(() => new Map());
+  const [draftByMonth, setDraftByMonth] = useState<
+    Map<MonthKey, RawMentorTimeslot[]>
+  >(() => new Map());
+  const [pendingDeleteByMonth, setPendingDeleteByMonth] = useState<
+    Map<MonthKey, number[]>
+  >(() => new Map());
+  const [dirtyMonths, setDirtyMonths] = useState<Set<MonthKey>>(
+    () => new Set()
+  );
+
   const [loaded, setLoaded] = useState(false);
   const [monthLoaded, setMonthLoaded] = useState(false);
   const [isFetching, setIsFetching] = useState(false);
   const [selectedDate, setSelectedDate] = useState<string | null>(
     dayjs().format('YYYY-MM-DD')
   );
-  const [pendingDeleteIds, setPendingDeleteIds] = useState<number[]>([]);
   const [meetingDurationMinutes, setMeetingDurationMinutes] =
     useState<number>(30);
 
-  const persistedIdSet = useMemo(
-    () => new Set(saved.filter((s) => s.id > 0).map((s) => s.id)),
-    [saved]
-  );
+  const currentMonthKey = monthKeyFromYearMonth(backend.year, backend.month);
+
+  // Mirror dirtyMonths into a ref so the load effect's per-month dirty guard
+  // sees the latest value without re-subscribing.
+  const dirtyMonthsRef = useRef<Set<MonthKey>>(dirtyMonths);
+  useEffect(() => {
+    dirtyMonthsRef.current = dirtyMonths;
+  }, [dirtyMonths]);
+
+  // Union of persisted ids across every loaded month. Slot ids are globally
+  // unique, so checking membership across months is safe and lets toServiceSlot
+  // emit the `id` field for any persisted slot regardless of which month
+  // confirmChanges is currently building a payload for.
+  const persistedIdSet = useMemo(() => {
+    const s = new Set<number>();
+    savedByMonth.forEach((raws) => {
+      for (const r of raws) if (r.id > 0) s.add(r.id);
+    });
+    return s;
+  }, [savedByMonth]);
 
   const toServiceSlot = useCallback(
     (r: RawMentorTimeslot): TimeSlotDTO => {
-      // user_id and timezone are normalized in saveMentorSchedule (path param +
-      // hardcoded UTC), so the values supplied here are placeholders.
       const slot: TimeSlotDTO = {
         user_id: 0,
         dt_type: 'ALLOW',
@@ -117,6 +151,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     [persistedIdSet]
   );
 
+  // Drop everything when the backend user changes — buffers belong to a
+  // specific user.
   const prevUserIdRef = useRef<string | null>(null);
   useEffect(() => {
     if (
@@ -124,22 +160,42 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       prevUserIdRef.current !== backend.userId
     ) {
       clearAllScheduleCache();
+      setSavedByMonth(new Map());
+      setDraftByMonth(new Map());
+      setPendingDeleteByMonth(new Map());
+      setDirtyMonths(new Set());
+      setLoaded(false);
     }
     prevUserIdRef.current = backend.userId;
   }, [backend.userId]);
 
-  const dirtyRef = useRef(false);
-
+  // Load the currently-viewed month into the buffer lazily. Months that are
+  // already buffered (clean OR dirty) are not re-applied: the per-month dirty
+  // guard inside `apply` protects unsaved edits even if a stale revalidate
+  // resolves later. Background revalidate still updates clean months silently.
   useEffect(() => {
     if (!backend.userId || !backend.year || !backend.month) return;
     let ignore = false;
 
+    const monthKey = currentMonthKey;
+    const ref: ScheduleMonthRef = {
+      userId: backend.userId,
+      year: backend.year,
+      month: backend.month,
+    };
+
     const apply = (raws: RawMentorTimeslot[]) => {
-      setSaved(raws);
-      setDraft(raws);
-      setLoaded(true);
-      setMonthLoaded(true);
-      setPendingDeleteIds([]);
+      if (dirtyMonthsRef.current.has(monthKey)) return;
+      setSavedByMonth((prev) => {
+        const next = new Map(prev);
+        next.set(monthKey, raws);
+        return next;
+      });
+      setDraftByMonth((prev) => {
+        const next = new Map(prev);
+        next.set(monthKey, raws);
+        return next;
+      });
       const firstAllow = raws.find((r) => r.type === 'ALLOW');
       if (firstAllow) {
         const derived = Math.round(
@@ -149,17 +205,21 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       }
     };
 
-    const { cached, revalidate } = loadMonthScheduleCached(backend);
-    if (cached) {
+    const hasBuffer = draftByMonth.has(monthKey);
+    const { cached, revalidate } = loadMonthScheduleCached(ref);
+
+    if (hasBuffer) {
+      // Already buffered earlier in this session — no fetch needed.
+      setLoaded(true);
+      setMonthLoaded(true);
+    } else if (cached) {
       apply(cached);
-    } else if (!dirtyRef.current) {
-      // Cache miss: clear stale month data so the calendar doesn't show
-      // last month's allowed dots / time slots while the fetch is in flight.
-      // monthLoaded -> false so consumers can distinguish "fetching" from
-      // "settled empty"; sticky `loaded` is left untouched.
-      setSaved([]);
-      setDraft([]);
-      setPendingDeleteIds([]);
+      setLoaded(true);
+      setMonthLoaded(true);
+    } else {
+      // Cache miss + no buffer: skeleton until revalidate lands. monthLoaded
+      // -> false so consumers can distinguish "fetching" from "settled empty";
+      // sticky `loaded` is left untouched.
       setMonthLoaded(false);
       setIsFetching(true);
     }
@@ -167,15 +227,20 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     revalidate
       .then((raws) => {
         if (ignore) return;
-        // Don't clobber unsaved edits when fresh data arrives in the background.
-        if (dirtyRef.current) return;
-        if (cached && JSON.stringify(cached) === JSON.stringify(raws)) return;
+        if (dirtyMonthsRef.current.has(monthKey)) return;
+        if (cached && JSON.stringify(cached) === JSON.stringify(raws)) {
+          setLoaded(true);
+          setMonthLoaded(true);
+          return;
+        }
         apply(raws);
+        setLoaded(true);
+        setMonthLoaded(true);
       })
       .catch(() => {
         // Treat fetch failure as "settled" so the UI doesn't hang on a
         // skeleton; the user will see the empty state instead.
-        if (!ignore && !cached) {
+        if (!ignore && !cached && !hasBuffer) {
           setLoaded(true);
           setMonthLoaded(true);
         }
@@ -205,12 +270,20 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     return () => clearTimeout(handle);
   }, [loaded, backend.userId, backend.year, backend.month]);
 
+  // Flatten all per-month draft buffers so calendar derivations cover every
+  // month the user has touched, not just the currently-viewed month.
+  const allDraftRaws = useMemo(() => {
+    const out: RawMentorTimeslot[] = [];
+    draftByMonth.forEach((raws) => out.push(...raws));
+    return out;
+  }, [draftByMonth]);
+
   const parsedDraft = useMemo(
     () =>
-      draft
+      allDraftRaws
         .map(formatTimeslot)
         .sort((a, b) => a.start.getTime() - b.start.getTime()),
-    [draft]
+    [allDraftRaws]
   );
 
   const draftForSelectedDate = useMemo(
@@ -223,7 +296,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   const allowedDates = useMemo(() => {
     const dates = new Set<string>();
-    for (const slot of draft) {
+    for (const slot of allDraftRaws) {
       if (slot.type !== 'ALLOW') continue;
       const occurrences = expandRrule(slot.dtstart, slot.rrule);
       for (const occ of occurrences) {
@@ -232,16 +305,16 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       }
     }
     return Array.from(dates);
-  }, [draft]);
+  }, [allDraftRaws]);
 
   const generateBookingSlots = useCallback(
     (dateKey: string): BookingSlot[] => {
       const bookedStarts = new Set(
-        draft.filter((s) => s.type === 'BOOKED').map((s) => s.dtstart)
+        allDraftRaws.filter((s) => s.type === 'BOOKED').map((s) => s.dtstart)
       );
       const result: BookingSlot[] = [];
 
-      for (const slot of draft) {
+      for (const slot of allDraftRaws) {
         if (slot.type !== 'ALLOW') continue;
         const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
         if (slotDateKey !== dateKey) continue;
@@ -263,7 +336,52 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       result.sort((a, b) => a.start.getTime() - b.start.getTime());
       return result;
     },
-    [draft]
+    [allDraftRaws]
+  );
+
+  const updateMonthDraft = useCallback(
+    (
+      monthKey: MonthKey,
+      updater: (prev: RawMentorTimeslot[]) => RawMentorTimeslot[]
+    ): boolean => {
+      let changed = false;
+      setDraftByMonth((prev) => {
+        const current = prev.get(monthKey) ?? [];
+        const next = updater(current);
+        if (next === current) return prev;
+        changed = true;
+        const out = new Map(prev);
+        out.set(monthKey, next);
+        return out;
+      });
+      return changed;
+    },
+    []
+  );
+
+  const markDirty = useCallback((monthKey: MonthKey) => {
+    setDirtyMonths((prev) => {
+      if (prev.has(monthKey)) return prev;
+      const next = new Set(prev);
+      next.add(monthKey);
+      return next;
+    });
+  }, []);
+
+  // Slots are scoped to a specific month buffer; when the dialog calls a
+  // mutator with just an id we recover the owning month by scanning all
+  // loaded buffers (cheap — a mentor rarely buffers more than a few months
+  // per session).
+  const findMonthForSlotId = useCallback(
+    (id: number): MonthKey | null => {
+      let result: MonthKey | null = null;
+      draftByMonth.forEach((raws, key) => {
+        if (result !== null) return;
+        if (raws.some((r) => r.id === id)) result = key;
+      });
+      return result;
+    },
+    [draftByMonth]
   );
 
   const addSlotForSelectedDate: UseMentorScheduleReturn['addSlotForSelectedDate'] =
@@ -281,7 +399,9 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const slotDurationSeconds = meetingDurationMinutes * 60;
         const newDtend = newDtstart + slotDurationSeconds;
 
-        setDraft((prev) => {
+        const monthKey = monthKeyFromDateStr(selectedDate);
+
+        const didMutate = updateMonthDraft(monthKey, (prev) => {
           if (
             hasOverlapAt(
               prev,
@@ -311,75 +431,101 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             },
           ];
         });
+
+        if (didMutate) markDirty(monthKey);
       },
-      [selectedDate, meetingDurationMinutes]
+      [selectedDate, meetingDurationMinutes, updateMonthDraft, markDirty]
     );
 
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
-    useCallback((id, patch) => {
-      setDraft((prev) => {
-        const target = prev.find((r) => r.id === id);
-        if (!target) return prev;
+    useCallback(
+      (id, patch) => {
+        const monthKey = findMonthForSlotId(id);
+        if (!monthKey) return;
 
-        const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
-        const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
-        const startHM = patch.startTime ?? fmtHM(target.dtstart);
+        const didMutate = updateMonthDraft(monthKey, (prev) => {
+          const target = prev.find((r) => r.id === id);
+          if (!target) return prev;
 
-        const occs = expandRrule(target.dtstart, target.rrule);
-        const lastOcc = occs[occs.length - 1] ?? target.dtstart;
-        const endHM =
-          patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
+          const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
+          const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
+          const startHM = patch.startTime ?? fmtHM(target.dtstart);
 
-        const s = buildDateTime(baseDate, startHM);
-        const e = buildDateTime(baseDate, endHM);
-        if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return prev;
+          const occs = expandRrule(target.dtstart, target.rrule);
+          const lastOcc = occs[occs.length - 1] ?? target.dtstart;
+          const endHM =
+            patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
 
-        const newDtstart = Math.floor(s.valueOf() / 1000);
-        const blockDurationSeconds =
-          Math.floor(e.valueOf() / 1000) - newDtstart;
-        const slotDurationSeconds = target.dtend - target.dtstart;
-        const newDtend = newDtstart + slotDurationSeconds;
+          const s = buildDateTime(baseDate, startHM);
+          const e = buildDateTime(baseDate, endHM);
+          if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return prev;
 
-        if (
-          hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
-        ) {
-          return prev;
-        }
+          const newDtstart = Math.floor(s.valueOf() / 1000);
+          const blockDurationSeconds =
+            Math.floor(e.valueOf() / 1000) - newDtstart;
+          const slotDurationSeconds = target.dtend - target.dtstart;
+          const newDtend = newDtstart + slotDurationSeconds;
 
-        const newRrule =
-          blockDurationSeconds > slotDurationSeconds
-            ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-            : undefined;
+          if (
+            hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
+          ) {
+            return prev;
+          }
 
-        const newBlockEnd = newDtstart + blockDurationSeconds;
-        const cleanedExdate = target.exdate.filter(
-          (occ) => occ >= newDtstart && occ < newBlockEnd
-        );
+          const newRrule =
+            blockDurationSeconds > slotDurationSeconds
+              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
+              : undefined;
 
-        return prev.map((r) =>
-          r.id === id
-            ? {
-                ...r,
-                dtstart: newDtstart,
-                dtend: newDtend,
-                rrule: newRrule,
-                exdate: cleanedExdate,
-              }
-            : r
-        );
-      });
-    }, []);
+          const newBlockEnd = newDtstart + blockDurationSeconds;
+          const cleanedExdate = target.exdate.filter(
+            (occ) => occ >= newDtstart && occ < newBlockEnd
+          );
 
-  const deleteDraftSlot = useCallback((id: number) => {
-    setDraft((prev) => prev.filter((r) => r.id !== id));
-    if (id > 0) {
-      setPendingDeleteIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
-    }
-  }, []);
+          return prev.map((r) =>
+            r.id === id
+              ? {
+                  ...r,
+                  dtstart: newDtstart,
+                  dtend: newDtend,
+                  rrule: newRrule,
+                  exdate: cleanedExdate,
+                }
+              : r
+          );
+        });
+
+        if (didMutate) markDirty(monthKey);
+      },
+      [findMonthForSlotId, updateMonthDraft, markDirty]
+    );
+
+  const deleteDraftSlot = useCallback(
+    (id: number) => {
+      const monthKey = findMonthForSlotId(id);
+      if (!monthKey) return;
+
+      updateMonthDraft(monthKey, (prev) => prev.filter((r) => r.id !== id));
+      if (id > 0) {
+        setPendingDeleteByMonth((prev) => {
+          const current = prev.get(monthKey) ?? [];
+          if (current.includes(id)) return prev;
+          const next = new Map(prev);
+          next.set(monthKey, [...current, id]);
+          return next;
+        });
+      }
+      markDirty(monthKey);
+    },
+    [findMonthForSlotId, updateMonthDraft, markDirty]
+  );
 
   const toggleOccurrence = useCallback(
     (slotId: number, occurrenceDtstart: number) => {
-      setDraft((prev) =>
+      const monthKey = findMonthForSlotId(slotId);
+      if (!monthKey) return;
+
+      const didMutate = updateMonthDraft(monthKey, (prev) =>
         prev.map((r) => {
           if (r.id !== slotId || r.type !== 'ALLOW') return r;
           const isExcluded = r.exdate.includes(occurrenceDtstart);
@@ -391,68 +537,126 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           };
         })
       );
+      if (didMutate) markDirty(monthKey);
     },
-    []
+    [findMonthForSlotId, updateMonthDraft, markDirty]
   );
 
-  const dirty =
-    JSON.stringify(saved) !== JSON.stringify(draft) ||
-    pendingDeleteIds.length > 0;
-
-  useEffect(() => {
-    dirtyRef.current = dirty;
-  }, [dirty]);
-
   const confirmChanges = useCallback(async (): Promise<SyncResult> => {
-    if (!dirty || !backend.userId) return { ok: true };
+    if (dirtyMonths.size === 0 || !backend.userId) return { ok: true };
 
-    const rawUpsert = draft
-      .filter((r) => !pendingDeleteIds.includes(r.id) && r.type === 'ALLOW')
-      .map(toServiceSlot);
+    const requests: MonthSyncRequest[] = Array.from(dirtyMonths).map(
+      (monthKey) => {
+        const { year, month } = parseMonthKey(monthKey);
+        const draftRaws = draftByMonth.get(monthKey) ?? [];
+        const pendingDeletes = pendingDeleteByMonth.get(monthKey) ?? [];
 
-    // Dedupe by (dtstart, dtend); when two slots collide on the same key,
-    // keep the first and queue any persisted duplicate for deletion.
-    const seenKeys = new Map<string, number>();
-    const upsertPayload: TimeSlotDTO[] = [];
-    const extraDeleteIds: number[] = [];
-    for (const slot of rawUpsert) {
-      const key = `${slot.dtstart}_${slot.dtend}`;
-      if (!seenKeys.has(key)) {
-        seenKeys.set(key, upsertPayload.length);
-        upsertPayload.push(slot);
-      } else if (typeof slot.id === 'number' && slot.id > 0) {
-        extraDeleteIds.push(slot.id);
+        const rawUpsert = draftRaws
+          .filter((r) => !pendingDeletes.includes(r.id) && r.type === 'ALLOW')
+          .map(toServiceSlot);
+
+        // Dedupe by (dtstart, dtend) within this month; queue any persisted
+        // duplicate for deletion to avoid PUT conflicts. Mirrors the original
+        // single-month behaviour from issue #224.
+        const seenKeys = new Map<string, number>();
+        const upsertPayload: TimeSlotDTO[] = [];
+        const extraDeleteIds: number[] = [];
+        for (const slot of rawUpsert) {
+          const key = `${slot.dtstart}_${slot.dtend}`;
+          if (!seenKeys.has(key)) {
+            seenKeys.set(key, upsertPayload.length);
+            upsertPayload.push(slot);
+          } else if (typeof slot.id === 'number' && slot.id > 0) {
+            extraDeleteIds.push(slot.id);
+          }
+        }
+
+        return {
+          ref: { userId: backend.userId, year, month },
+          upsertPayload,
+          deleteIds: [...pendingDeletes, ...extraDeleteIds],
+        };
       }
-    }
+    );
 
-    const idsToDelete = [...pendingDeleteIds, ...extraDeleteIds];
+    const results = await syncMonths(requests);
 
-    const outcome = await syncMonthSchedule({
-      ref: backend,
-      upsertPayload,
-      deleteIds: idsToDelete,
+    // Update buffers for every month that succeeded; leave failed months in
+    // place so the user can retry without losing edits.
+    setSavedByMonth((prev) => {
+      const next = new Map(prev);
+      for (const r of results)
+        if (r.outcome.ok) next.set(r.monthKey, r.outcome.raws);
+      return next;
     });
-    // On failure, leave saved/draft alone so the user keeps their unsaved
-    // edits and can fix the conflict and retry.
-    if (!outcome.ok) {
-      return { ok: false, reason: outcome.reason, message: outcome.message };
+    setDraftByMonth((prev) => {
+      const next = new Map(prev);
+      for (const r of results)
+        if (r.outcome.ok) next.set(r.monthKey, r.outcome.raws);
+      return next;
+    });
+    setPendingDeleteByMonth((prev) => {
+      const next = new Map(prev);
+      for (const r of results) if (r.outcome.ok) next.delete(r.monthKey);
+      return next;
+    });
+    setDirtyMonths((prev) => {
+      const next = new Set(prev);
+      for (const r of results) if (r.outcome.ok) next.delete(r.monthKey);
+      return next;
+    });
+
+    const firstFail = results.find((r) => !r.outcome.ok);
+    if (firstFail && !firstFail.outcome.ok) {
+      return {
+        ok: false,
+        reason: firstFail.outcome.reason,
+        message: firstFail.outcome.message,
+      };
     }
-    setSaved(outcome.raws);
-    setDraft(outcome.raws);
-    setPendingDeleteIds([]);
     return { ok: true };
-  }, [draft, toServiceSlot, dirty, pendingDeleteIds, backend]);
+  }, [
+    dirtyMonths,
+    draftByMonth,
+    pendingDeleteByMonth,
+    toServiceSlot,
+    backend.userId,
+  ]);
 
   const resetChanges = useCallback(() => {
-    if (!backend.userId || !backend.year || !backend.month) return;
+    if (!backend.userId || dirtyMonths.size === 0) return;
+    const monthKeys = Array.from(dirtyMonths);
     (async () => {
-      const raws = await loadMonthScheduleFresh(backend);
-      setDraft(raws);
-      setSaved(raws);
-      setPendingDeleteIds([]);
+      const reloaded = await Promise.all(
+        monthKeys.map(async (mk) => {
+          const { year, month } = parseMonthKey(mk);
+          const raws = await loadMonthScheduleFresh({
+            userId: backend.userId,
+            year,
+            month,
+          });
+          return [mk, raws] as const;
+        })
+      );
+      setSavedByMonth((prev) => {
+        const next = new Map(prev);
+        for (const [mk, raws] of reloaded) next.set(mk, raws);
+        return next;
+      });
+      setDraftByMonth((prev) => {
+        const next = new Map(prev);
+        for (const [mk, raws] of reloaded) next.set(mk, raws);
+        return next;
+      });
+      setPendingDeleteByMonth((prev) => {
+        const next = new Map(prev);
+        for (const [mk] of reloaded) next.delete(mk);
+        return next;
+      });
+      setDirtyMonths(new Set());
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [backend.userId, backend.year, backend.month]);
+  }, [backend.userId, dirtyMonths]);
 
   return {
     loaded,

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -8,6 +8,26 @@ dayjs.extend(isSameOrBefore);
 
 export type DtType = 'ALLOW' | 'BOOKED' | 'PENDING';
 
+/** 'YYYY-MM' — used to bucket per-month draft state in useMentorSchedule. */
+export type MonthKey = string;
+
+export function monthKeyFromUnix(unix: number): MonthKey {
+  return dayjs(unix * 1000).format('YYYY-MM');
+}
+
+export function monthKeyFromDateStr(dateStr: string): MonthKey {
+  return dateStr.slice(0, 7);
+}
+
+export function monthKeyFromYearMonth(year: number, month: number): MonthKey {
+  return `${year}-${String(month).padStart(2, '0')}`;
+}
+
+export function parseMonthKey(key: MonthKey): { year: number; month: number } {
+  const [y, m] = key.split('-');
+  return { year: Number(y), month: Number(m) };
+}
+
 // id: negative values are temporary local ids for new slots (-1, -2, ...)
 // type: narrowed from SegmentVO.dt_type
 // exdate: nulls excluded from SegmentVO.exdate

--- a/src/services/mentor-schedule/sync.ts
+++ b/src/services/mentor-schedule/sync.ts
@@ -162,3 +162,34 @@ export async function syncMonthSchedule(params: {
     return { ok: false, reason, message };
   }
 }
+
+export interface MonthSyncRequest {
+  ref: ScheduleMonthRef;
+  upsertPayload: TimeSlotDTO[];
+  deleteIds: number[];
+}
+
+export interface MonthSyncResult {
+  /** 'YYYY-MM' for the corresponding request's ref. */
+  monthKey: string;
+  outcome: SyncOutcome;
+}
+
+/**
+ * Sequentially commit one or more months. Each month is independent —
+ * earlier success is NOT rolled back if a later month fails. Callers use the
+ * per-month outcomes to update saved/draft state and to surface a targeted
+ * error toast (e.g. "5 月時段衝突"). Sequential (not parallel) avoids cache
+ * write races and matches the single-month sync's PUT→DELETE ordering.
+ */
+export async function syncMonths(
+  requests: MonthSyncRequest[]
+): Promise<MonthSyncResult[]> {
+  const results: MonthSyncResult[] = [];
+  for (const req of requests) {
+    const monthKey = `${req.ref.year}-${String(req.ref.month).padStart(2, '0')}`;
+    const outcome = await syncMonthSchedule(req);
+    results.push({ monthKey, outcome });
+  }
+  return results;
+}


### PR DESCRIPTION
## What Does This PR Do?

- Refactor `useMentorSchedule` from single-month draft state to per-month buffers (`Map<MonthKey, RawMentorTimeslot[]>` for saved/draft/pendingDelete + `Set<MonthKey>` for dirty tracking) so a mentor can edit slots across multiple months and have every dirty month committed by a single Save.
- Add per-month dirty guard in the load effect's `apply()` — cache hit, cache miss and background revalidate paths all skip months whose buffer has unsaved edits, fixing the original data-loss path where a stale revalidate or a cache-warm month switch would clobber the draft.
- Add `syncMonths()` in the sync service — sequential commit of multiple months with per-month outcomes so a single conflicting month surfaces a targeted error while other months continue.
- Add `MonthKey` helpers in `scheduleHelpers.ts` (`monthKeyFromUnix` / `monthKeyFromDateStr` / `monthKeyFromYearMonth` / `parseMonthKey`).
- Flatten all per-month draft buffers for `parsedDraft` / `allowedDates` / `generateBookingSlots`, so mentee dialog and calendar dot highlighting work transparently across months without consumer changes.
- `resetChanges` now reloads every dirty month (not just the currently-viewed one) to match the user's mental model of "discard the whole edit session".

## Demo

http://localhost:3000/profile/<mentorId>

## Screenshot

N/A

## Anything to Note?

- Backwards compatible at the hook API surface — `MentorScheduleDialog` and `MenteeReservationDialog` consume the same `UseMentorScheduleReturn` shape.
- Fail behaviour: if month A succeeds and month B conflicts, A's buffer is updated (no longer dirty) while B stays dirty for retry; the toast surfaces the first failure's message.
- Manual verification still pending for: (1) edit A → switch to B → edit B → save (both persisted), (2) switch back to A buffer survives, (3) per-month conflict toast, (4) mentee cross-month `allowedDates`.

Closes Xchange-Taiwan/X-Talent-Tracker#246

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
