### PR TITLE
chore(types): regenerate api.ts from BFF OpenAPI spec

### DIFF
--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1246,12 +1246,12 @@ export interface components {
       url: string | null;
       /**
        * Create Time
-       * @default 2026-04-29T13:59:26.811995Z
+       * @default 2026-04-30T14:46:35.498506Z
        */
       create_time: string | null;
       /**
        * Update Time
-       * @default 2026-04-29T13:59:26.812011Z
+       * @default 2026-04-30T14:46:35.498521Z
        */
       update_time: string | null;
       /** Create User Id */
@@ -1384,8 +1384,6 @@ export interface components {
        * @default
        */
       avatar: string | null;
-      /** Avatar Updated At */
-      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1450,8 +1448,6 @@ export interface components {
        * @default
        */
       avatar: string | null;
-      /** Avatar Updated At */
-      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1666,8 +1662,6 @@ export interface components {
        * @default
        */
       avatar: string | null;
-      /** Avatar Updated At */
-      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1724,8 +1718,6 @@ export interface components {
        * @default
        */
       avatar: string | null;
-      /** Avatar Updated At */
-      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default
@@ -1992,8 +1984,6 @@ export interface components {
        * @default
        */
       avatar: string | null;
-      /** Avatar Updated At */
-      avatar_updated_at?: number | null;
       /**
        * Job Title
        * @default


### PR DESCRIPTION
## Summary
- Regenerated `src/types/api.ts` via `pnpm generate:types` against the dev BFF OpenAPI spec
- Picks up upstream BFF schema change: `avatar_updated_at` is no longer part of profile-related response shapes; existing call sites in `src/auth.config.ts` already null-coalesce so behavior is unchanged
- Default-timestamp churn for `create_time` / `update_time` is just OpenAPI example metadata — not a real schema change

## Test plan
- [x] `pnpm type-check`
- [x] `pnpm build`
- [x] `pnpm test` (146/146)
- [ ] Manual smoke: signin still hydrates `avatarUpdatedAt` correctly (graceful undefined when BFF omits it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)