### PR TITLE
feat(mentor-schedule): weekly rrule + show past slots disabled

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -3,7 +3,7 @@
 import dayjs from 'dayjs';
 import { Clock, Plus, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { useEffect, useMemo, useState } from 'react';
+import { KeyboardEvent, useEffect, useMemo, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -131,7 +131,12 @@ export default function MentorScheduleDialog({
   const { toast } = useToast();
   const [isSaving, setIsSaving] = useState(false);
   const [addModalOpen, setAddModalOpen] = useState(false);
-  const [editingSlotId, setEditingSlotId] = useState<number | null>(null);
+  // Track both row id and occurrence so editing a single occurrence of a
+  // recurring row routes back to the correct exdate-and-detach call.
+  const [editingTarget, setEditingTarget] = useState<{
+    id: number;
+    occurrenceUnix: number;
+  } | null>(null);
   const [reservationPrompt, setReservationPrompt] =
     useState<ReservationPromptType>(null);
 
@@ -145,12 +150,16 @@ export default function MentorScheduleDialog({
     }
   }, [open]);
 
-  // Hide ALLOW slots that have already started — past slots can't be booked or
-  // meaningfully edited. BOOKED/PENDING are filtered out separately because we
-  // only manage reservation lifecycle on a different page.
+  // Show all ALLOW slots (including past) so the editor stays consistent with
+  // what was scheduled; past slots render disabled to make it clear they
+  // can't be edited or deleted. BOOKED/PENDING are tracked separately below
+  // because reservation lifecycle is managed on a different page.
   const nowSec = Math.floor(Date.now() / 1000);
-  const editableSlots = draftForSelectedDate.filter(
-    (s) => s.type === 'ALLOW' && Math.floor(s.start.getTime() / 1000) > nowSec
+  const visibleSlots = draftForSelectedDate.filter((s) => s.type === 'ALLOW');
+  // Future-only subset used for the AddSlotModal "next slot" default — we
+  // don't want the picker to suggest a time that's already in the past.
+  const futureSlots = visibleSlots.filter(
+    (s) => Math.floor(s.start.getTime() / 1000) > nowSec
   );
 
   // Block deletion/edit when a BOOKED or PENDING reservation exists at this
@@ -201,10 +210,13 @@ export default function MentorScheduleDialog({
     onOpenChange(false);
   };
 
-  const editingSlot =
-    editingSlotId !== null
-      ? (editableSlots.find((s) => s.id === editingSlotId) ?? null)
-      : null;
+  const editingSlot = editingTarget
+    ? (visibleSlots.find(
+        (s) =>
+          s.id === editingTarget.id &&
+          s.occurrenceUnix === editingTarget.occurrenceUnix
+      ) ?? null)
+    : null;
 
   return (
     <>
@@ -248,7 +260,7 @@ export default function MentorScheduleDialog({
                 </div>
               ) : (
                 <div className="mt-3 flex flex-col gap-3">
-                  {editableSlots.map((slot) => {
+                  {visibleSlots.map((slot) => {
                     const startLabel = fmtTime(
                       Math.floor(slot.start.getTime() / 1000)
                     );
@@ -256,29 +268,46 @@ export default function MentorScheduleDialog({
                       Math.floor(slot.end.getTime() / 1000)
                     );
                     const reservationBlock = getReservationBlock(slot);
+                    const isPast =
+                      Math.floor(slot.start.getTime() / 1000) <= nowSec;
                     return (
                       <div
-                        key={slot.id}
-                        role="button"
-                        tabIndex={0}
-                        onClick={() => {
-                          if (reservationBlock) {
-                            setReservationPrompt(reservationBlock);
-                            return;
-                          }
-                          setEditingSlotId(slot.id);
-                        }}
-                        onKeyDown={(e) => {
-                          if (e.key === 'Enter' || e.key === ' ') {
-                            e.preventDefault();
-                            if (reservationBlock) {
-                              setReservationPrompt(reservationBlock);
-                              return;
-                            }
-                            setEditingSlotId(slot.id);
-                          }
-                        }}
-                        className="flex cursor-pointer flex-col gap-2 rounded-lg border bg-background p-3 transition-colors hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring lg:p-4"
+                        key={`${slot.id}-${slot.occurrenceUnix}`}
+                        {...(isPast
+                          ? { 'aria-disabled': true }
+                          : {
+                              role: 'button',
+                              tabIndex: 0,
+                              onClick: () => {
+                                if (reservationBlock) {
+                                  setReservationPrompt(reservationBlock);
+                                  return;
+                                }
+                                setEditingTarget({
+                                  id: slot.id,
+                                  occurrenceUnix: slot.occurrenceUnix,
+                                });
+                              },
+                              onKeyDown: (e: KeyboardEvent) => {
+                                if (e.key === 'Enter' || e.key === ' ') {
+                                  e.preventDefault();
+                                  if (reservationBlock) {
+                                    setReservationPrompt(reservationBlock);
+                                    return;
+                                  }
+                                  setEditingTarget({
+                                    id: slot.id,
+                                    occurrenceUnix: slot.occurrenceUnix,
+                                  });
+                                }
+                              },
+                            })}
+                        className={cn(
+                          'flex flex-col gap-2 rounded-lg border bg-background p-3 transition-colors lg:p-4',
+                          isPast
+                            ? 'cursor-not-allowed opacity-50'
+                            : 'cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                        )}
                       >
                         <div className="flex flex-row flex-nowrap items-center justify-between gap-2 lg:gap-3">
                           <div className="flex items-center gap-2">
@@ -288,23 +317,26 @@ export default function MentorScheduleDialog({
                             </span>
                             <span className="text-sm text-muted-foreground">
                               ({slot.durationMinutes} 分)
+                              {isPast ? ' · 已過' : ''}
                             </span>
                           </div>
-                          <Button
-                            variant="ghost"
-                            size="icon"
-                            className="h-8 w-8 lg:h-10 lg:w-10"
-                            onClick={(e) => {
-                              e.stopPropagation();
-                              if (reservationBlock) {
-                                setReservationPrompt(reservationBlock);
-                                return;
-                              }
-                              deleteDraftSlot(slot.id);
-                            }}
-                          >
-                            <X className="h-4 w-4 lg:h-5 lg:w-5" />
-                          </Button>
+                          {!isPast && (
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 lg:h-10 lg:w-10"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                if (reservationBlock) {
+                                  setReservationPrompt(reservationBlock);
+                                  return;
+                                }
+                                deleteDraftSlot(slot.id, slot.occurrenceUnix);
+                              }}
+                            >
+                              <X className="h-4 w-4 lg:h-5 lg:w-5" />
+                            </Button>
+                          )}
                         </div>
                       </div>
                     );
@@ -344,7 +376,7 @@ export default function MentorScheduleDialog({
         open={addModalOpen}
         onOpenChange={setAddModalOpen}
         selectedDate={selectedDate}
-        existingSlots={editableSlots}
+        existingSlots={futureSlots}
         onSubmit={(form, weekly) => {
           const result = addSlotForSelectedDate({
             startTime: `${form.startHour}:${form.startMinute}`,
@@ -369,13 +401,17 @@ export default function MentorScheduleDialog({
 
       <EditSlotModal
         slot={editingSlot}
-        onClose={() => setEditingSlotId(null)}
+        onClose={() => setEditingTarget(null)}
         onSubmit={(form) => {
-          if (!editingSlotId) return;
-          const ok = updateDraftSlot(editingSlotId, {
-            startTime: `${form.startHour}:${form.startMinute}`,
-            durationMinutes: form.durationMinutes,
-          });
+          if (!editingTarget) return;
+          const ok = updateDraftSlot(
+            editingTarget.id,
+            editingTarget.occurrenceUnix,
+            {
+              startTime: `${form.startHour}:${form.startMinute}`,
+              durationMinutes: form.durationMinutes,
+            }
+          );
           if (!ok) {
             toast({
               variant: 'destructive',
@@ -383,7 +419,7 @@ export default function MentorScheduleDialog({
             });
             return;
           }
-          setEditingSlotId(null);
+          setEditingTarget(null);
         }}
       />
 

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -7,11 +7,12 @@ dayjs.extend(isSameOrBefore);
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import {
+  activeOccurrences,
   BookingSlot,
   buildDateTime,
   expandRrule,
   formatTimeslot,
-  hasOverlapAt,
+  hasAnyOccurrenceOverlap,
   MonthKey,
   monthKeyFromDateStr,
   monthKeyFromYearMonth,
@@ -62,10 +63,11 @@ export type UseMentorScheduleReturn = {
   generateBookingSlots: (dateKey: string) => BookingSlot[];
 
   /**
-   * Add one ALLOW slot at `startTime` for `durationMinutes`. If `weeklyWithinMonth`
-   * is true, also create slots for every same-weekday date remaining in the
-   * selected date's month. Each generated slot is an independent row (no rrule).
-   * Returns counts so callers can surface "added N, skipped M" to the user.
+   * Add one ALLOW entry at `startTime` for `durationMinutes`. If
+   * `weeklyWithinMonth` is true, the entry is a single row with a weekly
+   * `FREQ=WEEKLY;COUNT=N` rrule covering every same-weekday date remaining in
+   * the selected date's month; otherwise it's a non-recurring row. Returns
+   * counts of created occurrences so callers can show "added N, skipped M".
    */
   addSlotForSelectedDate: (opts: {
     startTime: string; // HH:mm
@@ -73,15 +75,27 @@ export type UseMentorScheduleReturn = {
     weeklyWithinMonth?: boolean;
   }) => { added: number; skipped: number };
 
+  /**
+   * Edit a single occurrence. For non-recurring rows this updates the row
+   * directly. For recurring rows the targeted occurrence is detached: it is
+   * added to the parent's exdate and a new non-recurring row is created with
+   * the patch applied — leaving sibling occurrences untouched.
+   */
   updateDraftSlot: (
     id: number,
+    occurrenceUnix: number,
     patch: {
       startTime?: string; // HH:mm
       durationMinutes?: SlotDurationMinutes;
     }
   ) => boolean;
 
-  deleteDraftSlot: (id: number) => void;
+  /**
+   * Delete a single occurrence. Non-recurring rows are removed entirely; on
+   * recurring rows the occurrence is added to exdate, and the row is removed
+   * only when no active occurrences remain.
+   */
+  deleteDraftSlot: (id: number, occurrenceUnix: number) => void;
 
   confirmChanges: () => Promise<SyncResult>;
   resetChanges: () => void;
@@ -275,7 +289,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const parsedDraft = useMemo(
     () =>
       allDraftRaws
-        .map(formatTimeslot)
+        .flatMap(formatTimeslot)
         .sort((a, b) => a.start.getTime() - b.start.getTime()),
     [allDraftRaws]
   );
@@ -391,52 +405,62 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const monthKey = monthKeyFromDateStr(selectedDate);
         const durationSeconds = durationMinutes * 60;
 
-        // Target dates in the same calendar month as `selectedDate`. Weekly
-        // mode walks 7 days at a time from the selected date until the month
-        // boundary; non-recurring mode is just the selected date itself.
-        const targetDates: string[] = [];
+        // Walk same-weekday dates from selectedDate to month-end. The first
+        // entry is always the selected date itself; subsequent entries exist
+        // only when weeklyWithinMonth is true.
+        const candidateOccurrences: number[] = [];
         if (weeklyWithinMonth) {
           const selectedDay = dayjs(selectedDate);
           let cursor = selectedDay;
           while (cursor.month() === selectedDay.month()) {
-            targetDates.push(cursor.format('YYYY-MM-DD'));
+            const d = buildDateTime(cursor.format('YYYY-MM-DD'), startTime);
+            if (d.isValid()) {
+              candidateOccurrences.push(Math.floor(d.valueOf() / 1000));
+            }
             cursor = cursor.add(7, 'day');
           }
         } else {
-          targetDates.push(selectedDate);
+          candidateOccurrences.push(Math.floor(startDayjs.valueOf() / 1000));
+        }
+
+        if (candidateOccurrences.length === 0) {
+          return { added: 0, skipped: 0 };
         }
 
         let added = 0;
         let skipped = 0;
         updateMonthDraft(monthKey, (prev) => {
-          let next = prev;
-          for (const dateStr of targetDates) {
-            const d = buildDateTime(dateStr, startTime);
-            if (!d.isValid()) {
-              skipped++;
-              continue;
-            }
-            const newDtstart = Math.floor(d.valueOf() / 1000);
-            if (
-              hasOverlapAt(next, null, dateStr, newDtstart, durationSeconds)
-            ) {
-              skipped++;
-              continue;
-            }
-            next = [
-              ...next,
-              {
-                id: nextTempId(next),
-                type: 'ALLOW' as const,
-                dtstart: newDtstart,
-                dtend: newDtstart + durationSeconds,
-                rrule: undefined,
-                exdate: [],
-              },
-            ];
-            added++;
+          // Reject the whole entry if any candidate occurrence overlaps an
+          // existing slot. This keeps weekly add atomic — we don't silently
+          // create a partial recurrence.
+          if (
+            hasAnyOccurrenceOverlap(
+              prev,
+              null,
+              candidateOccurrences,
+              durationSeconds
+            )
+          ) {
+            skipped = candidateOccurrences.length;
+            return prev;
           }
-          return next === prev ? prev : next;
+
+          const dtstart = candidateOccurrences[0];
+          const count = candidateOccurrences.length;
+          const rrule = count > 1 ? `FREQ=WEEKLY;COUNT=${count}` : undefined;
+
+          added = count;
+          return [
+            ...prev,
+            {
+              id: nextTempId(prev),
+              type: 'ALLOW' as const,
+              dtstart,
+              dtend: dtstart + durationSeconds,
+              rrule,
+              exdate: [],
+            },
+          ];
         });
 
         if (added > 0) markDirty(monthKey);
@@ -447,7 +471,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
-      (id, patch) => {
+      (id, occurrenceUnix, patch) => {
         const monthKey = findMonthForSlotId(id);
         if (!monthKey) return false;
 
@@ -456,9 +480,9 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const target = prev.find((r) => r.id === id);
           if (!target) return prev;
 
-          const baseDate = dayjs(target.dtstart * 1000).format('YYYY-MM-DD');
+          const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
-          const startHM = patch.startTime ?? fmtHM(target.dtstart);
+          const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
 
           const s = buildDateTime(baseDate, startHM);
           if (!s.isValid()) return prev;
@@ -467,9 +491,59 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const oldDurationSeconds = target.dtend - target.dtstart;
           const durationSeconds =
             (patch.durationMinutes ?? Math.round(oldDurationSeconds / 60)) * 60;
-          const newDtend = newDtstart + durationSeconds;
 
-          if (hasOverlapAt(prev, id, baseDate, newDtstart, durationSeconds)) {
+          // Recurring row: detach this occurrence (exdate it on the parent,
+          // emit a new non-recurring row with the patch) so sibling weeks
+          // stay untouched. Non-recurring row: mutate it in place.
+          const isRecurring = !!target.rrule;
+          const noChange =
+            newDtstart === occurrenceUnix &&
+            durationSeconds === oldDurationSeconds;
+          if (isRecurring && noChange) {
+            // Submitting the edit modal without changes shouldn't surface
+            // an overlap error — report success and skip the mutation.
+            succeeded = true;
+            return prev;
+          }
+
+          // Build the prospective next state and overlap-check it against
+          // candidate occurrences (excluding the parent row, whose own
+          // occurrence at occurrenceUnix is being replaced/exdated).
+          if (isRecurring) {
+            const updatedParent: RawMentorTimeslot = {
+              ...target,
+              exdate: target.exdate.includes(occurrenceUnix)
+                ? target.exdate
+                : [...target.exdate, occurrenceUnix],
+            };
+            const detachedRow: RawMentorTimeslot = {
+              id: nextTempId(prev),
+              type: 'ALLOW' as const,
+              dtstart: newDtstart,
+              dtend: newDtstart + durationSeconds,
+              rrule: undefined,
+              exdate: [],
+            };
+            const intermediate = prev.map((r) =>
+              r.id === id ? updatedParent : r
+            );
+            if (
+              hasAnyOccurrenceOverlap(
+                intermediate,
+                null,
+                [newDtstart],
+                durationSeconds
+              )
+            ) {
+              return prev;
+            }
+            succeeded = true;
+            return [...intermediate, detachedRow];
+          }
+
+          if (
+            hasAnyOccurrenceOverlap(prev, id, [newDtstart], durationSeconds)
+          ) {
             return prev;
           }
 
@@ -479,7 +553,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
               ? {
                   ...r,
                   dtstart: newDtstart,
-                  dtend: newDtend,
+                  dtend: newDtstart + durationSeconds,
                   rrule: undefined,
                   exdate: [],
                 }
@@ -494,12 +568,39 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     );
 
   const deleteDraftSlot = useCallback(
-    (id: number) => {
+    (id: number, occurrenceUnix: number) => {
       const monthKey = findMonthForSlotId(id);
       if (!monthKey) return;
 
-      updateMonthDraft(monthKey, (prev) => prev.filter((r) => r.id !== id));
-      if (id > 0) {
+      let removedFromDraft = false;
+      updateMonthDraft(monthKey, (prev) => {
+        const target = prev.find((r) => r.id === id);
+        if (!target) return prev;
+
+        // Recurring row: only this occurrence is removed via exdate. If that
+        // would empty the row of active occurrences, drop the row entirely.
+        if (target.rrule) {
+          const updatedExdate = target.exdate.includes(occurrenceUnix)
+            ? target.exdate
+            : [...target.exdate, occurrenceUnix];
+          const updated: RawMentorTimeslot = {
+            ...target,
+            exdate: updatedExdate,
+          };
+          if (activeOccurrences(updated).length === 0) {
+            removedFromDraft = true;
+            return prev.filter((r) => r.id !== id);
+          }
+          return prev.map((r) => (r.id === id ? updated : r));
+        }
+
+        removedFromDraft = true;
+        return prev.filter((r) => r.id !== id);
+      });
+
+      // Only persisted rows that were fully removed need a backend DELETE.
+      // Detached/exdated rrule rows ride the next save via rrule + exdate.
+      if (removedFromDraft && id > 0) {
         setPendingDeleteByMonth((prev) => {
           const current = prev.get(monthKey) ?? [];
           if (current.includes(id)) return prev;

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -40,17 +40,26 @@ export type RawMentorTimeslot = Pick<
   exdate: number[];
 };
 
+/**
+ * Represents a SINGLE occurrence of an ALLOW/BOOKED/PENDING entry. A non-rrule
+ * row produces exactly one entry; a weekly-rrule row produces one entry per
+ * non-exdated occurrence. The pair (id, occurrenceUnix) uniquely identifies
+ * each card the user sees in the editor and is what mutator callbacks use to
+ * scope edits/deletes back to the right occurrence of the underlying row.
+ */
 export type ParsedMentorTimeslot = {
-  id: number;
+  id: number; // = parent row id; shared by all occurrences of an rrule row
+  occurrenceUnix: number; // dtstart of THIS occurrence (= row.dtstart for non-recurring)
   type: DtType;
-  start: Date; // block start (= dtstart for all types)
-  end: Date; // block end: last occurrence end for ALLOW (derived from rrule), dtend for others
+  start: Date; // = new Date(occurrenceUnix * 1000)
+  end: Date; // = start + slotDurationSeconds
   durationMinutes: number;
   formatted: string;
-  dateKey: string; // YYYY-MM-DD (local)
-  rrule?: string;
-  exdate: number[];
-  slotDurationSeconds: number; // duration of one sub-slot (dtend - dtstart)
+  dateKey: string; // YYYY-MM-DD (local) of this occurrence
+  rrule?: string; // copied from parent row
+  exdate: number[]; // copied from parent row
+  slotDurationSeconds: number;
+  isRecurringInstance: boolean; // true if parent row has rrule
 };
 
 export type BookingSlot = {
@@ -76,6 +85,15 @@ export function expandRrule(
   }
 }
 
+/**
+ * Active occurrences of a row = rrule expansion minus exdate. For non-recurring
+ * rows this returns `[dtstart]` (or `[]` if dtstart is exdated, which shouldn't
+ * happen in practice).
+ */
+export function activeOccurrences(r: RawMentorTimeslot): number[] {
+  return expandRrule(r.dtstart, r.rrule).filter((o) => !r.exdate.includes(o));
+}
+
 export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
   return {
     id: t.id ?? Math.floor(Math.random() * 1e9),
@@ -87,35 +105,35 @@ export function segmentToRaw(t: SegmentVO): RawMentorTimeslot {
   };
 }
 
-export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot {
-  const start = new Date(r.dtstart * 1000);
+/**
+ * Expand a row into one ParsedMentorTimeslot per active occurrence. A
+ * non-recurring row yields a length-1 array; a weekly-rrule row yields one
+ * entry per non-exdated occurrence so the UI can render and act on each
+ * occurrence independently.
+ */
+export function formatTimeslot(r: RawMentorTimeslot): ParsedMentorTimeslot[] {
   const slotDurationSeconds = r.dtend - r.dtstart;
-
-  let end: Date;
-  if (r.type === 'ALLOW' && r.rrule) {
-    const occurrences = expandRrule(r.dtstart, r.rrule);
-    const lastOccDtstart = occurrences[occurrences.length - 1] ?? r.dtstart;
-    end = new Date((lastOccDtstart + slotDurationSeconds) * 1000);
-  } else {
-    end = new Date(r.dtend * 1000);
-  }
-
-  const durationMinutes = Math.round(
-    (end.getTime() - start.getTime()) / (1000 * 60)
-  );
-  const dateKey = dayjs(start).format('YYYY-MM-DD');
-  return {
-    id: r.id,
-    type: r.type,
-    start,
-    end,
-    durationMinutes,
-    formatted: `${dayjs(start).format('YYYY-MM-DD hh:mm A')} ~ ${dayjs(end).format('hh:mm A')}`,
-    dateKey,
-    rrule: r.rrule ?? undefined,
-    exdate: r.exdate,
-    slotDurationSeconds,
-  };
+  const durationMinutes = Math.round(slotDurationSeconds / 60);
+  const isRecurring = !!r.rrule;
+  return activeOccurrences(r).map((occ) => {
+    const start = new Date(occ * 1000);
+    const end = new Date((occ + slotDurationSeconds) * 1000);
+    const dateKey = dayjs(start).format('YYYY-MM-DD');
+    return {
+      id: r.id,
+      occurrenceUnix: occ,
+      type: r.type,
+      start,
+      end,
+      durationMinutes,
+      formatted: `${dayjs(start).format('YYYY-MM-DD hh:mm A')} ~ ${dayjs(end).format('hh:mm A')}`,
+      dateKey,
+      rrule: r.rrule ?? undefined,
+      exdate: r.exdate,
+      slotDurationSeconds,
+      isRecurringInstance: isRecurring,
+    };
+  });
 }
 
 export function nextTempId(rows: RawMentorTimeslot[]): number {
@@ -134,25 +152,29 @@ export function buildDateTime(dateStr: string, timeStr: string) {
 }
 
 /**
- * Whether [dtstart, dtstart+blockDurationSeconds) overlaps any other ALLOW
- * block on the same local date in `rows`. Pass `ignoreId` to skip the slot
- * being edited; pass `null` when adding a brand-new slot.
+ * Whether any of the candidate occurrences (each `[unix, unix+durationSeconds)`)
+ * overlap any active occurrence of an existing ALLOW row in `rows`. Pass
+ * `ignoreRowId` to skip a row being edited (its current occurrences are
+ * excluded entirely); pass `null` when adding a brand-new slot.
  */
-export function hasOverlapAt(
+export function hasAnyOccurrenceOverlap(
   rows: RawMentorTimeslot[],
-  ignoreId: number | null,
-  dateKey: string,
-  dtstart: number,
-  blockDurationSeconds: number
+  ignoreRowId: number | null,
+  candidateOccurrences: number[],
+  durationSeconds: number
 ): boolean {
-  const blockEnd = dtstart + blockDurationSeconds;
+  if (candidateOccurrences.length === 0) return false;
   return rows.some((r) => {
-    if (r.id === ignoreId) return false;
+    if (r.id === ignoreRowId) return false;
     if (r.type !== 'ALLOW') return false;
-    const rDate = dayjs(r.dtstart * 1000).format('YYYY-MM-DD');
-    if (rDate !== dateKey) return false;
-    const occs = expandRrule(r.dtstart, r.rrule);
-    const rEnd = (occs[occs.length - 1] ?? r.dtstart) + (r.dtend - r.dtstart);
-    return dtstart < rEnd && blockEnd > r.dtstart;
+    const existingDur = r.dtend - r.dtstart;
+    const existingOccs = activeOccurrences(r);
+    return existingOccs.some((eo) => {
+      const eEnd = eo + existingDur;
+      return candidateOccurrences.some((no) => {
+        const nEnd = no + durationSeconds;
+        return no < eEnd && nEnd > eo;
+      });
+    });
   });
 }


### PR DESCRIPTION
## What Does This PR Do?

- Bring rrule back on the wire for weekly recurrence: weekly mode now creates one row with `FREQ=WEEKLY;COUNT=N` instead of N independent rows.
- Refactor `formatTimeslot` to expand each row into one `ParsedMentorTimeslot` per active occurrence; the editor renders each occurrence as its own card, keyed by `(rowId, occurrenceUnix)`.
- Make mutators occurrence-aware:
  - `deleteDraftSlot(id, occurrenceUnix)`: rrule rows add the occurrence to `exdate`; the row is dropped only when no active occurrences remain.
  - `updateDraftSlot(id, occurrenceUnix, patch)`: rrule rows detach (parent gains exdate, a new non-recurring row is created with the patch) so sibling weeks stay untouched.
- Replace `hasOverlapAt` with `hasAnyOccurrenceOverlap`, an occurrence-aware check that correctly handles sparse rrule expansions.
- Stop hiding ALLOW slots that have already started — past occurrences now render disabled (no click, no delete, "已過" label) instead of disappearing from the editor.

## Demo

http://localhost:3000/profile/<mentor-id>

Open the mentor schedule dialog and try:
1. Pick a Tuesday, check 「此月每週二都重複」, save → one row with rrule on the wire, editor still shows one card per occurrence.
2. Click X on one week → that occurrence vanishes via exdate; sibling weeks stay.
3. Click an existing occurrence → edit modal changes only that week (detached as a new row).
4. Today's already-passed slot renders greyed-out and uninteractive instead of vanishing.

## Screenshot

N/A

## Anything to Note?

- Backend wire format already accepts rrule + exdate (see `services/mentor-schedule/schedule.ts`); no backend change required.
- Reservation guard is per-occurrence — only the specific BOOKED/PENDING week of a recurring slot is locked.
- Rejecting a weekly add is atomic: if any candidate occurrence overlaps an existing slot, the entire row is skipped (`skipped` count covers all N).
- Verified locally: type-check, vitest 156/156, build all pass. Browser smoke test still pending — please verify the four demo steps before merging.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
