### PR TITLE
chore(sentry): gate uploads behind NEXT_PUBLIC_SENTRY_ENV

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,12 @@ NEXTAUTH_SECRET=secret
 # Sentry DSN — get from https://sentry.io → Project Settings → Client Keys
 NEXT_PUBLIC_SENTRY_DSN=
 
+# Sentry environment gate — Sentry only sends events when this is `production` or `staging`.
+# Leave UNSET locally (and in `pnpm build && pnpm start` testing) so local errors never
+# reach Sentry. Set on the deployment platform (Vercel → Project Settings → Environment
+# Variables, scoped per environment) to `production` or `staging`.
+NEXT_PUBLIC_SENTRY_ENV=
+
 # Google Analytics 4 Measurement ID — get from GA4 → Admin → Data Streams → Measurement ID
 # Format: G-XXXXXXXXXX. Leave empty to disable GA4.
 NEXT_PUBLIC_GA_ID=

--- a/sentry.edge.config.ts
+++ b/sentry.edge.config.ts
@@ -4,9 +4,12 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const sentryEnv = process.env.NEXT_PUBLIC_SENTRY_ENV;
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: sentryEnv === 'production' || sentryEnv === 'staging',
+  environment: sentryEnv ?? 'local',
 
   // Trace 10% of requests in production; increase temporarily for debugging
   tracesSampleRate: 0.1,

--- a/sentry.server.config.ts
+++ b/sentry.server.config.ts
@@ -4,9 +4,12 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const sentryEnv = process.env.NEXT_PUBLIC_SENTRY_ENV;
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: sentryEnv === 'production' || sentryEnv === 'staging',
+  environment: sentryEnv ?? 'local',
 
   // Trace 10% of requests in production; increase temporarily for debugging
   tracesSampleRate: 0.1,

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -4,9 +4,12 @@
 
 import * as Sentry from '@sentry/nextjs';
 
+const sentryEnv = process.env.NEXT_PUBLIC_SENTRY_ENV;
+
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: process.env.NODE_ENV === 'production',
+  enabled: sentryEnv === 'production' || sentryEnv === 'staging',
+  environment: sentryEnv ?? 'local',
 
   // Trace 10% of requests in production; increase temporarily for debugging
   tracesSampleRate: 0.1,


### PR DESCRIPTION
## Summary

- Sentry now only sends events when `NEXT_PUBLIC_SENTRY_ENV` is `production` or `staging`. The previous `NODE_ENV === 'production'` gate let local `pnpm build && pnpm start` runs leak into the production Sentry project (visible in stacktrace paths like `C:\D\side project\X-Talent-Frontend\...`).
- `environment` is now set explicitly from the same flag, defaulting to `local` so locally-emitted events (if anything ever does send) are clearly distinguishable.
- `.env.example` documents the new variable.

## Required follow-up on Vercel (deployer action)

In **Project Settings → Environment Variables**, add:

| Variable | Value | Scope |
|----------|-------|-------|
| `NEXT_PUBLIC_SENTRY_ENV` | `production` | Production only |
| `NEXT_PUBLIC_SENTRY_ENV` | `staging` | Preview (optional) |

Leave **Development** unset — local dev will then never send.

## Test plan

- [x] `pnpm type-check` passes
- [x] Pre-push test suite passes (167/167)
- [ ] After merge + Vercel env var set: redeploy, browse production, confirm new events arrive at Sentry tagged `environment=production`
- [ ] On a local `pnpm build && pnpm start` (no env var set), trigger an error and confirm no event reaches Sentry