### PR TITLE
fix(auth): keep Google refreshToken server-side via cookie bridge

### DIFF
--- a/src/app/auth/google/callback/redirect/container.tsx
+++ b/src/app/auth/google/callback/redirect/container.tsx
@@ -50,20 +50,14 @@ export default function GoogleOAuthRedirectPage() {
           return;
         }
 
-        const refreshToken = response.refreshToken;
-
         const deleteEmail = sessionStorage.getItem('delete_account_email');
         if (deleteEmail) {
           sessionStorage.removeItem('delete_account_email');
-          await handleDeleteAccountFlow(
-            callbackData,
-            deleteEmail,
-            refreshToken
-          );
+          await handleDeleteAccountFlow(callbackData, deleteEmail);
           return;
         }
 
-        await proceedWithSignIn(callbackData, refreshToken);
+        await proceedWithSignIn(callbackData);
       } catch (err) {
         toast({
           variant: 'destructive',
@@ -81,8 +75,7 @@ export default function GoogleOAuthRedirectPage() {
 
   const handleDeleteAccountFlow = async (
     data: GoogleCallbackVO,
-    email: string,
-    refreshToken: string | null
+    email: string
   ) => {
     if (data.auth_type !== 'LOGIN') {
       toast({
@@ -111,7 +104,6 @@ export default function GoogleOAuthRedirectPage() {
       token: auth.token,
       email: auth.email ?? '',
       user: JSON.stringify(user),
-      refreshToken: refreshToken ?? '',
     });
 
     const result = await deleteAccount({ email, id_token });
@@ -143,10 +135,7 @@ export default function GoogleOAuthRedirectPage() {
     router.push('/auth/signin');
   };
 
-  const proceedWithSignIn = async (
-    data: GoogleCallbackVO,
-    refreshToken: string | null
-  ) => {
+  const proceedWithSignIn = async (data: GoogleCallbackVO) => {
     if (data.auth_type === 'SIGNUP') {
       sessionStorage.setItem('email', data.auth.email ?? '');
       router.push('/auth/email-verify');
@@ -168,7 +157,6 @@ export default function GoogleOAuthRedirectPage() {
       token: data.auth.token,
       email: data.auth.email ?? '',
       user: JSON.stringify(data.user),
-      refreshToken: refreshToken ?? '',
     });
 
     const session = await getSession();

--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,6 +1,8 @@
 import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
+import { cookies } from 'next/headers';
 
+import { OAUTH_REFRESH_BRIDGE_COOKIE } from '@/lib/auth/oauthRefreshBridge';
 import { SignInSchema } from '@/schemas/auth';
 import { refreshAccessToken } from '@/services/auth/refreshToken';
 
@@ -93,13 +95,18 @@ const authOptions = {
         token: { label: 'Token', type: 'text' },
         email: { label: 'Email', type: 'text' },
         user: { label: 'User JSON', type: 'text' },
-        refreshToken: { label: 'Refresh Token', type: 'text' },
       },
       async authorize(credentials) {
         if (!credentials?.token || !credentials?.user) return null;
 
         try {
           const user = JSON.parse(credentials.user as string);
+
+          const cookieStore = cookies();
+          const refreshToken = cookieStore.get(
+            OAUTH_REFRESH_BRIDGE_COOKIE
+          )?.value;
+          cookieStore.delete(OAUTH_REFRESH_BRIDGE_COOKIE);
 
           const experiences: {
             category: string;
@@ -119,7 +126,7 @@ const authOptions = {
           return {
             id: String(user.user_id),
             token: credentials.token,
-            refreshToken: (credentials.refreshToken as string) || undefined,
+            refreshToken: refreshToken || undefined,
             email: (credentials.email as string) || undefined,
             name: user.name,
             avatar: user.avatar,

--- a/src/lib/actions/googleCallback.ts
+++ b/src/lib/actions/googleCallback.ts
@@ -1,5 +1,11 @@
 'use server';
 
+import { cookies } from 'next/headers';
+
+import {
+  OAUTH_REFRESH_BRIDGE_COOKIE,
+  OAUTH_REFRESH_BRIDGE_TTL_SECONDS,
+} from '@/lib/auth/oauthRefreshBridge';
 import type { components } from '@/types/api';
 
 type OAuthCallbackResponse =
@@ -15,7 +21,7 @@ function extractRefreshToken(headers: Headers): string | null {
 export async function googleCallback(
   code: string,
   state: string
-): Promise<OAuthCallbackResponse & { refreshToken: string | null }> {
+): Promise<OAuthCallbackResponse> {
   const res = await fetch(`${BFF_URL}/v2/oauth/google/callback`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
@@ -24,5 +30,16 @@ export async function googleCallback(
 
   const data = (await res.json()) as OAuthCallbackResponse;
 
-  return { ...data, refreshToken: extractRefreshToken(res.headers) };
+  const refreshToken = extractRefreshToken(res.headers);
+  if (refreshToken) {
+    cookies().set(OAUTH_REFRESH_BRIDGE_COOKIE, refreshToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: OAUTH_REFRESH_BRIDGE_TTL_SECONDS,
+    });
+  }
+
+  return data;
 }

--- a/src/lib/auth/oauthRefreshBridge.ts
+++ b/src/lib/auth/oauthRefreshBridge.ts
@@ -1,0 +1,2 @@
+export const OAUTH_REFRESH_BRIDGE_COOKIE = 'g_oauth_rt';
+export const OAUTH_REFRESH_BRIDGE_TTL_SECONDS = 60;


### PR DESCRIPTION
## What Does This PR Do?

- Stop returning Google OAuth `refreshToken` from the `googleCallback` server action — it is no longer serialized to the browser
- Bridge the token from the server action to the NextAuth `custom-google-token` provider via a short-lived (60s) httpOnly cookie set with `next/headers` `cookies()`
- Inside `authorize`, read the cookie and immediately delete it; remove `refreshToken` from the credentials surface
- Drop the `refreshToken` argument from `proceedWithSignIn` / `handleDeleteAccountFlow` and from both `signIn('custom-google-token', ...)` calls
- Add shared cookie name + TTL constants in `src/lib/auth/oauthRefreshBridge.ts` so the producer and consumer cannot drift

Fixes Xchange-Taiwan/X-Talent-Tracker#261

## Demo

http://localhost:3000/auth/signin — Google login + Google account-deletion flows should keep working; refresh token never appears in any client-visible network response or React state.

## Screenshot

N/A

## Anything to Note?

- Aligns Google sign-in with the password credentials provider — refresh token now stays server-side throughout, exactly like `auth.config.ts:75`
- Bridge cookie is `httpOnly`, `sameSite: 'lax'`, `path: '/'`, `maxAge: 60s`, plus `secure` in production
- Out of scope (covered separately by #257 follow-up): the `console.log('[Google OAuth] backend response:', response)` at `container.tsx:40` — the response no longer contains the refresh token after this change, but the log line itself is left for that ticket

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
