### PR TITLE
feat(#226): v2 user-tag picker cutover (DRAFT — /tags migration pending)

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -7,6 +7,7 @@ import {
   ProfileFormValues,
 } from '@/components/profile/edit/profileSchema';
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
+import { useUserTags } from '@/hooks/userTags/useUserTags';
 import {
   parseEducations,
   parseLinks,
@@ -37,12 +38,24 @@ export function useEditProfileData({
   // (redirected by useProfileAuth) never see the data populated.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
+  // #229: WHAT_I_OFFER lives in user_tags(kind=what_i_offer, intent=OFFER)
+  // now. Fetch alongside the profile dto; when the response is empty we
+  // fall back to parseWhatIOffer so users with legacy mentor_experiences
+  // data still see their values until they re-save.
+  const { tags: whatIOfferTags, isLoading: whatIOfferTagsLoading } =
+    useUserTags({
+      userId,
+      kind: 'what_i_offer',
+      intent: 'OFFER',
+      enabled: isAuthorized && Boolean(userId),
+    });
+
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
   // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
   // spinner that otherwise paints between the initial render and the effect.
   useLayoutEffect(() => {
-    if (!isAuthorized || !userDto) return;
+    if (!isAuthorized || !userDto || whatIOfferTagsLoading) return;
 
     const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
     const experiences =
@@ -51,6 +64,13 @@ export function useEditProfileData({
     const parsedExperiences = parseWorkExperiences(experiences);
     const parsedEducations = parseEducations(experiences);
     const parsedLinks = parseLinks(experiences);
+
+    const whatIOfferFromTags = whatIOfferTags
+      .map((t) => t.subject_group)
+      .filter((g): g is string => Boolean(g));
+    const whatIOfferFromLegacy = parseWhatIOffer(experiences);
+    const whatIOfferValues =
+      whatIOfferFromTags.length > 0 ? whatIOfferFromTags : whatIOfferFromLegacy;
 
     // Reset must include every server-driven field so RHF treats them as the
     // new defaults; otherwise dirtyFields starts non-empty and submit-time
@@ -75,7 +95,7 @@ export function useEditProfileData({
       twitter: parsedLinks.twitter || defaultValues.twitter,
       youtube: parsedLinks.youtube || defaultValues.youtube,
       website: parsedLinks.website || defaultValues.website,
-      what_i_offer: parseWhatIOffer(experiences),
+      what_i_offer: whatIOfferValues,
       expertises:
         userDto.expertises?.professions?.map((i) => i.subject_group) || [],
       interested_positions:
@@ -89,6 +109,8 @@ export function useEditProfileData({
     setIsPageLoading(false);
   }, [
     userDto,
+    whatIOfferTags,
+    whatIOfferTagsLoading,
     isAuthorized,
     isMentorOnboarding,
     form,

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -38,24 +38,23 @@ export function useEditProfileData({
   // (redirected by useProfileAuth) never see the data populated.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
-  // #229: WHAT_I_OFFER lives in user_tags(kind=what_i_offer, intent=OFFER)
-  // now. Fetch alongside the profile dto; when the response is empty we
-  // fall back to parseWhatIOffer so users with legacy mentor_experiences
-  // data still see their values until they re-save.
-  const { tags: whatIOfferTags, isLoading: whatIOfferTagsLoading } =
-    useUserTags({
-      userId,
-      kind: 'what_i_offer',
-      intent: 'OFFER',
-      enabled: isAuthorized && Boolean(userId),
-    });
+  // #229–#232: every per-kind picker (what_i_offer / skill / topic /
+  // position / expertise) is now backed by user_tags. Fetch the full
+  // per-user tag list once and group client-side rather than running
+  // one request per (kind, intent) pair. Empty groups fall back to
+  // legacy JSONB / mentor_experiences so users who haven't re-saved
+  // on the new path still see their values during transition.
+  const { tags: allUserTags, isLoading: userTagsLoading } = useUserTags({
+    userId,
+    enabled: isAuthorized && Boolean(userId),
+  });
 
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
   // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
   // spinner that otherwise paints between the initial render and the effect.
   useLayoutEffect(() => {
-    if (!isAuthorized || !userDto || whatIOfferTagsLoading) return;
+    if (!isAuthorized || !userDto || userTagsLoading) return;
 
     const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
     const experiences =
@@ -65,12 +64,43 @@ export function useEditProfileData({
     const parsedEducations = parseEducations(experiences);
     const parsedLinks = parseLinks(experiences);
 
-    const whatIOfferFromTags = whatIOfferTags
-      .map((t) => t.subject_group)
-      .filter((g): g is string => Boolean(g));
-    const whatIOfferFromLegacy = parseWhatIOffer(experiences);
+    const subjectsByKindIntent = (kind: string, intent: string): string[] =>
+      allUserTags
+        .filter((t) => t.kind === kind && t.intent === intent)
+        .map((t) => t.subject_group)
+        .filter((g): g is string => Boolean(g));
+
+    const whatIOfferFromTags = subjectsByKindIntent('what_i_offer', 'OFFER');
     const whatIOfferValues =
-      whatIOfferFromTags.length > 0 ? whatIOfferFromTags : whatIOfferFromLegacy;
+      whatIOfferFromTags.length > 0
+        ? whatIOfferFromTags
+        : parseWhatIOffer(experiences);
+
+    const skillsFromTags = subjectsByKindIntent('skill', 'WANT');
+    const skillsValues =
+      skillsFromTags.length > 0
+        ? skillsFromTags
+        : userDto.skills?.interests?.map((i) => i.subject_group) || [];
+
+    const topicsFromTags = subjectsByKindIntent('topic', 'WANT');
+    const topicsValues =
+      topicsFromTags.length > 0
+        ? topicsFromTags
+        : userDto.topics?.interests?.map((i) => i.subject_group) || [];
+
+    const positionsFromTags = subjectsByKindIntent('position', 'WANT');
+    const positionsValues =
+      positionsFromTags.length > 0
+        ? positionsFromTags
+        : userDto.interested_positions?.interests?.map(
+            (i) => i.subject_group
+          ) || [];
+
+    const expertisesFromTags = subjectsByKindIntent('expertise', 'OFFER');
+    const expertisesValues =
+      expertisesFromTags.length > 0
+        ? expertisesFromTags
+        : userDto.expertises?.professions?.map((i) => i.subject_group) || [];
 
     // Reset must include every server-driven field so RHF treats them as the
     // new defaults; otherwise dirtyFields starts non-empty and submit-time
@@ -96,21 +126,18 @@ export function useEditProfileData({
       youtube: parsedLinks.youtube || defaultValues.youtube,
       website: parsedLinks.website || defaultValues.website,
       what_i_offer: whatIOfferValues,
-      expertises:
-        userDto.expertises?.professions?.map((i) => i.subject_group) || [],
-      interested_positions:
-        userDto.interested_positions?.interests?.map((i) => i.subject_group) ||
-        [],
-      skills: userDto.skills?.interests?.map((i) => i.subject_group) || [],
-      topics: userDto.topics?.interests?.map((i) => i.subject_group) || [],
+      expertises: expertisesValues,
+      interested_positions: positionsValues,
+      skills: skillsValues,
+      topics: topicsValues,
     });
 
     setIsMentor(mentorFlag);
     setIsPageLoading(false);
   }, [
     userDto,
-    whatIOfferTags,
-    whatIOfferTagsLoading,
+    allUserTags,
+    userTagsLoading,
     isAuthorized,
     isMentorOnboarding,
     form,

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -24,6 +24,10 @@ vi.mock('@/services/profile/upsertExperience', () => ({
   upsertMentorExperience: vi.fn(),
 }));
 
+vi.mock('@/services/userTags/replaceUserTags', () => ({
+  replaceUserTags: vi.fn(),
+}));
+
 vi.mock('@/lib/profile/pollUntilSynced', () => ({
   pollUntilSynced: vi.fn(),
   firstSyncedFetch: vi.fn(),
@@ -51,6 +55,7 @@ import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
 import type { MentorProfileVO } from '@/services/profile/user';
+import { replaceUserTags } from '@/services/userTags/replaceUserTags';
 import { mockRouter } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
 
@@ -59,6 +64,7 @@ import { useProfileSubmit } from './useProfileSubmit';
 const mockUpdateAvatar = vi.mocked(updateAvatar);
 const mockUpdateProfile = vi.mocked(updateProfile);
 const mockUpsertMentorExperience = vi.mocked(upsertMentorExperience);
+const mockReplaceUserTags = vi.mocked(replaceUserTags);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
 const mockPrimeUserDataCache = vi.mocked(primeUserDataCache);
@@ -133,6 +139,7 @@ describe('useProfileSubmit', () => {
     vi.clearAllMocks();
     mockUpdateProfile.mockResolvedValue(undefined);
     mockUpsertMentorExperience.mockResolvedValue(undefined);
+    mockReplaceUserTags.mockResolvedValue(null);
     mockPollUntilSynced.mockResolvedValue(mockUserDTO);
     // Default: backend has not synced fast enough → exercise the historical
     // clear-cache + background-poll fallback. Tests covering the new prime

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -142,6 +142,10 @@ export function useProfileSubmit({
         isDirty('youtube') ||
         isDirty('website');
       const whatIOfferDirty = isDirty('what_i_offer');
+      const skillsDirty = isDirty('skills');
+      const topicsDirty = isDirty('topics');
+      const positionsDirty = isDirty('interested_positions');
+      const expertisesDirty = isDirty('expertises');
 
       const payload = { ...values, avatar, avatarFile: undefined };
       const links = [
@@ -218,6 +222,41 @@ export function useProfileSubmit({
                 kind: 'what_i_offer',
                 intent: 'OFFER',
                 subject_groups: values.what_i_offer ?? [],
+              })
+            : Promise.resolve(),
+
+          // #230-#232 cutover: per-kind picker writes also flow through
+          // the unified user-tags endpoint. updateProfile above still
+          // persists the legacy JSONB columns for the duration of the
+          // transition (per the #226 strategy — old write path stays
+          // until #233 cleanup), so v1 search and other consumers that
+          // still read those columns are unaffected.
+          skillsDirty
+            ? replaceUserTags({
+                kind: 'skill',
+                intent: 'WANT',
+                subject_groups: values.skills ?? [],
+              })
+            : Promise.resolve(),
+          topicsDirty
+            ? replaceUserTags({
+                kind: 'topic',
+                intent: 'WANT',
+                subject_groups: values.topics ?? [],
+              })
+            : Promise.resolve(),
+          positionsDirty
+            ? replaceUserTags({
+                kind: 'position',
+                intent: 'WANT',
+                subject_groups: values.interested_positions ?? [],
+              })
+            : Promise.resolve(),
+          expertisesDirty
+            ? replaceUserTags({
+                kind: 'expertise',
+                intent: 'OFFER',
+                subject_groups: values.expertises ?? [],
               })
             : Promise.resolve(),
         ]);

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -22,6 +22,7 @@ import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { upsertMentorExperience } from '@/services/profile/upsertExperience';
 import { MentorProfileVO } from '@/services/profile/user';
+import { replaceUserTags } from '@/services/userTags/replaceUserTags';
 
 // RHF's dirtyFields is a deep partial where leaves are `true`. Nested fields
 // (objects, arrays) carry the same shape, so we recurse to detect "anything
@@ -206,16 +207,17 @@ export function useProfileSubmit({
               })
             : Promise.resolve(),
 
-          whatIOfferDirty && values.what_i_offer?.length > 0
-            ? upsertMentorExperience(ExperienceType.WHAT_I_OFFER, true, {
-                id: 4,
-                category: ExperienceType.WHAT_I_OFFER,
-                mentor_experiences_metadata: {
-                  data: values.what_i_offer.map((item) => ({
-                    subject_group: item,
-                  })),
-                },
-                order: 4,
+          // #229 cutover: WHAT_I_OFFER now writes through the unified
+          // user-tags endpoint as kind=what_i_offer, intent=OFFER. The
+          // legacy upsertMentorExperience(WHAT_I_OFFER, id:4) call is gone.
+          // Empty array clears the user's offers (replace-all semantics on
+          // the backend), matching the dirty-and-empty case the legacy path
+          // could not express.
+          whatIOfferDirty
+            ? replaceUserTags({
+                kind: 'what_i_offer',
+                intent: 'OFFER',
+                subject_groups: values.what_i_offer ?? [],
               })
             : Promise.resolve(),
         ]);

--- a/src/hooks/userTags/useUserTags.ts
+++ b/src/hooks/userTags/useUserTags.ts
@@ -1,0 +1,64 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+import { getUserTags } from '@/services/userTags/getUserTags';
+import type { TagIntent, TagKind, UserTag } from '@/services/userTags/types';
+
+interface Options {
+  userId: number;
+  kind?: TagKind;
+  intent?: TagIntent;
+  enabled?: boolean;
+}
+
+export interface UseUserTagsResult {
+  tags: UserTag[];
+  isLoading: boolean;
+  error: string | null;
+}
+
+export function useUserTags({
+  userId,
+  kind,
+  intent,
+  enabled = true,
+}: Options): UseUserTagsResult {
+  const [tags, setTags] = useState<UserTag[]>([]);
+  const [isLoading, setIsLoading] = useState(enabled);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
+    if (!enabled || !isUserIdValid) {
+      setIsLoading(false);
+      return;
+    }
+
+    let cancelled = false;
+    const controller = new AbortController();
+    setIsLoading(true);
+    setError(null);
+
+    getUserTags({ userId, kind, intent, signal: controller.signal })
+      .then((result) => {
+        if (cancelled) return;
+        setTags(result);
+      })
+      .catch((e) => {
+        if (cancelled) return;
+        if (e instanceof DOMException && e.name === 'AbortError') return;
+        console.error('Failed to load user tags:', e);
+        setError('Failed to load user tags');
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+
+    return () => {
+      cancelled = true;
+      controller.abort();
+    };
+  }, [userId, kind, intent, enabled]);
+
+  return { tags, isLoading, error };
+}

--- a/src/services/userTags/getUserTags.ts
+++ b/src/services/userTags/getUserTags.ts
@@ -1,0 +1,51 @@
+import { getSession } from 'next-auth/react';
+
+import { apiClient } from '@/lib/apiClient';
+
+import type { TagIntent, TagKind, UserTag, UserTagListVO } from './types';
+
+interface ApiEnvelope<T> {
+  data?: T;
+  code?: string;
+  msg?: string;
+}
+
+interface GetUserTagsOptions {
+  userId?: number;
+  kind?: TagKind;
+  intent?: TagIntent;
+  signal?: AbortSignal;
+}
+
+export async function getUserTags({
+  userId,
+  kind,
+  intent,
+  signal,
+}: GetUserTagsOptions = {}): Promise<UserTag[]> {
+  let id = userId;
+  if (!id) {
+    const session = await getSession();
+    id = session?.user?.id ? Number(session.user.id) : undefined;
+  }
+
+  if (!id) {
+    throw new Error('未找到使用者 ID，請重新登入。');
+  }
+
+  try {
+    const res = await apiClient.get<ApiEnvelope<UserTagListVO>>(
+      `/v1/users/${id}/tags`,
+      {
+        params: { kind, intent },
+        signal,
+      }
+    );
+    return res?.data?.user_tags ?? [];
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網路連線。');
+    }
+    throw error;
+  }
+}

--- a/src/services/userTags/replaceUserTags.ts
+++ b/src/services/userTags/replaceUserTags.ts
@@ -1,0 +1,39 @@
+import { getSession } from 'next-auth/react';
+
+import { apiClient } from '@/lib/apiClient';
+
+import type { ReplaceUserTagsPayload, ReplaceUserTagsVO } from './types';
+
+interface ApiEnvelope<T> {
+  data?: T;
+  code?: string;
+  msg?: string;
+}
+
+export async function replaceUserTags(
+  payload: ReplaceUserTagsPayload,
+  userId?: number
+): Promise<ReplaceUserTagsVO | null> {
+  let id = userId;
+  if (!id) {
+    const session = await getSession();
+    id = session?.user?.id ? Number(session.user.id) : undefined;
+  }
+
+  if (!id) {
+    throw new Error('未找到使用者 ID，請重新登入。');
+  }
+
+  try {
+    const res = await apiClient.put<ApiEnvelope<ReplaceUserTagsVO>>(
+      `/v1/users/${id}/tags`,
+      payload
+    );
+    return res?.data ?? null;
+  } catch (error) {
+    if (error instanceof TypeError && error.message === 'Failed to fetch') {
+      throw new Error('無法連接到伺服器。請檢查您的網路連線。');
+    }
+    throw new Error(error instanceof Error ? error.message : '未知錯誤');
+  }
+}

--- a/src/services/userTags/types.ts
+++ b/src/services/userTags/types.ts
@@ -1,0 +1,36 @@
+export type TagKind =
+  | 'expertise'
+  | 'skill'
+  | 'position'
+  | 'topic'
+  | 'what_i_offer';
+
+export type TagIntent = 'WANT' | 'OFFER';
+
+export interface UserTag {
+  tag_id: number;
+  intent: string;
+  kind: string;
+  subject_group?: string;
+  subject?: string;
+  language?: string;
+}
+
+export interface UserTagListVO {
+  user_tags: UserTag[];
+}
+
+export interface ReplaceUserTagsPayload {
+  kind: TagKind;
+  intent: TagIntent;
+  subject_groups: string[];
+  language?: string;
+}
+
+export interface ReplaceUserTagsVO {
+  user_id: number;
+  kind: string;
+  intent: string;
+  tag_ids: number[];
+  replaced: boolean;
+}


### PR DESCRIPTION
## ⚠️ DRAFT — do not merge until /tags migration

This branch (PRs #583/#584) cut over the 5 profile pickers (`what_i_offer / skill / topic / position / expertise`) to write through `PUT /v1/users/{user_id}/tags`. Backend has since:

1. **Removed the `/tags` GET + PUT endpoints entirely** (see X-Career-User feature → dev PR). They were part of #226 but never made it to `dev` — the integration branch added them, then collapsed everything into the buckets payload on profile endpoints, then removed them.
2. **Collapsed `kind` enum** to `{skill, topic, position}`. Frontend currently sends `kind: 'expertise'` and `kind: 'what_i_offer'` which the backend rejects (no longer in `TagKind`).

Net effect: merging this PR as-is will cause **mentor / mentee save to 404** on dev once the backend → dev PRs ship.

### Required before un-drafting

- [ ] `useProfileSubmit.ts:220-262` — collapse the 5 `replaceUserTags` calls into a single `user_tags` buckets payload on `updateProfile`. Mapping:
  - `values.skills` → `user_tags.want_skills`
  - `values.topics` → `user_tags.want_topics`
  - `values.interested_positions` → `user_tags.want_positions`
  - `values.expertises` → `user_tags.offer_skills` (collapse: expertise = skill+OFFER)
  - `values.what_i_offer` → `user_tags.offer_topics` (collapse: what_i_offer = topic+OFFER)
- [ ] `useEditProfileData.ts:47` — replace `useUserTags` with reading `userDto.user_tags` (now hydrated buckets on the profile endpoint, both mentor and mentee paths).
- [ ] Delete `src/services/userTags/` and `src/hooks/userTags/`.
- [ ] `pnpm build` + `pnpm type-check` clean
- [ ] Manual mentor + mentee save round-trip verified locally against backend feature branch

### Memory entry
`#226 frontend /tags migration pending` (in user's auto-memory) tracks the migration plan and shape mapping.

## Original branch summary
PRs #583 + #584 — cutover write/read of all 5 profile pickers to the v2 unified user-tags pattern. Done before backend collapsed `kind` enum and removed standalone `/tags`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)