### PR TITLE
fix(tag-catalog): disable SSR cache for tag catalog fetch

### DIFF
--- a/src/services/profile/tagCatalog.server.ts
+++ b/src/services/profile/tagCatalog.server.ts
@@ -14,7 +14,6 @@ type ApiResponse = components['schemas']['ApiResponse_TagCatalogsVO_'];
 // NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
 const BASE_URL =
   process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
-const REVALIDATE_SECONDS = 86400;
 
 export async function fetchTagCatalogServer(
   language: string
@@ -22,7 +21,7 @@ export async function fetchTagCatalogServer(
   if (!BASE_URL) return EMPTY_TAG_CATALOGS;
   try {
     const res = await fetch(`${BASE_URL}/v1/users/${language}/tags/catalog`, {
-      next: { revalidate: REVALIDATE_SECONDS },
+      cache: 'no-store',
     });
     if (!res.ok) {
       console.error(`SSR fetchTagCatalog failed: ${res.status}`);


### PR DESCRIPTION
## Summary
- 把 `fetchTagCatalogServer` 從 `next: { revalidate: 86400 }`（24h）改成 `cache: 'no-store'`，後端 tag 異動可以立即反映在 SSR，不用等下一個 revalidate 視窗或重新部署
- 移除不再使用的 `REVALIDATE_SECONDS` 常數

## Why
目前 tag catalog 在 SSR 端被快取一整天，後台更新 tag 後，要等到隔天或重新部署才會生效。先改成不快取以解決即時性問題；之後若要回到有快取＋按需 bust 的做法，可改用 `next: { tags: [...] }` + `revalidateTag`。

## Test plan
- [x] `pnpm type-check` pass
- [x] `pnpm build` pass
- [x] `pnpm test` pass (Husky pre-push)
- [ ] 手動驗證：後端更新一筆 tag 後，重新整理 profile/expertise 頁，新 tag 立即出現

🤖 Generated with [Claude Code](https://claude.com/claude-code)