### PR TITLE
fix(auth): dedupe in-flight refresh-token rotations

### DIFF
--- a/src/auth.config.ts
+++ b/src/auth.config.ts
@@ -1,6 +1,6 @@
+import { cookies } from 'next/headers';
 import type { NextAuthOptions } from 'next-auth';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { cookies } from 'next/headers';
 
 import { OAUTH_REFRESH_BRIDGE_COOKIE } from '@/lib/auth/oauthRefreshBridge';
 import { SignInSchema } from '@/schemas/auth';
@@ -24,6 +24,27 @@ function decodeJwtExp(jwtString: string): number | null {
 function extractRefreshToken(headers: Headers): string | undefined {
   const setCookie = headers.get('set-cookie') ?? '';
   return setCookie.match(/refresh_token=([^;,]+)/)?.[1] ?? undefined;
+}
+
+// BFF rotates the refresh_token on every /v1/auth/token call (revokes the old
+// rt:* index immediately). Concurrent jwt callbacks reading the same stored
+// refresh token would all POST it; first wins, the rest get invalid_grant.
+// Coalesce in-flight refreshes by token so parallel callers share one result.
+const inflightRefresh = new Map<
+  string,
+  ReturnType<typeof refreshAccessToken>
+>();
+
+function refreshAccessTokenSingleflight(
+  currentRefreshToken: string
+): ReturnType<typeof refreshAccessToken> {
+  const existing = inflightRefresh.get(currentRefreshToken);
+  if (existing) return existing;
+  const promise = refreshAccessToken(currentRefreshToken).finally(() => {
+    inflightRefresh.delete(currentRefreshToken);
+  });
+  inflightRefresh.set(currentRefreshToken, promise);
+  return promise;
 }
 
 const authOptions = {
@@ -171,7 +192,7 @@ const authOptions = {
         if (isExpiringSoon) {
           try {
             const { token: newToken, refreshToken: newRefreshToken } =
-              await refreshAccessToken(storedRefreshToken);
+              await refreshAccessTokenSingleflight(storedRefreshToken);
             return {
               ...token,
               token: newToken,


### PR DESCRIPTION
## What Does This PR Do?

- Coalesce concurrent `refreshAccessToken` calls in the NextAuth `jwt` callback (`src/auth.config.ts`) by an in-flight `Map<refreshToken, Promise>`, so parallel callers share one result instead of each POSTing the same token

## Why

CloudWatch shows the classic rotation-race signature on `/aws/lambda/x-career-bff-dev-app`: a successful `POST /api/v1/auth/token 201` followed within ~2s by 2–4× `401`s, and only the success has the `valid_refresh_token` log line — the failures fail earlier at `auth_service.py:448` (`rt:* index missing`).

What's happening:

1. Multiple components / server reads trigger the `jwt` callback in parallel for the same user during one render
2. Each callback reads the same `storedRefreshToken` from the JWT cookie
3. All POST `/v1/auth/token` with the same value
4. BFF (`auth_service.py:464`) rotates and `revoke_previous_refresh` deletes the old `rt:*` index immediately — the first call wins
5. The losers get `invalid_grant` and return `error: ''RefreshTokenError''`

This race has existed since #418 (the auto-refresh mechanism), but #614 (`feat/263-middleware-verify-jwt`) made it user-visible: the middleware now treats `error === ''RefreshTokenError''` as unauthenticated AND deletes `next-auth.session-token` / `__Secure-next-auth.session-token`, so a single race-induced 401 boots the user to `/auth/signin`.

The singleflight closes the window by ensuring only one POST per unique refresh token is in flight per Node process. Followers `await` the same promise and all see the rotated `RT_v2`.

## Demo

http://localhost:3000 — log in, leave an access token to drift toward the 5-minute pre-expiry threshold, then load any protected page that triggers multiple concurrent session reads. Before this change CloudWatch shows 1× 201 + N× 401 in a burst; after, only the single 201.

## Screenshot

N/A

## Anything to Note?

- Per-process Map. If parallel `/api/auth/session` calls land on different Lambda instances, dedupe doesn''t apply across them — but in practice NextAuth''s `SessionProvider` already dedupes browser-side, so the realistic case is multiple `getServerSession()` within one server render, which IS one process.
- Map entry is removed in `.finally()` — covers both success and failure paths, no leak.
- Does not touch the BFF. A more thorough fix would also add a short rotation grace window on the BFF (keep `rt:OLD` valid for a few seconds after rotation), but that''s out of scope here.
- No backend changes; no new env config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)