### PR TITLE
fix(profile): sync jobTitle and company to session after update

### DIFF
--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -292,6 +292,8 @@ export function useProfileSubmit({
           onBoarding: optimisticOnBoarding,
           msg: sessionUser?.msg,
           personalLinks,
+          jobTitle: job_title || sessionUser?.jobTitle,
+          company: companyFromPrimary || sessionUser?.company,
         },
       });
 


### PR DESCRIPTION
## What Does This PR Do?

- Add `jobTitle` and `company` to the optimistic `updateSession` call in `useProfileSubmit`, so the header dropdown reflects the new values immediately after a profile save instead of waiting for NextAuth's auto-refetch.
- Values mirror the `job_title` / `company` already sent in the backend payload (derived from the primary work experience), with a fallback to the existing session values.

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
