### PR TITLE
fix(mentor-pool): show about field on mentor card

### DIFF
--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -49,7 +49,7 @@ const MentorCardListBase = ({
             name={mentor.name}
             job_title={mentor.job_title}
             company={mentor.company}
-            personalStatment={mentor.personal_statement}
+            about={mentor.about}
             whatIOffers={mentor.what_i_offers}
           />
         ))}

--- a/src/components/mentor-pool/mentor-card/Information.tsx
+++ b/src/components/mentor-pool/mentor-card/Information.tsx
@@ -6,7 +6,7 @@ interface InformationProps {
   name: string;
   job_title: string;
   company: string;
-  personalStatment: string;
+  about: string;
   whatIOffers: string[];
 }
 
@@ -17,7 +17,7 @@ export const Information = ({
   name,
   job_title,
   company,
-  personalStatment,
+  about,
   whatIOffers = [],
 }: InformationProps) => {
   const containerRef = useRef<HTMLDivElement>(null);
@@ -77,7 +77,7 @@ export const Information = ({
         )}
       </div>
       <p className="line-clamp-2 text-sm font-normal tracking-wide text-[#9DA8B9]">
-        {personalStatment}
+        {about}
       </p>
       <div className="relative">
         <div

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -12,7 +12,7 @@ export interface MentorCardProps {
   name: string;
   job_title: string;
   company: string;
-  personalStatment: string;
+  about: string;
   whatIOffers: string[];
 }
 
@@ -25,7 +25,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
       name,
       job_title,
       company,
-      personalStatment,
+      about,
       whatIOffers,
     }: MentorCardProps,
     ref
@@ -46,7 +46,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
             name={name}
             job_title={job_title}
             company={company}
-            personalStatment={personalStatment}
+            about={about}
             whatIOffers={whatIOffers}
           />
         </div>


### PR DESCRIPTION
## What Does This PR Do?

- Mentor card now reads `mentor.about` (the 關於我 field mentors fill in) instead of `mentor.personal_statement`, which is a separate API field that is typically empty.
- Renames the `personalStatment` prop on `MentorCard` / `Information` to `about` (also fixes the original typo) so the prop name matches the data it carries.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A
