### PR TITLE
fix(mentor-pool): match search index shape for filters and tags

### DIFF
--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -30,19 +30,28 @@ import {
 } from './searchParams';
 import MentorPoolUI from './ui';
 
+// BE search index stores filter targets (industry, skills, topics) as the
+// `subject_group` code (e.g. "culture_education"), not the localized label —
+// so the option's value must round-trip subject_group while `subject` stays
+// as the display label.
 function subjectsToOptions(
-  items: ReadonlyArray<{ subject?: string | null }>
+  items: ReadonlyArray<{ subject_group?: string; subject?: string | null }>
 ): { label: string; value: string }[] {
   return items
-    .map((i) => ({ label: i.subject ?? '', value: i.subject ?? '' }))
+    .map((i) => ({ label: i.subject ?? '', value: i.subject_group ?? '' }))
     .filter((o) => o.value);
 }
 
 // Filter dropdowns show the BE-stored leaf labels, not catalog group labels —
 // flatten each bucket's groups down to leaves so the user picks tags directly.
-function flattenLeaves(groups: TagCatalogGroupVO[]): { subject: string }[] {
+function flattenLeaves(
+  groups: TagCatalogGroupVO[]
+): { subject_group: string; subject: string }[] {
   return groups.flatMap((g) =>
-    g.leaves.map((leaf) => ({ subject: leaf.subject }))
+    g.leaves.map((leaf) => ({
+      subject_group: leaf.subject_group,
+      subject: leaf.subject,
+    }))
   );
 }
 
@@ -86,6 +95,18 @@ export default function MentorPoolContainer({
     }),
     [tagCatalog.have_skill, tagCatalog.have_topic, industries]
   );
+
+  // /v1/mentors returns have_topic as subject_group codes (e.g.
+  // "promotion_review"), not the localized labels — translate via the catalog
+  // so cards show the zh_TW subject (e.g. "升遷考核制度"). Falls back to the
+  // code if a tag isn't in the catalog (legacy or unpublished tag).
+  const haveTopicLabelMap = useMemo(() => {
+    const map = new Map<string, string>();
+    tagCatalog.have_topic.forEach((g) =>
+      g.leaves.forEach((l) => map.set(l.subject_group, l.subject))
+    );
+    return map;
+  }, [tagCatalog.have_topic]);
 
   const [mentorCount, setMentorCount] = useState<number>(initialMentorCount);
   const [mentors, setMentors] = useState<MentorType[]>(initialMentors);
@@ -173,9 +194,18 @@ export default function MentorPoolContainer({
     });
   }, [params, router]);
 
+  const mentorsForUI = useMemo(
+    () =>
+      mentors.map((m) => ({
+        ...m,
+        have_topic: m.have_topic.map((c) => haveTopicLabelMap.get(c) ?? c),
+      })),
+    [mentors, haveTopicLabelMap]
+  );
+
   return (
     <MentorPoolUI
-      mentors={mentors}
+      mentors={mentorsForUI}
       mentorCount={mentorCount}
       isLoading={isLoading}
       isReplacing={isPending}

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -31,10 +31,18 @@ export interface MentorType {
   updated_at: number | null;
 }
 
-function readTagLabels(tags: TagVO[] | null | undefined): string[] {
+// OpenAPI types these as TagVO[], but the search index actually returns a
+// flat string[] of subject_group codes (e.g. ["promotion_review"]). Accept
+// both — for codes, the consumer is responsible for translating to a
+// localized label via the tag catalog.
+function readTagLabels(
+  tags: ReadonlyArray<TagVO | string> | null | undefined
+): string[] {
   if (!tags) return [];
   return tags
-    .map((t) => t.subject ?? t.subject_group ?? '')
+    .map((t) =>
+      typeof t === 'string' ? t : (t.subject ?? t.subject_group ?? '')
+    )
     .filter((s): s is string => Boolean(s));
 }
 
@@ -61,7 +69,13 @@ export function mapMentor(raw: RawMentor): MentorType {
     personal_statement: raw.personal_statement ?? '',
     about: raw.about ?? '',
     seniority_level: raw.seniority_level ?? '',
-    industry: raw.industry?.subject ?? null,
+    // OpenAPI schema types `industry` as ProfessionVO, but the search index
+    // returns it as a flat subject_group code string (e.g. "culture_education").
+    // Handle both shapes so we don't silently drop the value.
+    industry:
+      typeof raw.industry === 'string'
+        ? raw.industry
+        : (raw.industry?.subject_group ?? null),
     want_position: readTagLabels(raw.want_position),
     want_skill: readTagLabels(raw.want_skill),
     want_topic: readTagLabels(raw.want_topic),


### PR DESCRIPTION
## What Does This PR Do?

- Filter dropdown now sends `subject_group` codes (e.g. `culture_education`) as the value while keeping the localized `subject` (e.g. 文教相關業) as the label, so industry/skills/topics filters actually match the field stored in the `/v1/mentors` search index. Previously the FE sent the zh_TW label and got 0 results for any selection.
- Mentor card's "我能提供服務" tags now resolve `have_topic` codes (e.g. `promotion_review`) to localized labels (e.g. 升遷考核制度) via the tag catalog, falling back to the raw code for tags missing from the catalog. Previously `readTagLabels` expected `TagVO[]` but Search returns `string[]`, so every tag silently became empty.
- `mapMentor` reads `industry` defensively as either a string code (Search shape) or `ProfessionVO` (OpenAPI shape) so the value is no longer dropped.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

OpenAPI schema for `SearchMentorProfileVO` types `industry`, `have_topic`, etc. as object/array-of-object, but `/v1/mentors` returns flat `subject_group` code strings — worth raising with BE so schema and response align.
