### PR TITLE
fix(auth): stop exposing refreshToken to browser session

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -196,9 +196,6 @@ const authOptions = {
       };
 
       session.accessToken = (token.token as string | undefined) ?? undefined;
-      // TEST: expose refreshToken to client for debugging (remove after testing)
-      session.user.refreshToken =
-        (token.refreshToken as string | undefined) ?? undefined;
       session.user.provider =
         (token.provider as string | undefined) ?? undefined;
       session.user.email = (token.email as string | undefined) ?? undefined;

--- a/src/components/SessionErrorWatcher.tsx
+++ b/src/components/SessionErrorWatcher.tsx
@@ -7,13 +7,6 @@ export default function SessionErrorWatcher() {
   const { data: session } = useSession();
 
   useEffect(() => {
-    if (session) {
-      console.log('[Auth] accessToken:', session.accessToken);
-      console.log('[Auth] refreshToken:', session.user?.refreshToken);
-    }
-  }, [session]);
-
-  useEffect(() => {
     if (session?.error === 'RefreshTokenError') {
       signOut({ callbackUrl: '/auth/signin' });
     }

--- a/src/types/types.d.ts
+++ b/src/types/types.d.ts
@@ -24,7 +24,7 @@ declare module 'next-auth' {
   }
 
   interface Session {
-    user: Omit<User, 'token'> & DefaultSession['user']; // TEST: temporarily expose refreshToken (restore Omit after testing)
+    user: Omit<User, 'token' | 'refreshToken'> & DefaultSession['user'];
     accessToken?: string;
     error?: 'RefreshTokenError';
   }


### PR DESCRIPTION
## What Does This PR Do?

- Remove debugging code that wrote `refreshToken` onto `session.user` in the NextAuth `session` callback (`src/auth.config.ts`)
- Restore `Session.user` type to `Omit<User, 'token' | 'refreshToken'>` (`src/types/types.d.ts`)
- Drop the `console.log` of `accessToken` / `refreshToken` in `SessionErrorWatcher` (keeps the `RefreshTokenError` signOut behavior intact)

Fixes Xchange-Taiwan/X-Talent-Tracker#257

## Demo

http://localhost:3000 — after login, `fetch('/api/auth/session').then(r => r.json())` should no longer return `data.user.refreshToken`, and the browser console should not print `[Auth] accessToken` / `[Auth] refreshToken` lines.

## Screenshot

N/A

## Anything to Note?

Front-end fix alone does not close the incident — refresh tokens issued before this change may already be in the wild (third-party scripts, extensions, session-replay tools). Backend / DevOps follow-up needed:

- Rotate / invalidate all existing refresh tokens
- Force all currently-signed-in users to re-authenticate

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
