### PR TITLE
feat(seo): add Person JSON-LD and richer metadata to mentor profile

### DIFF
--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -3,6 +3,9 @@ import { notFound } from 'next/navigation';
 import { getServerSession } from 'next-auth/next';
 
 import authOptions from '@/auth.config';
+import { PersonJsonLd } from '@/components/seo/PersonJsonLd';
+import { buildMentorMetadata } from '@/lib/seo/buildMentorMetadata';
+import { sanitizePublicProfile } from '@/lib/seo/sanitizePublicProfile';
 import { fetchUserByIdServer } from '@/services/profile/user.server';
 
 import ProfilePageContainer from './container';
@@ -15,29 +18,19 @@ interface PageProps {
   params: { pageUserId: string };
 }
 
-function truncate(text: string, max: number): string {
-  if (text.length <= max) return text;
-  return `${text.slice(0, max - 1).trimEnd()}…`;
-}
+const FALLBACK_METADATA: Metadata = {
+  title: 'XChange Talent Pool',
+  robots: { index: false, follow: false },
+};
 
 export async function generateMetadata({
   params,
 }: PageProps): Promise<Metadata> {
   const userIdNum = Number(params.pageUserId);
-  if (!Number.isFinite(userIdNum)) return {};
+  if (!Number.isFinite(userIdNum)) return FALLBACK_METADATA;
   const dto = await fetchUserByIdServer(userIdNum, 'zh_TW');
-  if (!dto) return {};
-  const name = dto.name ?? 'Profile';
-  const about = dto.about ? truncate(dto.about, 160) : undefined;
-  return {
-    title: name,
-    description: about,
-    openGraph: {
-      title: name,
-      description: about,
-      images: dto.avatar ? [{ url: dto.avatar }] : undefined,
-    },
-  };
+  if (!dto) return FALLBACK_METADATA;
+  return buildMentorMetadata(sanitizePublicProfile(dto));
 }
 
 export default async function Page({ params: { pageUserId } }: PageProps) {
@@ -52,12 +45,17 @@ export default async function Page({ params: { pageUserId } }: PageProps) {
   if (!initialDto) notFound();
 
   const initialLoginUserId = session?.user?.id ? String(session.user.id) : '';
+  const publicProfile = sanitizePublicProfile(initialDto);
+  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 
   return (
-    <ProfilePageContainer
-      pageUserId={pageUserId}
-      initialDto={initialDto}
-      initialLoginUserId={initialLoginUserId}
-    />
+    <>
+      <PersonJsonLd profile={publicProfile} siteUrl={siteUrl} />
+      <ProfilePageContainer
+        pageUserId={pageUserId}
+        initialDto={initialDto}
+        initialLoginUserId={initialLoginUserId}
+      />
+    </>
   );
 }

--- a/src/components/seo/PersonJsonLd.tsx
+++ b/src/components/seo/PersonJsonLd.tsx
@@ -1,0 +1,47 @@
+import type { PublicMentorProfile } from '@/lib/seo/sanitizePublicProfile';
+
+interface Props {
+  profile: PublicMentorProfile;
+  siteUrl: string;
+}
+
+function safeStringify(value: unknown): string {
+  return JSON.stringify(value).replace(/</g, '\\u003c');
+}
+
+export function PersonJsonLd({ profile, siteUrl }: Props): JSX.Element | null {
+  if (!profile.isMentor || !profile.name) return null;
+
+  const absoluteUrl = `${siteUrl.replace(/\/$/, '')}/profile/${profile.userId}`;
+
+  const knowsAbout = Array.from(
+    new Set([...profile.expertises, ...profile.topics])
+  ).filter(Boolean);
+
+  const jsonLd: Record<string, unknown> = {
+    '@context': 'https://schema.org',
+    '@type': 'Person',
+    name: profile.name,
+    url: absoluteUrl,
+  };
+
+  if (profile.avatar) jsonLd.image = profile.avatar;
+  if (profile.jobTitle) jsonLd.jobTitle = profile.jobTitle;
+  if (profile.company) {
+    jsonLd.worksFor = {
+      '@type': 'Organization',
+      name: profile.company,
+    };
+  }
+  if (knowsAbout.length > 0) jsonLd.knowsAbout = knowsAbout;
+  if (profile.personalLinks.length > 0) {
+    jsonLd.sameAs = profile.personalLinks.map((link) => link.url);
+  }
+
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: safeStringify(jsonLd) }}
+    />
+  );
+}

--- a/src/lib/seo/buildMentorMetadata.ts
+++ b/src/lib/seo/buildMentorMetadata.ts
@@ -1,0 +1,99 @@
+import type { Metadata } from 'next';
+
+import type { PublicMentorProfile } from './sanitizePublicProfile';
+
+const MAX_DESCRIPTION_LENGTH = 160;
+
+function stripMarkdown(text: string): string {
+  return text
+    .replace(/!\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, '$1')
+    .replace(/[`*_>#~]+/g, '')
+    .replace(/<[^>]*>/g, '')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function truncate(text: string, max: number): string {
+  if (text.length <= max) return text;
+  const slice = text.slice(0, max);
+  const lastBoundary = Math.max(
+    slice.lastIndexOf('。'),
+    slice.lastIndexOf('！'),
+    slice.lastIndexOf('？'),
+    slice.lastIndexOf('，'),
+    slice.lastIndexOf('. '),
+    slice.lastIndexOf('! '),
+    slice.lastIndexOf('? '),
+    slice.lastIndexOf(', '),
+    slice.lastIndexOf(' ')
+  );
+  const cut = lastBoundary > max * 0.6 ? lastBoundary + 1 : max;
+  return slice.slice(0, cut).trimEnd() + '…';
+}
+
+function buildDescription(profile: PublicMentorProfile): string {
+  const cleaned = stripMarkdown(profile.about);
+  if (cleaned) return truncate(cleaned, MAX_DESCRIPTION_LENGTH);
+
+  const headlineFragments: string[] = [];
+  if (profile.jobTitle) headlineFragments.push(profile.jobTitle);
+  if (profile.company) headlineFragments.push(`@ ${profile.company}`);
+  const headline = headlineFragments.join(' ');
+
+  if (profile.name && headline) {
+    return truncate(
+      `${profile.name}｜${headline} 查看導師資歷與預約方式`,
+      MAX_DESCRIPTION_LENGTH
+    );
+  }
+
+  return profile.name
+    ? `查看 ${profile.name} 的導師資歷與預約方式`
+    : '查看 XChange Talent Pool 導師資歷與預約方式';
+}
+
+export function buildMentorMetadata(profile: PublicMentorProfile): Metadata {
+  const canonical = `/profile/${profile.userId}`;
+  const description = buildDescription(profile);
+
+  if (!profile.name) {
+    return {
+      title: 'XChange Talent Pool',
+      description,
+      alternates: { canonical },
+      robots: { index: false, follow: false },
+    };
+  }
+
+  if (!profile.isMentor) {
+    return {
+      title: profile.name,
+      description,
+      alternates: { canonical },
+      robots: { index: false, follow: false },
+    };
+  }
+
+  const title = `${profile.name} - 導師專業背景`;
+  const ogImages = profile.avatar ? [{ url: profile.avatar }] : [];
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      type: 'profile',
+      title: profile.name,
+      description,
+      url: canonical,
+      images: ogImages,
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: profile.name,
+      description,
+      images: ogImages.map((image) => image.url),
+    },
+  };
+}

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -1,0 +1,156 @@
+import { ExperienceType } from '@/services/profile/experienceType';
+import type { MentorProfileVO } from '@/services/profile/user';
+
+export type SocialPlatform =
+  | 'linkedin'
+  | 'facebook'
+  | 'instagram'
+  | 'twitter'
+  | 'youtube'
+  | 'website';
+
+const SOCIAL_PLATFORMS: readonly SocialPlatform[] = [
+  'linkedin',
+  'facebook',
+  'instagram',
+  'twitter',
+  'youtube',
+  'website',
+];
+
+export interface PublicPersonalLink {
+  platform: SocialPlatform;
+  url: string;
+}
+
+export interface PublicMentorProfile {
+  userId: number;
+  name: string;
+  avatar: string | null;
+  jobTitle: string;
+  company: string;
+  about: string;
+  industry: string | null;
+  expertises: string[];
+  topics: string[];
+  isMentor: boolean;
+  personalLinks: PublicPersonalLink[];
+}
+
+interface ExperienceBlock {
+  category?: string | null;
+  mentor_experiences_metadata?: { data?: unknown[] } | null;
+}
+
+interface WorkMetadata {
+  job?: string;
+  company?: string;
+  isPrimary?: boolean;
+}
+
+interface LinkMetadata {
+  platform?: string;
+  url?: string;
+}
+
+function isHttpsUrl(url: string): boolean {
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}
+
+function getBlocks(
+  experiences: MentorProfileVO['experiences'] | null | undefined,
+  category: string
+): ExperienceBlock[] {
+  if (!experiences) return [];
+  return (experiences as unknown as ExperienceBlock[]).filter(
+    (e) => e.category === category
+  );
+}
+
+function getMetadataItems<T>(block: ExperienceBlock): T[] {
+  return (block.mentor_experiences_metadata?.data ?? []) as T[];
+}
+
+function pickCurrentJob(profile: MentorProfileVO): {
+  jobTitle: string;
+  company: string;
+} {
+  const workEntries = getBlocks(
+    profile.experiences,
+    ExperienceType.WORK
+  ).flatMap((block) => getMetadataItems<WorkMetadata>(block));
+
+  if (workEntries.length === 0) {
+    return {
+      jobTitle: profile.job_title ?? '',
+      company: profile.company ?? '',
+    };
+  }
+
+  const current =
+    workEntries.find((entry) => entry.isPrimary) ?? workEntries[0];
+
+  return {
+    jobTitle: current.job ?? profile.job_title ?? '',
+    company: current.company ?? profile.company ?? '',
+  };
+}
+
+function pickPublicLinks(profile: MentorProfileVO): PublicPersonalLink[] {
+  const links = getBlocks(profile.experiences, ExperienceType.LINK).flatMap(
+    (block) => getMetadataItems<LinkMetadata>(block)
+  );
+
+  const seen = new Set<SocialPlatform>();
+  const result: PublicPersonalLink[] = [];
+
+  for (const link of links) {
+    const platform = link.platform as SocialPlatform | undefined;
+    const url = link.url ?? '';
+    if (
+      platform &&
+      SOCIAL_PLATFORMS.includes(platform) &&
+      isHttpsUrl(url) &&
+      !seen.has(platform)
+    ) {
+      seen.add(platform);
+      result.push({ platform, url });
+    }
+  }
+
+  return result;
+}
+
+export function sanitizePublicProfile(
+  profile: MentorProfileVO
+): PublicMentorProfile {
+  const { jobTitle, company } = pickCurrentJob(profile);
+
+  const expertises =
+    profile.expertises?.professions
+      ?.map((p) => p.subject ?? '')
+      .filter(Boolean) ?? [];
+
+  const topics =
+    profile.topics?.interests?.map((i) => i.subject ?? '').filter(Boolean) ??
+    [];
+
+  return {
+    userId: profile.user_id,
+    name: profile.name ?? '',
+    avatar: profile.avatar || null,
+    jobTitle,
+    company,
+    about: profile.about ?? '',
+    industry: profile.industry?.subject ?? null,
+    expertises,
+    topics,
+    isMentor: Boolean(profile.is_mentor),
+    personalLinks: pickPublicLinks(profile),
+  };
+}


### PR DESCRIPTION
## What Does This PR Do?

- Add `PersonJsonLd` server component that emits schema.org `Person` structured data on mentor profile pages (jobTitle, worksFor, knowsAbout, sameAs)
- Add `buildMentorMetadata` helper that produces canonical URL, OpenGraph, Twitter card, and `noindex,nofollow` for non-mentor / anonymous profiles
- Add `sanitizePublicProfile` to strip PII from `MentorProfileVO` and restrict `sameAs` to an https-only allow-list (LinkedIn, Facebook, Instagram, Twitter, YouTube, website)
- Wire `/profile/[pageUserId]/page.tsx` to use the new metadata helper and inject `PersonJsonLd` alongside the existing container

## Demo

http://localhost:3000/profile/<mentorUserId>

View page source to confirm `<meta>` tags and `<script type="application/ld+json">` render server-side.

## Screenshot

N/A

## Anything to Note?

- `metadataBase` is already configured in `src/app/layout.tsx` from `NEXT_PUBLIC_SITE_URL`, so canonical and OG image URLs use relative paths
- Social `sameAs` is intentionally narrow: any new platform requires updating `SOCIAL_PLATFORMS` in `sanitizePublicProfile.ts`
- Mentee / anonymous profiles are now `noindex,nofollow` to avoid Google indexing low-quality pages
- Closes Xchange-Taiwan/X-Talent-Tracker#181

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
