### PR TITLE
fix(avatar): drop stale sessionUser spread in reconcile updateSession

### DIFF
--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -312,9 +312,14 @@ export function useProfileSubmit({
         ) {
           return;
         }
+        // Send only the fields we're correcting. Spreading `sessionUser`
+        // here would overwrite step-4's just-updated avatar with the
+        // pre-submit URL captured at the top of onSubmit, snapping the
+        // header / profile page back to the old avatar a few seconds
+        // after navigation. NextAuth's JWT callback shallow-merges, so
+        // omitted fields retain their current token value.
         void updateSession({
           user: {
-            ...sessionUser,
             isMentor: latestIsMentor,
             onBoarding: latestOnBoarding,
           },


### PR DESCRIPTION
## What Does This PR Do?

- Background `reconcileSession` in `useProfileSubmit` was spreading the `sessionUser` snapshot captured at the top of `onSubmit` (where `avatar` is still the pre-submit URL) into `updateSession`. NextAuth's JWT callback shallow-merges `session.user` into the token, so this overwrote step-4's just-updated avatar a few seconds later — header and profile page snapped back to the old avatar until re-login. Fix: only send the two fields we're correcting (`isMentor`, `onBoarding`); omitted fields retain their current token value
- Trigger window is narrow: reconcile only fires when `optimisticIsMentor !== latestIsMentor` or `optimisticOnBoarding !== latestOnBoarding`, so this primarily hit mentor onboarding submits and "just became a mentor" submits. Plain mentee profile edits were unaffected
- Existing `useProfileSubmit.test.ts` reconcile tests assert only the two patched fields, so they still pass; no test churn needed

## Demo

http://localhost:3000/profile/[id]/edit

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
