### PR TITLE
fix(auth): drop Google OAuth callback console.log of refresh token

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -37,7 +37,6 @@ export default function GoogleOAuthRedirectPage() {
 
       try {
         const response = await googleCallback(code, state);
-        console.log('[Google OAuth] backend response:', response);
 
         const callbackData = response.data;
         if (!callbackData) {


### PR DESCRIPTION
## What Does This PR Do?

- Remove `console.log('[Google OAuth] backend response:', response)` from `src/app/auth/google/callback/redirect/container.tsx`
- The logged `response` is the return value of the `googleCallback` server action, which spreads `refreshToken: extractRefreshToken(res.headers)` onto the data — so this single line was printing the refresh token verbatim to every Google sign-in user's browser console

Fixes Xchange-Taiwan/X-Talent-Tracker#260

## Demo

http://localhost:3000/auth/signin → click "Continue with Google". After the OAuth roundtrip, the browser console should no longer print `[Google OAuth] backend response: { ... refreshToken: ... }`.

## Screenshot

N/A

## Anything to Note?

Same root cause family as #257 (refresh token leaking to the browser); the #257 fix only covered the NextAuth `session` callback / `SessionErrorWatcher` paths and missed this one. As with #257, the front-end change alone does not close the incident — refresh tokens already issued through Google sign-in may have been captured by third-party scripts, extensions, or session-replay tools. Recommend the same backend follow-up: rotate / invalidate existing refresh tokens and force re-authentication.

A separate ticket (#261) tracks the deeper design issue of the refresh token transiting through the client at all.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
