### PR TITLE
feat(avatar-crop): replace desktop preview with in-editor card band

### DIFF
--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -161,6 +161,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
                     right: 0,
                     height: (editorSize * (1 - CARD_ASPECT)) / 2,
                     background: 'rgba(0, 0, 0, 0.45)',
+                    pointerEvents: 'none',
                   }}
                 />
                 <div
@@ -171,6 +172,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
                     right: 0,
                     height: (editorSize * (1 - CARD_ASPECT)) / 2,
                     background: 'rgba(0, 0, 0, 0.45)',
+                    pointerEvents: 'none',
                   }}
                 />
                 <div
@@ -181,6 +183,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
                     left: 0,
                     right: 0,
                     boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.9)',
+                    pointerEvents: 'none',
                   }}
                 />
               </div>

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -1,5 +1,5 @@
 import { Modal, Slider } from '@mui/material';
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import AvatarEditor from 'react-avatar-editor';
 
 import { Button } from '@/components/ui/button';
@@ -13,12 +13,14 @@ interface AvatarCropModalProps {
 
 const MIN_SCALE = 1;
 const MAX_SCALE = 3;
+const EDITOR_BORDER = 50;
 
 // Mentor-pool desktop card avatar area is 413×292 (see AvatarWithBadge.tsx).
-// Preview keeps that aspect so users see exactly which slice of the square
-// crop will end up on the card before they save.
-const PREVIEW_WIDTH = 240;
-const PREVIEW_HEIGHT = Math.round((PREVIEW_WIDTH * 292) / 413);
+// We still save a full square (so circular/square avatar consumers have
+// content), but visually highlight the desktop card's visible band inside
+// the editor — anything outside that band only shows in the non-card
+// displays.
+const CARD_ASPECT = 292 / 413;
 
 const clampScale = (value: number): number =>
   Math.min(MAX_SCALE, Math.max(MIN_SCALE, value));
@@ -36,39 +38,9 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
 }) => {
   const [zoomScale, setZoomScale] = useState(1);
   const editorRef = useRef<AvatarEditor | null>(null);
-  const previewCanvasRef = useRef<HTMLCanvasElement | null>(null);
   const pinchStartRef = useRef<{ distance: number; scale: number } | null>(
     null
   );
-
-  // Mirrors object-cover: scales the square crop to cover the wider preview
-  // box, then centers it horizontally and vertically — same math the browser
-  // applies to the mentor-pool card.
-  const renderPreview = useCallback(() => {
-    const editor = editorRef.current;
-    const preview = previewCanvasRef.current;
-    if (!editor || !preview) return;
-
-    const cropped = editor.getImageScaledToCanvas();
-    const ctx = preview.getContext('2d');
-    if (!ctx) return;
-
-    ctx.clearRect(0, 0, preview.width, preview.height);
-
-    const sw = cropped.width;
-    const sh = cropped.height;
-    const dw = preview.width;
-    const dh = preview.height;
-    const scale = Math.max(dw / sw, dh / sh);
-    const renderW = sw * scale;
-    const renderH = sh * scale;
-    const offsetX = (dw - renderW) / 2;
-    const offsetY = (dh - renderH) / 2;
-
-    ctx.imageSmoothingEnabled = true;
-    ctx.imageSmoothingQuality = 'high';
-    ctx.drawImage(cropped, offsetX, offsetY, renderW, renderH);
-  }, []);
 
   const handleTouchStart = (e: React.TouchEvent<HTMLDivElement>): void => {
     if (e.touches.length === 2) {
@@ -93,9 +65,6 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
   };
 
   // Responsive editor size: constrained by both viewport width and height.
-  // Width overhead: p-6 padding (24×2) + safety = 56px.
-  // Height overhead: p-6 padding (48px) + slider (~48px) + button (~56px) + browser chrome = 200px.
-  // Plus the desktop-card preview block: label (~18px) + gap (~12px) + canvas.
   // Capped at 512px on larger screens, minimum 160px.
   const [editorSize, setEditorSize] = useState(512);
   useEffect(() => {
@@ -103,10 +72,8 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
       // Overhead breakdown:
       //   p-4 backdrop (16×2) + p-6 card (24×2) + AvatarEditor border (50×2) + safety = 196px
       const byWidth = Math.max(160, window.innerWidth - 196);
-      const byHeight = Math.max(
-        160,
-        window.innerHeight - 200 - PREVIEW_HEIGHT - 30
-      );
+      // p-6 padding (48px) + slider (~48px) + button (~56px) + browser chrome = 200px
+      const byHeight = Math.max(160, window.innerHeight - 200);
       setEditorSize(Math.min(512, byWidth, byHeight));
     };
     calculate();
@@ -161,20 +128,62 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
               onTouchMove={handleTouchMove}
               onTouchEnd={handleTouchEnd}
               onTouchCancel={handleTouchEnd}
-              style={{ touchAction: 'none' }}
+              style={{ position: 'relative', touchAction: 'none' }}
             >
               <AvatarEditor
                 ref={editorRef}
                 image={file}
                 width={editorSize}
                 height={editorSize}
-                border={50}
-                borderRadius={300}
+                border={EDITOR_BORDER}
                 scale={zoomScale}
                 style={{ touchAction: 'none' }}
-                onImageReady={renderPreview}
-                onImageChange={renderPreview}
               />
+              {/* Desktop-card visible band overlay. The dim strips show the
+                  area that gets cropped away on the desktop mentor card
+                  (other avatar surfaces still consume the full square). */}
+              <div
+                aria-hidden
+                style={{
+                  position: 'absolute',
+                  top: EDITOR_BORDER,
+                  left: EDITOR_BORDER,
+                  width: editorSize,
+                  height: editorSize,
+                  pointerEvents: 'none',
+                }}
+              >
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    right: 0,
+                    height: (editorSize * (1 - CARD_ASPECT)) / 2,
+                    background: 'rgba(0, 0, 0, 0.45)',
+                  }}
+                />
+                <div
+                  style={{
+                    position: 'absolute',
+                    bottom: 0,
+                    left: 0,
+                    right: 0,
+                    height: (editorSize * (1 - CARD_ASPECT)) / 2,
+                    background: 'rgba(0, 0, 0, 0.45)',
+                  }}
+                />
+                <div
+                  style={{
+                    position: 'absolute',
+                    top: (editorSize * (1 - CARD_ASPECT)) / 2,
+                    bottom: (editorSize * (1 - CARD_ASPECT)) / 2,
+                    left: 0,
+                    right: 0,
+                    boxShadow: '0 0 0 1px rgba(255, 255, 255, 0.9)',
+                  }}
+                />
+              </div>
             </div>
           )}
           <Slider
@@ -185,15 +194,6 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
             onChange={(_, newScale) => setZoomScale(newScale as number)}
             className="mt-4"
           />
-          <div className="mt-3 flex flex-col items-center gap-1.5">
-            <span className="text-xs text-[#9DA8B9]">桌機卡片顯示預覽</span>
-            <canvas
-              ref={previewCanvasRef}
-              width={PREVIEW_WIDTH}
-              height={PREVIEW_HEIGHT}
-              className="bg-white rounded-lg border border-[#E6E8EA]"
-            />
-          </div>
           <div className="mt-4 flex justify-center gap-3">
             <Button
               variant="outline"


### PR DESCRIPTION
## What Does This PR Do?

- Drop the circular crop indicator (`borderRadius`) and the separate desktop-card preview canvas underneath the editor.
- Overlay a horizontal band inside the editor representing the desktop mentor-card's 413×292 visible area: dim strips above/below mark the regions that only show on circular/square avatar surfaces, and a thin white outline marks the card crop boundary.
- Saved file stays at 1024×1024 PNG (square) so circular and rectangular avatar consumers both still work.
- Recalc `editorSize` budget without the preview block (~199px reclaimed) → editor can be larger on small screens.

## Demo

http://localhost:3000/profile (open avatar editor → upload an image → confirm the dimmed strips + white outline indicate the desktop card visible band)

## Screenshot

N/A

## Anything to Note?

Supersedes #578. The earlier DPR-aware preview fix is no longer needed because the preview canvas is gone — the user now sees the card crop directly inside the editor.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
