### PR TITLE
fix(avatar-crop): sharpen desktop card preview on retina displays

### DIFF
--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -43,22 +43,32 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
 
   // Mirrors object-cover: scales the square crop to cover the wider preview
   // box, then centers it horizontally and vertically — same math the browser
-  // applies to the mentor-pool card.
+  // applies to the mentor-pool card. Uses getImage() (original resolution) +
+  // DPR-aware backing store so the preview stays sharp on retina displays.
   const renderPreview = useCallback(() => {
     const editor = editorRef.current;
     const preview = previewCanvasRef.current;
     if (!editor || !preview) return;
 
-    const cropped = editor.getImageScaledToCanvas();
+    const dpr = window.devicePixelRatio || 1;
+    const targetWidth = PREVIEW_WIDTH * dpr;
+    const targetHeight = PREVIEW_HEIGHT * dpr;
+    if (preview.width !== targetWidth || preview.height !== targetHeight) {
+      preview.width = targetWidth;
+      preview.height = targetHeight;
+    }
+
+    const cropped = editor.getImage();
     const ctx = preview.getContext('2d');
     if (!ctx) return;
 
-    ctx.clearRect(0, 0, preview.width, preview.height);
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, PREVIEW_WIDTH, PREVIEW_HEIGHT);
 
     const sw = cropped.width;
     const sh = cropped.height;
-    const dw = preview.width;
-    const dh = preview.height;
+    const dw = PREVIEW_WIDTH;
+    const dh = PREVIEW_HEIGHT;
     const scale = Math.max(dw / sw, dh / sh);
     const renderW = sw * scale;
     const renderH = sh * scale;
@@ -191,6 +201,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
               ref={previewCanvasRef}
               width={PREVIEW_WIDTH}
               height={PREVIEW_HEIGHT}
+              style={{ width: PREVIEW_WIDTH, height: PREVIEW_HEIGHT }}
               className="bg-white rounded-lg border border-[#E6E8EA]"
             />
           </div>


### PR DESCRIPTION
## What Does This PR Do?

- Make the desktop-card preview canvas DPR-aware so the backing store matches device pixels (no more browser upscaling).
- Switch the preview source from `getImageScaledToCanvas()` (editor display size, ≤512px) to `getImage()` (original resolution) so we downsample instead of near-1:1 sampling.
- Lock the canvas CSS size with inline `style` so the larger backing store doesn't visually expand the preview.

## Demo

http://localhost:3000/profile (open avatar editor → upload an image → check the 桌機卡片顯示預覽 thumbnail)

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
