### PR TITLE
feat(#229): cut WHAT_I_OFFER write/read to v2 user-tags endpoint (Frontend)

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -7,6 +7,7 @@ import {
   ProfileFormValues,
 } from '@/components/profile/edit/profileSchema';
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
+import { useUserTags } from '@/hooks/userTags/useUserTags';
 import {
   parseEducations,
   parseLinks,
@@ -37,12 +38,24 @@ export function useEditProfileData({
   // (redirected by useProfileAuth) never see the data populated.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
+  // #229: WHAT_I_OFFER lives in user_tags(kind=what_i_offer, intent=OFFER)
+  // now. Fetch alongside the profile dto; when the response is empty we
+  // fall back to parseWhatIOffer so users with legacy mentor_experiences
+  // data still see their values until they re-save.
+  const { tags: whatIOfferTags, isLoading: whatIOfferTagsLoading } =
+    useUserTags({
+      userId,
+      kind: 'what_i_offer',
+      intent: 'OFFER',
+      enabled: isAuthorized && Boolean(userId),
+    });
+
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
   // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
   // spinner that otherwise paints between the initial render and the effect.
   useLayoutEffect(() => {
-    if (!isAuthorized || !userDto) return;
+    if (!isAuthorized || !userDto || whatIOfferTagsLoading) return;
 
     const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
     const experiences =
@@ -51,6 +64,13 @@ export function useEditProfileData({
     const parsedExperiences = parseWorkExperiences(experiences);
     const parsedEducations = parseEducations(experiences);
     const parsedLinks = parseLinks(experiences);
+
+    const whatIOfferFromTags = whatIOfferTags
+      .map((t) => t.subject_group)
+      .filter((g): g is string => Boolean(g));
+    const whatIOfferFromLegacy = parseWhatIOffer(experiences);
+    const whatIOfferValues =
+      whatIOfferFromTags.length > 0 ? whatIOfferFromTags : whatIOfferFromLegacy;
 
     // Reset must include every server-driven field so RHF treats them as the
     // new defaults; otherwise dirtyFields starts non-empty and submit-time
@@ -75,7 +95,7 @@ export function useEditProfileData({
       twitter: parsedLinks.twitter || defaultValues.twitter,
       youtube: parsedLinks.youtube || defaultValues.youtube,
       website: parsedLinks.website || defaultValues.website,
-      what_i_offer: parseWhatIOffer(experiences),
+      what_i_offer: whatIOfferValues,
       expertises:
         userDto.expertises?.professions?.map((i) => i.subject_group) || [],
       interested_positions:
@@ -89,6 +109,8 @@ export function useEditProfileData({
     setIsPageLoading(false);
   }, [
     userDto,
+    whatIOfferTags,
+    whatIOfferTagsLoading,
     isAuthorized,
     isMentorOnboarding,
     form,

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -24,6 +24,10 @@ vi.mock('@/services/profile/upsertExperience', () => ({
   upsertMentorExperience: vi.fn(),
 }));
 
+vi.mock('@/services/userTags/replaceUserTags', () => ({
+  replaceUserTags: vi.fn(),
+}));
+
 vi.mock('@/lib/profile/pollUntilSynced', () => ({
   pollUntilSynced: vi.fn(),
   firstSyncedFetch: vi.fn(),
@@ -51,6 +55,7 @@ import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
 import type { MentorProfileVO } from '@/services/profile/user';
+import { replaceUserTags } from '@/services/userTags/replaceUserTags';
 import { mockRouter } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
 
@@ -59,6 +64,7 @@ import { useProfileSubmit } from './useProfileSubmit';
 const mockUpdateAvatar = vi.mocked(updateAvatar);
 const mockUpdateProfile = vi.mocked(updateProfile);
 const mockUpsertMentorExperience = vi.mocked(upsertMentorExperience);
+const mockReplaceUserTags = vi.mocked(replaceUserTags);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
 const mockPrimeUserDataCache = vi.mocked(primeUserDataCache);
@@ -133,6 +139,7 @@ describe('useProfileSubmit', () => {
     vi.clearAllMocks();
     mockUpdateProfile.mockResolvedValue(undefined);
     mockUpsertMentorExperience.mockResolvedValue(undefined);
+    mockReplaceUserTags.mockResolvedValue(null);
     mockPollUntilSynced.mockResolvedValue(mockUserDTO);
     // Default: backend has not synced fast enough → exercise the historical
     // clear-cache + background-poll fallback. Tests covering the new prime

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -22,6 +22,7 @@ import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
 import { MentorProfileVO } from '@/services/profile/user';
+import { replaceUserTags } from '@/services/userTags/replaceUserTags';
 
 // RHF's dirtyFields is a deep partial where leaves are `true`. Nested fields
 // (objects, arrays) carry the same shape, so we recurse to detect "anything
@@ -206,16 +207,17 @@ export function useProfileSubmit({
               })
             : Promise.resolve(),
 
-          whatIOfferDirty && values.what_i_offer?.length > 0
-            ? upsertMentorExperience(ExperienceType.WHAT_I_OFFER, true, {
-                id: 4,
-                category: ExperienceType.WHAT_I_OFFER,
-                mentor_experiences_metadata: {
-                  data: values.what_i_offer.map((item) => ({
-                    subject_group: item,
-                  })),
-                },
-                order: 4,
+          // #229 cutover: WHAT_I_OFFER now writes through the unified
+          // user-tags endpoint as kind=what_i_offer, intent=OFFER. The
+          // legacy upsertMentorExperience(WHAT_I_OFFER, id:4) call is gone.
+          // Empty array clears the user's offers (replace-all semantics on
+          // the backend), matching the dirty-and-empty case the legacy path
+          // could not express.
+          whatIOfferDirty
+            ? replaceUserTags({
+                kind: 'what_i_offer',
+                intent: 'OFFER',
+                subject_groups: values.what_i_offer ?? [],
               })
             : Promise.resolve(),
         ]);

--- a/src/hooks/userTags/useUserTags.ts
+++ b/src/hooks/userTags/useUserTags.ts
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+import { getUserTags } from '@/services/userTags/getUserTags';
+import type { TagIntent, TagKind, UserTag } from '@/services/userTags/types';
+
+interface Options {
+  userId: number;
+  kind?: TagKind;
+  intent?: TagIntent;
+  enabled?: boolean;
+}
+
+export interface UseUserTagsResult {
+  tags: UserTag[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useUserTags({
+  userId,
+  kind,
+  intent,
+  enabled = true,
+}: Options): UseUserTagsResult {
+  const [tags, setTags] = useState<UserTag[]>([]);
+  const [isLoading, setIsLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
+    if (!enabled || !isUserIdValid) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    getUserTags({ userId, kind, intent, signal: controller.signal })
+      .then((result) => {
+        if (cancelled) return;
+        setTags(result);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load user tags:', e);
+        setError('Failed to load user tags');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [userId, kind, intent, enabled]);
+
+  return { tags, isLoading, error };
+}

--- a/src/services/userTags/getUserTags.ts
+++ b/src/services/userTags/getUserTags.ts
@@ -1,0 +1,51 @@
+import { getSession } from 'next-auth/react';
+
+import { apiClient } from '@/lib/apiClient';
+
+import type { TagIntent, TagKind, UserTag, UserTagListVO } from './types';
+
+interface ApiEnvelope<T> {
+  data?: T;
+  code?: string;
+  msg?: string;
+}
+
+interface GetUserTagsOptions {
+  userId?: number;
+  kind?: TagKind;
+  intent?: TagIntent;
+  signal?: AbortSignal;
+}
+
+export async function getUserTags({
+  userId,
+  kind,
+  intent,
+  signal,
+}: GetUserTagsOptions = {}): Promise<UserTag[]> {
+  let id = userId;
+  if (!id) {
+    const session = await getSession();
+    id = session?.user?.id ? Number(session.user.id) : undefined;
+  }
+
+  if (!id) {
+    throw new Error('未找到使用者 ID，請重新登入。');
+  }
+
+  try {
+    const res = await apiClient.get<ApiEnvelope<UserTagListVO>>(
+      `/v1/users/${id}/tags`,
+      {
+        params: { kind, intent },
+        signal,
+      }
+    );
+    return res?.data?.user_tags ?? [];
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網路連線。');
+    }
+    throw error;
+  }
+}

--- a/src/services/userTags/replaceUserTags.ts
+++ b/src/services/userTags/replaceUserTags.ts
@@ -1,0 +1,39 @@
+import { getSession } from 'next-auth/react';
+
+import { apiClient } from '@/lib/apiClient';
+
+import type { ReplaceUserTagsPayload, ReplaceUserTagsVO } from './types';
+
+interface ApiEnvelope<T> {
+  data?: T;
+  code?: string;
+  msg?: string;
+}
+
+export async function replaceUserTags(
+  payload: ReplaceUserTagsPayload,
+  userId?: number
+): Promise<ReplaceUserTagsVO | null> {
+  let id = userId;
+  if (!id) {
+    const session = await getSession();
+    id = session?.user?.id ? Number(session.user.id) : undefined;
+  }
+
+  if (!id) {
+    throw new Error('未找到使用者 ID，請重新登入。');
+  }
+
+  try {
+    const res = await apiClient.put<ApiEnvelope<ReplaceUserTagsVO>>(
+      `/v1/users/${id}/tags`,
+      payload
+    );
+    return res?.data ?? null;
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網路連線。');
+    }
+    throw new Error(error instanceof Error ? error.message : '未知錯誤');
+  }
+}

--- a/src/services/userTags/types.ts
+++ b/src/services/userTags/types.ts
@@ -1,0 +1,36 @@
+export type TagKind =
+  | 'expertise'
+  | 'skill'
+  | 'position'
+  | 'topic'
+  | 'what_i_offer';
+
+export type TagIntent = 'WANT' | 'OFFER';
+
+export interface UserTag {
+  tag_id: number;
+  intent: string;
+  kind: string;
+  subject_group?: string;
+  subject?: string;
+  language?: string;
+}
+
+export interface UserTagListVO {
+  user_tags: UserTag[];
+}
+
+export interface ReplaceUserTagsPayload {
+  kind: TagKind;
+  intent: TagIntent;
+  subject_groups: string[];
+  language?: string;
+}
+
+export interface ReplaceUserTagsVO {
+  user_id: number;
+  kind: string;
+  intent: string;
+  tag_ids: number[];
+  replaced: boolean;
+}


### PR DESCRIPTION
## Summary

Cuts the WHAT_I_OFFER write/read in the profile-edit flow over to the unified `PUT /v1/users/{id}/tags` endpoint introduced by the User backend (#85) and BFF proxy (#116). Closes the frontend acceptance for #229.

## What changed

### New service layer (`src/services/userTags/`)

- `types.ts` — `TagKind`, `TagIntent`, `UserTag`, `UserTagListVO`, `ReplaceUserTagsPayload`, `ReplaceUserTagsVO`. Local mirror of the BFF schema; will switch to the auto-generated `api.ts` types once they're regenerated post-merge.
- `replaceUserTags.ts` — `PUT /v1/users/{id}/tags`. Replace-all semantics for `(user_id, kind, intent)`.
- `getUserTags.ts` — `GET /v1/users/{id}/tags?kind=&intent=`. Accepts an `AbortSignal` (caller-driven cancellation, matching the `apiClient` convention).

### New hook (`src/hooks/userTags/useUserTags.ts`)

Owns its own AbortController + cancellation. Components never call the service directly per CLAUDE.md.

### `useProfileSubmit.ts` — write cutover

Removes `upsertMentorExperience(WHAT_I_OFFER, id:4)`. WHAT_I_OFFER now writes through:

```ts
replaceUserTags({
  kind: 'what_i_offer',
  intent: 'OFFER',
  subject_groups: values.what_i_offer ?? [],
})
```

The legacy `&& length > 0` guard is gone — an empty array is the supported "clear" case the old path could never express.

### `useEditProfileData.ts` — read cutover

Form initialisation pulls what_i_offer from `useUserTags(kind=what_i_offer, intent=OFFER)`. When the response is empty we fall back to `parseWhatIOffer(experiences)` so users with legacy `mentor_experiences` data still see their values until they re-save through the new endpoint.

### Test mock

`useProfileSubmit.test.ts` adds a `vi.mock('@/services/userTags/replaceUserTags')` so the existing 146-test suite still runs to green. No new test code (per the #226 sub-feature testing convention — verification is local docker-compose + curl).

## What's NOT in this PR (deliberate)

- `parseWhatIOffer` and the `id:4` literal in `parseUserExperiences.ts` stay as the legacy-data fallback during transition. Both are removed in #233 cleanup once every user has re-saved on the new path.
- `mentor-card/Information.tsx` still renders from the search response's `experiences` field. The mentor-pool browse query stays on `profiles` (v1) — switching the source there requires either an alias swap or the User-side SQS publisher emitting `user_tags` in the profile-update payload, both of which are tracked in #233 / a User-service follow-up.

## Acceptance status (from #229)

- [x] Frontend 完全不再呼叫 `upsertMentorExperience(WHAT_I_OFFER)`
- [x] Profile edit form reads what_i_offer from `userTags(intent=OFFER, kind=what_i_offer)` (with legacy fallback)
- [ ] mentor-card display source switch — deferred (see above)
- [x] No regressions in the existing test suite (146 / 146 pass)
- [x] Production build succeeds

## Test plan

- [ ] `pnpm dev` — open `/profile/{my_id}/edit`, edit WHAT_I_OFFER, save → request goes to `PUT /v1/users/{id}/tags` (DevTools network tab)
- [ ] Reload the edit page → form is pre-filled from the new endpoint
- [ ] Empty WHAT_I_OFFER + save → request still fires with `subject_groups: []` and clears the user's offers
- [ ] Edit other fields (name, links, work, education) → unaffected
- [ ] Mentor card on `/mentor-pool` still displays existing WHAT_I_OFFER values for users with legacy data

Refs Xchange-Taiwan/X-Talent-Tracker#229, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
