### PR TITLE
feat(avatar-crop): add desktop card preview to crop modal

### DIFF
--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Slider } from '@mui/material';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import AvatarEditor from 'react-avatar-editor';
 
 import { Button } from '@/components/ui/button';
@@ -13,6 +13,12 @@ interface AvatarCropModalProps {
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 3;
+
+// Mentor-pool desktop card avatar area is 413×292 (see AvatarWithBadge.tsx).
+// Preview keeps that aspect so users see exactly which slice of the square
+// crop will end up on the card before they save.
+const PREVIEW_WIDTH = 240;
+const PREVIEW_HEIGHT = Math.round((PREVIEW_WIDTH * 292) / 413);
 
 const clampScale = (value: number): number =>
   Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
@@ -30,9 +36,39 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
 }) => {
   const [zoomScale, setZoomScale] = useState(1);
   const editorRef = useRef<AvatarEditor | null>(null);
+  const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const pinchStartRef = useRef<{ distance: number; scale: number } | null>(
     null
   );
+
+  // Mirrors object-cover: scales the square crop to cover the wider preview
+  // box, then centers it horizontally and vertically — same math the browser
+  // applies to the mentor-pool card.
+  const renderPreview = useCallback(() => {
+    const editor = editorRef.current;
+    const preview = previewCanvasRef.current;
+    if (!editor || !preview) return;
+
+    const cropped = editor.getImageScaledToCanvas();
+    const ctx = preview.getContext('2d');
+    if (!ctx) return;
+
+    ctx.clearRect(0, 0, preview.width, preview.height);
+
+    const sw = cropped.width;
+    const sh = cropped.height;
+    const dw = preview.width;
+    const dh = preview.height;
+    const scale = Math.max(dw / sw, dh / sh);
+    const renderW = sw * scale;
+    const renderH = sh * scale;
+    const offsetX = (dw - renderW) / 2;
+    const offsetY = (dh - renderH) / 2;
+
+    ctx.imageSmoothingEnabled = true;
+    ctx.imageSmoothingQuality = 'high';
+    ctx.drawImage(cropped, offsetX, offsetY, renderW, renderH);
+  }, []);
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>): void => {
     if (e.touches.length === 2) {
@@ -59,6 +95,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
   // Responsive editor size: constrained by both viewport width and height.
   // Width overhead: p-6 padding (24×2) + safety = 56px.
   // Height overhead: p-6 padding (48px) + slider (~48px) + button (~56px) + browser chrome = 200px.
+  // Plus the desktop-card preview block: label (~18px) + gap (~12px) + canvas.
   // Capped at 512px on larger screens, minimum 160px.
   const [editorSize, setEditorSize] = useState(512);
   useEffect(() => {
@@ -66,7 +103,10 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
       // Overhead breakdown:
       //   p-4 backdrop (16×2) + p-6 card (24×2) + AvatarEditor border (50×2) + safety = 196px
       const byWidth = Math.max(160, window.innerWidth - 196);
-      const byHeight = Math.max(160, window.innerHeight - 200);
+      const byHeight = Math.max(
+        160,
+        window.innerHeight - 200 - PREVIEW_HEIGHT - 30
+      );
       setEditorSize(Math.min(512, byWidth, byHeight));
     };
     calculate();
@@ -132,6 +172,8 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
                 borderRadius={300}
                 scale={zoomScale}
                 style={{ touchAction: 'none' }}
+                onImageReady={renderPreview}
+                onImageChange={renderPreview}
               />
             </div>
           )}
@@ -143,6 +185,15 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
             onChange={(_, newScale) => setZoomScale(newScale as number)}
             className="mt-4"
           />
+          <div className="mt-3 flex flex-col items-center gap-1.5">
+            <span className="text-xs text-[#9DA8B9]">桌機卡片顯示預覽</span>
+            <canvas
+              ref={previewCanvasRef}
+              width={PREVIEW_WIDTH}
+              height={PREVIEW_HEIGHT}
+              className="bg-white rounded-lg border border-[#E6E8EA]"
+            />
+          </div>
           <div className="mt-4 flex justify-center gap-3">
             <Button
               variant="outline"


### PR DESCRIPTION
## What Does This PR Do?

- Adds a 240×170 (mentor-pool desktop card aspect 413:292) live preview canvas under the zoom slider in the avatar crop modal.
- Mirrors `object-cover` math against `getImageScaledToCanvas()` so the preview reflects exactly which slice of the square crop will land on the desktop mentor-pool card.
- Wires `onImageReady` / `onImageChange` so the preview updates in real time while the user drags or zooms.
- Reserves preview height in the responsive `editorSize` calculation to keep the cropper from being pushed off small viewports.

Fixes the perceived "off-center" avatar bug on mentor-pool desktop: users previously cropped against a circular mask but the desktop card crops the square top/bottom (60.5px each side), so faces ended up shifted up. The preview makes that crop visible during cropping.

## Demo

http://localhost:3000/profile/<id>/edit

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
