### PR TITLE
refactor(mentor-schedule): per-slot rows + weekly-within-month recurrence

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -1,10 +1,12 @@
 'use client';
 
+import dayjs from 'dayjs';
 import { Clock, Plus, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import {
   Dialog,
   DialogContent,
@@ -23,42 +25,28 @@ import {
 import { Skeleton } from '@/components/ui/skeleton';
 import { useToast } from '@/components/ui/use-toast';
 import {
-  expandRrule,
+  SlotDurationMinutes,
   UseMentorScheduleReturn,
 } from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
-import {
-  buildDateTime,
-  buildRrule,
-  DtType,
-} from '@/lib/profile/scheduleHelpers';
+import { DtType, ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
+import { cn } from '@/lib/utils';
 
 import { ScheduleCalendar } from './ScheduleCalendar';
-
-type EditingSlot = {
-  id: number;
-  startHour: string;
-  startMinute: string;
-  endHour: string;
-  endMinute: string;
-};
-
-type SlotErrors = {
-  timeRange?: string;
-  overlap?: string;
-};
-
-type ReservationPromptType = Exclude<DtType, 'ALLOW'> | null;
-
-type BlockPromptState = {
-  type: Exclude<DtType, 'ALLOW'>;
-  reason: 'delete' | 'shrink';
-} | null;
 
 const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) =>
   String(i).padStart(2, '0')
 );
 const MINUTE_OPTIONS = ['00', '15', '30', '45'];
+const DURATION_OPTIONS: SlotDurationMinutes[] = [30, 45, 60];
+const WEEKDAY_LABELS = ['日', '一', '二', '三', '四', '五', '六'];
+
+type ReservationPromptType = Exclude<DtType, 'ALLOW'> | null;
+
+const fmtTime = (unix: number): string => {
+  const d = new Date(unix * 1000);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+};
 
 const snapMinute = (m: number): string => {
   const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
@@ -67,11 +55,52 @@ const snapMinute = (m: number): string => {
   return String(snapped).padStart(2, '0');
 };
 
-const fmtTime = (unix: number): string => {
-  const d = new Date(unix * 1000);
-  const h = String(d.getHours()).padStart(2, '0');
-  const m = String(d.getMinutes()).padStart(2, '0');
-  return `${h}:${m}`;
+// Closest 30/45/60 default for the form when editing a slot whose stored
+// duration drifted from those values (e.g. legacy block data).
+const snapDuration = (m: number): SlotDurationMinutes => {
+  return DURATION_OPTIONS.reduce((prev, curr) =>
+    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
+  );
+};
+
+type SlotFormState = {
+  startHour: string;
+  startMinute: string;
+  durationMinutes: SlotDurationMinutes;
+};
+
+const defaultFormForDate = (
+  existingSlots: ParsedMentorTimeslot[]
+): SlotFormState => {
+  // Default new slot to start right after the latest slot of the day, or 09:00
+  // if the day is empty. Round up to the next 15-minute mark so the picker
+  // matches its options.
+  let startH = 9;
+  let startM = 0;
+  if (existingSlots.length > 0) {
+    const sorted = [...existingSlots].sort(
+      (a, b) => a.end.getTime() - b.end.getTime()
+    );
+    const lastEnd = sorted[sorted.length - 1].end;
+    startH = lastEnd.getHours();
+    startM = lastEnd.getMinutes();
+    const snapped = Math.ceil(startM / 15) * 15;
+    if (snapped >= 60) {
+      startH += 1;
+      startM = 0;
+    } else {
+      startM = snapped;
+    }
+  }
+  if (startH >= 24) {
+    startH = 9;
+    startM = 0;
+  }
+  return {
+    startHour: String(startH).padStart(2, '0'),
+    startMinute: String(startM).padStart(2, '0'),
+    durationMinutes: 30,
+  };
 };
 
 export default function MentorScheduleDialog({
@@ -91,24 +120,20 @@ export default function MentorScheduleDialog({
     draftForSelectedDate,
     addSlotForSelectedDate,
     deleteDraftSlot,
-    toggleOccurrence,
     confirmChanges,
     resetChanges,
-    parsedDraft,
-    allowedDates,
     updateDraftSlot,
-    meetingDurationMinutes,
+    allowedDates,
     monthLoaded,
   } = schedule;
 
   const router = useRouter();
   const { toast } = useToast();
   const [isSaving, setIsSaving] = useState(false);
-  const [editingSlots, setEditingSlots] = useState<EditingSlot[]>([]);
-  const [slotErrors, setSlotErrors] = useState<Record<number, SlotErrors>>({});
-  const [slotPrompt, setSlotPrompt] = useState<ReservationPromptType>(null);
-  const [blockPrompt, setBlockPrompt] = useState<BlockPromptState>(null);
+  const [addModalOpen, setAddModalOpen] = useState(false);
   const [editingSlotId, setEditingSlotId] = useState<number | null>(null);
+  const [reservationPrompt, setReservationPrompt] =
+    useState<ReservationPromptType>(null);
 
   useEffect(() => {
     if (open) {
@@ -120,143 +145,50 @@ export default function MentorScheduleDialog({
     }
   }, [open]);
 
-  // Only ALLOW slots are editable; BOOKED/PENDING are read-only.
-  // For today, also drop blocks whose every occurrence has already started —
-  // past slots can't be booked or meaningfully edited, so they shouldn't clutter
-  // the editor (matches the calendar's disablePastDates behaviour at minute granularity).
+  // Hide ALLOW slots that have already started — past slots can't be booked or
+  // meaningfully edited. BOOKED/PENDING are filtered out separately because we
+  // only manage reservation lifecycle on a different page.
   const nowSec = Math.floor(Date.now() / 1000);
-  const editableSlotsForDate = draftForSelectedDate.filter((s) => {
-    if (s.type !== 'ALLOW') return false;
-    const occurrences = s.rrule
-      ? expandRrule(Math.floor(s.start.getTime() / 1000), s.rrule)
-      : [Math.floor(s.start.getTime() / 1000)];
-    return occurrences.some((occ) => occ > nowSec);
-  });
-
-  // Collect booked dtstart values for the selected date (for locking sub-slots)
-  const bookedStartsForDate = new Set(
-    draftForSelectedDate
-      .filter((s) => s.type === 'BOOKED')
-      .map((s) => Math.floor(s.start.getTime() / 1000))
+  const editableSlots = draftForSelectedDate.filter(
+    (s) => s.type === 'ALLOW' && Math.floor(s.start.getTime() / 1000) > nowSec
   );
 
-  // PENDING occurrences must be cancelled via the reservation-management page,
-  // not by excluding them from the schedule editor — see issue #144.
-  const pendingStartsForDate = new Set(
-    draftForSelectedDate
-      .filter((s) => s.type === 'PENDING')
-      .map((s) => Math.floor(s.start.getTime() / 1000))
+  // Block deletion/edit when a BOOKED or PENDING reservation exists at this
+  // slot's start. With one row per slot, the start timestamp is the natural
+  // identity to match against reservation segments.
+  const bookedStarts = useMemo(
+    () =>
+      new Set(
+        draftForSelectedDate
+          .filter((s) => s.type === 'BOOKED')
+          .map((s) => Math.floor(s.start.getTime() / 1000))
+      ),
+    [draftForSelectedDate]
+  );
+  const pendingStarts = useMemo(
+    () =>
+      new Set(
+        draftForSelectedDate
+          .filter((s) => s.type === 'PENDING')
+          .map((s) => Math.floor(s.start.getTime() / 1000))
+      ),
+    [draftForSelectedDate]
   );
 
-  // Block-level guard: deleting the whole ALLOW block must not silently drop
-  // any BOOKED or PENDING occurrences inside it. BOOKED takes priority because
-  // it represents a confirmed reservation that requires a heavier remediation.
-  const getBlockingReservationType = (
-    slotId: number
-  ): Exclude<DtType, 'ALLOW'> | null => {
-    const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW') return null;
-
-    const occurrences = parsed.rrule
-      ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-      : [Math.floor(parsed.start.getTime() / 1000)];
-
-    if (occurrences.some((occ) => bookedStartsForDate.has(occ)))
-      return 'BOOKED';
-    if (occurrences.some((occ) => pendingStartsForDate.has(occ)))
-      return 'PENDING';
+  const getReservationBlock = (
+    slot: ParsedMentorTimeslot
+  ): ReservationPromptType => {
+    const slotStart = Math.floor(slot.start.getTime() / 1000);
+    if (bookedStarts.has(slotStart)) return 'BOOKED';
+    if (pendingStarts.has(slotStart)) return 'PENDING';
     return null;
   };
-
-  // Time-edit guard: shrinking or shifting an ALLOW block must keep every
-  // existing BOOKED/PENDING occurrence inside the new occurrence set; otherwise
-  // the candidate would silently drop them. Mirrors updateDraftSlot's geometry.
-  // Only bookings owned by THIS ALLOW block (i.e. inside its original occurrence
-  // set) are considered — bookings inside other ALLOW blocks on the same date
-  // are unrelated to this edit.
-  const getOrphanedReservationType = (
-    slotId: number,
-    candidate: EditingSlot
-  ): Exclude<DtType, 'ALLOW'> | null => {
-    const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW' || !selectedDate) return null;
-
-    const candStart = buildDateTime(
-      selectedDate,
-      `${candidate.startHour}:${candidate.startMinute}`
-    );
-    const candEnd = buildDateTime(
-      selectedDate,
-      `${candidate.endHour}:${candidate.endMinute}`
-    );
-    if (
-      !candStart.isValid() ||
-      !candEnd.isValid() ||
-      candEnd.isSameOrBefore(candStart)
-    )
-      return null;
-
-    const newDtstart = Math.floor(candStart.valueOf() / 1000);
-    const blockDur = Math.floor(candEnd.valueOf() / 1000) - newDtstart;
-    const slotDur = parsed.slotDurationSeconds;
-    const newRrule =
-      blockDur > slotDur ? buildRrule(blockDur, slotDur) : undefined;
-    const newStarts = new Set(expandRrule(newDtstart, newRrule));
-
-    const oldStarts = new Set(
-      parsed.rrule
-        ? expandRrule(Math.floor(parsed.start.getTime() / 1000), parsed.rrule)
-        : [Math.floor(parsed.start.getTime() / 1000)]
-    );
-
-    const ownedBooked = Array.from(bookedStartsForDate).filter((occ) =>
-      oldStarts.has(occ)
-    );
-    const ownedPending = Array.from(pendingStartsForDate).filter((occ) =>
-      oldStarts.has(occ)
-    );
-
-    if (ownedBooked.some((occ) => !newStarts.has(occ))) return 'BOOKED';
-    if (ownedPending.some((occ) => !newStarts.has(occ))) return 'PENDING';
-    return null;
-  };
-
-  useEffect(() => {
-    setEditingSlots(
-      editableSlotsForDate.map((slot) => {
-        const endHM = fmtTime(Math.floor(slot.end.getTime() / 1000));
-        const [endH, endM] = endHM.split(':');
-        return {
-          id: slot.id,
-          startHour: String(slot.start.getHours()).padStart(2, '0'),
-          startMinute: snapMinute(slot.start.getMinutes()),
-          endHour: endH ?? '00',
-          endMinute: snapMinute(parseInt(endM ?? '0')),
-        };
-      })
-    );
-    setSlotErrors({});
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [draftForSelectedDate]);
-
-  const hasAnyError = Object.values(slotErrors).some(
-    (e) => e.timeRange || e.overlap
-  );
-
-  const hasInvalidTimes = editingSlots.some((slot) => {
-    const startTotal =
-      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute);
-    const endTotal = parseInt(slot.endHour) * 60 + parseInt(slot.endMinute);
-    return endTotal - startTotal < 30;
-  });
 
   const handleSave = async () => {
     setIsSaving(true);
     const result = await confirmChanges();
     setIsSaving(false);
     if (!result.ok) {
-      // Keep the dialog open so the mentor can adjust the conflicting slot
-      // and retry. The draft state is preserved on failure.
       toast({
         variant: 'destructive',
         description:
@@ -269,251 +201,10 @@ export default function MentorScheduleDialog({
     onOpenChange(false);
   };
 
-  const checkOverlapWithOthers = (
-    id: number,
-    startTotal: number,
-    endTotal: number
-  ): boolean => {
-    return parsedDraft
-      .filter(
-        (s) => s.type === 'ALLOW' && s.id !== id && s.dateKey === selectedDate
-      )
-      .some((s) => {
-        const otherStart = s.start.getHours() * 60 + s.start.getMinutes();
-        const otherEnd = s.end.getHours() * 60 + s.end.getMinutes();
-        return startTotal < otherEnd && endTotal > otherStart;
-      });
-  };
-
-  const handleTimeChange = (
-    id: number,
-    part: keyof Omit<EditingSlot, 'id'>,
-    value: string
-  ) => {
-    const originalSlot = editingSlots.find((s) => s.id === id);
-    if (!originalSlot) return;
-
-    const updatedSlot: EditingSlot = { ...originalSlot, [part]: value };
-
-    const startTotal =
-      parseInt(updatedSlot.startHour) * 60 + parseInt(updatedSlot.startMinute);
-    const endTotal =
-      parseInt(updatedSlot.endHour) * 60 + parseInt(updatedSlot.endMinute);
-
-    if (endTotal <= startTotal) {
-      setEditingSlots((prev) =>
-        prev.map((slot) => (slot.id === id ? updatedSlot : slot))
-      );
-      setSlotErrors((prev) => ({
-        ...prev,
-        [id]: { timeRange: '結束時間必須晚於開始時間' },
-      }));
-      return;
-    }
-
-    // Block the change before mutating UI so the input snaps back to the
-    // previous valid value; mentor must resolve the reservation first.
-    const orphan = getOrphanedReservationType(id, updatedSlot);
-    if (orphan) {
-      setBlockPrompt({ type: orphan, reason: 'shrink' });
-      return;
-    }
-
-    setEditingSlots((prev) =>
-      prev.map((slot) => (slot.id === id ? updatedSlot : slot))
-    );
-
-    if (checkOverlapWithOthers(id, startTotal, endTotal)) {
-      setSlotErrors((prev) => ({
-        ...prev,
-        [id]: { overlap: '此時段與其他時段重疊' },
-      }));
-      return;
-    }
-
-    setSlotErrors((prev) => {
-      const next = { ...prev };
-      delete next[id];
-      return next;
-    });
-
-    updateDraftSlot(id, {
-      startTime: `${updatedSlot.startHour}:${updatedSlot.startMinute}`,
-      endTime: `${updatedSlot.endHour}:${updatedSlot.endMinute}`,
-    });
-  };
-
-  const addNewTimeSlot = () => {
-    const slotsToday = parsedDraft
-      .filter((s) => s.type === 'ALLOW' && s.dateKey === selectedDate)
-      .sort((a, b) => a.end.getTime() - b.end.getTime());
-
-    let startH = 9;
-    let startM = 0;
-
-    if (slotsToday.length > 0) {
-      const lastEnd = slotsToday[slotsToday.length - 1].end;
-      startH = lastEnd.getHours();
-      startM = lastEnd.getMinutes();
-      const snapped = Math.ceil(startM / 15) * 15;
-      if (snapped >= 60) {
-        startH += 1;
-        startM = 0;
-      } else {
-        startM = snapped;
-      }
-    }
-
-    if (startH >= 24) return;
-
-    const totalEndMin = startH * 60 + startM + meetingDurationMinutes;
-    const endH = Math.floor(totalEndMin / 60);
-    const endM = totalEndMin % 60;
-
-    if (endH >= 24) return;
-
-    addSlotForSelectedDate({
-      type: 'ALLOW',
-      startTime: `${String(startH).padStart(2, '0')}:${String(startM).padStart(2, '0')}`,
-      endTime: `${String(endH).padStart(2, '0')}:${String(endM).padStart(2, '0')}`,
-    });
-  };
-
-  const renderTimeSelectPair = (
-    id: number,
-    hourPart: keyof Omit<EditingSlot, 'id'>,
-    minutePart: keyof Omit<EditingSlot, 'id'>,
-    hourValue: string,
-    minuteValue: string,
-    hourOptions: string[],
-    minuteOptions: string[]
-  ) => (
-    <div className="flex items-center gap-3">
-      <Select
-        value={hourValue}
-        onValueChange={(v) => handleTimeChange(id, hourPart, v)}
-      >
-        <SelectTrigger className="h-12 w-24 text-base lg:w-28">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent className="min-w-[10rem]">
-          {hourOptions.map((opt) => (
-            <SelectItem key={opt} value={opt} className="py-3 text-base">
-              {opt}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-      <span className="text-base text-muted-foreground">:</span>
-      <Select
-        value={minuteValue}
-        onValueChange={(v) => handleTimeChange(id, minutePart, v)}
-      >
-        <SelectTrigger className="h-12 w-24 text-base lg:w-28">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent className="min-w-[10rem]">
-          {minuteOptions.map((opt) => (
-            <SelectItem key={opt} value={opt} className="py-3 text-base">
-              {opt}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
-  );
-
-  const MIN_DURATION = 30;
-
-  const getEndHourOptions = (slot: EditingSlot): string[] => {
-    const minEnd =
-      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
-    return HOUR_OPTIONS.filter((h) => parseInt(h) * 60 + 45 >= minEnd);
-  };
-
-  const getEndMinuteOptions = (slot: EditingSlot): string[] => {
-    const minEnd =
-      parseInt(slot.startHour) * 60 + parseInt(slot.startMinute) + MIN_DURATION;
-    return MINUTE_OPTIONS.filter(
-      (m) => parseInt(slot.endHour) * 60 + parseInt(m) >= minEnd
-    );
-  };
-
-  /** Render the sub-slot chips for an ALLOW block so mentor can toggle individual occurrences. */
-  const renderSubSlots = (slotId: number) => {
-    const parsed = editableSlotsForDate.find((s) => s.id === slotId);
-    if (!parsed || parsed.type !== 'ALLOW' || !parsed.rrule) return null;
-
-    const allOccurrences = expandRrule(
-      Math.floor(parsed.start.getTime() / 1000),
-      parsed.rrule
-    );
-    if (allOccurrences.length <= 1) return null;
-
-    // Hide sub-slots that have already started today; the parent block filter
-    // guarantees at least one future occurrence remains.
-    const occurrences = allOccurrences.filter((occ) => occ > nowSec);
-
-    const slotDurSec = parsed.slotDurationSeconds;
-
-    return (
-      <div className="mt-2 flex flex-wrap gap-1.5">
-        {occurrences.map((occ) => {
-          const isBooked = bookedStartsForDate.has(occ);
-          const isPending = pendingStartsForDate.has(occ);
-          const isExcluded = parsed.exdate?.includes(occ) ?? false;
-          const startLabel = fmtTime(occ);
-          const endLabel = fmtTime(occ + slotDurSec);
-
-          const handleClick = (e: React.MouseEvent) => {
-            e.stopPropagation();
-            if (isBooked) {
-              setSlotPrompt('BOOKED');
-              return;
-            }
-            if (isPending) {
-              setSlotPrompt('PENDING');
-              return;
-            }
-            toggleOccurrence(slotId, occ);
-          };
-
-          return (
-            <button
-              key={occ}
-              type="button"
-              onClick={handleClick}
-              className={[
-                'rounded border px-2 py-0.5 text-xs transition-colors',
-                isBooked
-                  ? 'border-gray-200 bg-gray-100 text-gray-400'
-                  : isPending
-                    ? 'border-primary bg-primary/10 text-primary hover:bg-primary/20'
-                    : isExcluded
-                      ? 'bg-white border-gray-300 text-gray-400 line-through'
-                      : 'border-primary bg-primary/10 text-primary hover:bg-primary/20',
-              ].join(' ')}
-            >
-              {startLabel}–{endLabel}
-              {isBooked && (
-                <span className="ml-1 text-[10px] text-gray-400">已預約</span>
-              )}
-              {isPending && (
-                <span className="ml-1 text-[10px] text-primary/70">已申請</span>
-              )}
-            </button>
-          );
-        })}
-      </div>
-    );
-  };
-
   const editingSlot =
     editingSlotId !== null
-      ? (editingSlots.find((s) => s.id === editingSlotId) ?? null)
+      ? (editableSlots.find((s) => s.id === editingSlotId) ?? null)
       : null;
-  const editingSlotErrors =
-    editingSlotId !== null ? (slotErrors[editingSlotId] ?? {}) : {};
 
   return (
     <>
@@ -557,33 +248,46 @@ export default function MentorScheduleDialog({
                 </div>
               ) : (
                 <div className="mt-3 flex flex-col gap-3">
-                  {editingSlots.map((slot) => {
-                    const errors = slotErrors[slot.id] ?? {};
-                    const hasError = Boolean(
-                      errors.timeRange || errors.overlap
+                  {editableSlots.map((slot) => {
+                    const startLabel = fmtTime(
+                      Math.floor(slot.start.getTime() / 1000)
                     );
-                    const startValue = `${slot.startHour}:${slot.startMinute}`;
-                    const endValue = `${slot.endHour}:${slot.endMinute}`;
-
+                    const endLabel = fmtTime(
+                      Math.floor(slot.end.getTime() / 1000)
+                    );
+                    const reservationBlock = getReservationBlock(slot);
                     return (
                       <div
                         key={slot.id}
                         role="button"
                         tabIndex={0}
-                        onClick={() => setEditingSlotId(slot.id)}
+                        onClick={() => {
+                          if (reservationBlock) {
+                            setReservationPrompt(reservationBlock);
+                            return;
+                          }
+                          setEditingSlotId(slot.id);
+                        }}
                         onKeyDown={(e) => {
                           if (e.key === 'Enter' || e.key === ' ') {
                             e.preventDefault();
+                            if (reservationBlock) {
+                              setReservationPrompt(reservationBlock);
+                              return;
+                            }
                             setEditingSlotId(slot.id);
                           }
                         }}
-                        className={`flex cursor-pointer flex-col gap-2 rounded-lg border bg-background p-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:p-4 ${hasError ? 'border-red-500' : ''}`}
+                        className="flex cursor-pointer flex-col gap-2 rounded-lg border bg-background p-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:p-4"
                       >
                         <div className="flex flex-row flex-nowrap items-center justify-between gap-2 lg:gap-3">
                           <div className="flex items-center gap-2">
                             <Clock className="h-4 w-4 text-muted-foreground" />
                             <span className="text-base font-medium tabular-nums">
-                              {startValue} – {endValue}
+                              {startLabel} – {endLabel}
+                            </span>
+                            <span className="text-sm text-muted-foreground">
+                              ({slot.durationMinutes} 分)
                             </span>
                           </div>
                           <Button
@@ -592,14 +296,8 @@ export default function MentorScheduleDialog({
                             className="h-8 w-8 lg:h-10 lg:w-10"
                             onClick={(e) => {
                               e.stopPropagation();
-                              const blocking = getBlockingReservationType(
-                                slot.id
-                              );
-                              if (blocking) {
-                                setBlockPrompt({
-                                  type: blocking,
-                                  reason: 'delete',
-                                });
+                              if (reservationBlock) {
+                                setReservationPrompt(reservationBlock);
                                 return;
                               }
                               deleteDraftSlot(slot.id);
@@ -608,28 +306,15 @@ export default function MentorScheduleDialog({
                             <X className="h-4 w-4 lg:h-5 lg:w-5" />
                           </Button>
                         </div>
-
-                        {renderSubSlots(slot.id)}
-
-                        {errors.timeRange && (
-                          <p className="text-red-500 text-xs lg:text-sm">
-                            {errors.timeRange}
-                          </p>
-                        )}
-
-                        {errors.overlap && (
-                          <p className="text-red-500 text-xs lg:text-sm">
-                            {errors.overlap}
-                          </p>
-                        )}
                       </div>
                     );
                   })}
 
                   <Button
                     variant="ghost"
-                    onClick={addNewTimeSlot}
+                    onClick={() => setAddModalOpen(true)}
                     className="h-10 w-full lg:h-11 lg:text-base"
+                    disabled={!selectedDate}
                   >
                     <Plus className="h-4 w-4 lg:h-5 lg:w-5" />
                   </Button>
@@ -648,146 +333,333 @@ export default function MentorScheduleDialog({
             >
               取消
             </Button>
-            <Button
-              onClick={handleSave}
-              disabled={
-                isSaving || hasAnyError || hasInvalidTimes || !monthLoaded
-              }
-            >
+            <Button onClick={handleSave} disabled={isSaving || !monthLoaded}>
               {isSaving ? '儲存中...' : '儲存'}
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
 
+      <AddSlotModal
+        open={addModalOpen}
+        onOpenChange={setAddModalOpen}
+        selectedDate={selectedDate}
+        existingSlots={editableSlots}
+        onSubmit={(form, weekly) => {
+          const result = addSlotForSelectedDate({
+            startTime: `${form.startHour}:${form.startMinute}`,
+            durationMinutes: form.durationMinutes,
+            weeklyWithinMonth: weekly,
+          });
+          setAddModalOpen(false);
+          if (result.added === 0) {
+            toast({
+              variant: 'destructive',
+              description: '無可用時段(可能與既有時段重疊)',
+            });
+            return;
+          }
+          if (result.skipped > 0) {
+            toast({
+              description: `已新增 ${result.added} 個時段(略過 ${result.skipped} 個重疊時段)`,
+            });
+          }
+        }}
+      />
+
+      <EditSlotModal
+        slot={editingSlot}
+        onClose={() => setEditingSlotId(null)}
+        onSubmit={(form) => {
+          if (!editingSlotId) return;
+          const ok = updateDraftSlot(editingSlotId, {
+            startTime: `${form.startHour}:${form.startMinute}`,
+            durationMinutes: form.durationMinutes,
+          });
+          if (!ok) {
+            toast({
+              variant: 'destructive',
+              description: '此時段與其他時段重疊',
+            });
+            return;
+          }
+          setEditingSlotId(null);
+        }}
+      />
+
       <Dialog
-        open={slotPrompt !== null}
-        onOpenChange={(o) => !o && setSlotPrompt(null)}
+        open={reservationPrompt !== null}
+        onOpenChange={(o) => !o && setReservationPrompt(null)}
       >
         <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
           <DialogHeader>
             <DialogTitle>
-              {slotPrompt === 'BOOKED'
+              {reservationPrompt === 'BOOKED'
                 ? '此時段已有預約'
                 : '此時段有未處理的預約申請'}
             </DialogTitle>
             <DialogDescription>
-              {slotPrompt === 'BOOKED'
-                ? '此時段已有 mentee 預約成功,無法移除。如需取消,請至「預約管理」頁面處理。'
+              {reservationPrompt === 'BOOKED'
+                ? '此時段已有 mentee 預約成功,無法編輯或移除。如需取消,請至「預約管理」頁面處理。'
                 : '請至「預約管理」頁面接受或拒絕該申請,僅在拒絕後此時段才會重新釋出。'}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="justify-center">
-            <Button variant="outline" onClick={() => setSlotPrompt(null)}>
+            <Button
+              variant="outline"
+              onClick={() => setReservationPrompt(null)}
+            >
               取消
             </Button>
             <Button
               onClick={() => {
-                setSlotPrompt(null);
+                setReservationPrompt(null);
                 onOpenChange(false);
                 router.push('/reservation/mentor');
               }}
             >
               前往預約管理
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={blockPrompt !== null}
-        onOpenChange={(o) => !o && setBlockPrompt(null)}
-      >
-        <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
-          <DialogHeader>
-            <DialogTitle>
-              {blockPrompt?.type === 'BOOKED'
-                ? '此時段內有已成立的預約'
-                : '此時段內有未處理的預約申請'}
-            </DialogTitle>
-            <DialogDescription>
-              {blockPrompt?.type === 'BOOKED'
-                ? blockPrompt.reason === 'shrink'
-                  ? '此調整會排除已成立的預約,無法縮短或變更時段。如需取消預約,請至「預約管理」頁面處理。'
-                  : '此時段內有 mentee 預約成功,無法刪除整個時段。如需取消,請至「預約管理」頁面處理。'
-                : blockPrompt?.reason === 'shrink'
-                  ? '此調整會排除尚未處理的預約申請,請先至「預約管理」頁面接受或拒絕後再調整時段。'
-                  : '此時段內有 mentee 提出預約申請尚未處理,請先至「預約管理」頁面接受或拒絕後再刪除整個時段。'}
-            </DialogDescription>
-          </DialogHeader>
-          <DialogFooter className="justify-center">
-            <Button variant="outline" onClick={() => setBlockPrompt(null)}>
-              取消
-            </Button>
-            <Button
-              onClick={() => {
-                setBlockPrompt(null);
-                onOpenChange(false);
-                router.push('/reservation/mentor');
-              }}
-            >
-              前往預約管理
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-
-      <Dialog
-        open={editingSlot !== null}
-        onOpenChange={(o) => !o && setEditingSlotId(null)}
-      >
-        <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
-          <DialogHeader>
-            <DialogTitle>編輯時段</DialogTitle>
-          </DialogHeader>
-          {editingSlot && (
-            <div className="flex flex-col items-center gap-6 py-2">
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-sm font-medium">開始</p>
-                {renderTimeSelectPair(
-                  editingSlot.id,
-                  'startHour',
-                  'startMinute',
-                  editingSlot.startHour,
-                  editingSlot.startMinute,
-                  HOUR_OPTIONS,
-                  MINUTE_OPTIONS
-                )}
-              </div>
-              <div className="flex flex-col items-center gap-2">
-                <p className="text-sm font-medium">結束</p>
-                {renderTimeSelectPair(
-                  editingSlot.id,
-                  'endHour',
-                  'endMinute',
-                  editingSlot.endHour,
-                  editingSlot.endMinute,
-                  getEndHourOptions(editingSlot),
-                  getEndMinuteOptions(editingSlot)
-                )}
-              </div>
-              {editingSlotErrors.timeRange && (
-                <p className="text-red-500 text-center text-xs lg:text-sm">
-                  {editingSlotErrors.timeRange}
-                </p>
-              )}
-              {editingSlotErrors.overlap && (
-                <p className="text-red-500 text-center text-xs lg:text-sm">
-                  {editingSlotErrors.overlap}
-                </p>
-              )}
-            </div>
-          )}
-          <DialogFooter className="justify-center gap-3 sm:gap-4 sm:space-x-0">
-            <Button
-              className="h-12 px-8 text-base"
-              onClick={() => setEditingSlotId(null)}
-            >
-              完成
             </Button>
           </DialogFooter>
         </DialogContent>
       </Dialog>
     </>
+  );
+}
+
+function TimeSelectPair({
+  hourValue,
+  minuteValue,
+  onHourChange,
+  onMinuteChange,
+}: {
+  hourValue: string;
+  minuteValue: string;
+  onHourChange: (v: string) => void;
+  onMinuteChange: (v: string) => void;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <Select value={hourValue} onValueChange={onHourChange}>
+        <SelectTrigger className="h-12 w-24 text-base lg:w-28">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="min-w-[10rem]">
+          {HOUR_OPTIONS.map((opt) => (
+            <SelectItem key={opt} value={opt} className="py-3 text-base">
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <span className="text-base text-muted-foreground">:</span>
+      <Select value={minuteValue} onValueChange={onMinuteChange}>
+        <SelectTrigger className="h-12 w-24 text-base lg:w-28">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent className="min-w-[10rem]">
+          {MINUTE_OPTIONS.map((opt) => (
+            <SelectItem key={opt} value={opt} className="py-3 text-base">
+              {opt}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}
+
+function DurationRadio({
+  value,
+  onChange,
+}: {
+  value: SlotDurationMinutes;
+  onChange: (v: SlotDurationMinutes) => void;
+}) {
+  return (
+    <div className="flex gap-2">
+      {DURATION_OPTIONS.map((opt) => (
+        <button
+          key={opt}
+          type="button"
+          onClick={() => onChange(opt)}
+          className={cn(
+            'flex-1 rounded-lg border px-4 py-2 text-base transition-colors',
+            value === opt
+              ? 'border-primary bg-primary/10 text-primary'
+              : 'border-input bg-background hover:bg-muted/50'
+          )}
+        >
+          {opt} 分
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function AddSlotModal({
+  open,
+  onOpenChange,
+  selectedDate,
+  existingSlots,
+  onSubmit,
+}: {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  selectedDate: string | null;
+  existingSlots: ParsedMentorTimeslot[];
+  onSubmit: (form: SlotFormState, weeklyWithinMonth: boolean) => void;
+}) {
+  const [form, setForm] = useState<SlotFormState>(() =>
+    defaultFormForDate(existingSlots)
+  );
+  const [weekly, setWeekly] = useState(false);
+
+  useEffect(() => {
+    if (open) {
+      setForm(defaultFormForDate(existingSlots));
+      setWeekly(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [open, selectedDate]);
+
+  const previewDates = useMemo(() => {
+    if (!selectedDate || !weekly) return [];
+    const dates: string[] = [];
+    const startMonth = dayjs(selectedDate).month();
+    let cursor = dayjs(selectedDate);
+    while (cursor.month() === startMonth) {
+      dates.push(cursor.format('M/D'));
+      cursor = cursor.add(7, 'day');
+    }
+    return dates;
+  }, [selectedDate, weekly]);
+
+  const weekdayLabel = selectedDate
+    ? WEEKDAY_LABELS[dayjs(selectedDate).day()]
+    : '';
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[420px]">
+        <DialogHeader>
+          <DialogTitle>新增可預約時段</DialogTitle>
+          {selectedDate && (
+            <DialogDescription>
+              {dayjs(selectedDate).format('YYYY/MM/DD')} (週{weekdayLabel})
+            </DialogDescription>
+          )}
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5 py-2">
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium">開始時間</p>
+            <TimeSelectPair
+              hourValue={form.startHour}
+              minuteValue={form.startMinute}
+              onHourChange={(v) => setForm((f) => ({ ...f, startHour: v }))}
+              onMinuteChange={(v) =>
+                setForm((f) => ({ ...f, startMinute: snapMinute(parseInt(v)) }))
+              }
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium">會議長度</p>
+            <DurationRadio
+              value={form.durationMinutes}
+              onChange={(v) => setForm((f) => ({ ...f, durationMinutes: v }))}
+            />
+          </div>
+
+          <label className="flex cursor-pointer items-center gap-2 text-sm">
+            <Checkbox
+              checked={weekly}
+              onCheckedChange={(v) => setWeekly(v === true)}
+            />
+            此月每週{weekdayLabel}都重複
+          </label>
+
+          {weekly && previewDates.length > 0 && (
+            <p className="text-sm text-muted-foreground">
+              將建立 {previewDates.length} 個時段:{previewDates.join('、')}
+            </p>
+          )}
+        </div>
+
+        <DialogFooter className="justify-center gap-3 sm:gap-4 sm:space-x-0">
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            取消
+          </Button>
+          <Button onClick={() => onSubmit(form, weekly)}>建立</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function EditSlotModal({
+  slot,
+  onClose,
+  onSubmit,
+}: {
+  slot: ParsedMentorTimeslot | null;
+  onClose: () => void;
+  onSubmit: (form: SlotFormState) => void;
+}) {
+  const open = slot !== null;
+  const [form, setForm] = useState<SlotFormState>({
+    startHour: '09',
+    startMinute: '00',
+    durationMinutes: 30,
+  });
+
+  useEffect(() => {
+    if (slot) {
+      setForm({
+        startHour: String(slot.start.getHours()).padStart(2, '0'),
+        startMinute: snapMinute(slot.start.getMinutes()),
+        durationMinutes: snapDuration(slot.durationMinutes),
+      });
+    }
+  }, [slot]);
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && onClose()}>
+      <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>編輯時段</DialogTitle>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-5 py-2">
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium">開始時間</p>
+            <TimeSelectPair
+              hourValue={form.startHour}
+              minuteValue={form.startMinute}
+              onHourChange={(v) => setForm((f) => ({ ...f, startHour: v }))}
+              onMinuteChange={(v) =>
+                setForm((f) => ({ ...f, startMinute: snapMinute(parseInt(v)) }))
+              }
+            />
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <p className="text-sm font-medium">會議長度</p>
+            <DurationRadio
+              value={form.durationMinutes}
+              onChange={(v) => setForm((f) => ({ ...f, durationMinutes: v }))}
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="justify-center gap-3 sm:gap-4 sm:space-x-0">
+          <Button variant="outline" onClick={onClose}>
+            取消
+          </Button>
+          <Button onClick={() => onSubmit(form)}>完成</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -9,7 +9,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import {
   BookingSlot,
   buildDateTime,
-  buildRrule,
   expandRrule,
   formatTimeslot,
   hasOverlapAt,
@@ -44,6 +43,8 @@ type Options = {
   };
 };
 
+export type SlotDurationMinutes = 30 | 45 | 60;
+
 export type UseMentorScheduleReturn = {
   /** Sticky: true once any month has resolved. Use this for first-paint skeletons. */
   loaded: boolean;
@@ -58,27 +59,29 @@ export type UseMentorScheduleReturn = {
   /** All local dates (YYYY-MM-DD) that have at least one ALLOW occurrence after expanding rrules. */
   allowedDates: string[];
 
-  meetingDurationMinutes: number;
   generateBookingSlots: (dateKey: string) => BookingSlot[];
 
+  /**
+   * Add one ALLOW slot at `startTime` for `durationMinutes`. If `weeklyWithinMonth`
+   * is true, also create slots for every same-weekday date remaining in the
+   * selected date's month. Each generated slot is an independent row (no rrule).
+   * Returns counts so callers can surface "added N, skipped M" to the user.
+   */
   addSlotForSelectedDate: (opts: {
-    type: 'ALLOW';
     startTime: string; // HH:mm
-    endTime: string; // HH:mm
-  }) => void;
+    durationMinutes: SlotDurationMinutes;
+    weeklyWithinMonth?: boolean;
+  }) => { added: number; skipped: number };
 
   updateDraftSlot: (
     id: number,
     patch: {
       startTime?: string; // HH:mm
-      endTime?: string; // HH:mm
+      durationMinutes?: SlotDurationMinutes;
     }
-  ) => void;
+  ) => boolean;
 
   deleteDraftSlot: (id: number) => void;
-
-  /** Toggle a single sub-slot occurrence in/out of exdate for an ALLOW slot. */
-  toggleOccurrence: (slotId: number, occurrenceDtstart: number) => void;
 
   confirmChanges: () => Promise<SyncResult>;
   resetChanges: () => void;
@@ -110,8 +113,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const [selectedDate, setSelectedDate] = useState<string | null>(
     dayjs().format('YYYY-MM-DD')
   );
-  const [meetingDurationMinutes, setMeetingDurationMinutes] =
-    useState<number>(30);
 
   const currentMonthKey = monthKeyFromYearMonth(backend.year, backend.month);
 
@@ -196,13 +197,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         next.set(monthKey, raws);
         return next;
       });
-      const firstAllow = raws.find((r) => r.type === 'ALLOW');
-      if (firstAllow) {
-        const derived = Math.round(
-          (firstAllow.dtend - firstAllow.dtstart) / 60
-        );
-        if (derived > 0) setMeetingDurationMinutes(derived);
-      }
     };
 
     const hasBuffer = draftByMonth.has(monthKey);
@@ -388,64 +382,77 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   const addSlotForSelectedDate: UseMentorScheduleReturn['addSlotForSelectedDate'] =
     useCallback(
-      ({ startTime, endTime }) => {
-        if (!selectedDate || !startTime || !endTime) return;
+      ({ startTime, durationMinutes, weeklyWithinMonth }) => {
+        if (!selectedDate || !startTime) return { added: 0, skipped: 0 };
 
-        const s = buildDateTime(selectedDate, startTime);
-        const e = buildDateTime(selectedDate, endTime);
-        if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return;
-
-        const newDtstart = Math.floor(s.valueOf() / 1000);
-        const blockDurationSeconds =
-          Math.floor(e.valueOf() / 1000) - newDtstart;
-        const slotDurationSeconds = meetingDurationMinutes * 60;
-        const newDtend = newDtstart + slotDurationSeconds;
+        const startDayjs = buildDateTime(selectedDate, startTime);
+        if (!startDayjs.isValid()) return { added: 0, skipped: 0 };
 
         const monthKey = monthKeyFromDateStr(selectedDate);
+        const durationSeconds = durationMinutes * 60;
 
-        const didMutate = updateMonthDraft(monthKey, (prev) => {
-          if (
-            hasOverlapAt(
-              prev,
-              null,
-              selectedDate,
-              newDtstart,
-              blockDurationSeconds
-            )
-          ) {
-            return prev;
+        // Target dates in the same calendar month as `selectedDate`. Weekly
+        // mode walks 7 days at a time from the selected date until the month
+        // boundary; non-recurring mode is just the selected date itself.
+        const targetDates: string[] = [];
+        if (weeklyWithinMonth) {
+          const selectedDay = dayjs(selectedDate);
+          let cursor = selectedDay;
+          while (cursor.month() === selectedDay.month()) {
+            targetDates.push(cursor.format('YYYY-MM-DD'));
+            cursor = cursor.add(7, 'day');
           }
+        } else {
+          targetDates.push(selectedDate);
+        }
 
-          const rrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
-
-          return [
-            ...prev,
-            {
-              id: nextTempId(prev),
-              type: 'ALLOW' as const,
-              dtstart: newDtstart,
-              dtend: newDtend,
-              rrule,
-              exdate: [],
-            },
-          ];
+        let added = 0;
+        let skipped = 0;
+        updateMonthDraft(monthKey, (prev) => {
+          let next = prev;
+          for (const dateStr of targetDates) {
+            const d = buildDateTime(dateStr, startTime);
+            if (!d.isValid()) {
+              skipped++;
+              continue;
+            }
+            const newDtstart = Math.floor(d.valueOf() / 1000);
+            if (
+              hasOverlapAt(next, null, dateStr, newDtstart, durationSeconds)
+            ) {
+              skipped++;
+              continue;
+            }
+            next = [
+              ...next,
+              {
+                id: nextTempId(next),
+                type: 'ALLOW' as const,
+                dtstart: newDtstart,
+                dtend: newDtstart + durationSeconds,
+                rrule: undefined,
+                exdate: [],
+              },
+            ];
+            added++;
+          }
+          return next === prev ? prev : next;
         });
 
-        if (didMutate) markDirty(monthKey);
+        if (added > 0) markDirty(monthKey);
+        return { added, skipped };
       },
-      [selectedDate, meetingDurationMinutes, updateMonthDraft, markDirty]
+      [selectedDate, updateMonthDraft, markDirty]
     );
 
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, patch) => {
         const monthKey = findMonthForSlotId(id);
-        if (!monthKey) return;
+        if (!monthKey) return false;
 
-        const didMutate = updateMonthDraft(monthKey, (prev) => {
+        let succeeded = false;
+        updateMonthDraft(monthKey, (prev) => {
           const target = prev.find((r) => r.id === id);
           if (!target) return prev;
 
@@ -453,51 +460,35 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
           const startHM = patch.startTime ?? fmtHM(target.dtstart);
 
-          const occs = expandRrule(target.dtstart, target.rrule);
-          const lastOcc = occs[occs.length - 1] ?? target.dtstart;
-          const endHM =
-            patch.endTime ?? fmtHM(lastOcc + (target.dtend - target.dtstart));
-
           const s = buildDateTime(baseDate, startHM);
-          const e = buildDateTime(baseDate, endHM);
-          if (!s.isValid() || !e.isValid() || e.isSameOrBefore(s)) return prev;
+          if (!s.isValid()) return prev;
 
           const newDtstart = Math.floor(s.valueOf() / 1000);
-          const blockDurationSeconds =
-            Math.floor(e.valueOf() / 1000) - newDtstart;
-          const slotDurationSeconds = target.dtend - target.dtstart;
-          const newDtend = newDtstart + slotDurationSeconds;
+          const oldDurationSeconds = target.dtend - target.dtstart;
+          const durationSeconds =
+            (patch.durationMinutes ?? Math.round(oldDurationSeconds / 60)) * 60;
+          const newDtend = newDtstart + durationSeconds;
 
-          if (
-            hasOverlapAt(prev, id, baseDate, newDtstart, blockDurationSeconds)
-          ) {
+          if (hasOverlapAt(prev, id, baseDate, newDtstart, durationSeconds)) {
             return prev;
           }
 
-          const newRrule =
-            blockDurationSeconds > slotDurationSeconds
-              ? buildRrule(blockDurationSeconds, slotDurationSeconds)
-              : undefined;
-
-          const newBlockEnd = newDtstart + blockDurationSeconds;
-          const cleanedExdate = target.exdate.filter(
-            (occ) => occ >= newDtstart && occ < newBlockEnd
-          );
-
+          succeeded = true;
           return prev.map((r) =>
             r.id === id
               ? {
                   ...r,
                   dtstart: newDtstart,
                   dtend: newDtend,
-                  rrule: newRrule,
-                  exdate: cleanedExdate,
+                  rrule: undefined,
+                  exdate: [],
                 }
               : r
           );
         });
 
-        if (didMutate) markDirty(monthKey);
+        if (succeeded) markDirty(monthKey);
+        return succeeded;
       },
       [findMonthForSlotId, updateMonthDraft, markDirty]
     );
@@ -518,28 +509,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         });
       }
       markDirty(monthKey);
-    },
-    [findMonthForSlotId, updateMonthDraft, markDirty]
-  );
-
-  const toggleOccurrence = useCallback(
-    (slotId: number, occurrenceDtstart: number) => {
-      const monthKey = findMonthForSlotId(slotId);
-      if (!monthKey) return;
-
-      const didMutate = updateMonthDraft(monthKey, (prev) =>
-        prev.map((r) => {
-          if (r.id !== slotId || r.type !== 'ALLOW') return r;
-          const isExcluded = r.exdate.includes(occurrenceDtstart);
-          return {
-            ...r,
-            exdate: isExcluded
-              ? r.exdate.filter((d) => d !== occurrenceDtstart)
-              : [...r.exdate, occurrenceDtstart],
-          };
-        })
-      );
-      if (didMutate) markDirty(monthKey);
     },
     [findMonthForSlotId, updateMonthDraft, markDirty]
   );
@@ -669,12 +638,10 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     parsedDraft,
     draftForSelectedDate,
     allowedDates,
-    meetingDurationMinutes,
     generateBookingSlots,
     addSlotForSelectedDate,
     updateDraftSlot,
     deleteDraftSlot,
-    toggleOccurrence,
     confirmChanges,
     resetChanges,
   };

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -123,15 +123,6 @@ export function nextTempId(rows: RawMentorTimeslot[]): number {
   return negatives.length ? Math.min(...negatives) - 1 : -1;
 }
 
-export function buildRrule(
-  blockDurationSeconds: number,
-  slotDurationSeconds: number
-): string {
-  const count = Math.round(blockDurationSeconds / slotDurationSeconds);
-  const intervalMinutes = Math.round(slotDurationSeconds / 60);
-  return `FREQ=MINUTELY;INTERVAL=${intervalMinutes};COUNT=${count}`;
-}
-
 /** Build a dayjs from a YYYY-MM-DD date and HH:mm time. */
 export function buildDateTime(dateStr: string, timeStr: string) {
   const [h, m] = timeStr.split(':').map(Number);


### PR DESCRIPTION
## What Does This PR Do?

- Drop the "block + FREQ=MINUTELY rrule" abuse used to slice one ALLOW row into N sub-slots; each row now represents exactly one bookable slot.
- Mentor picks meeting duration (30 / 45 / 60 min) per slot via a radio in the add/edit modal.
- Opt-in "此月每週X都重複" checkbox generates one independent row per same-weekday occurrence in the selected month, with a live preview of the dates that will be created.
- Remove sub-slot chips and exdate toggling — no longer meaningful when each row is a single slot.
- Reservation-block guard simplified: a slot is locked from edit/delete when a BOOKED/PENDING reservation exists at its dtstart on the same date.

## Demo

http://localhost:3000/profile/<mentor-id>

Open the mentor schedule dialog and try:
1. Single add: pick time + duration → one row created.
2. Weekly add: pick a Tuesday → check 「此月每週二都重複」 → preview lists every Tuesday from selected date to month-end → save → calendar lights up on each Tuesday.
3. Click an existing slot → edit modal updates time / duration.
4. Mentee side: sees the new slots and can book them.

## Anything to Note?

- Backend (X-Career-User, BFF) untouched. The existing rrule-aware code still accepts rrule on the wire; the frontend just no longer emits it.
- Recurrence is intentionally scoped to the current month. Backend queries schedule rows by (dt_year, dt_month), so a row's occurrences must all live inside one month. Cross-month weekly recurrence is a much larger refactor (reverted twice already as PR #596 / #109) and is out of scope here.
- Verified locally: type-check, lint, build, vitest 156/156 all pass. Browser smoke test still pending — please verify the five paths in Demo before merging.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
