### PR TITLE
fix(profile): seed tag catalog cache from SSR to avoid label flicker

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -8,8 +8,10 @@ import { useEffect, useState } from 'react';
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
 import { useMentorSchedule } from '@/hooks/useMentorSchedule';
 import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import { primeTagCatalogCacheIfEmpty } from '@/hooks/user/tags/useTagCatalog';
 import useUserData from '@/hooks/user/user-data/useUserData';
 import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
+import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 import { ProfilePageSkeleton } from './skeleton';
@@ -21,12 +23,14 @@ const ProfilePageUI = dynamic(() => import('./ui'), {
 interface Props {
   pageUserId: string;
   initialDto: MentorProfileVO;
+  initialCatalogs: TagCatalogsByBucket;
   initialLoginUserId: string;
 }
 
 export default function ProfilePageContainer({
   pageUserId,
   initialDto,
+  initialCatalogs,
   initialLoginUserId,
 }: Props) {
   const router = useRouter();
@@ -41,6 +45,10 @@ export default function ProfilePageContainer({
   if (Number.isFinite(pageUserIdNumber)) {
     primeUserProfileDtoCacheIfEmpty(pageUserIdNumber, 'zh_TW', initialDto);
   }
+  // Same idea for the tag catalog: SSR already fetched the localized labels,
+  // so seed the client cache here so useTagCatalog resolves subject_group
+  // codes to Chinese labels on first paint instead of flashing raw codes.
+  primeTagCatalogCacheIfEmpty('zh_TW', initialCatalogs);
 
   const [year, setYear] = useState(() => new Date().getFullYear());
   const [month, setMonth] = useState(() => new Date().getMonth() + 1);

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -65,6 +65,7 @@ export default async function Page({ params: { pageUserId } }: PageProps) {
       <ProfilePageContainer
         pageUserId={pageUserId}
         initialDto={initialDto}
+        initialCatalogs={catalogs}
         initialLoginUserId={initialLoginUserId}
       />
     </>

--- a/src/hooks/user/tags/useTagCatalog.ts
+++ b/src/hooks/user/tags/useTagCatalog.ts
@@ -15,6 +15,21 @@ export function getTagCatalogCachedSync(
   return tagCatalogDataCache.get(language);
 }
 
+/**
+ * Seed the in-memory catalog cache from SSR-fetched catalogs so that the
+ * first render of useTagCatalog reads localized labels synchronously — avoids
+ * a one-frame flash of raw subject_group codes before the client-side fetch
+ * resolves. `IfEmpty` preserves any prior client-side prime.
+ */
+export function primeTagCatalogCacheIfEmpty(
+  language: string,
+  catalogs: TagCatalogsByBucket
+): void {
+  if (!language) return;
+  if (tagCatalogDataCache.has(language)) return;
+  tagCatalogDataCache.set(language, catalogs);
+}
+
 export async function getTagCatalogCached(
   language: string
 ): Promise<TagCatalogsByBucket> {
@@ -46,11 +61,18 @@ export default function useTagCatalog(
 ): UseTagCatalogResult {
   const initialDataRef = useRef(initialData);
 
+  // Lazy-init from initialData, then the sync cache (e.g. seeded by
+  // primeTagCatalogCacheIfEmpty during SSR-to-client handoff), and only fall
+  // back to EMPTY_TAG_CATALOGS when neither is available. Without this fall-
+  // through, callers that don't pass initialData would render raw
+  // subject_group codes for one frame before useEffect's fetch resolves.
   const [data, setData] = useState<TagCatalogsByBucket>(
-    initialData ?? EMPTY_TAG_CATALOGS
+    () => initialData ?? getTagCatalogCachedSync(language) ?? EMPTY_TAG_CATALOGS
   );
   const [isLoading, setIsLoading] = useState<boolean>(
-    initialData === undefined
+    () =>
+      initialData === undefined &&
+      getTagCatalogCachedSync(language) === undefined
   );
   const [error, setError] = useState<string | null>(null);
 
@@ -65,6 +87,14 @@ export default function useTagCatalog(
 
     const run = async () => {
       if (!language) {
+        setIsLoading(false);
+        return;
+      }
+      // Sync-cache hit: state was already lazy-init'd from cache, so skip
+      // the network round trip and stay in non-loading state.
+      const cached = getTagCatalogCachedSync(language);
+      if (cached) {
+        setData(cached);
         setIsLoading(false);
         return;
       }


### PR DESCRIPTION
## What Does This PR Do?

- Add `primeTagCatalogCacheIfEmpty` and lazy-init `useTagCatalog` from the sync cache so the first render resolves `subject_group` codes to localized labels instead of flashing raw codes.
- Pass SSR-fetched `catalogs` from the profile page through `ProfilePageContainer` and seed the client cache synchronously during render, mirroring the existing `primeUserProfileDtoCacheIfEmpty` pattern.
- Skip the client-side catalog fetch in `useEffect` when the sync cache is already populated.

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

N/A

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
