### PR TITLE
feat(security): add CSP Report-Only header (#264)

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,81 @@
 /** @type {import('next').NextConfig} */
 const { withSentryConfig } = require('@sentry/nextjs');
 
+// Derive Sentry's CSP report endpoint from the public DSN so report-uri stays
+// in sync with whichever Sentry project the deployment is wired up to.
+// Sentry DSN format: https://<publicKey>@<host>/<projectId>
+function buildCspReportUri() {
+  const dsn = process.env.NEXT_PUBLIC_SENTRY_DSN;
+  if (!dsn) return null;
+  try {
+    const url = new URL(dsn);
+    const publicKey = url.username;
+    const projectId = url.pathname.replace(/^\//, '');
+    if (!publicKey || !projectId) return null;
+    return `${url.protocol}//${url.host}/api/${projectId}/security/?sentry_key=${publicKey}`;
+  } catch {
+    return null;
+  }
+}
+
+function safeOrigin(value) {
+  if (!value) return null;
+  try {
+    return new URL(value).origin;
+  } catch {
+    return null;
+  }
+}
+
+function buildCsp() {
+  const apiOrigin = safeOrigin(process.env.NEXT_PUBLIC_API_URL);
+  const reportUri = buildCspReportUri();
+
+  const directives = {
+    'default-src': ["'self'"],
+    // 'unsafe-inline' is required for the GA / Clarity bootstrap scripts and
+    // the JSON-LD `<script>` block in PersonJsonLd. Phase 2b will replace it
+    // with a per-request nonce; keeping it here for the Report-Only rollout.
+    'script-src': [
+      "'self'",
+      "'unsafe-inline'",
+      'https://www.googletagmanager.com',
+      'https://www.clarity.ms',
+    ],
+    'style-src': ["'self'", "'unsafe-inline'"],
+    'img-src': [
+      "'self'",
+      'data:',
+      'blob:',
+      'https://x-career-multimedia.s3.ap-northeast-1.amazonaws.com',
+      'https://x-career-multimedia.s3.amazonaws.com',
+      'https://lh3.googleusercontent.com',
+    ],
+    'font-src': ["'self'", 'data:'],
+    'connect-src': [
+      "'self'",
+      apiOrigin,
+      'https://www.google-analytics.com',
+      'https://*.clarity.ms',
+      'https://*.sentry.io',
+      'https://*.ingest.sentry.io',
+    ].filter(Boolean),
+    // Sentry Replay lazy-loads a web worker from a blob URL.
+    'worker-src': ["'self'", 'blob:'],
+    'frame-ancestors': ["'self'"],
+    'base-uri': ["'self'"],
+    'form-action': ["'self'"],
+  };
+
+  if (reportUri) {
+    directives['report-uri'] = [reportUri];
+  }
+
+  return Object.entries(directives)
+    .map(([directive, values]) => `${directive} ${values.join(' ')}`)
+    .join('; ');
+}
+
 const nextConfig = {
   images: {
     // TEMP: disabled the 30-day Image Optimizer cache.
@@ -35,25 +110,36 @@ const nextConfig = {
     optimizePackageImports: ['lucide-react'],
   },
   async headers() {
+    const baseHeaders = [
+      { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
+      { key: 'X-Content-Type-Options', value: 'nosniff' },
+      {
+        key: 'Referrer-Policy',
+        value: 'strict-origin-when-cross-origin',
+      },
+      {
+        key: 'Strict-Transport-Security',
+        value: 'max-age=31536000; includeSubDomains',
+      },
+      {
+        key: 'Permissions-Policy',
+        value: 'camera=(), microphone=(), geolocation=()',
+      },
+    ];
+
+    // Skip CSP in dev because HMR / React Refresh need 'unsafe-eval' and
+    // inline event handlers that the production policy intentionally rejects.
+    if (process.env.NODE_ENV === 'production') {
+      baseHeaders.push({
+        key: 'Content-Security-Policy-Report-Only',
+        value: buildCsp(),
+      });
+    }
+
     return [
       {
         source: '/:path*',
-        headers: [
-          { key: 'X-Frame-Options', value: 'SAMEORIGIN' },
-          { key: 'X-Content-Type-Options', value: 'nosniff' },
-          {
-            key: 'Referrer-Policy',
-            value: 'strict-origin-when-cross-origin',
-          },
-          {
-            key: 'Strict-Transport-Security',
-            value: 'max-age=31536000; includeSubDomains',
-          },
-          {
-            key: 'Permissions-Policy',
-            value: 'camera=(), microphone=(), geolocation=()',
-          },
-        ],
+        headers: baseHeaders,
       },
     ];
   },


### PR DESCRIPTION
## What Does This PR Do?

- Add `Content-Security-Policy-Report-Only` to all routes in production via `next.config.js`
- Build CSP from a typed `directives` object covering `default-src`, `script-src`, `style-src`, `img-src`, `font-src`, `connect-src`, `worker-src`, `frame-ancestors`, `base-uri`, `form-action`
- Allowlist current third parties: GA (`googletagmanager.com`, `google-analytics.com`), Clarity (`clarity.ms`), Sentry (`*.sentry.io`, `*.ingest.sentry.io`), S3 multimedia, `lh3.googleusercontent.com`, and `${NEXT_PUBLIC_API_URL}` if set
- Include `worker-src 'self' blob:` for Sentry Replay's lazy-loaded web worker
- Derive Sentry's CSP report endpoint from `NEXT_PUBLIC_SENTRY_DSN` so violations are funnelled to the existing Sentry project — no new `/api/csp-report` route needed
- Skip CSP in dev (HMR / React Refresh would otherwise need `'unsafe-eval'` and inline handlers the prod policy rejects)
- `'unsafe-inline'` in `script-src` is intentionally retained for the GA / Clarity bootstrap and JSON-LD inline scripts; replacing it with a per-request nonce is Phase 2b and out of scope here

## Demo

http://localhost:3000

Verified locally:
- `pnpm start` (prod): `Content-Security-Policy-Report-Only` present alongside the 5 baseline headers
- `pnpm dev`: only the 5 baseline headers — CSP correctly absent so HMR is unaffected

## Screenshot

N/A

## Anything to Note?

- This is **Report-Only** — nothing is blocked. Browsers send violations to Sentry and we observe.
- Plan: merge → staging at least one week → review Sentry CSP violations → tighten allowlist → open follow-up PR to switch to enforced `Content-Security-Policy` (same ticket #264)
- `report-uri` only appears when `NEXT_PUBLIC_SENTRY_DSN` is set; `connect-src` only includes the API origin when `NEXT_PUBLIC_API_URL` is set — both should already be configured in staging / prod
- Phase 2b (nonce-based CSP to drop `'unsafe-inline'`) intentionally deferred; will be opened as a separate ticket if/when needed

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
