### PR TITLE
fix(security): add baseline security HTTP headers (#262)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -34,6 +34,29 @@ const nextConfig = {
     optimizeCss: false,
     optimizePackageImports: ['lucide-react'],
   },
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          {
+            key: 'Referrer-Policy',
+            value: 'strict-origin-when-cross-origin',
+          },
+          {
+            key: 'Strict-Transport-Security',
+            value: 'max-age=31536000; includeSubDomains',
+          },
+          {
+            key: 'Permissions-Policy',
+            value: 'camera=(), microphone=(), geolocation=()',
+          },
+        ],
+      },
+    ];
+  },
   // Ensure webpack hot reload works properly
   webpack: (config, { dev }) => {
     if (dev) {


### PR DESCRIPTION
## What Does This PR Do?

- Add `async headers()` block in `next.config.js` to apply 5 baseline security HTTP headers to all routes:
  - `X-Frame-Options: SAMEORIGIN` — block clickjacking via cross-origin iframes
  - `X-Content-Type-Options: nosniff` — disable MIME-sniffing
  - `Referrer-Policy: strict-origin-when-cross-origin` — limit referer leakage
  - `Strict-Transport-Security: max-age=31536000; includeSubDomains` — enforce HTTPS for one year
  - `Permissions-Policy: camera=(), microphone=(), geolocation=()` — minimum-permission for sensitive APIs
- HSTS deliberately ships without `preload` first; revisit after staging soak.
- CSP intentionally **not** included here — will be done in a follow-up PR using `Content-Security-Policy-Report-Only` to avoid breaking GA / Clarity / Sentry / OAuth.

## Demo

http://localhost:3000

Verified locally with `Invoke-WebRequest -Method Get http://localhost:3001/auth/signin` — all 5 headers appear in response.

## Screenshot

N/A

## Anything to Note?

- Phase 1 of #262. Phase 2 (CSP, Report-Only) will be tracked in a separate PR.
- Once merged to staging, re-verify headers with `curl -I` against the staging origin before we consider HSTS `preload`.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
