### PR TITLE
fix(mentor-pool): rename keyword param to search_pattern (silently dropped by BFF)

### DIFF
--- a/src/app/mentor-pool/searchParams.ts
+++ b/src/app/mentor-pool/searchParams.ts
@@ -13,7 +13,10 @@ export type ServerSearchParams = Record<string, string | string[] | undefined>;
 type AnyParams = URLSearchParams | ReadonlyURLSearchParams;
 
 export interface MentorPoolFetchConditions {
-  searchPattern: string;
+  // Key name matches the BFF/Search query param so that spreading these
+  // conditions into a MentorRequest preserves snake_case all the way out
+  // to the URL. See MentorRequest in services/search-mentor/mapMentor.ts.
+  search_pattern: string;
   filter_skills?: string;
   filter_topics?: string;
   filter_industries?: string;
@@ -58,7 +61,7 @@ export function paramsToFetchConditions(
   params: AnyParams | null
 ): MentorPoolFetchConditions {
   const conditions: MentorPoolFetchConditions = {
-    searchPattern: getSearchPatternFromParams(params),
+    search_pattern: getSearchPatternFromParams(params),
   };
   if (!params) return conditions;
   const writable = conditions as MentorPoolFetchConditions &

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -38,7 +38,11 @@ function readCodes(codes: ReadonlyArray<string> | null | undefined): string[] {
 export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
 
 export interface MentorRequest {
-  searchPattern?: string;
+  // snake_case to match the BFF/Search query param exactly. Object.entries
+  // in mentors.server.ts / mentors.ts forwards keys verbatim into the URL,
+  // so a camelCase key here would silently be dropped by FastAPI's
+  // search_pattern: str = Query(None) and the keyword would have no effect.
+  search_pattern?: string;
   filter_skills?: string;
   filter_topics?: string;
   filter_industries?: string;

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -40,7 +40,7 @@ function buildUrl(
 
 function hasMentorRequestConditions(param: MentorRequest): boolean {
   return Boolean(
-    param.searchPattern ||
+    param.search_pattern ||
     param.filter_skills ||
     param.filter_topics ||
     param.filter_industries


### PR DESCRIPTION
﻿## Summary

- Mentor-pool keyword search returned the same set of mentors no matter what the user typed. The keyword was being silently dropped at the BFF/Search boundary.
- Cause: `MentorRequest.searchPattern` (camelCase) was forwarded verbatim into the URL by `Object.entries(param)` in `mentors.server.ts`/`mentors.ts`, but BFF and Search both declare `search_pattern: str = Query(None)`. FastAPI didn't match the param, treated the keyword as absent, and skipped the search_pattern branch in `format_search_mentors_query`.
- Fix: rename the field to snake_case in the two hand-written interfaces (and the one read site). Codegen in `src/types/api.ts` already had the right name -- this was just hand-written types drifting away from the contract.

## Verified directly against Search

\\\
GET .../search/mentors?search_pattern=Mentee  -> 1 result  (filtered, correct)
GET .../search/mentors?searchPattern=Mentee   -> 2 results (unfiltered, the bug)
\\\

The other filter keys on the same interface (`filter_skills` / `filter_topics` / `filter_industries`) were already snake_case and worked correctly -- only the keyword was broken.

## Changes

- `MentorRequest.searchPattern` -> `search_pattern` (services/search-mentor/mapMentor.ts)
- `MentorPoolFetchConditions.searchPattern` -> `search_pattern` (app/mentor-pool/searchParams.ts) and the assignment in `paramsToFetchConditions`
- The matching read in `hasMentorRequestConditions` (services/search-mentor/mentors.server.ts)

Object.entries in the two `fetch*` helpers forwards keys verbatim into URLSearchParams, so the rename propagates straight to the wire. Added inline comments on both interfaces so the next contributor doesn't camelCase it back.

## Out of scope

The URL search-param key the page itself uses (`q`) is unchanged -- still `/mentor-pool?q=foo`. `getSearchPatternFromParams` reads `q` from the page URL and writes it into the (now-correctly-named) `search_pattern` field for the API call. So shareable URLs and the SEO canonical are unaffected.

## Test plan

- [x] `pnpm type-check` clean locally
- [ ] Husky pre-push runs type-check again
- [ ] After deploy: type a keyword on /mentor-pool and verify the result list narrows accordingly
- [ ] DevTools network tab: confirm the request shows `?search_pattern=...` (was `?searchPattern=...`)
