### PR TITLE
fix(profile): map BE tag catalog kinds to want_*/have_* buckets

### DIFF
--- a/src/services/profile/tagCatalog.ts
+++ b/src/services/profile/tagCatalog.ts
@@ -33,21 +33,23 @@ export const EMPTY_TAG_CATALOGS: TagCatalogsByBucket = {
   have_topic: [],
 };
 
+// BE returns a flat catalog keyed by `kind` (`skill`/`topic`/`position`) — the
+// same skill catalog is reused for both want_skill (mentee picks) and have_skill
+// (mentor picks), likewise for topic. Position only applies to want_position.
 export function splitCatalogsByBucket(
   catalogs: TagCatalogsVO | null | undefined
 ): TagCatalogsByBucket {
-  const result: TagCatalogsByBucket = {
-    want_position: [],
-    want_skill: [],
-    want_topic: [],
-    have_skill: [],
-    have_topic: [],
+  if (!catalogs?.catalogs) return { ...EMPTY_TAG_CATALOGS };
+  const skillGroups = catalogs.catalogs.skill?.groups ?? [];
+  const topicGroups = catalogs.catalogs.topic?.groups ?? [];
+  const positionGroups = catalogs.catalogs.position?.groups ?? [];
+  return {
+    want_position: positionGroups,
+    want_skill: skillGroups,
+    want_topic: topicGroups,
+    have_skill: skillGroups,
+    have_topic: topicGroups,
   };
-  if (!catalogs?.catalogs) return result;
-  for (const key of TAG_BUCKET_KEYS) {
-    result[key] = catalogs.catalogs[key]?.groups ?? [];
-  }
-  return result;
 }
 
 export async function fetchTagCatalog(


### PR DESCRIPTION
## What Does This PR Do?

- Fix `splitCatalogsByBucket` so the FE actually picks up tags from the BE catalog. BE returns 3 buckets keyed by `kind` (`skill` / `topic` / `position`), but the previous code looked them up under the FE's 5 bucket names (`want_skill / want_topic / want_position / have_skill / have_topic`) and got empty arrays for all of them.
- Map the 3 BE buckets to the 5 FE buckets: the same `skill` catalog feeds both `want_skill` and `have_skill`, `topic` feeds both `want_topic` and `have_topic`, and `position` feeds `want_position`.
- This unblocks onboarding step 3/4/5 selections, the mentor-pool 技能/主題 filter dropdowns, and the mentor profile edit 我能提供的服務 / 專業能力 sections — all of which were silently empty after the want_*/have_* migration in #590.

## Demo

- http://localhost:3000/auth/onboarding (step 3/4/5)
- http://localhost:3000/mentor-pool (filter dropdowns)
- http://localhost:3000/profile/{userId}/edit (mentor sections)

## Screenshot

N/A

## Anything to Note?

- BE keys (`skill` / `topic` / `position`) are verified against the dev BFF response; if BE later splits the catalog into separate want/have buckets we'll need to revisit this mapping.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
