### PR TITLE
fix(mentor-pool): show subject label instead of code on filter chip

### DIFF
--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -67,28 +67,36 @@ export default function MentorPoolUI({
           </div>
         </div>
         <div className="mb-5 flex flex-wrap gap-3">
-          {Object.entries(selectedFilters).map(([key, filter]) => (
-            <Badge
-              key={key}
-              variant={'filter'}
-              className="text-sm font-medium leading-5"
-            >
-              <span>
-                {filter.name}: {filter.value}
-              </span>
-              <button
-                type="button"
-                onClick={(event) => {
-                  event.stopPropagation();
-                  onRemoveFilter(key);
-                }}
-                aria-label={`移除「${filter.name}：${filter.value}」篩選`}
-                className="bg-transparent inline-flex items-center rounded-sm p-0 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+          {Object.entries(selectedFilters).map(([key, filter]) => {
+            // URL params persist the BE `subject_group` code; resolve back to
+            // the localized `subject` label for display, falling back to the
+            // code if the tag isn't in the current catalog.
+            const label =
+              filterOptions[key]?.options.find((o) => o.value === filter.value)
+                ?.label ?? filter.value;
+            return (
+              <Badge
+                key={key}
+                variant={'filter'}
+                className="text-sm font-medium leading-5"
               >
-                <XIcon className="h-4 w-4" aria-hidden />
-              </button>
-            </Badge>
-          ))}
+                <span>
+                  {filter.name}: {label}
+                </span>
+                <button
+                  type="button"
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    onRemoveFilter(key);
+                  }}
+                  aria-label={`移除「${filter.name}：${label}」篩選`}
+                  className="bg-transparent inline-flex items-center rounded-sm p-0 hover:opacity-70 focus:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                >
+                  <XIcon className="h-4 w-4" aria-hidden />
+                </button>
+              </Badge>
+            );
+          })}
         </div>
         {hasMentors && (
           <div className="relative mb-6">


### PR DESCRIPTION
## What Does This PR Do?

- Resolve filter chip text from the `subject_group` code stored in URL params back to the localized `subject` label via `filterOptions[key].options`, falling back to the code if a tag isn't in the current catalog.
- Update the chip's `aria-label` to use the same resolved label so screen readers match the visible text.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

N/A
