### PR TITLE
fix(schedule): render recurring slots on every occurrence date

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -613,7 +613,7 @@ function AddSlotModal({
               checked={weekly}
               onCheckedChange={(v) => setWeekly(v === true)}
             />
-            此月每週{weekdayLabel}都重複
+            套用至本月剩餘的每週{weekdayLabel}
           </label>
 
           {weekly && previewDates.length > 0 && (

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -325,8 +325,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
       for (const slot of allDraftRaws) {
         if (slot.type !== 'ALLOW') continue;
-        const slotDateKey = dayjs(slot.dtstart * 1000).format('YYYY-MM-DD');
-        if (slotDateKey !== dateKey) continue;
 
         const occurrences = expandRrule(slot.dtstart, slot.rrule);
         const slotDuration = slot.dtend - slot.dtstart;
@@ -334,6 +332,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         for (const occ of occurrences) {
           if (slot.exdate.includes(occ)) continue;
           if (occ <= nowSec) continue;
+          if (dayjs(occ * 1000).format('YYYY-MM-DD') !== dateKey) continue;
           result.push({
             start: new Date(occ * 1000),
             end: new Date((occ + slotDuration) * 1000),


### PR DESCRIPTION
## What Does This PR Do?

- Fix booking slot list on profile calendar showing time only on the first occurrence of a weekly-recurring slot. `generateBookingSlots` was filtering rows by `dtstart` date before expanding the rrule, so rows whose dtstart did not match the queried day were skipped entirely (and the dtstart day spuriously surfaced every occurrence). Filter is now applied per-occurrence after rrule expansion.
- Clarify the repeat-checkbox label in the add-slot modal: `此月每週X都重複` → `套用至本月剩餘的每週X`, so it accurately conveys the scope (current month only, from the picked date).

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
