### PR TITLE
chore: add Dockerfile + .dockerignore for local stack

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,9 @@
+node_modules
+.next
+.git
+playwright-report
+test-results
+.vscode
+.eslintcache
+*.log
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+RUN corepack enable && corepack prepare pnpm@latest --activate
+
+COPY package.json pnpm-lock.yaml ./
+RUN pnpm install --frozen-lockfile
+
+COPY . .
+
+EXPOSE 3000
+
+CMD ["pnpm", "dev"]


### PR DESCRIPTION
## Summary
- Add a dev-mode `Dockerfile` (`node:20-slim` + corepack pnpm + `pnpm dev`) plus a `.dockerignore` that excludes `node_modules` / `.next` / playwright + test artifacts.
- Consumed by `X-Talent-infra/docker-compose.yml` so that `cd X-Talent-infra && .\scripts\go-local.ps1` brings up the frontend alongside Auth / User / Search / BFF / Postgres / Redis / OpenSearch / LocalStack — full local stack in one command, no host-side \`pnpm dev\` required.
- Hot reload is preserved via the bind mount in compose; `node_modules` and `.next` live on named volumes so host caches don't conflict with the container's.
- Production / Vercel build is unaffected — this Dockerfile is only consumed by the local docker-compose stack and not referenced by Vercel or CI.

## Test plan
- [x] `docker compose up -d --build frontend` builds without error
- [x] Frontend container reaches `▲ Next.js 14.2.35  - Local: http://localhost:3000`
- [x] `Invoke-WebRequest http://127.0.0.1:3000/` → 200 OK with HTML body (~68KB)
- [x] Editing a `.tsx` file on host triggers Next.js hot reload inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)