### PR TITLE
fix(sentry): bypass middleware for tunnel route /monitoring

### DIFF
--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -13,6 +13,13 @@ export async function middleware(req: NextRequest) {
   const { nextUrl } = req;
   const pathname = nextUrl.pathname;
 
+  // Sentry tunnel route — bypass middleware so anonymous-user envelope POSTs
+  // aren't redirected to /auth/signin (defined by withSentryConfig
+  // tunnelRoute in next.config.js).
+  if (pathname === '/monitoring' || pathname.startsWith('/monitoring/')) {
+    return NextResponse.next();
+  }
+
   // -------- 1. Verify session via NextAuth getToken (JWT signature + exp) --------
   const token = await getToken({
     req,


### PR DESCRIPTION
## Summary

匿名訪客貢獻了 Sentry 主要事件量（首頁、mentor-pool、public profile 等 public route）。但 `src/middleware.ts` 把 `/monitoring` 當成受保護路由處理，未登入使用者的 envelope POST 被 307 redirect 到 `/auth/signin`，等於**全部匿名訪客的 Sentry events 都被悄悄丟掉**。

`/monitoring` 是 `next.config.js` 裡 `withSentryConfig({ tunnelRoute: '/monitoring' })` 開的 SDK 繞 ad-blocker tunnel，必須讓 envelope POST 通過，不論 auth 狀態。

## Why this PR exists

PR #624 + Vercel 環境變數設定都做了之後，`firstEvent` 仍為 `null`。透過手動 curl 直送 `/api/.../store/` 確認 Sentry 端完全正常（已收到驗證 event），所以瓶頸在前端送出之前就被 middleware 攔下。

## Test plan

- [x] type-check 通過
- [x] pre-push test suite 通過
- [ ] Merge 後 Vercel 自動 redeploy（順便把所有 NEXT_PUBLIC_* env vars 重新 inject）
- [ ] 開 production 首頁（不用登入）→ DevTools Network filter \`monitoring\` → 看到 POST 200
- [ ] 1 分鐘內 Sentry dashboard 看到 transaction / web vital event