### PR TITLE
fix(api): drop apiClient console.log of request/response bodies

### DIFF
--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -98,7 +98,6 @@ async function request<T>(
   const authHeader = auth ? await getAuthHeader() : {};
 
   const startTime = Date.now();
-  console.log('[api →]', method, path, { params, body });
   let response: Response;
 
   try {
@@ -117,13 +116,6 @@ async function request<T>(
     if (isAbortError(networkError)) {
       throw networkError;
     }
-    console.log(
-      '[api ✗]',
-      method,
-      path,
-      `${Date.now() - startTime}ms`,
-      networkError
-    );
     // fetch() itself threw — DNS failure, connection refused, timeout, etc.
     captureApiFailure({
       endpoint: path,
@@ -149,14 +141,6 @@ async function request<T>(
       (errorBody as Record<string, string>).msg ||
       (errorBody as Record<string, string>).message ||
       `Request failed with status ${response.status}`;
-    console.log(
-      '[api ✗]',
-      method,
-      path,
-      response.status,
-      `${Date.now() - startTime}ms`,
-      { message, body: errorBody }
-    );
     captureApiFailure({
       endpoint: path,
       method,
@@ -170,25 +154,9 @@ async function request<T>(
   // Handle 204 No Content and other empty responses
   const text = await response.text();
   if (!text) {
-    console.log(
-      '[api ←]',
-      method,
-      path,
-      response.status,
-      `${Date.now() - startTime}ms`,
-      '(empty)'
-    );
     return undefined as T;
   }
   const parsed = JSON.parse(text) as T;
-  console.log(
-    '[api ←]',
-    method,
-    path,
-    response.status,
-    `${Date.now() - startTime}ms`,
-    parsed
-  );
   return parsed;
 }
 


### PR DESCRIPTION
## What Does This PR Do?

- Remove all `console.log` statements from `src/lib/apiClient.ts` (5 places: outgoing request, fetch network error, non-OK response, 204 empty response, parsed success response)
- Structured failure paths still go through `captureApiFailure` (Sentry); the log calls were pure browser-console noise

Fixes Xchange-Taiwan/X-Talent-Tracker#259

## Demo

http://localhost:3000 — open DevTools, sign up / reset password / load any authenticated page; the console should no longer print `[api →]` / `[api ←]` / `[api ✗]` lines containing request bodies or response payloads.

## Screenshot

N/A

## Anything to Note?

Sensitive data that the removed log calls were leaking to the browser console:
- Sign-up POST body — `{ email, password, confirm_password }` plain-text password
- Password reset PUT body — `{ password, confirm_password }` plus `verify_token` query param
- All authenticated API responses (profile DTO, reservations, tag catalog) — full PII payloads

Sentry's default `consoleIntegration` collects console messages as breadcrumbs and bundles them with error events. Combined with Replay sampling and `tunnelRoute: '/monitoring'`, this could ship credentials and PII to Sentry. Recommend auditing recent Sentry events for any captured passwords / tokens, and rotating affected user credentials if found.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
