### PR TITLE
fix(mentor-schedule): adopt block + meeting_duration_minutes model

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -22,15 +22,12 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
-import {
-  expandRrule,
-  UseMentorScheduleReturn,
-} from '@/hooks/useMentorSchedule';
+import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
 import {
   buildDateTime,
-  buildRrule,
   DtType,
+  expandBlockSubSlots,
 } from '@/lib/profile/scheduleHelpers';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
@@ -127,9 +124,11 @@ export default function MentorScheduleDialog({
   const nowSec = Math.floor(Date.now() / 1000);
   const editableSlotsForDate = draftForSelectedDate.filter((s) => {
     if (s.type !== 'ALLOW') return false;
-    const occurrences = s.rrule
-      ? expandRrule(Math.floor(s.start.getTime() / 1000), s.rrule)
-      : [Math.floor(s.start.getTime() / 1000)];
+    const occurrences = expandBlockSubSlots(
+      Math.floor(s.start.getTime() / 1000),
+      Math.floor(s.end.getTime() / 1000),
+      s.meetingDurationMinutes
+    );
     return occurrences.some((occ) => occ > nowSec);
   });
 
@@ -157,9 +156,11 @@ export default function MentorScheduleDialog({
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
     if (!parsed || parsed.type !== 'ALLOW') return null;
 
-    const occurrences = parsed.rrule
-      ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-      : [Math.floor(parsed.start.getTime() / 1000)];
+    const occurrences = expandBlockSubSlots(
+      Math.floor(parsed.start.getTime() / 1000),
+      Math.floor(parsed.end.getTime() / 1000),
+      parsed.meetingDurationMinutes
+    );
 
     if (occurrences.some((occ) => bookedStartsForDate.has(occ)))
       return 'BOOKED';
@@ -197,16 +198,17 @@ export default function MentorScheduleDialog({
       return null;
 
     const newDtstart = Math.floor(candStart.valueOf() / 1000);
-    const blockDur = Math.floor(candEnd.valueOf() / 1000) - newDtstart;
-    const slotDur = parsed.slotDurationSeconds;
-    const newRrule =
-      blockDur > slotDur ? buildRrule(blockDur, slotDur) : undefined;
-    const newStarts = new Set(expandRrule(newDtstart, newRrule));
+    const newDtend = Math.floor(candEnd.valueOf() / 1000);
+    const newStarts = new Set(
+      expandBlockSubSlots(newDtstart, newDtend, parsed.meetingDurationMinutes)
+    );
 
     const oldStarts = new Set(
-      parsed.rrule
-        ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-        : [Math.floor(parsed.start.getTime() / 1000)]
+      expandBlockSubSlots(
+        Math.floor(parsed.start.getTime() / 1000),
+        Math.floor(parsed.end.getTime() / 1000),
+        parsed.meetingDurationMinutes
+      )
     );
 
     const ownedBooked = Array.from(bookedStartsForDate).filter((occ) =>
@@ -442,11 +444,12 @@ export default function MentorScheduleDialog({
   /** Render the sub-slot chips for an ALLOW block so mentor can toggle individual occurrences. */
   const renderSubSlots = (slotId: number) => {
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
+    if (!parsed || parsed.type !== 'ALLOW') return null;
 
-    const allOccurrences = expandRrule(
+    const allOccurrences = expandBlockSubSlots(
       Math.floor(parsed.start.getTime() / 1000),
-      parsed.rrule
+      Math.floor(parsed.end.getTime() / 1000),
+      parsed.meetingDurationMinutes
     );
     if (allOccurrences.length <= 1) return null;
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -9,8 +9,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   BookingSlot,
   buildDateTime,
-  buildRrule,
-  expandRrule,
+  expandBlockSubSlots,
   formatTimeslot,
   hasOverlapAt,
   MonthKey,
@@ -144,6 +143,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         rrule: r.rrule,
         timezone: 'UTC',
         exdate: r.exdate,
+        meeting_duration_minutes: r.meetingDurationMinutes,
       };
       if (r.id > 0 && persistedIdSet.has(r.id)) slot.id = r.id;
       return slot;
@@ -197,11 +197,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         return next;
       });
       const firstAllow = raws.find((r) => r.type === 'ALLOW');
-      if (firstAllow) {
-        const derived = Math.round(
-          (firstAllow.dtend - firstAllow.dtstart) / 60
-        );
-        if (derived > 0) setMeetingDurationMinutes(derived);
+      if (firstAllow && firstAllow.meetingDurationMinutes > 0) {
+        setMeetingDurationMinutes(firstAllow.meetingDurationMinutes);
       }
     };
 
@@ -298,7 +295,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     const dates = new Set<string>();
     for (const slot of allDraftRaws) {
       if (slot.type !== 'ALLOW') continue;
-      const occurrences = expandRrule(slot.dtstart, slot.rrule);
+      const occurrences = expandBlockSubSlots(
+        slot.dtstart,
+        slot.dtend,
+        slot.meetingDurationMinutes
+      );
       for (const occ of occurrences) {
         if (slot.exdate.includes(occ)) continue;
         dates.add(dayjs(occ * 1000).format('YYYY-MM-DD'));
@@ -320,8 +321,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
         if (slotDateKey !== dateKey) continue;
 
-        const occurrences = expandRrule(slot.dtstart, slot.rrule);
-        const slotDuration = slot.dtend - slot.dtstart;
+        const occurrences = expandBlockSubSlots(
+          slot.dtstart,
+          slot.dtend,
+          slot.meetingDurationMinutes
+        );
+        const slotDuration = slot.meetingDurationMinutes * 60;
 
         for (const occ of occurrences) {
           if (slot.exdate.includes(occ)) continue;
@@ -398,8 +403,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const newDtstart = Math.floor(s.valueOf() / 1000);
         const blockDurationSeconds =
           Math.floor(e.valueOf() / 1000) - newDtstart;
-        const slotDurationSeconds = meetingDurationMinutes * 60;
-        const newDtend = newDtstart + slotDurationSeconds;
 
         const monthKey = monthKeyFromDateStr(selectedDate);
 
@@ -416,20 +419,16 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             return prev;
           }
 
-          const rrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
-
           return [
             ...prev,
             {
               id: nextTempId(prev),
               type: 'ALLOW' as const,
               dtstart: newDtstart,
-              dtend: newDtend,
-              rrule,
+              dtend: newDtstart + blockDurationSeconds,
+              rrule: undefined,
               exdate: [],
+              meetingDurationMinutes,
             },
           ];
         });
@@ -452,11 +451,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
           const startHM = patch.startTime ?? fmtHM(target.dtstart);
-
-          const occs = expandRrule(target.dtstart, target.rrule);
-          const lastOcc = occs[occs.length - 1] ?? target.dtstart;
-          const endHM =
-            patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
+          const endHM = patch.endTime ?? fmtHM(target.dtend);
 
           const s = buildDateTime(baseDate, startHM);
           const e = buildDateTime(baseDate, endHM);
@@ -465,19 +460,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const newDtstart = Math.floor(s.valueOf() / 1000);
           const blockDurationSeconds =
             Math.floor(e.valueOf() / 1000) - newDtstart;
-          const slotDurationSeconds = target.dtend - target.dtstart;
-          const newDtend = newDtstart + slotDurationSeconds;
 
           if (
             hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
           ) {
             return prev;
           }
-
-          const newRrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
 
           const newBlockEnd = newDtstart + blockDurationSeconds;
           const cleanedExdate = target.exdate.filter(
@@ -489,8 +477,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
               ? {
                   ...r,
                   dtstart: newDtstart,
-                  dtend: newDtend,
-                  rrule: newRrule,
+                  dtend: newBlockEnd,
+                  rrule: undefined,
                   exdate: cleanedExdate,
                 }
               : r

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -31,6 +31,8 @@ export function parseMonthKey(key: MonthKey): { year: number; month: number } {
 // id: negative values are temporary local ids for new slots (-1, -2, ...)
 // type: narrowed from SegmentVO.dt_type
 // exdate: nulls excluded from SegmentVO.exdate
+// dtstart/dtend: block bounds (entire window). Sub-slots are derived via
+//   expandBlockSubSlots(dtstart, dtend, meetingDurationMinutes).
 export type RawMentorTimeslot = Pick<
   SegmentVO,
   'dtstart' | 'dtend' | 'rrule'
@@ -38,19 +40,21 @@ export type RawMentorTimeslot = Pick<
   id: number;
   type: DtType;
   exdate: number[];
+  meetingDurationMinutes: number;
 };
 
 export type ParsedMentorTimeslot = {
   id: number;
   type: DtType;
-  start: Date; // block start (= dtstart for all types)
-  end: Date; // block end: last occurrence end for ALLOW (derived from rrule), dtend for others
+  start: Date; // block start
+  end: Date; // block end
   durationMinutes: number;
   formatted: string;
   dateKey: string; // YYYY-MM-DD (local)
   rrule?: string;
   exdate: number[];
-  slotDurationSeconds: number; // duration of one sub-slot (dtend - dtstart)
+  slotDurationSeconds: number; // duration of one sub-slot (meetingDurationMinutes * 60)
+  meetingDurationMinutes: number;
 };
 
 export type BookingSlot = {
@@ -76,30 +80,62 @@ export function expandRrule(
   }
 }
 
+/** Sub-slot start times within a block, derived from meetingDurationMinutes. */
+export function expandBlockSubSlots(
+  dtstart: number,
+  dtend: number,
+  meetingDurationMinutes: number
+): number[] {
+  if (meetingDurationMinutes <= 0 || dtend <= dtstart) return [dtstart];
+  const step = meetingDurationMinutes * 60;
+  const result: number[] = [];
+  for (let t = dtstart; t < dtend; t += step) result.push(t);
+  return result;
+}
+
 export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
+  const id = t.id ?? Math.floor(Math.random() * 1e9);
+  const type = t.dt_type as RawMentorTimeslot['type'];
+  const exdate = (t.exdate ?? []).filter((x): x is number => x !== null);
+
+  if (t.meeting_duration_minutes != null) {
+    return {
+      id,
+      type,
+      dtstart: t.dtstart,
+      dtend: t.dtend,
+      rrule: t.rrule ?? undefined,
+      exdate,
+      meetingDurationMinutes: t.meeting_duration_minutes,
+    };
+  }
+
+  // Legacy fallback: backend pre-Phase-1-4 row with no meeting_duration_minutes.
+  // Old MINUTELY rrule encoded sub-slots; block end was lastOcc + (dtend-dtstart).
+  const subSlotSeconds = Math.max(0, t.dtend - t.dtstart);
+  const isMinutely = t.rrule?.includes('FREQ=MINUTELY');
+  let blockEnd = t.dtend;
+  if (isMinutely) {
+    const occs = expandRrule(t.dtstart, t.rrule);
+    const lastOcc = occs[occs.length - 1] ?? t.dtstart;
+    blockEnd = lastOcc + subSlotSeconds;
+  }
   return {
-    id: t.id ?? Math.floor(Math.random() * 1e9),
-    type: t.dt_type as RawMentorTimeslot['type'],
+    id,
+    type,
     dtstart: t.dtstart,
-    dtend: t.dtend,
-    rrule: t.rrule ?? undefined,
-    exdate: (t.exdate ?? []).filter((x): x is number => x !== null),
+    dtend: blockEnd,
+    rrule: isMinutely ? undefined : (t.rrule ?? undefined),
+    exdate,
+    meetingDurationMinutes:
+      subSlotSeconds > 0 ? Math.round(subSlotSeconds / 60) : 0,
   };
 }
 
 export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
   const start = new Date(r.dtstart * 1000);
-  const slotDurationSeconds = r.dtend - r.dtstart;
-
-  let end: Date;
-  if (r.type === 'ALLOW' && r.rrule) {
-    const occurrences = expandRrule(r.dtstart, r.rrule);
-    const lastOccDtstart = occurrences[occurrences.length - 1] ?? r.dtstart;
-    end = new Date((lastOccDtstart + slotDurationSeconds) * 1000);
-  } else {
-    end = new Date(r.dtend * 1000);
-  }
-
+  const end = new Date(r.dtend * 1000);
+  const slotDurationSeconds = r.meetingDurationMinutes * 60;
   const durationMinutes = Math.round(
     (end.getTime() - start.getTime()) / (1000 * 60)
   );
@@ -115,21 +151,13 @@ export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
     rrule: r.rrule ?? undefined,
     exdate: r.exdate,
     slotDurationSeconds,
+    meetingDurationMinutes: r.meetingDurationMinutes,
   };
 }
 
 export function nextTempId(rows: RawMentorTimeslot[]): number {
   const negatives = rows.filter((r) => r.id < 0).map((r) => r.id);
   return negatives.length ? Math.min(...negatives) - 1 : -1;
-}
-
-export function buildRrule(
-  blockDurationSeconds: number,
-  slotDurationSeconds: number
-): string {
-  const count = Math.round(blockDurationSeconds / slotDurationSeconds);
-  const intervalMinutes = Math.round(slotDurationSeconds / 60);
-  return `FREQ=MINUTELY;INTERVAL=${intervalMinutes};COUNT=${count}`;
 }
 
 /** Build a dayjs from a YYYY-MM-DD date and HH:mm time. */
@@ -160,8 +188,6 @@ export function hasOverlapAt(
     if (r.type !== 'ALLOW') return false;
     const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
     if (rDate !== dateKey) return false;
-    const occs = expandRrule(r.dtstart, r.rrule);
-    const rEnd = (occs[occs.length - 1] ?? r.dtstart) + (r.dtend - r.dtstart);
-    return dtstart < rEnd && blockEnd > r.dtstart;
+    return dtstart < r.dtend && blockEnd > r.dtstart;
   });
 }

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -72,6 +72,7 @@ export async function saveMentorSchedule(params: {
         rrule: t.rrule,
         timezone: 'UTC',
         exdate: t.exdate,
+        meeting_duration_minutes: t.meeting_duration_minutes,
       })
     ),
   });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1634,6 +1634,11 @@ export interface components {
        * @example 100
        */
       source_id?: number | null;
+      /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
     };
     /** MentorScheduleVO */
     MentorScheduleVO: {
@@ -2274,6 +2279,11 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
+      /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
     };
     /**
      * TimeSlotType
@@ -2334,6 +2344,11 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
+      /**
+       * Meeting Duration Minutes
+       * @example 30
+       */
+      meeting_duration_minutes?: number | null;
     };
     /** TokenRefreshAuthVO */
     TokenRefreshAuthVO: {


### PR DESCRIPTION
## What Does This PR Do?

- Add `meeting_duration_minutes` to `MentorScheduleSegmentVO` / `TimeSlotDTO` / `TimeSlotVO` to match BFF rrule refactor Phase 1-4
- Switch internal `RawMentorTimeslot` / `ParsedMentorTimeslot` to the new model: `(dtstart, dtend)` are block bounds, sub-slots derived from `meetingDurationMinutes`
- Replace `buildRrule` (`FREQ=MINUTELY` output) with `expandBlockSubSlots(dtstart, dtend, meetingDurationMinutes)`; remove the helper and all call sites
- `segmentToRaw` handles legacy rows: when backend returns `meeting_duration_minutes=null` plus a `FREQ=MINUTELY` rrule, expand to recover the block end and derive duration from `(dtend - dtstart) / 60`
- `useMentorSchedule.toServiceSlot` and `saveMentorSchedule` PUT body now carry `meeting_duration_minutes`; mentor edit page reads the field directly instead of reverse-deriving it
- Closes #253

## Demo

http://localhost:3000/reservation/mentor

## Screenshot

N/A

## Anything to Note?

- Per-slot `meeting_duration` is out of scope: UI keeps a single global state and writes the same value into every slot DTO on save
- Legacy rows with `meeting_duration_minutes=null` continue to read correctly through the `segmentToRaw` fallback
- Phase 5 (weekly-repeat UI) remains deferred; `expandRrule` is preserved for future non-MINUTELY rrules

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
