### PR TITLE
fix(share-profile): prevent copy button overflow on mobile

### DIFF
--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -167,7 +167,7 @@ export function ShareProfileDialog({
                   id="share-profile-link"
                   value={profileUrl}
                   readOnly
-                  className="bg-transparent text-black flex-1 rounded-sm border-0 text-base outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 md:text-[14px]"
+                  className="bg-transparent text-black w-full min-w-0 flex-1 rounded-sm border-0 text-base outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 md:text-[14px]"
                 />
 
                 <Button


### PR DESCRIPTION
## What Does This PR Do?

- Add `w-full min-w-0` to the profile URL input in `ShareProfileDialog` so it can shrink below its intrinsic content width
- Without `min-w-0`, a long profile URL forced the row past the dialog edge on mobile, pushing the `shrink-0` 複製 button out of view

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A
