### PR TITLE
refactor(schedule): switch mentor slots to (block, meeting_duration) format

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -22,15 +22,13 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
-import {
-  expandRrule,
-  UseMentorScheduleReturn,
-} from '@/hooks/useMentorSchedule';
+import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
 import {
   buildDateTime,
-  buildRrule,
   DtType,
+  parsedSubSlotStarts,
+  subdivideBlock,
 } from '@/lib/profile/scheduleHelpers';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
@@ -127,10 +125,7 @@ export default function MentorScheduleDialog({
   const nowSec = Math.floor(Date.now() / 1000);
   const editableSlotsForDate = draftForSelectedDate.filter((s) => {
     if (s.type !== 'ALLOW') return false;
-    const occurrences = s.rrule
-      ? expandRrule(Math.floor(s.start.getTime() / 1000), s.rrule)
-      : [Math.floor(s.start.getTime() / 1000)];
-    return occurrences.some((occ) => occ > nowSec);
+    return parsedSubSlotStarts(s).some((occ) => occ > nowSec);
   });
 
   // Collect booked dtstart values for the selected date (for locking sub-slots)
@@ -157,10 +152,7 @@ export default function MentorScheduleDialog({
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
     if (!parsed || parsed.type !== 'ALLOW') return null;
 
-    const occurrences = parsed.rrule
-      ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-      : [Math.floor(parsed.start.getTime() / 1000)];
-
+    const occurrences = parsedSubSlotStarts(parsed);
     if (occurrences.some((occ) => bookedStartsForDate.has(occ)))
       return 'BOOKED';
     if (occurrences.some((occ) => pendingStartsForDate.has(occ)))
@@ -197,17 +189,14 @@ export default function MentorScheduleDialog({
       return null;
 
     const newDtstart = Math.floor(candStart.valueOf() / 1000);
-    const blockDur = Math.floor(candEnd.valueOf() / 1000) - newDtstart;
-    const slotDur = parsed.slotDurationSeconds;
-    const newRrule =
-      blockDur > slotDur ? buildRrule(blockDur, slotDur) : undefined;
-    const newStarts = new Set(expandRrule(newDtstart, newRrule));
-
-    const oldStarts = new Set(
-      parsed.rrule
-        ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-        : [Math.floor(parsed.start.getTime() / 1000)]
+    const newDtend = Math.floor(candEnd.valueOf() / 1000);
+    const slotMinutes =
+      parsed.meetingDurationMinutes ??
+      Math.round(parsed.slotDurationSeconds / 60);
+    const newStarts = new Set(
+      subdivideBlock(newDtstart, newDtend, slotMinutes)
     );
+    const oldStarts = new Set(parsedSubSlotStarts(parsed));
 
     const ownedBooked = Array.from(bookedStartsForDate).filter((occ) =>
       oldStarts.has(occ)
@@ -442,12 +431,10 @@ export default function MentorScheduleDialog({
   /** Render the sub-slot chips for an ALLOW block so mentor can toggle individual occurrences. */
   const renderSubSlots = (slotId: number) => {
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
+    if (!parsed || parsed.type !== 'ALLOW') return null;
 
-    const allOccurrences = expandRrule(
-      Math.floor(parsed.start.getTime() / 1000),
-      parsed.rrule
-    );
+    const allOccurrences = parsedSubSlotStarts(parsed);
+    // Single-slot blocks (e.g. exactly one meeting fits) don't need chips.
     if (allOccurrences.length <= 1) return null;
 
     // Hide sub-slots that have already started today; the parent block filter

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -9,9 +9,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   BookingSlot,
   buildDateTime,
-  buildRrule,
-  expandRrule,
+  DEFAULT_MEETING_DURATION_MINUTES,
   formatTimeslot,
+  getBlockEnd,
+  getSubSlotDurationSeconds,
+  getSubSlotStarts,
   hasOverlapAt,
   MonthKey,
   monthKeyFromDateStr,
@@ -110,8 +112,9 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const [selectedDate, setSelectedDate] = useState<string | null>(
     dayjs().format('YYYY-MM-DD')
   );
-  const [meetingDurationMinutes, setMeetingDurationMinutes] =
-    useState<number>(30);
+  const [meetingDurationMinutes, setMeetingDurationMinutes] = useState<number>(
+    DEFAULT_MEETING_DURATION_MINUTES
+  );
 
   const currentMonthKey = monthKeyFromYearMonth(backend.year, backend.month);
 
@@ -144,6 +147,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         rrule: r.rrule,
         timezone: 'UTC',
         exdate: r.exdate,
+        meeting_duration_minutes: r.meetingDurationMinutes,
       };
       if (r.id > 0 && persistedIdSet.has(r.id)) slot.id = r.id;
       return slot;
@@ -198,9 +202,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       });
       const firstAllow = raws.find((r) => r.type === 'ALLOW');
       if (firstAllow) {
-        const derived = Math.round(
-          (firstAllow.dtend - firstAllow.dtstart) / 60
-        );
+        // New-format rows carry the duration explicitly; legacy rows still
+        // encode it as the dtend-dtstart slot length.
+        const derived =
+          firstAllow.meetingDurationMinutes ??
+          Math.round((firstAllow.dtend - firstAllow.dtstart) / 60);
         if (derived > 0) setMeetingDurationMinutes(derived);
       }
     };
@@ -298,8 +304,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     const dates = new Set<string>();
     for (const slot of allDraftRaws) {
       if (slot.type !== 'ALLOW') continue;
-      const occurrences = expandRrule(slot.dtstart, slot.rrule);
-      for (const occ of occurrences) {
+      const subSlotStarts = getSubSlotStarts(slot);
+      for (const occ of subSlotStarts) {
         if (slot.exdate.includes(occ)) continue;
         dates.add(dayjs(occ * 1000).format('YYYY-MM-DD'));
       }
@@ -320,10 +326,10 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
         if (slotDateKey !== dateKey) continue;
 
-        const occurrences = expandRrule(slot.dtstart, slot.rrule);
-        const slotDuration = slot.dtend - slot.dtstart;
+        const subSlotStarts = getSubSlotStarts(slot);
+        const slotDuration = getSubSlotDurationSeconds(slot);
 
-        for (const occ of occurrences) {
+        for (const occ of subSlotStarts) {
           if (slot.exdate.includes(occ)) continue;
           if (occ <= nowSec) continue;
           result.push({
@@ -396,10 +402,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return;
 
         const newDtstart = Math.floor(s.valueOf() / 1000);
-        const blockDurationSeconds =
-          Math.floor(e.valueOf() / 1000) - newDtstart;
-        const slotDurationSeconds = meetingDurationMinutes * 60;
-        const newDtend = newDtstart + slotDurationSeconds;
+        const newDtend = Math.floor(e.valueOf() / 1000);
+        const blockDurationSeconds = newDtend - newDtstart;
 
         const monthKey = monthKeyFromDateStr(selectedDate);
 
@@ -416,11 +420,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             return prev;
           }
 
-          const rrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
-
+          // New format: dtend is the block end and meetingDurationMinutes
+          // carries the sub-slot length. No rrule for non-recurring slots.
           return [
             ...prev,
             {
@@ -428,8 +429,9 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
               type: 'ALLOW' as const,
               dtstart: newDtstart,
               dtend: newDtend,
-              rrule,
+              rrule: undefined,
               exdate: [],
+              meetingDurationMinutes,
             },
           ];
         });
@@ -452,21 +454,15 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
           const startHM = patch.startTime ?? fmtHM(target.dtstart);
-
-          const occs = expandRrule(target.dtstart, target.rrule);
-          const lastOcc = occs[occs.length - 1] ?? target.dtstart;
-          const endHM =
-            patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
+          const endHM = patch.endTime ?? fmtHM(getBlockEnd(target));
 
           const s = buildDateTime(baseDate, startHM);
           const e = buildDateTime(baseDate, endHM);
           if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return prev;
 
           const newDtstart = Math.floor(s.valueOf() / 1000);
-          const blockDurationSeconds =
-            Math.floor(e.valueOf() / 1000) - newDtstart;
-          const slotDurationSeconds = target.dtend - target.dtstart;
-          const newDtend = newDtstart + slotDurationSeconds;
+          const newDtend = Math.floor(e.valueOf() / 1000);
+          const blockDurationSeconds = newDtend - newDtstart;
 
           if (
             hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
@@ -474,14 +470,15 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             return prev;
           }
 
-          const newRrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
+          // Migrate legacy rows to new format on edit: pick up the duration
+          // from the legacy slot length so we don't change the mentor's
+          // intended sub-slot size when they touch a pre-refactor row.
+          const newMdm =
+            target.meetingDurationMinutes ??
+            Math.round((target.dtend - target.dtstart) / 60);
 
-          const newBlockEnd = newDtstart + blockDurationSeconds;
           const cleanedExdate = target.exdate.filter(
-            (occ) => occ >= newDtstart && occ < newBlockEnd
+            (occ) => occ >= newDtstart && occ < newDtend
           );
 
           return prev.map((r) =>
@@ -490,8 +487,9 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
                   ...r,
                   dtstart: newDtstart,
                   dtend: newDtend,
-                  rrule: newRrule,
+                  rrule: undefined,
                   exdate: cleanedExdate,
+                  meetingDurationMinutes: newMdm,
                 }
               : r
           );

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -11,6 +11,8 @@ export type DtType = 'ALLOW' | 'BOOKED' | 'PENDING';
 /** 'YYYY-MM' — used to bucket per-month draft state in useMentorSchedule. */
 export type MonthKey = string;
 
+export const DEFAULT_MEETING_DURATION_MINUTES = 30;
+
 export function monthKeyFromUnix(unix: number): MonthKey {
   return dayjs(unix * 1000).format('YYYY-MM');
 }
@@ -31,6 +33,11 @@ export function parseMonthKey(key: MonthKey): { year: number; month: number } {
 // id: negative values are temporary local ids for new slots (-1, -2, ...)
 // type: narrowed from SegmentVO.dt_type
 // exdate: nulls excluded from SegmentVO.exdate
+// meetingDurationMinutes: new-format marker. null = legacy MINUTELY-rrule row
+//   where (dtstart, dtend) is one sub-slot and `rrule` iterates sub-slots.
+//   When set: (dtstart, dtend) is the whole block and sub-slots are derived
+//   by dividing the block by this length — `rrule` is reserved for true
+//   weekly/daily recurrence (not yet exposed in the UI).
 export type RawMentorTimeslot = Pick<
   SegmentVO,
   'dtstart' | 'dtend' | 'rrule'
@@ -38,19 +45,21 @@ export type RawMentorTimeslot = Pick<
   id: number;
   type: DtType;
   exdate: number[];
+  meetingDurationMinutes: number | null;
 };
 
 export type ParsedMentorTimeslot = {
   id: number;
   type: DtType;
   start: Date; // block start (= dtstart for all types)
-  end: Date; // block end: last occurrence end for ALLOW (derived from rrule), dtend for others
+  end: Date; // block end: derived via getBlockEnd to handle both formats
   durationMinutes: number;
   formatted: string;
   dateKey: string; // YYYY-MM-DD (local)
   rrule?: string;
   exdate: number[];
-  slotDurationSeconds: number; // duration of one sub-slot (dtend - dtstart)
+  slotDurationSeconds: number; // duration of one sub-slot
+  meetingDurationMinutes: number | null;
 };
 
 export type BookingSlot = {
@@ -76,6 +85,78 @@ export function expandRrule(
   }
 }
 
+/**
+ * Subdivide a block [start, end) into sub-slot start timestamps. Trailing
+ * remainder shorter than one slot is dropped.
+ */
+export function subdivideBlock(
+  blockStart: number,
+  blockEnd: number,
+  slotMinutes: number
+): number[] {
+  if (slotMinutes <= 0 || blockEnd <= blockStart) return [];
+  const slotSec = slotMinutes * 60;
+  const out: number[] = [];
+  for (let t = blockStart; t + slotSec <= blockEnd; t += slotSec) {
+    out.push(t);
+  }
+  return out;
+}
+
+type SubSlotInput = Pick<
+  RawMentorTimeslot,
+  'dtstart' | 'dtend' | 'rrule' | 'meetingDurationMinutes'
+>;
+
+/**
+ * Return all sub-slot start timestamps for a slot, hiding the new vs. legacy
+ * format split. New format divides (dtstart, dtend) by meetingDurationMinutes;
+ * legacy expands the FREQ=MINUTELY rrule.
+ */
+export function getSubSlotStarts(slot: SubSlotInput): number[] {
+  if (slot.meetingDurationMinutes != null && slot.meetingDurationMinutes > 0) {
+    return subdivideBlock(
+      slot.dtstart,
+      slot.dtend,
+      slot.meetingDurationMinutes
+    );
+  }
+  return expandRrule(slot.dtstart, slot.rrule);
+}
+
+/** Block end timestamp for a slot. New format: dtend. Legacy: last sub-slot end. */
+export function getBlockEnd(slot: SubSlotInput): number {
+  if (slot.meetingDurationMinutes != null && slot.meetingDurationMinutes > 0) {
+    return slot.dtend;
+  }
+  const occs = expandRrule(slot.dtstart, slot.rrule);
+  const last = occs[occs.length - 1] ?? slot.dtstart;
+  return last + (slot.dtend - slot.dtstart);
+}
+
+/** Sub-slot length in seconds. New format reads meetingDurationMinutes; legacy uses dtend-dtstart. */
+export function getSubSlotDurationSeconds(slot: SubSlotInput): number {
+  if (slot.meetingDurationMinutes != null && slot.meetingDurationMinutes > 0) {
+    return slot.meetingDurationMinutes * 60;
+  }
+  return slot.dtend - slot.dtstart;
+}
+
+/**
+ * Sub-slot starts derived from a ParsedMentorTimeslot. Convenience wrapper
+ * for UI code that holds parsed slots (the dialog) so it doesn't need to
+ * re-derive raw fields. p.end is treated as the block end in both formats —
+ * see formatTimeslot for how that's computed.
+ */
+export function parsedSubSlotStarts(p: ParsedMentorTimeslot): number[] {
+  const startSec = Math.floor(p.start.getTime() / 1000);
+  if (p.meetingDurationMinutes != null && p.meetingDurationMinutes > 0) {
+    const endSec = Math.floor(p.end.getTime() / 1000);
+    return subdivideBlock(startSec, endSec, p.meetingDurationMinutes);
+  }
+  return expandRrule(startSec, p.rrule);
+}
+
 export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
   return {
     id: t.id ?? Math.floor(Math.random() * 1e9),
@@ -84,21 +165,14 @@ export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
     dtend: t.dtend,
     rrule: t.rrule ?? undefined,
     exdate: (t.exdate ?? []).filter((x): x is number => x !== null),
+    meetingDurationMinutes: t.meeting_duration_minutes ?? null,
   };
 }
 
 export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
   const start = new Date(r.dtstart * 1000);
-  const slotDurationSeconds = r.dtend - r.dtstart;
-
-  let end: Date;
-  if (r.type === 'ALLOW' && r.rrule) {
-    const occurrences = expandRrule(r.dtstart, r.rrule);
-    const lastOccDtstart = occurrences[occurrences.length - 1] ?? r.dtstart;
-    end = new Date((lastOccDtstart + slotDurationSeconds) * 1000);
-  } else {
-    end = new Date(r.dtend * 1000);
-  }
+  const slotDurationSeconds = getSubSlotDurationSeconds(r);
+  const end = new Date(getBlockEnd(r) * 1000);
 
   const durationMinutes = Math.round(
     (end.getTime() - start.getTime()) / (1000 * 60)
@@ -115,21 +189,13 @@ export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
     rrule: r.rrule ?? undefined,
     exdate: r.exdate,
     slotDurationSeconds,
+    meetingDurationMinutes: r.meetingDurationMinutes,
   };
 }
 
 export function nextTempId(rows: RawMentorTimeslot[]): number {
   const negatives = rows.filter((r) => r.id < 0).map((r) => r.id);
   return negatives.length ? Math.min(...negatives) - 1 : -1;
-}
-
-export function buildRrule(
-  blockDurationSeconds: number,
-  slotDurationSeconds: number
-): string {
-  const count = Math.round(blockDurationSeconds / slotDurationSeconds);
-  const intervalMinutes = Math.round(slotDurationSeconds / 60);
-  return `FREQ=MINUTELY;INTERVAL=${intervalMinutes};COUNT=${count}`;
 }
 
 /** Build a dayjs from a YYYY-MM-DD date and HH:mm time. */
@@ -160,8 +226,7 @@ export function hasOverlapAt(
     if (r.type !== 'ALLOW') return false;
     const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
     if (rDate !== dateKey) return false;
-    const occs = expandRrule(r.dtstart, r.rrule);
-    const rEnd = (occs[occs.length - 1] ?? r.dtstart) + (r.dtend - r.dtstart);
+    const rEnd = getBlockEnd(r);
     return dtstart < rEnd && blockEnd > r.dtstart;
   });
 }

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -72,6 +72,7 @@ export async function saveMentorSchedule(params: {
         rrule: t.rrule,
         timezone: 'UTC',
         exdate: t.exdate,
+        meeting_duration_minutes: t.meeting_duration_minutes,
       })
     ),
   });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1625,6 +1625,11 @@ export interface components {
        */
       exdate: (number | null)[];
       /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
+      /**
        * Source
        * @example schedule
        */
@@ -2274,6 +2279,11 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
+      /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
     };
     /**
      * TimeSlotType
@@ -2334,6 +2344,11 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
+      /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
     };
     /** TokenRefreshAuthVO */
     TokenRefreshAuthVO: {


### PR DESCRIPTION
## Summary

Backend X-Career-User now carries sub-slot length in its own column instead of encoding it as a `FREQ=MINUTELY` rrule, freeing rrule for true recurrence later. This change cuts over the frontend.

- Drop `buildRrule()` — block subdivision is now arithmetic, not an rrule abuse
- New helpers in `scheduleHelpers`: `subdivideBlock`, `getSubSlotStarts`, `getBlockEnd`, `getSubSlotDurationSeconds`, `parsedSubSlotStarts` — they centralise the new vs. legacy branch so callers don't repeat it
- `useMentorSchedule.addSlotForSelectedDate` / `updateDraftSlot` send `dtend = block end` (not single sub-slot end) and `meetingDurationMinutes` alongside it. Editing a legacy slot migrates it to the new shape, picking the duration up from the legacy slot length so the mentor's intent is preserved
- `MentorScheduleDialog` uses `parsedSubSlotStarts` everywhere it previously called `expandRrule` directly
- `types/api.ts` hand-edited to add the new field on `TimeSlotDTO`/`VO` and `MentorScheduleSegmentVO` — regenerate via `pnpm generate:types` after the BFF PR deploys to make this permanent

Companion PRs (must deploy together):
- X-Career-User: column + validation + backfill
- BFF: pass-through field

Phase 5 (weekly recurrence UI) is intentionally deferred — backend already supports `FREQ=WEEKLY`, but no frontend toggle yet.

## Test plan

- [x] `pnpm type-check` — passes
- [x] `pnpm build` — production build succeeds
- [x] `pnpm test` — 160 tests pass (pre-push hook)
- [ ] Open mentor schedule editor on a date with no slots → add a 30-min slot 09:00-09:30 → save. Verify in DB: `dtend - dtstart = 1800`, `meeting_duration_minutes = 30`, `rrule IS NULL`
- [ ] Add a 3-hour slot 09:00-12:00 (default 30-min meetings) → save. Verify: `dtend - dtstart = 10800`, `meeting_duration_minutes = 30`, `rrule IS NULL`. UI should still show 6 sub-slot chips
- [ ] Toggle a sub-slot chip off → save → reopen — chip is still excluded (exdate works)
- [ ] Edit an existing slot's start/end times → save — slot updates correctly, `meeting_duration_minutes` preserved
- [ ] Mentee view: book a sub-slot → mentor's editor still shows it as booked (chip locked)
- [ ] Re-load page after save — calendar highlights stay consistent across new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)