### PR TITLE
feat(seo): add canonical metadata for public pages and switch to Noto Sans TC

### DIFF
--- a/src/app/(landing)/about/page.tsx
+++ b/src/app/(landing)/about/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Image from 'next/image';
 import { FC, Fragment, ReactNode } from 'react';
 
@@ -7,6 +8,19 @@ import aboutPage_icon_2 from '@/assets/landing/aboutPage_icon_2.svg';
 import aboutPage_icon_3 from '@/assets/landing/aboutPage_icon_3.svg';
 
 import { featureData } from '../data';
+
+export const metadata: Metadata = {
+  title: '關於 X-Talent',
+  description:
+    '認識 X-Talent — 我們如何串聯業界導師與職涯探索者，協助你在轉職、升遷、跨界探索時，找到對的人聊對的事。',
+  alternates: { canonical: '/about' },
+  openGraph: {
+    title: '關於 X-Talent',
+    description:
+      '認識 X-Talent — 我們如何串聯業界導師與職涯探索者，協助你在轉職、升遷、跨界探索時，找到對的人聊對的事。',
+    url: '/about',
+  },
+};
 
 const SectionTitle: FC<{ children: ReactNode }> = ({ children }) => (
   <h2 className="mb-20 text-center text-xl font-bold md:text-2xl">

--- a/src/app/(landing)/page.tsx
+++ b/src/app/(landing)/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import Image from 'next/image';
 
 import HomePageHeroImgUrl from '@/assets/landing/home-page-hero.webp';
@@ -14,6 +15,10 @@ import landingPage_icon_6 from '@/assets/landing/landingPage_icon_6.svg';
 import { HomePageSliderClient } from '@/components/landing/HomePageSliderClient';
 
 import { featureData } from './data';
+
+export const metadata: Metadata = {
+  alternates: { canonical: '/' },
+};
 
 const FeatureItem = ({ icon, text }: { icon: string; text: string }) => {
   return (

--- a/src/app/font.ts
+++ b/src/app/font.ts
@@ -1,6 +1,6 @@
-import { Noto_Sans } from 'next/font/google';
+import { Noto_Sans_TC } from 'next/font/google';
 
-export const notoSans = Noto_Sans({
+export const notoSansTC = Noto_Sans_TC({
   weight: ['300', '400', '500', '700'],
   subsets: ['latin'],
   display: 'swap',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { Header } from '@/components/layout/Header';
 import Providers from '@/components/Providers';
 import { Toaster } from '@/components/ui/toaster';
 
-import { notoSans } from './font';
+import { notoSansTC } from './font';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
 const SITE_DESCRIPTION =
@@ -73,7 +73,7 @@ export default async function RootLayout({
     : null;
 
   return (
-    <html lang="zh-TW" className={notoSans.className}>
+    <html lang="zh-TW" className={notoSansTC.className}>
       <head>
         {avatarSrcSet && (
           <link

--- a/src/app/mentor-pool/page.tsx
+++ b/src/app/mentor-pool/page.tsx
@@ -1,3 +1,4 @@
+import type { Metadata } from 'next';
 import { Suspense } from 'react';
 
 import MentorGridSkeleton from './MentorGridSkeleton';
@@ -5,6 +6,21 @@ import MentorPoolHero from './MentorPoolHero';
 import MentorPoolSearchBar from './MentorPoolSearchBar';
 import MentorPoolWithData from './MentorPoolWithData';
 import type { ServerSearchParams } from './searchParams';
+
+// canonical points to the bare path so search engines collapse all
+// `?keyword=...` / filter variants onto a single indexable URL.
+export const metadata: Metadata = {
+  title: '尋找導師',
+  description:
+    '瀏覽 XChange Talent Pool 上的業界導師，依領域、職能、年資搜尋並預約 1:1 會談。',
+  alternates: { canonical: '/mentor-pool' },
+  openGraph: {
+    title: '尋找導師',
+    description:
+      '瀏覽 XChange Talent Pool 上的業界導師，依領域、職能、年資搜尋並預約 1:1 會談。',
+    url: '/mentor-pool',
+  },
+};
 
 interface PageProps {
   searchParams: ServerSearchParams;

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -32,9 +32,11 @@ export async function generateMetadata({
   return {
     title: name,
     description: about,
+    alternates: { canonical: `/profile/${userIdNum}` },
     openGraph: {
       title: name,
       description: about,
+      url: `/profile/${userIdNum}`,
       images: dto.avatar ? [{ url: dto.avatar }] : undefined,
     },
   };


### PR DESCRIPTION
## What Does This PR Do?

- Add `metadata` with `alternates.canonical` and OpenGraph url for `/`, `/about`, and `/mentor-pool` so search engines consolidate query/filter variants onto a single indexable URL
- Set canonical url on dynamic mentor profile pages (`/profile/[pageUserId]`) using the numeric user id
- Switch the root font from `Noto_Sans` to `Noto_Sans_TC` to render Traditional Chinese glyphs correctly across the app

## Demo

http://localhost:3000/

## Screenshot

N/A

## Anything to Note?

N/A
