### PR TITLE
feat(sentry): add level param to captureFlowFailure (#266)

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -208,6 +208,7 @@ export default function OnboardingContainer({ initialTagCatalog }: Props) {
             step: 'avatar_upload',
             message:
               err instanceof Error ? err.message : 'Avatar upload failed',
+            level: 'warning',
           });
           // Drop the failed job so the next Step 1 submit starts a fresh upload
           avatarUploadRef.current = null;

--- a/src/components/profile/reservation/MenteeReservationDialog.tsx
+++ b/src/components/profile/reservation/MenteeReservationDialog.tsx
@@ -144,15 +144,19 @@ export default function MenteeReservationDialog({
     } catch (error) {
       console.error('Failed to create reservation:', error);
       const msg = error instanceof Error ? error.message : 'Unknown error';
-      captureFlowFailure({
-        flow: 'reservation_create',
-        step: msg.includes('logged in') ? 'get_session' : 'create_reservation',
-        message: msg,
-      });
       const isDuplicate =
         msg.includes('409') ||
         msg.toLowerCase().includes('conflict') ||
         msg.toLowerCase().includes('already');
+      captureFlowFailure({
+        flow: 'reservation_create',
+        step: msg.includes('logged in') ? 'get_session' : 'create_reservation',
+        message: msg,
+        // Slot conflicts are an expected user-side outcome (the user picked a
+        // slot they already booked) — downgrade so they don't trigger error
+        // alerts on Sentry.
+        ...(isDuplicate ? { level: 'info' as const } : {}),
+      });
       if (isDuplicate) {
         setView('conflict');
       } else {

--- a/src/hooks/auth/useDeleteAccountForm.ts
+++ b/src/hooks/auth/useDeleteAccountForm.ts
@@ -68,6 +68,7 @@ export default function useDeleteAccountForm(): UseDeleteAccountFormReturn {
         flow: 'delete_account',
         step: 'submit',
         message: result.message,
+        level: 'info',
       });
       toast({
         variant: 'destructive',

--- a/src/hooks/auth/useSignInForm.ts
+++ b/src/hooks/auth/useSignInForm.ts
@@ -37,6 +37,7 @@ export default function useSignInForm(): AuthFormProps<SignInValues> {
           flow: 'sign_in',
           step: 'validate_credentials',
           message: validated.error,
+          level: 'info',
         });
         toast({
           variant: 'destructive',
@@ -58,6 +59,7 @@ export default function useSignInForm(): AuthFormProps<SignInValues> {
           step: 'authenticate',
           message: 'Invalid credentials',
           errorCode: login.error,
+          level: 'info',
         });
         toast({
           variant: 'destructive',

--- a/src/hooks/auth/useSignUpForm.ts
+++ b/src/hooks/auth/useSignUpForm.ts
@@ -53,6 +53,7 @@ export default function useSignUpForm(): AuthFormProps<SignUpValues> {
         message:
           error instanceof Error ? error.message : 'Unexpected sign-up error',
         errorCode: (error as AuthResponse)?.code,
+        level: 'info',
       });
       handleSignUpError(error as AuthResponse, toast);
     } finally {

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -93,6 +93,7 @@ export function useProfileSubmit({
             step: 'avatar_upload',
             message:
               err instanceof Error ? err.message : 'Avatar upload failed',
+            level: 'warning',
           });
           throw err;
         }

--- a/src/lib/monitoring.test.ts
+++ b/src/lib/monitoring.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@sentry/nextjs', () => ({
+  captureEvent: vi.fn(),
+}));
+
+import * as Sentry from '@sentry/nextjs';
+
+import { captureFlowFailure } from './monitoring';
+
+const mockCaptureEvent = vi.mocked(Sentry.captureEvent);
+
+describe('captureFlowFailure', () => {
+  beforeEach(() => {
+    vi.stubEnv('NODE_ENV', 'production');
+    mockCaptureEvent.mockClear();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('defaults to level "error" when no level is provided', () => {
+    captureFlowFailure({
+      flow: 'sign_in',
+      step: 'authenticate',
+      message: 'Invalid credentials',
+    });
+
+    expect(mockCaptureEvent).toHaveBeenCalledTimes(1);
+    expect(mockCaptureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'error' })
+    );
+  });
+
+  it('forwards explicit level "info" to Sentry', () => {
+    captureFlowFailure({
+      flow: 'sign_in',
+      step: 'authenticate',
+      message: 'Invalid credentials',
+      level: 'info',
+    });
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'info' })
+    );
+  });
+
+  it('forwards explicit level "warning" to Sentry', () => {
+    captureFlowFailure({
+      flow: 'profile_update',
+      step: 'background_sync',
+      message: 'pollUntilSynced exhausted retries without sync',
+      level: 'warning',
+    });
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ level: 'warning' })
+    );
+  });
+
+  it('does NOT call Sentry when NODE_ENV is not production', () => {
+    vi.stubEnv('NODE_ENV', 'test');
+
+    captureFlowFailure({
+      flow: 'sign_in',
+      step: 'authenticate',
+      message: 'Invalid credentials',
+      level: 'info',
+    });
+
+    expect(mockCaptureEvent).not.toHaveBeenCalled();
+  });
+
+  it('emits flow.<flow>.failure as the event message and tags flow/step/route', () => {
+    captureFlowFailure({
+      flow: 'sign_up',
+      step: 'submit',
+      message: 'Email registered',
+      level: 'info',
+    });
+
+    expect(mockCaptureEvent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'flow.sign_up.failure',
+        level: 'info',
+        tags: expect.objectContaining({
+          event_name: 'flow.sign_up.failure',
+          flow: 'sign_up',
+          step: 'submit',
+        }),
+      })
+    );
+  });
+
+  it('sanitizes sensitive query params and JSON values in the message', () => {
+    captureFlowFailure({
+      flow: 'sign_in',
+      step: 'authenticate',
+      message:
+        'failed url=/login?token=abc123&password=secret payload={"email":"a@b.c"}',
+    });
+
+    const arg = mockCaptureEvent.mock.calls[0][0] as {
+      extra: { message: string };
+    };
+    expect(arg.extra.message).toContain('token=[REDACTED]');
+    expect(arg.extra.message).toContain('password=[REDACTED]');
+    expect(arg.extra.message).toContain('"email":"[REDACTED]"');
+    expect(arg.extra.message).not.toContain('abc123');
+    expect(arg.extra.message).not.toContain('a@b.c');
+  });
+});

--- a/src/lib/monitoring.ts
+++ b/src/lib/monitoring.ts
@@ -169,6 +169,14 @@ export function buildBaseEvent(
 // ─── Flow failure capture ─────────────────────────────────────────────────────
 
 /**
+ * Severity for flow-failure events.
+ * - 'error' (default): unexpected system or network failure
+ * - 'warning': expected-but-abnormal (rate limits, sync timeouts, conflicts)
+ * - 'info': expected user-input failure (wrong password, email already taken)
+ */
+export type FlowFailureLevel = 'error' | 'warning' | 'info';
+
+/**
  * Structured event for a failure in a critical user flow.
  * Distinguishable from generic runtime errors and API failures by the
  * flow + step fields, which identify exactly where in a user journey
@@ -193,6 +201,8 @@ export interface FlowFailureEvent {
   message: string;
   /** Optional error/status code from the API or SDK */
   errorCode?: string | number;
+  /** Severity forwarded to Sentry; defaults to 'error' when omitted */
+  level?: FlowFailureLevel;
 }
 
 /**
@@ -222,11 +232,12 @@ export function captureFlowFailure(
     step: event.step,
     message: sanitize(event.message) ?? event.message,
     errorCode: event.errorCode,
+    level: event.level ?? 'error',
   };
 
   Sentry.captureEvent({
     message: fullEvent.name,
-    level: 'error',
+    level: fullEvent.level,
     tags: {
       event_name: fullEvent.name,
       flow: fullEvent.flow,

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -94,6 +94,7 @@ export async function pollUntilSynced(
       flow: 'profile_update',
       step: 'background_sync',
       message: 'pollUntilSynced exhausted retries without sync',
+      level: 'warning',
     });
   }
 


### PR DESCRIPTION
## What Does This PR Do?

- Add optional `level: 'error' | 'warning' | 'info'` to `captureFlowFailure` (defaults to `error` so existing call sites stay unchanged)
- Forward the chosen level to `Sentry.captureEvent` so expected user-input failures stop polluting the Sentry error inbox
- Reclassify call sites by signal type:
  - `info`: sign_in (validate / authenticate), sign_up.submit, delete_account.submit, reservation_create slot conflicts
  - `warning`: avatar uploads (onboarding & profile edit), pollUntilSynced exhaustion
  - `error` (unchanged): network/API failures (reservation fetches, profile_write, accept/reject mutations, unexpected catch-alls)
- Add unit tests for default / explicit level / non-prod skip / sanitize behaviour

## Demo

N/A — Sentry-only behaviour change

## Screenshot

N/A

## Anything to Note?

- `FlowFailureEvent.level` is optional and defaults to `'error'`, so any future call site that omits it keeps current behaviour
- Sentry inbound alert rules that key on `level=error` may need to be reviewed if the team relies on flow failures triggering them

Closes #266
