### PR TITLE
fix(avatar): keep header avatar fresh across submit round trip

### DIFF
--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -17,6 +17,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
+import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
 
 import { ShareProfileDialog } from './ShareProfileDialog';
 
@@ -40,8 +41,10 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
     'testing_mentor@xchange.com.tw',
   ].includes(user.email ?? '');
   const name = user.name ?? '';
-  // Avatar URL already carries its own `?v=` cache buster from upload time.
-  const avatarSrc = user.avatar ?? '';
+  // Read through useCurrentAvatar so a just-uploaded avatar shows up before
+  // NextAuth's session round-trip lands. URL already carries its own `?v=`
+  // cache buster from upload time.
+  const avatarSrc = useCurrentAvatar() ?? '';
   const jobTitle = user.jobTitle ?? '';
   const company = user.company ?? '';
   const personalLinks = user.personalLinks ?? [];

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -15,6 +15,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
 
 import { ShareProfileDialog } from './ShareProfileDialog';
 
@@ -39,10 +40,11 @@ export const UserDropdown = React.memo(function UserDropdown({
     'testing_mentor@xchange.com.tw',
   ].includes(user.email ?? '');
   const name = user.name ?? '';
-  // Avatar URLs already carry their own `?v=<upload-timestamp>` cache buster
-  // (set by updateAvatar at upload time), so render the URL as-is — header /
-  // dropdown / share dialog / profile pages all share one cache entry.
-  const avatarSrc = user.avatar ?? '';
+  // Read through useCurrentAvatar so a just-uploaded avatar shows up before
+  // NextAuth's session round-trip lands. Falls back to user.avatar once the
+  // session catches up. URLs carry their own `?v=<upload-timestamp>` cache
+  // buster from updateAvatar, so they're rendered as-is.
+  const avatarSrc = useCurrentAvatar() ?? '';
   const jobTitle = user.jobTitle ?? '';
   const company = user.company ?? '';
 

--- a/src/hooks/user/profile/useCurrentAvatar.ts
+++ b/src/hooks/user/profile/useCurrentAvatar.ts
@@ -1,0 +1,40 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+import { useEffect } from 'react';
+
+import {
+  clearAvatarOverride,
+  useAvatarOverride,
+} from '@/lib/avatar/avatarOverrideStore';
+
+/**
+ * Returns the avatar URL to render for the currently signed-in user.
+ *
+ * Reads from a client-side override (set synchronously on a successful
+ * profile submit) and falls back to the NextAuth session. Bridges the gap
+ * left by NextAuth v4's `update()` round-trip — without it the header
+ * shows the old avatar between submit and the session refetch landing.
+ */
+export function useCurrentAvatar(): string | null {
+  const { data: session } = useSession();
+  const override = useAvatarOverride();
+  const sessionUserId = session?.user?.id ?? null;
+  const sessionAvatar = session?.user?.avatar ?? null;
+
+  useEffect(() => {
+    if (!override) return;
+    if (override.userId !== sessionUserId) {
+      clearAvatarOverride();
+      return;
+    }
+    if (sessionAvatar === override.url) {
+      clearAvatarOverride();
+    }
+  }, [override, sessionUserId, sessionAvatar]);
+
+  if (override && override.userId === sessionUserId) {
+    return override.url;
+  }
+  return sessionAvatar;
+}

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -11,6 +11,7 @@ import {
   primeUserDataCache,
 } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
+import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
 import { captureFlowFailure } from '@/lib/monitoring';
 import {
   firstSyncedFetch,
@@ -253,14 +254,23 @@ export function useProfileSubmit({
         console.error('revalidateProfilePath failed:', e);
       });
 
-      // 4) optimistic session update — keep role/onboarding from current
+      // 4) optimistic avatar override — NextAuth's update() is async (POST
+      //    + GET round trip), so the header would otherwise show the old
+      //    avatar until the round trip lands. Setting the override here is
+      //    synchronous, so consumers reading useCurrentAvatar() see the new
+      //    URL on the very next render. The override clears itself once
+      //    session.user.avatar catches up.
+      if (values.avatarFile && avatar && sessionUser?.id) {
+        setAvatarOverride(String(sessionUser.id), avatar);
+      }
+
+      // 5) optimistic session update — keep role/onboarding from current
       //    session so we never flicker mentor → mentee while the backend
-      //    catches up. The reconcile in step 6 corrects them if the user
+      //    catches up. The reconcile in step 7 corrects them if the user
       //    actually transitioned during this submit.
       //    Fire-and-forget: navigation no longer waits for NextAuth's
-      //    /api/auth/session round trip. The optimistic data is already
-      //    in the call args, so the JWT update lands before the next
-      //    render.
+      //    /api/auth/session round trip. The avatar override above keeps
+      //    the header in sync until the JWT update lands.
       void updateSession({
         user: {
           id: sessionUser?.id,
@@ -276,7 +286,7 @@ export function useProfileSubmit({
         },
       });
 
-      // 5) navigate immediately — user no longer waits for backend sync.
+      // 6) navigate immediately — user no longer waits for backend sync.
       trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
       if (isMentorOnboarding) {
         router.push('/profile/card');
@@ -284,7 +294,7 @@ export function useProfileSubmit({
         router.push(`/profile/${pageUserId}`);
       }
 
-      // 6) background prime + reconcile — try the fast first-sync read; if
+      // 7) background prime + reconcile — try the fast first-sync read; if
       //    the backend has already caught up, prime the cache so subsequent
       //    reads on the next page are instant. Otherwise fall back to the
       //    longer pollUntilSynced. Either way, reconcile the session if the

--- a/src/lib/avatar/avatarOverrideStore.ts
+++ b/src/lib/avatar/avatarOverrideStore.ts
@@ -1,0 +1,46 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+interface AvatarOverride {
+  userId: string;
+  url: string;
+}
+
+let override: AvatarOverride | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  listeners.forEach((listener) => listener());
+}
+
+export function setAvatarOverride(userId: string, url: string): void {
+  if (override?.userId === userId && override.url === url) return;
+  override = { userId, url };
+  emit();
+}
+
+export function clearAvatarOverride(): void {
+  if (override === null) return;
+  override = null;
+  emit();
+}
+
+function getSnapshot(): AvatarOverride | null {
+  return override;
+}
+
+function getServerSnapshot(): null {
+  return null;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+export function useAvatarOverride(): AvatarOverride | null {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## What Does This PR Do?

- Adds an avatar override store (`src/lib/avatar/avatarOverrideStore.ts`) plus a `useCurrentAvatar` hook so just-uploaded avatars can be read synchronously without waiting for NextAuth's `update()` POST + GET round trip
- Sets the override at profile-submit time once the new S3 URL is resolved, so the header reflects the new image on the first render after `router.push` instead of after the session refetch lands
- Switches `UserDropdown` and `MobileUserMenu` to read through `useCurrentAvatar`; the override auto-clears once `session.user.avatar` catches up or the user changes
- Side-effect: the mentor-onboarding reconcile path that briefly overwrites `session.user.avatar` with the pre-submit value no longer flickers the header back to the old image

## Demo

http://localhost:3000/profile/[id]/edit

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
