### PR TITLE
fix(profile): flip role optimistically on mentor onboarding submit

### DIFF
--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -465,6 +465,70 @@ describe('useProfileSubmit', () => {
     expect(firstCallArg.user.onBoarding).toBe(true);
   });
 
+  it('isMentorOnboarding: true with mentee session → optimistic update flips isMentor/onBoarding to true', async () => {
+    // Repro for the dropdown bug: an existing mentee submits the "成為導師"
+    // onboarding form, but the header keeps showing "成為導師" because the
+    // optimistic update preserved the stale isMentor=false until the
+    // background poll reconciled (up to 60s later). Onboarding is a known
+    // mentee → mentor transition, so we flip both flags immediately.
+    const menteeSession: Session = {
+      ...mockSession,
+      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
+    };
+    const updateSession = vi.fn().mockResolvedValue(menteeSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(
+        makeOptions({
+          session: menteeSession,
+          updateSession,
+          isMentorOnboarding: true,
+        })
+      )
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    const firstCallArg = updateSession.mock.calls[0][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(firstCallArg.user.isMentor).toBe(true);
+    expect(firstCallArg.user.onBoarding).toBe(true);
+  });
+
+  it('isMentorOnboarding: true with mentee session → reconcile is a no-op when backend confirms is_mentor=true', async () => {
+    // Backend has caught up and reports is_mentor=true, matching our
+    // optimistic flip — no second updateSession call needed.
+    const menteeSession: Session = {
+      ...mockSession,
+      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
+    };
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: true,
+      onboarding: true,
+    });
+    const updateSession = vi.fn().mockResolvedValue(menteeSession);
+    const { result } = renderHook(() =>
+      useProfileSubmit(
+        makeOptions({
+          session: menteeSession,
+          updateSession,
+          isMentorOnboarding: true,
+        })
+      )
+    );
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(updateSession).toHaveBeenCalledTimes(1);
+  });
+
   it('background reconcile patches session when latest disagrees with optimistic role', async () => {
     // Optimistic session: isMentor=true. Backend poll says isMentor=false.
     mockPollUntilSynced.mockResolvedValueOnce({

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -264,13 +264,22 @@ export function useProfileSubmit({
         setAvatarOverride(String(sessionUser.id), avatar);
       }
 
-      // 5) optimistic session update — keep role/onboarding from current
-      //    session so we never flicker mentor → mentee while the backend
-      //    catches up. The reconcile in step 7 corrects them if the user
-      //    actually transitioned during this submit.
+      // 5) optimistic session update — for the mentor onboarding flow we
+      //    know the user is becoming a mentor, so flip role/onboarding to
+      //    true immediately. Otherwise keep them from the current session
+      //    to avoid flickering mentor → mentee while the backend catches
+      //    up. The reconcile in step 7 corrects them if the backend
+      //    disagrees.
       //    Fire-and-forget: navigation no longer waits for NextAuth's
       //    /api/auth/session round trip. The avatar override above keeps
       //    the header in sync until the JWT update lands.
+      const optimisticIsMentor = isMentorOnboarding
+        ? true
+        : (sessionUser?.isMentor ?? false);
+      const optimisticOnBoarding = isMentorOnboarding
+        ? true
+        : (sessionUser?.onBoarding ?? false);
+
       void updateSession({
         user: {
           id: sessionUser?.id,
@@ -279,8 +288,8 @@ export function useProfileSubmit({
           avatarUpdatedAt: values.avatarFile
             ? Date.now()
             : sessionUser?.avatarUpdatedAt,
-          isMentor: sessionUser?.isMentor,
-          onBoarding: sessionUser?.onBoarding,
+          isMentor: optimisticIsMentor,
+          onBoarding: optimisticOnBoarding,
           msg: sessionUser?.msg,
           personalLinks,
         },
@@ -302,8 +311,6 @@ export function useProfileSubmit({
       //    optimistic value.
       const reconcileSession = (latest: MentorProfileVO | null) => {
         if (!latest) return;
-        const optimisticIsMentor = sessionUser?.isMentor ?? false;
-        const optimisticOnBoarding = sessionUser?.onBoarding ?? false;
         const latestIsMentor = Boolean(latest.is_mentor);
         const latestOnBoarding = Boolean(latest.onboarding);
         if (


### PR DESCRIPTION
## What Does This PR Do?

- After a mentee submitted the "成為導師" onboarding form, the header dropdown kept showing "成為導師" until the background poll reconciled (800 ms best case, up to 60 s).
- `useProfileSubmit` step 5 now flips `isMentor` and `onBoarding` to `true` immediately when `isMentorOnboarding` is set; otherwise it still preserves the current session values to avoid mentor → mentee flicker.
- Step 7 reconcile keeps acting as the safety net if the backend disagrees.
- Added regression tests for the mentee → mentor optimistic flip and the matching no-op reconcile.

## Demo

http://localhost:3000/profile/<userId>/edit?onboarding=true

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
