### PR TITLE
fix(onboarding): persist industry into primed user-profile cache

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -232,6 +232,7 @@ export default function OnboardingContainer({ initialTagCatalog }: Props) {
             userId: sessionUserId,
             formData: validatedData,
             isMentor: session?.user?.isMentor ?? false,
+            industryCatalog: industries,
           });
           primeUserDataCache(sessionUserId, 'zh_TW', stub);
         } else if (session?.user?.id) {

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
+import type { IndustryOption } from '@/services/profile/tagCatalog';
+
 import { buildOnboardingDtoStub } from './buildOnboardingDtoStub';
 
 const baseFormData = {
@@ -11,6 +13,11 @@ const baseFormData = {
   want_skill: ['typescript'],
   want_topic: ['career'],
 };
+
+const industryCatalog: IndustryOption[] = [
+  { subject_group: 'tech', subject: '科技 / 軟體' },
+  { subject_group: 'finance', subject: '金融 / 投資' },
+];
 
 describe('buildOnboardingDtoStub', () => {
   it('passes raw subject_group codes through onto the stubbed buckets', () => {
@@ -86,5 +93,41 @@ describe('buildOnboardingDtoStub', () => {
       formData: baseFormData,
     });
     expect(menteeStub.is_mentor).toBe(false);
+  });
+
+  // Regression: prior to this fix, industry was hardcoded to null in the
+  // stub, so navigating from /onboarding → /profile/edit through the primed
+  // cache rendered an empty industry field even when one was just selected.
+  it('resolves the submitted industry against the catalog into a TagVO-shaped object', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: { ...baseFormData, industry: 'tech' },
+      industryCatalog,
+    });
+
+    expect(dto.industry).toEqual({
+      subject_group: 'tech',
+      subject: '科技 / 軟體',
+    });
+  });
+
+  it('returns industry=null when the submitted code is not in the catalog', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: { ...baseFormData, industry: 'unknown' },
+      industryCatalog,
+    });
+
+    expect(dto.industry).toBeNull();
+  });
+
+  it('returns industry=null when no industry was submitted, even if a catalog is provided', () => {
+    const dto = buildOnboardingDtoStub({
+      userId: 42,
+      formData: baseFormData,
+      industryCatalog,
+    });
+
+    expect(dto.industry).toBeNull();
   });
 });

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
@@ -1,3 +1,4 @@
+import type { IndustryOption } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 export interface OnboardingStubInput {
@@ -5,9 +6,31 @@ export interface OnboardingStubInput {
   avatar?: string | null;
   location?: string | null;
   years_of_experience?: string | null;
+  // subject_group code from the onboarding industry select
+  industry?: string | null;
   want_position?: string[];
   want_skill?: string[];
   want_topic?: string[];
+}
+
+// The BFF read response enriches `industry` to a TagVO-shaped object —
+// useEditProfileData and useUserData both pull subject_group / subject off
+// it. Onboarding submits a flat subject_group string, so we resolve it
+// against the catalog the caller already has and stash an enriched object
+// in the cache stub. Without this, the freshly-primed cache reports
+// industry as null and /profile/edit renders an empty industry field
+// despite onboarding having just collected one.
+function resolveIndustryStub(
+  subjectGroup: string | null | undefined,
+  catalog: IndustryOption[]
+): MentorProfileVO['industry'] {
+  if (!subjectGroup) return null;
+  const match = catalog.find((opt) => opt.subject_group === subjectGroup);
+  if (!match) return null;
+  return {
+    subject_group: match.subject_group,
+    subject: match.subject,
+  } as unknown as MentorProfileVO['industry'];
 }
 
 /**
@@ -20,16 +43,22 @@ export interface OnboardingStubInput {
  *
  * The wire format for the want and have buckets is now flat subject_group
  * codes; display labels are resolved downstream against the shared tag
- * catalog, so this stub no longer needs the catalog to hydrate fields itself.
+ * catalog, so this stub no longer needs the catalog to hydrate those
+ * fields itself. Industry is the exception: the BFF returns it enriched
+ * (TagVO-shaped) on read, so the stub resolves the submitted code against
+ * the industry catalog so the cached shape matches what edit/profile pages
+ * expect.
  */
 export function buildOnboardingDtoStub({
   userId,
   formData,
   isMentor = false,
+  industryCatalog = [],
 }: {
   userId: number;
   formData: OnboardingStubInput;
   isMentor?: boolean;
+  industryCatalog?: IndustryOption[];
 }): MentorProfileVO {
   return {
     user_id: userId,
@@ -39,7 +68,7 @@ export function buildOnboardingDtoStub({
     company: null,
     years_of_experience: formData.years_of_experience ?? null,
     location: formData.location ?? null,
-    industry: null,
+    industry: resolveIndustryStub(formData.industry, industryCatalog),
     onboarding: true,
     is_mentor: isMentor,
     language: 'zh_TW',


### PR DESCRIPTION
## Bug

After completing onboarding (where the user picks an industry), navigating to `/profile/[id]/edit` showed the **產業 (industry)** field empty — even though the value was correctly POSTed to the backend.

## Root cause

`OnboardingContainer` primes the user-profile DTO cache from a stub right after submit so `/profile/card` and `/profile/edit` mount without a refetch. The stub builder (`buildOnboardingDtoStub.ts`) hardcoded `industry: null` and didn't even accept an industry input — so the cache hit shadowed any later network response, and `useEditProfileData` (which reads `industry.subject_group` off an enriched TagVO object) read `null` and reset the form field to `''`.

## Fix

- `buildOnboardingDtoStub` now accepts the submitted `industry` subject_group plus the `industryCatalog` (which the container already has from `useTagCatalog`).
- It resolves the code against the catalog and writes a TagVO-shaped `{ subject_group, subject }` object into the stub, matching what the BFF returns on a cold fetch.
- `OnboardingContainer` passes `industries` through.
- Added regression tests covering: catalog hit, catalog miss, and no industry submitted.

## Test plan

- [x] `pnpm test src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts` — 8 / 8 pass
- [x] `pnpm type-check`
- [x] `pnpm lint` (no new warnings introduced)
- [x] `pnpm build`
- [ ] Manual: complete onboarding as a fresh mentee with an industry selected → navigate to `/profile/[id]/edit` → industry field is populated
- [ ] Manual: hard-refresh `/profile/[id]/edit` after onboarding → industry still populated (this verifies the BFF read path is also producing TagVO-shaped industry; if it isn't, the bug recurs once the cache expires and is a separate backend ticket)

🤖 Generated with [Claude Code](https://claude.com/claude-code)