### PR TITLE
fix(ssr): allow SSR_API_URL override for in-container fetches

### DIFF
--- a/src/services/profile/industries.server.ts
+++ b/src/services/profile/industries.server.ts
@@ -4,7 +4,12 @@ import type { ProfessionVO } from './industries';
 
 type ApiResponse = components['schemas']['ApiResponse_ProfessionListVO_'];
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// SSR_API_URL is preferred when set, so server-side fetches inside a
+// Docker container can reach the BFF via the docker network DNS name
+// (e.g. http://bff:8000/api), while the browser bundle still uses
+// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
+const BASE_URL =
+  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
 // Industry list is near-static; lazy 24h revalidate trades worst-case
 // staleness for one shared cache entry instead of one per-user fetch.
 const REVALIDATE_SECONDS = 86400;

--- a/src/services/profile/tagCatalog.server.ts
+++ b/src/services/profile/tagCatalog.server.ts
@@ -8,7 +8,12 @@ import {
 
 type ApiResponse = components['schemas']['ApiResponse_TagCatalogsVO_'];
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// SSR_API_URL is preferred when set, so server-side fetches inside a
+// Docker container can reach the BFF via the docker network DNS name
+// (e.g. http://bff:8000/api), while the browser bundle still uses
+// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
+const BASE_URL =
+  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
 const REVALIDATE_SECONDS = 86400;
 
 export async function fetchTagCatalogServer(

--- a/src/services/profile/user.server.ts
+++ b/src/services/profile/user.server.ts
@@ -5,7 +5,12 @@ import type { MentorProfileVO } from './user';
 type ApiResponseMentorProfileVO =
   components['schemas']['ApiResponse_MentorProfileVO_'];
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// SSR_API_URL is preferred when set, so server-side fetches inside a
+// Docker container can reach the BFF via the docker network DNS name
+// (e.g. http://bff:8000/api), while the browser bundle still uses
+// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
+const BASE_URL =
+  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
 // Profile pages are read-heavy and per-user-id; ISR caches each id for 60s so
 // concurrent visitors share one BFF call. Edit submit calls revalidatePath to
 // invalidate this entry on demand.

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -5,7 +5,12 @@ import { mapMentor, type MentorRequest, type MentorType } from './mapMentor';
 type MentorListResponse =
   components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
 
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
+// SSR_API_URL is preferred when set, so server-side fetches inside a
+// Docker container can reach the BFF via the docker network DNS name
+// (e.g. http://bff:8000/api), while the browser bundle still uses
+// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
+const BASE_URL =
+  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
 // Unfiltered listing is shared by every visitor — keep ISR so LCP stays fast.
 // Filtered/searched listings have unbounded cache-key combinations, so we
 // bypass the data cache to avoid blowing up Next's fetch cache and the BFF.


### PR DESCRIPTION
## Summary
- Server-side fetches in 4 \`.server.ts\` files (industries, tagCatalog, user, search-mentor) all build their URL from \`NEXT_PUBLIC_API_URL\`. When the frontend runs inside a Docker container (per \`X-Talent-infra\` local stack), this URL is \`http://localhost:8006/api\` so the browser can reach the BFF on the host — but the SSR runtime is **inside the container**, so \`localhost\` resolves to the container itself and the fetch fails with \`ECONNREFUSED 127.0.0.1:8006\`.
- Add an SSR-only env var \`SSR_API_URL\` that takes precedence when set, falling back to \`NEXT_PUBLIC_API_URL\` otherwise. SSR can then point at \`http://bff:8000/api\` (docker-network DNS) while the browser bundle still uses the host-relative URL.
- Vercel and host \`pnpm dev\` flows are unaffected — \`SSR_API_URL\` is unset there, so the fallback to \`NEXT_PUBLIC_API_URL\` matches today's behavior exactly.

## Companion PR
- \`X-Talent-infra\` PR #1 sets \`SSR_API_URL=http://bff:8000/api\` on the frontend service in \`docker-compose.yml\`. Either side is harmless on its own (no env set → fallback path; env set → 4 unrelated files just ignore it).

## Test plan
- [x] Restart frontend container with SSR_API_URL set → previous \`ECONNREFUSED\` errors gone from \`docker compose logs frontend\`
- [x] \`GET http://localhost:3000/mentor-pool\` returns 200 with seeded mentor cards rendered into the HTML (verified against the X-Talent-infra seed-mentors.ps1 sample dataset)
- [x] No regression on Vercel-style flow: when SSR_API_URL is unset, \`process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL\` resolves identically to the prior \`process.env.NEXT_PUBLIC_API_URL\`

## Out of scope
- BFF is currently missing two passthrough endpoints (\`GET /v1/users/{lang}/industries\` and \`GET /v1/users/{lang}/tags/catalog\`) — those still 404 after this fix. Tracking separately; this PR doesn't touch them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)