### PR TITLE
fix(mentor-schedule): hide today's already-started slots in editor and booking

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -120,10 +120,18 @@ export default function MentorScheduleDialog({
     }
   }, [open]);
 
-  // Only ALLOW slots are editable; BOOKED/PENDING are read-only
-  const editableSlotsForDate = draftForSelectedDate.filter(
-    (s) => s.type === 'ALLOW'
-  );
+  // Only ALLOW slots are editable; BOOKED/PENDING are read-only.
+  // For today, also drop blocks whose every occurrence has already started —
+  // past slots can't be booked or meaningfully edited, so they shouldn't clutter
+  // the editor (matches the calendar's disablePastDates behaviour at minute granularity).
+  const nowSec = Math.floor(Date.now() / 1000);
+  const editableSlotsForDate = draftForSelectedDate.filter((s) => {
+    if (s.type !== 'ALLOW') return false;
+    const occurrences = s.rrule
+      ? expandRrule(Math.floor(s.start.getTime() / 1000), s.rrule)
+      : [Math.floor(s.start.getTime() / 1000)];
+    return occurrences.some((occ) => occ > nowSec);
+  });
 
   // Collect booked dtstart values for the selected date (for locking sub-slots)
   const bookedStartsForDate = new Set(
@@ -422,11 +430,15 @@ export default function MentorScheduleDialog({
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
     if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
 
-    const occurrences = expandRrule(
+    const allOccurrences = expandRrule(
       Math.floor(parsed.start.getTime() / 1000),
       parsed.rrule
     );
-    if (occurrences.length <= 1) return null;
+    if (allOccurrences.length <= 1) return null;
+
+    // Hide sub-slots that have already started today; the parent block filter
+    // guarantees at least one future occurrence remains.
+    const occurrences = allOccurrences.filter((occ) => occ > nowSec);
 
     const slotDurSec = parsed.slotDurationSeconds;
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -312,6 +312,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       const bookedStarts = new Set(
         allDraftRaws.filter((s) => s.type === 'BOOKED').map((s) => s.dtstart)
       );
+      const nowSec = Math.floor(Date.now() / 1000);
       const result: BookingSlot[] = [];
 
       for (const slot of allDraftRaws) {
@@ -324,6 +325,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         for (const occ of occurrences) {
           if (slot.exdate.includes(occ)) continue;
+          if (occ <= nowSec) continue;
           result.push({
             start: new Date(occ * 1000),
             end: new Date((occ + slotDuration) * 1000),


### PR DESCRIPTION
## What Does This PR Do?

- In MentorScheduleDialog, drop ALLOW blocks whose every rrule occurrence has already started (and filter past sub-slot chips inside partially-past blocks) so the editor stops showing slots that can no longer be booked or edited.
- In useMentorSchedule.generateBookingSlots, skip occurrences whose start is <= now so the mentee booking dialog only lists slots a mentee can actually reserve.
- Aligns slot visibility with the calendar's existing disablePastDates / disableEmptyDates behaviour at minute granularity instead of just day granularity.

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
