### PR TITLE
feat(reservation): add relative-time status badge and email hint

### DIFF
--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -1,13 +1,16 @@
-import { CalendarDays, Clock, MessageSquare } from 'lucide-react';
+import { CalendarDays, Clock, Mail, MessageSquare } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
 import * as React from 'react';
 
+import { ReservationStatusBadge } from '@/components/reservation/ReservationStatusBadge';
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 
 import type { Reservation } from './types';
+
+export type ReservationCardVariant = 'upcoming' | 'pending' | 'history';
 
 export function ReservationCard({
   item,
@@ -15,6 +18,7 @@ export function ReservationCard({
   footer,
   profileHref,
   onProfileClick,
+  variant,
 }: {
   item: Reservation;
   actions?: React.ReactNode;
@@ -23,7 +27,10 @@ export function ReservationCard({
   footer?: React.ReactNode;
   profileHref?: string;
   onProfileClick?: () => void;
+  // Drives upcoming-only affordances (status badge and email hint).
+  variant?: ReservationCardVariant;
 }) {
+  const isUpcoming = variant === 'upcoming';
   const { menteeMessage, mentorMessage } = item;
   const hasAnyMessage = Boolean(menteeMessage || mentorMessage);
 
@@ -105,15 +112,23 @@ export function ReservationCard({
             <div className="my-3 hidden h-px bg-border sm:block" />
 
             {/* Date & time row */}
-            <div className="mt-2 flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-muted-foreground sm:mt-0 sm:text-sm">
-              <div className="flex items-center gap-1.5">
-                <CalendarDays className="h-4 w-4" aria-hidden />
-                <span className="truncate">{item.date}</span>
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-muted-foreground sm:mt-0 sm:text-sm">
+              <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+                <div className="flex items-center gap-1.5">
+                  <CalendarDays className="h-4 w-4" aria-hidden />
+                  <span className="truncate">{item.date}</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <Clock className="h-4 w-4" aria-hidden />
+                  <span className="truncate">{item.time}</span>
+                </div>
               </div>
-              <div className="flex items-center gap-1.5">
-                <Clock className="h-4 w-4" aria-hidden />
-                <span className="truncate">{item.time}</span>
-              </div>
+              {isUpcoming ? (
+                <ReservationStatusBadge
+                  dtstart={item.dtstart}
+                  dtend={item.dtend}
+                />
+              ) : null}
             </div>
 
             {hasAnyMessage ? (
@@ -154,6 +169,13 @@ export function ReservationCard({
             ) : null}
 
             {footer ? <div className="mt-3">{footer}</div> : null}
+
+            {isUpcoming ? (
+              <div className="mt-3 flex items-center gap-1.5 text-[11px] text-muted-foreground sm:text-xs">
+                <Mail className="h-3.5 w-3.5 shrink-0" aria-hidden />
+                <span>會議連結已寄至您的信箱</span>
+              </div>
+            ) : null}
           </div>
         </div>
       </CardContent>

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -15,11 +15,21 @@ import {
   updateReservationStatus,
 } from '@/services/reservations';
 
-import { ReservationCard } from './ReservationCard';
+import {
+  ReservationCard,
+  type ReservationCardVariant,
+} from './ReservationCard';
 import type { Reservation } from './types';
 
 type Variant = 'upcoming' | 'pending-mentee' | 'pending-mentor' | 'history';
 type SourceRole = 'mentor' | 'mentee';
+
+const cardVariantOf = (variant: Variant): ReservationCardVariant =>
+  variant === 'upcoming'
+    ? 'upcoming'
+    : variant === 'history'
+      ? 'history'
+      : 'pending';
 
 export function ReservationList({
   items,
@@ -196,6 +206,7 @@ export function ReservationList({
         <ReservationCard
           key={it.id}
           item={it}
+          variant={cardVariantOf(variant)}
           profileHref={buildProfileHref(it)}
           onProfileClick={handleProfileClick}
           actions={

--- a/src/components/reservation/ReservationStatusBadge.tsx
+++ b/src/components/reservation/ReservationStatusBadge.tsx
@@ -1,0 +1,53 @@
+'use client';
+
+import { cva } from 'class-variance-authority';
+import * as React from 'react';
+
+import { useReservationTimeStatus } from '@/hooks/reservation/useReservationTimeStatus';
+import { cn } from '@/lib/utils';
+
+const statusBadgeVariants = cva(
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium leading-none sm:text-xs',
+  {
+    variants: {
+      status: {
+        far: 'bg-muted text-muted-foreground',
+        soon: 'bg-status-500/20 text-status-400',
+        imminent: 'bg-status-300/20 text-status-200',
+        live: 'bg-status-100/20 text-status-50',
+        ended: 'bg-muted text-muted-foreground/70',
+      },
+    },
+    defaultVariants: {
+      status: 'far',
+    },
+  }
+);
+
+export function ReservationStatusBadge({
+  dtstart,
+  dtend,
+  className,
+}: {
+  dtstart: number;
+  dtend: number;
+  className?: string;
+}) {
+  const { status, label } = useReservationTimeStatus(dtstart, dtend);
+
+  return (
+    <span
+      className={cn(statusBadgeVariants({ status }), className)}
+      role="status"
+      aria-live="polite"
+    >
+      {status === 'live' ? (
+        <span
+          className="h-1.5 w-1.5 rounded-full bg-status-50 motion-safe:animate-pulse"
+          aria-hidden
+        />
+      ) : null}
+      {label}
+    </span>
+  );
+}

--- a/src/hooks/reservation/useReservationTimeStatus.test.ts
+++ b/src/hooks/reservation/useReservationTimeStatus.test.ts
@@ -1,0 +1,109 @@
+import { describe, expect, it } from 'vitest';
+
+import { computeReservationTimeInfo } from './useReservationTimeStatus';
+
+const SECOND = 1;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+const NOW_MS = 1_700_000_000_000;
+const NOW_S = NOW_MS / 1000;
+
+describe('computeReservationTimeInfo', () => {
+  it('returns ended when now >= dtend', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S - HOUR, NOW_S - MINUTE, NOW_MS)
+    ).toEqual({ status: 'ended', label: '已結束' });
+  });
+
+  it('returns ended at the exact dtend boundary', () => {
+    expect(computeReservationTimeInfo(NOW_S - HOUR, NOW_S, NOW_MS)).toEqual({
+      status: 'ended',
+      label: '已結束',
+    });
+  });
+
+  it('returns live when dtstart <= now < dtend', () => {
+    expect(
+      computeReservationTimeInfo(
+        NOW_S - 5 * MINUTE,
+        NOW_S + 25 * MINUTE,
+        NOW_MS
+      )
+    ).toEqual({ status: 'live', label: '進行中' });
+  });
+
+  it('returns live at the exact dtstart boundary', () => {
+    expect(computeReservationTimeInfo(NOW_S, NOW_S + HOUR, NOW_MS)).toEqual({
+      status: 'live',
+      label: '進行中',
+    });
+  });
+
+  it('returns "即將開始" when less than one minute away', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + 30, NOW_S + 30 + HOUR, NOW_MS)
+    ).toEqual({ status: 'imminent', label: '即將開始' });
+  });
+
+  it('returns minutes label when within the hour bucket', () => {
+    expect(
+      computeReservationTimeInfo(
+        NOW_S + 5 * MINUTE,
+        NOW_S + 35 * MINUTE,
+        NOW_MS
+      )
+    ).toEqual({ status: 'imminent', label: '5 分鐘後開始' });
+  });
+
+  it('returns 59 minutes at one second under the hour boundary', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + HOUR - 1, NOW_S + 2 * HOUR, NOW_MS)
+    ).toEqual({ status: 'imminent', label: '59 分鐘後開始' });
+  });
+
+  it('crosses into the hour bucket exactly at one hour', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + HOUR, NOW_S + 2 * HOUR, NOW_MS)
+    ).toEqual({ status: 'soon', label: '1 小時後開始' });
+  });
+
+  it('returns hours label when within the day bucket', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + 5 * HOUR, NOW_S + 6 * HOUR, NOW_MS)
+    ).toEqual({ status: 'soon', label: '5 小時後開始' });
+  });
+
+  it('returns 23 hours at one second under the day boundary', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + DAY - 1, NOW_S + DAY + HOUR, NOW_MS)
+    ).toEqual({ status: 'soon', label: '23 小時後開始' });
+  });
+
+  it('crosses into the day bucket exactly at 24 hours', () => {
+    expect(
+      computeReservationTimeInfo(NOW_S + DAY, NOW_S + DAY + HOUR, NOW_MS)
+    ).toEqual({ status: 'far', label: '1 天後' });
+  });
+
+  it('returns days label for far-future reservations', () => {
+    expect(
+      computeReservationTimeInfo(
+        NOW_S + 3 * DAY,
+        NOW_S + 3 * DAY + HOUR,
+        NOW_MS
+      )
+    ).toEqual({ status: 'far', label: '3 天後' });
+  });
+
+  it('floors partial days down (1 day 23 hours -> 1 day)', () => {
+    expect(
+      computeReservationTimeInfo(
+        NOW_S + DAY + 23 * HOUR,
+        NOW_S + DAY + 24 * HOUR,
+        NOW_MS
+      )
+    ).toEqual({ status: 'far', label: '1 天後' });
+  });
+});

--- a/src/hooks/reservation/useReservationTimeStatus.ts
+++ b/src/hooks/reservation/useReservationTimeStatus.ts
@@ -1,0 +1,91 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+export type ReservationTimeStatus =
+  | 'far'
+  | 'soon'
+  | 'imminent'
+  | 'live'
+  | 'ended';
+
+export interface ReservationTimeInfo {
+  status: ReservationTimeStatus;
+  label: string;
+}
+
+const ONE_MINUTE_MS = 60_000;
+const ONE_HOUR_MS = 60 * ONE_MINUTE_MS;
+const ONE_DAY_MS = 24 * ONE_HOUR_MS;
+
+let intervalId: ReturnType<typeof setInterval> | null = null;
+const listeners = new Set<() => void>();
+
+function startInterval(): void {
+  if (intervalId !== null) return;
+  intervalId = setInterval(() => {
+    listeners.forEach((listener) => listener());
+  }, ONE_MINUTE_MS);
+}
+
+function stopInterval(): void {
+  if (intervalId === null) return;
+  clearInterval(intervalId);
+  intervalId = null;
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (listeners.size === 1) startInterval();
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0) stopInterval();
+  };
+}
+
+function getSnapshot(): number {
+  return Math.floor(Date.now() / ONE_MINUTE_MS);
+}
+
+function getServerSnapshot(): number {
+  return 0;
+}
+
+export function computeReservationTimeInfo(
+  dtstartUnixSeconds: number,
+  dtendUnixSeconds: number,
+  nowMs: number = Date.now()
+): ReservationTimeInfo {
+  const startMs = dtstartUnixSeconds * 1000;
+  const endMs = dtendUnixSeconds * 1000;
+
+  if (nowMs >= endMs) return { status: 'ended', label: '已結束' };
+  if (nowMs >= startMs) return { status: 'live', label: '進行中' };
+
+  const diffMs = startMs - nowMs;
+
+  if (diffMs >= ONE_DAY_MS) {
+    const days = Math.floor(diffMs / ONE_DAY_MS);
+    return { status: 'far', label: `${days} 天後` };
+  }
+
+  if (diffMs >= ONE_HOUR_MS) {
+    const hours = Math.floor(diffMs / ONE_HOUR_MS);
+    return { status: 'soon', label: `${hours} 小時後開始` };
+  }
+
+  if (diffMs >= ONE_MINUTE_MS) {
+    const minutes = Math.floor(diffMs / ONE_MINUTE_MS);
+    return { status: 'imminent', label: `${minutes} 分鐘後開始` };
+  }
+
+  return { status: 'imminent', label: '即將開始' };
+}
+
+export function useReservationTimeStatus(
+  dtstartUnixSeconds: number,
+  dtendUnixSeconds: number
+): ReservationTimeInfo {
+  useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+  return computeReservationTimeInfo(dtstartUnixSeconds, dtendUnixSeconds);
+}


### PR DESCRIPTION
## What Does This PR Do?

- Add a status badge on upcoming reservation cards that updates every minute, showing one of: N 天後 / N 小時後開始 / N 分鐘後開始 / 即將開始 / 進行中 / 已結束 with neutral / yellow / red / green / gray styling per Tracker #218 spec (Style A)
- Share a single 60s tick across all badges via useSyncExternalStore so render cost stays flat regardless of list length
- Show "📧 會議連結已寄至您的信箱" at the bottom of each upcoming card so users know where to find the meeting link
- Pass a simplified upcoming/pending/history variant from ReservationList so badge and email hint render only on the upcoming tab
- Cover boundary cases (24h / 1h / 1m / dtstart / dtend) with unit tests

## Demo

http://localhost:3000/reservation/mentor
http://localhost:3000/reservation/mentee

## Screenshot

N/A

## Anything to Note?

- "已結束" state intentionally not auto-moved to history client-side; backend handles re-categorisation on refresh per ticket discussion
- Accept-reservation toast wording left unchanged ("會議連結將於數分鐘內寄至雙方信箱") — more accurate than the issue's proposed copy

Closes Xchange-Taiwan/X-Talent-Tracker#218

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
