### PR TITLE
feat(#230-#232): cut skill/topic/position/expertise to v2 user-tags (Frontend)

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -38,24 +38,23 @@ export function useEditProfileData({
   // (redirected by useProfileAuth) never see the data populated.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
-  // #229: WHAT_I_OFFER lives in user_tags(kind=what_i_offer, intent=OFFER)
-  // now. Fetch alongside the profile dto; when the response is empty we
-  // fall back to parseWhatIOffer so users with legacy mentor_experiences
-  // data still see their values until they re-save.
-  const { tags: whatIOfferTags, isLoading: whatIOfferTagsLoading } =
-    useUserTags({
-      userId,
-      kind: 'what_i_offer',
-      intent: 'OFFER',
-      enabled: isAuthorized && Boolean(userId),
-    });
+  // #229–#232: every per-kind picker (what_i_offer / skill / topic /
+  // position / expertise) is now backed by user_tags. Fetch the full
+  // per-user tag list once and group client-side rather than running
+  // one request per (kind, intent) pair. Empty groups fall back to
+  // legacy JSONB / mentor_experiences so users who haven't re-saved
+  // on the new path still see their values during transition.
+  const { tags: allUserTags, isLoading: userTagsLoading } = useUserTags({
+    userId,
+    enabled: isAuthorized && Boolean(userId),
+  });
 
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
   // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
   // spinner that otherwise paints between the initial render and the effect.
   useLayoutEffect(() => {
-    if (!isAuthorized || !userDto || whatIOfferTagsLoading) return;
+    if (!isAuthorized || !userDto || userTagsLoading) return;
 
     const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
     const experiences =
@@ -65,12 +64,43 @@ export function useEditProfileData({
     const parsedEducations = parseEducations(experiences);
     const parsedLinks = parseLinks(experiences);
 
-    const whatIOfferFromTags = whatIOfferTags
-      .map((t) => t.subject_group)
-      .filter((g): g is string => Boolean(g));
-    const whatIOfferFromLegacy = parseWhatIOffer(experiences);
+    const subjectsByKindIntent = (kind: string, intent: string): string[] =>
+      allUserTags
+        .filter((t) => t.kind === kind && t.intent === intent)
+        .map((t) => t.subject_group)
+        .filter((g): g is string => Boolean(g));
+
+    const whatIOfferFromTags = subjectsByKindIntent('what_i_offer', 'OFFER');
     const whatIOfferValues =
-      whatIOfferFromTags.length > 0 ? whatIOfferFromTags : whatIOfferFromLegacy;
+      whatIOfferFromTags.length > 0
+        ? whatIOfferFromTags
+        : parseWhatIOffer(experiences);
+
+    const skillsFromTags = subjectsByKindIntent('skill', 'WANT');
+    const skillsValues =
+      skillsFromTags.length > 0
+        ? skillsFromTags
+        : userDto.skills?.interests?.map((i) => i.subject_group) || [];
+
+    const topicsFromTags = subjectsByKindIntent('topic', 'WANT');
+    const topicsValues =
+      topicsFromTags.length > 0
+        ? topicsFromTags
+        : userDto.topics?.interests?.map((i) => i.subject_group) || [];
+
+    const positionsFromTags = subjectsByKindIntent('position', 'WANT');
+    const positionsValues =
+      positionsFromTags.length > 0
+        ? positionsFromTags
+        : userDto.interested_positions?.interests?.map(
+            (i) => i.subject_group
+          ) || [];
+
+    const expertisesFromTags = subjectsByKindIntent('expertise', 'OFFER');
+    const expertisesValues =
+      expertisesFromTags.length > 0
+        ? expertisesFromTags
+        : userDto.expertises?.professions?.map((i) => i.subject_group) || [];
 
     // Reset must include every server-driven field so RHF treats them as the
     // new defaults; otherwise dirtyFields starts non-empty and submit-time
@@ -96,21 +126,18 @@ export function useEditProfileData({
       youtube: parsedLinks.youtube || defaultValues.youtube,
       website: parsedLinks.website || defaultValues.website,
       what_i_offer: whatIOfferValues,
-      expertises:
-        userDto.expertises?.professions?.map((i) => i.subject_group) || [],
-      interested_positions:
-        userDto.interested_positions?.interests?.map((i) => i.subject_group) ||
-        [],
-      skills: userDto.skills?.interests?.map((i) => i.subject_group) || [],
-      topics: userDto.topics?.interests?.map((i) => i.subject_group) || [],
+      expertises: expertisesValues,
+      interested_positions: positionsValues,
+      skills: skillsValues,
+      topics: topicsValues,
     });
 
     setIsMentor(mentorFlag);
     setIsPageLoading(false);
   }, [
     userDto,
-    whatIOfferTags,
-    whatIOfferTagsLoading,
+    allUserTags,
+    userTagsLoading,
     isAuthorized,
     isMentorOnboarding,
     form,

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -142,6 +142,10 @@ export function useProfileSubmit({
         isDirty('youtube') ||
         isDirty('website');
       const whatIOfferDirty = isDirty('what_i_offer');
+      const skillsDirty = isDirty('skills');
+      const topicsDirty = isDirty('topics');
+      const positionsDirty = isDirty('interested_positions');
+      const expertisesDirty = isDirty('expertises');
 
       const payload = { ...values, avatar, avatarFile: undefined };
       const links = [
@@ -218,6 +222,41 @@ export function useProfileSubmit({
                 kind: 'what_i_offer',
                 intent: 'OFFER',
                 subject_groups: values.what_i_offer ?? [],
+              })
+            : Promise.resolve(),
+
+          // #230-#232 cutover: per-kind picker writes also flow through
+          // the unified user-tags endpoint. updateProfile above still
+          // persists the legacy JSONB columns for the duration of the
+          // transition (per the #226 strategy — old write path stays
+          // until #233 cleanup), so v1 search and other consumers that
+          // still read those columns are unaffected.
+          skillsDirty
+            ? replaceUserTags({
+                kind: 'skill',
+                intent: 'WANT',
+                subject_groups: values.skills ?? [],
+              })
+            : Promise.resolve(),
+          topicsDirty
+            ? replaceUserTags({
+                kind: 'topic',
+                intent: 'WANT',
+                subject_groups: values.topics ?? [],
+              })
+            : Promise.resolve(),
+          positionsDirty
+            ? replaceUserTags({
+                kind: 'position',
+                intent: 'WANT',
+                subject_groups: values.interested_positions ?? [],
+              })
+            : Promise.resolve(),
+          expertisesDirty
+            ? replaceUserTags({
+                kind: 'expertise',
+                intent: 'OFFER',
+                subject_groups: values.expertises ?? [],
               })
             : Promise.resolve(),
         ]);


### PR DESCRIPTION
## Summary

Batches the frontend cutover for **#230** (skill WANT), **#231** (expertise OFFER), and **#232** (position+topic WANT) — same pattern as #229's WHAT_I_OFFER cut, just for four more pickers.

The Search-side PR (`feat/230-232-v2-filter-routing`) routes `filter_skills` / `filter_topics` / `filter_positions` / `filter_expertises` to `profiles_v2.user_tags`; this PR is what populates that data from the edit form.

## What changed

### `useProfileSubmit` — write fan-out

- Per-kind dirty flags for `skills` / `topics` / `interested_positions` / `expertises`. Each fires a `replaceUserTags()` with the matching `(kind, intent)` when its dirty flag flips. Empty array clears the user's tags for that pair (replace-all semantics).
- `updateProfile(payload)` is unchanged, so the legacy JSONB columns still get written during the transition. Per the #226 strategy, old writes stay until #233 cleanup — v1 search and any other consumers reading those columns are unaffected.

### `useEditProfileData` — read fan-in

- Refactor: one `useUserTags()` call returns the full per-user tag list; we group client-side by `(kind, intent)` instead of running five separate hook calls. Cleaner deps array, fewer fetches.
- Each picker prefers user_tags-derived values; falls back to the legacy `userDto.skills.interests` / `.professions` when v2 is empty (users who haven't re-saved on the new path still see their values until they do).

## (kind, intent) mapping

| Form field | Endpoint payload `kind` | `intent` |
|---|---|---|
| `what_i_offer` (mentor) | `what_i_offer` | `OFFER` |
| `expertises` (mentor) | `expertise` | `OFFER` |
| `skills` | `skill` | `WANT` |
| `interested_positions` | `position` | `WANT` |
| `topics` | `topic` | `WANT` |

## Acceptance touched

- **#230** `前端不再從 profile.skills JSONB 直接讀` — read prefers `user_tags(kind=skill, intent=WANT)`, falls back only when v2 is empty for this user
- **#231** `前端不再從 profile.expertises JSONB 直接讀` — same pattern with `(expertise, OFFER)`
- **#232** `前端不再從 profile.interested_positions / topics JSONB 直接讀` — same pattern with `(position, WANT)` / `(topic, WANT)`
- v1 endpoint + JSONB write paths intentionally kept (additive only)

## Quality gates

- 146 / 146 tests pass
- `pnpm type-check` clean
- `pnpm build` succeeds (no new ESLint warnings)

## Test plan

- [ ] `pnpm dev`; open `/profile/{my_id}/edit`
- [ ] Edit each picker (skills, topics, interested_positions, expertises) and save → DevTools shows a `PUT /v1/users/{id}/tags` per dirty kind, plus the existing `PUT /v1/mentors/{id}/profile`
- [ ] Reload the edit page → form is hydrated from the new `GET /v1/users/{id}/tags` endpoint
- [ ] Clear all skills + save → request fires with `subject_groups: []` and clears the user's `skill / WANT` tags on the backend
- [ ] Mentor pool browse with `filter_skills` selected — filter now hits `profiles_v2`
- [ ] Onboarding flow's `SkillsToImprove` / `InterestedPosition` / `TopicsToDiscuss` still works (those steps still write through the bundled `updateProfile`; the v2 write is an additive companion)

Refs Xchange-Taiwan/X-Talent-Tracker#230, Xchange-Taiwan/X-Talent-Tracker#231, Xchange-Taiwan/X-Talent-Tracker#232, Xchange-Taiwan/X-Talent-Tracker#226

Generated with [Claude Code](https://claude.com/claude-code)
