### PR TITLE
revert(mentor-schedule): undo block + meeting_duration_minutes (BE reverted)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -22,12 +22,15 @@ import {
 } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
-import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
+import {
+  expandRrule,
+  UseMentorScheduleReturn,
+} from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
 import {
   buildDateTime,
+  buildRrule,
   DtType,
-  expandBlockSubSlots,
 } from '@/lib/profile/scheduleHelpers';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
@@ -124,11 +127,9 @@ export default function MentorScheduleDialog({
   const nowSec = Math.floor(Date.now() / 1000);
   const editableSlotsForDate = draftForSelectedDate.filter((s) => {
     if (s.type !== 'ALLOW') return false;
-    const occurrences = expandBlockSubSlots(
-      Math.floor(s.start.getTime() / 1000),
-      Math.floor(s.end.getTime() / 1000),
-      s.meetingDurationMinutes
-    );
+    const occurrences = s.rrule
+      ? expandRrule(Math.floor(s.start.getTime() / 1000), s.rrule)
+      : [Math.floor(s.start.getTime() / 1000)];
     return occurrences.some((occ) => occ > nowSec);
   });
 
@@ -156,11 +157,9 @@ export default function MentorScheduleDialog({
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
     if (!parsed || parsed.type !== 'ALLOW') return null;
 
-    const occurrences = expandBlockSubSlots(
-      Math.floor(parsed.start.getTime() / 1000),
-      Math.floor(parsed.end.getTime() / 1000),
-      parsed.meetingDurationMinutes
-    );
+    const occurrences = parsed.rrule
+      ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
+      : [Math.floor(parsed.start.getTime() / 1000)];
 
     if (occurrences.some((occ) => bookedStartsForDate.has(occ)))
       return 'BOOKED';
@@ -198,17 +197,16 @@ export default function MentorScheduleDialog({
       return null;
 
     const newDtstart = Math.floor(candStart.valueOf() / 1000);
-    const newDtend = Math.floor(candEnd.valueOf() / 1000);
-    const newStarts = new Set(
-      expandBlockSubSlots(newDtstart, newDtend, parsed.meetingDurationMinutes)
-    );
+    const blockDur = Math.floor(candEnd.valueOf() / 1000) - newDtstart;
+    const slotDur = parsed.slotDurationSeconds;
+    const newRrule =
+      blockDur > slotDur ? buildRrule(blockDur, slotDur) : undefined;
+    const newStarts = new Set(expandRrule(newDtstart, newRrule));
 
     const oldStarts = new Set(
-      expandBlockSubSlots(
-        Math.floor(parsed.start.getTime() / 1000),
-        Math.floor(parsed.end.getTime() / 1000),
-        parsed.meetingDurationMinutes
-      )
+      parsed.rrule
+        ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
+        : [Math.floor(parsed.start.getTime() / 1000)]
     );
 
     const ownedBooked = Array.from(bookedStartsForDate).filter((occ) =>
@@ -444,12 +442,11 @@ export default function MentorScheduleDialog({
   /** Render the sub-slot chips for an ALLOW block so mentor can toggle individual occurrences. */
   const renderSubSlots = (slotId: number) => {
     const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW') return null;
+    if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
 
-    const allOccurrences = expandBlockSubSlots(
+    const allOccurrences = expandRrule(
       Math.floor(parsed.start.getTime() / 1000),
-      Math.floor(parsed.end.getTime() / 1000),
-      parsed.meetingDurationMinutes
+      parsed.rrule
     );
     if (allOccurrences.length <= 1) return null;
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -9,7 +9,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   BookingSlot,
   buildDateTime,
-  expandBlockSubSlots,
+  buildRrule,
+  expandRrule,
   formatTimeslot,
   hasOverlapAt,
   MonthKey,
@@ -143,7 +144,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         rrule: r.rrule,
         timezone: 'UTC',
         exdate: r.exdate,
-        meeting_duration_minutes: r.meetingDurationMinutes,
       };
       if (r.id > 0 && persistedIdSet.has(r.id)) slot.id = r.id;
       return slot;
@@ -197,8 +197,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         return next;
       });
       const firstAllow = raws.find((r) => r.type === 'ALLOW');
-      if (firstAllow && firstAllow.meetingDurationMinutes > 0) {
-        setMeetingDurationMinutes(firstAllow.meetingDurationMinutes);
+      if (firstAllow) {
+        const derived = Math.round(
+          (firstAllow.dtend - firstAllow.dtstart) / 60
+        );
+        if (derived > 0) setMeetingDurationMinutes(derived);
       }
     };
 
@@ -295,11 +298,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     const dates = new Set<string>();
     for (const slot of allDraftRaws) {
       if (slot.type !== 'ALLOW') continue;
-      const occurrences = expandBlockSubSlots(
-        slot.dtstart,
-        slot.dtend,
-        slot.meetingDurationMinutes
-      );
+      const occurrences = expandRrule(slot.dtstart, slot.rrule);
       for (const occ of occurrences) {
         if (slot.exdate.includes(occ)) continue;
         dates.add(dayjs(occ * 1000).format('YYYY-MM-DD'));
@@ -321,12 +320,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
         if (slotDateKey !== dateKey) continue;
 
-        const occurrences = expandBlockSubSlots(
-          slot.dtstart,
-          slot.dtend,
-          slot.meetingDurationMinutes
-        );
-        const slotDuration = slot.meetingDurationMinutes * 60;
+        const occurrences = expandRrule(slot.dtstart, slot.rrule);
+        const slotDuration = slot.dtend - slot.dtstart;
 
         for (const occ of occurrences) {
           if (slot.exdate.includes(occ)) continue;
@@ -403,6 +398,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const newDtstart = Math.floor(s.valueOf() / 1000);
         const blockDurationSeconds =
           Math.floor(e.valueOf() / 1000) - newDtstart;
+        const slotDurationSeconds = meetingDurationMinutes * 60;
+        const newDtend = newDtstart + slotDurationSeconds;
 
         const monthKey = monthKeyFromDateStr(selectedDate);
 
@@ -419,16 +416,20 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             return prev;
           }
 
+          const rrule =
+            blockDurationSeconds > slotDurationSeconds
+              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
+              : undefined;
+
           return [
             ...prev,
             {
               id: nextTempId(prev),
               type: 'ALLOW' as const,
               dtstart: newDtstart,
-              dtend: newDtstart + blockDurationSeconds,
-              rrule: undefined,
+              dtend: newDtend,
+              rrule,
               exdate: [],
-              meetingDurationMinutes,
             },
           ];
         });
@@ -451,7 +452,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
           const startHM = patch.startTime ?? fmtHM(target.dtstart);
-          const endHM = patch.endTime ?? fmtHM(target.dtend);
+
+          const occs = expandRrule(target.dtstart, target.rrule);
+          const lastOcc = occs[occs.length - 1] ?? target.dtstart;
+          const endHM =
+            patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
 
           const s = buildDateTime(baseDate, startHM);
           const e = buildDateTime(baseDate, endHM);
@@ -460,12 +465,19 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const newDtstart = Math.floor(s.valueOf() / 1000);
           const blockDurationSeconds =
             Math.floor(e.valueOf() / 1000) - newDtstart;
+          const slotDurationSeconds = target.dtend - target.dtstart;
+          const newDtend = newDtstart + slotDurationSeconds;
 
           if (
             hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
           ) {
             return prev;
           }
+
+          const newRrule =
+            blockDurationSeconds > slotDurationSeconds
+              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
+              : undefined;
 
           const newBlockEnd = newDtstart + blockDurationSeconds;
           const cleanedExdate = target.exdate.filter(
@@ -477,8 +489,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
               ? {
                   ...r,
                   dtstart: newDtstart,
-                  dtend: newBlockEnd,
-                  rrule: undefined,
+                  dtend: newDtend,
+                  rrule: newRrule,
                   exdate: cleanedExdate,
                 }
               : r

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -31,8 +31,6 @@ export function parseMonthKey(key: MonthKey): { year: number; month: number } {
 // id: negative values are temporary local ids for new slots (-1, -2, ...)
 // type: narrowed from SegmentVO.dt_type
 // exdate: nulls excluded from SegmentVO.exdate
-// dtstart/dtend: block bounds (entire window). Sub-slots are derived via
-//   expandBlockSubSlots(dtstart, dtend, meetingDurationMinutes).
 export type RawMentorTimeslot = Pick<
   SegmentVO,
   'dtstart' | 'dtend' | 'rrule'
@@ -40,21 +38,19 @@ export type RawMentorTimeslot = Pick<
   id: number;
   type: DtType;
   exdate: number[];
-  meetingDurationMinutes: number;
 };
 
 export type ParsedMentorTimeslot = {
   id: number;
   type: DtType;
-  start: Date; // block start
-  end: Date; // block end
+  start: Date; // block start (= dtstart for all types)
+  end: Date; // block end: last occurrence end for ALLOW (derived from rrule), dtend for others
   durationMinutes: number;
   formatted: string;
   dateKey: string; // YYYY-MM-DD (local)
   rrule?: string;
   exdate: number[];
-  slotDurationSeconds: number; // duration of one sub-slot (meetingDurationMinutes * 60)
-  meetingDurationMinutes: number;
+  slotDurationSeconds: number; // duration of one sub-slot (dtend - dtstart)
 };
 
 export type BookingSlot = {
@@ -80,62 +76,30 @@ export function expandRrule(
   }
 }
 
-/** Sub-slot start times within a block, derived from meetingDurationMinutes. */
-export function expandBlockSubSlots(
-  dtstart: number,
-  dtend: number,
-  meetingDurationMinutes: number
-): number[] {
-  if (meetingDurationMinutes <= 0 || dtend <= dtstart) return [dtstart];
-  const step = meetingDurationMinutes * 60;
-  const result: number[] = [];
-  for (let t = dtstart; t < dtend; t += step) result.push(t);
-  return result;
-}
-
 export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
-  const id = t.id ?? Math.floor(Math.random() * 1e9);
-  const type = t.dt_type as RawMentorTimeslot['type'];
-  const exdate = (t.exdate ?? []).filter((x): x is number => x !== null);
-
-  if (t.meeting_duration_minutes != null) {
-    return {
-      id,
-      type,
-      dtstart: t.dtstart,
-      dtend: t.dtend,
-      rrule: t.rrule ?? undefined,
-      exdate,
-      meetingDurationMinutes: t.meeting_duration_minutes,
-    };
-  }
-
-  // Legacy fallback: backend pre-Phase-1-4 row with no meeting_duration_minutes.
-  // Old MINUTELY rrule encoded sub-slots; block end was lastOcc + (dtend-dtstart).
-  const subSlotSeconds = Math.max(0, t.dtend - t.dtstart);
-  const isMinutely = t.rrule?.includes('FREQ=MINUTELY');
-  let blockEnd = t.dtend;
-  if (isMinutely) {
-    const occs = expandRrule(t.dtstart, t.rrule);
-    const lastOcc = occs[occs.length - 1] ?? t.dtstart;
-    blockEnd = lastOcc + subSlotSeconds;
-  }
   return {
-    id,
-    type,
+    id: t.id ?? Math.floor(Math.random() * 1e9),
+    type: t.dt_type as RawMentorTimeslot['type'],
     dtstart: t.dtstart,
-    dtend: blockEnd,
-    rrule: isMinutely ? undefined : (t.rrule ?? undefined),
-    exdate,
-    meetingDurationMinutes:
-      subSlotSeconds > 0 ? Math.round(subSlotSeconds / 60) : 0,
+    dtend: t.dtend,
+    rrule: t.rrule ?? undefined,
+    exdate: (t.exdate ?? []).filter((x): x is number => x !== null),
   };
 }
 
 export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
   const start = new Date(r.dtstart * 1000);
-  const end = new Date(r.dtend * 1000);
-  const slotDurationSeconds = r.meetingDurationMinutes * 60;
+  const slotDurationSeconds = r.dtend - r.dtstart;
+
+  let end: Date;
+  if (r.type === 'ALLOW' && r.rrule) {
+    const occurrences = expandRrule(r.dtstart, r.rrule);
+    const lastOccDtstart = occurrences[occurrences.length - 1] ?? r.dtstart;
+    end = new Date((lastOccDtstart + slotDurationSeconds) * 1000);
+  } else {
+    end = new Date(r.dtend * 1000);
+  }
+
   const durationMinutes = Math.round(
     (end.getTime() - start.getTime()) / (1000 * 60)
   );
@@ -151,13 +115,21 @@ export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
     rrule: r.rrule ?? undefined,
     exdate: r.exdate,
     slotDurationSeconds,
-    meetingDurationMinutes: r.meetingDurationMinutes,
   };
 }
 
 export function nextTempId(rows: RawMentorTimeslot[]): number {
   const negatives = rows.filter((r) => r.id < 0).map((r) => r.id);
   return negatives.length ? Math.min(...negatives) - 1 : -1;
+}
+
+export function buildRrule(
+  blockDurationSeconds: number,
+  slotDurationSeconds: number
+): string {
+  const count = Math.round(blockDurationSeconds / slotDurationSeconds);
+  const intervalMinutes = Math.round(slotDurationSeconds / 60);
+  return `FREQ=MINUTELY;INTERVAL=${intervalMinutes};COUNT=${count}`;
 }
 
 /** Build a dayjs from a YYYY-MM-DD date and HH:mm time. */
@@ -188,6 +160,8 @@ export function hasOverlapAt(
     if (r.type !== 'ALLOW') return false;
     const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
     if (rDate !== dateKey) return false;
-    return dtstart < r.dtend && blockEnd > r.dtstart;
+    const occs = expandRrule(r.dtstart, r.rrule);
+    const rEnd = (occs[occs.length - 1] ?? r.dtstart) + (r.dtend - r.dtstart);
+    return dtstart < rEnd && blockEnd > r.dtstart;
   });
 }

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -72,7 +72,6 @@ export async function saveMentorSchedule(params: {
         rrule: t.rrule,
         timezone: 'UTC',
         exdate: t.exdate,
-        meeting_duration_minutes: t.meeting_duration_minutes,
       })
     ),
   });

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -1634,11 +1634,6 @@ export interface components {
        * @example 100
        */
       source_id?: number | null;
-      /**
-       * Meeting Duration Minutes
-       * @example 30
-       */
-      meeting_duration_minutes?: number | null;
     };
     /** MentorScheduleVO */
     MentorScheduleVO: {
@@ -2279,11 +2274,6 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
-      /**
-       * Meeting Duration Minutes
-       * @example 30
-       */
-      meeting_duration_minutes?: number | null;
     };
     /**
      * TimeSlotType
@@ -2344,11 +2334,6 @@ export interface components {
        *     ]
        */
       exdate: (number | null)[];
-      /**
-       * Meeting Duration Minutes
-       * @example 30
-       */
-      meeting_duration_minutes?: number | null;
     };
     /** TokenRefreshAuthVO */
     TokenRefreshAuthVO: {


### PR DESCRIPTION
## Summary

- Reverts PR #596 (`feat/253-mentor-schedule-meeting-duration`)
- Backend counterpart was reverted in `X-Career-User` (PR #112 reverting #109), so the frontend can no longer rely on `meeting_duration_minutes` or the block-based `(dtstart, dtend)` model
- Restores the previous `FREQ=MINUTELY` rrule + per-slot model

## Files reverted

- `src/components/profile/reservation/MentorScheduleDialog.tsx`
- `src/hooks/useMentorSchedule.ts`
- `src/lib/profile/scheduleHelpers.ts`
- `src/services/mentor-schedule/schedule.ts`
- `src/types/api.ts`

## Test plan

- [ ] `pnpm type-check` passes (verified locally)
- [ ] `pnpm build` passes (verified locally)
- [ ] `pnpm test` passes — 160/160 (verified locally via pre-push hook)
- [ ] Mentor schedule edit page on `/reservation/mentor` round-trips against the reverted backend
- [ ] Mentee booking on `/reservation/mentee` shows existing slots correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)