### PR TITLE
perf: address Lighthouse mobile audit findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,6 +50,7 @@ CLAUDE.md
 # Test reports and screenshots
 /reports/
 /.playwright-mcp/
+/lighthouse-reports/
 
 # Playwright E2E
 /playwright-report/

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -10,10 +10,11 @@ import { Footer } from '@/components/layout/Footer';
 import { Header } from '@/components/layout/Header';
 import Providers from '@/components/Providers';
 import { Toaster } from '@/components/ui/toaster';
+import { getSiteUrl } from '@/lib/site-url';
 
 import { notoSansTC } from './font';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const SITE_URL = getSiteUrl();
 const SITE_DESCRIPTION =
   'XChange Talent Pool 是連結業界導師與職涯探索者的 mentorship 平台，協助你在轉職、升遷、跨界探索時，找到對的人聊對的事。';
 
@@ -82,6 +83,31 @@ export default async function RootLayout({
             imageSrcSet={avatarSrcSet}
             imageSizes="160px"
             fetchPriority="high"
+          />
+        )}
+        {/* Preconnect to third-party origins so the TLS handshake overlaps with
+            HTML parse instead of blocking the first script byte. crossOrigin
+            is required so the warmed connection is reused for the actual
+            (CORS-credentialed) script fetch. */}
+        {process.env.NEXT_PUBLIC_CLARITY_ID && (
+          <>
+            <link
+              rel="preconnect"
+              href="https://www.clarity.ms"
+              crossOrigin="anonymous"
+            />
+            <link
+              rel="preconnect"
+              href="https://c.clarity.ms"
+              crossOrigin="anonymous"
+            />
+          </>
+        )}
+        {process.env.NEXT_PUBLIC_SENTRY_DSN && (
+          <link
+            rel="preconnect"
+            href="https://browser.sentry-cdn.com"
+            crossOrigin="anonymous"
           />
         )}
       </head>

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -6,6 +6,7 @@ import authOptions from '@/auth.config';
 import { PersonJsonLd } from '@/components/seo/PersonJsonLd';
 import { buildMentorMetadata } from '@/lib/seo/buildMentorMetadata';
 import { sanitizePublicProfile } from '@/lib/seo/sanitizePublicProfile';
+import { getSiteUrl } from '@/lib/site-url';
 import { buildTagLabelMap } from '@/services/profile/tagCatalog';
 import { fetchTagCatalogServer } from '@/services/profile/tagCatalog.server';
 import { fetchUserByIdServer } from '@/services/profile/user.server';
@@ -57,7 +58,7 @@ export default async function Page({ params: { pageUserId } }: PageProps) {
     initialDto,
     buildTagLabelMap(catalogs)
   );
-  const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+  const siteUrl = getSiteUrl();
 
   return (
     <>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,6 +1,6 @@
 import type { MetadataRoute } from 'next';
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+import { getSiteUrl } from '@/lib/site-url';
 
 export default function robots(): MetadataRoute.Robots {
   return {
@@ -9,6 +9,6 @@ export default function robots(): MetadataRoute.Robots {
       allow: '/',
       disallow: ['/auth/', '/profile/*/edit', '/reservation/', '/api/'],
     },
-    sitemap: `${SITE_URL}/sitemap.xml`,
+    sitemap: `${getSiteUrl()}/sitemap.xml`,
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,11 +1,12 @@
 import type { MetadataRoute } from 'next';
 
+import { getSiteUrl } from '@/lib/site-url';
 import type { components } from '@/types/api';
 
 type MentorListResponse =
   components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL ?? 'http://localhost:3000';
+const SITE_URL = getSiteUrl();
 const API_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
 
 // Single-page fetch keeps build-time work bounded. Bump or add cursor pagination

--- a/src/components/auth/AuthFormInput.tsx
+++ b/src/components/auth/AuthFormInput.tsx
@@ -68,7 +68,7 @@ const AuthFormInput = <T extends FieldValues>({
               <button
                 type="button"
                 onClick={togglePasswordVisibility}
-                className="absolute right-3 top-1/2 -translate-y-1/2 rounded-sm text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                className="absolute right-1 top-1/2 -translate-y-1/2 rounded-sm p-2 text-gray-400 hover:text-gray-600 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
                 aria-label={showPassword ? '隱藏密碼' : '顯示密碼'}
               >
                 {showPassword ? (

--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -51,6 +51,7 @@ const MentorCardListBase = ({
             company={mentor.company}
             about={mentor.about}
             haveTopicLabels={mentor.have_topic}
+            priority={index === 0}
           />
         ))}
       </div>

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.tsx
@@ -7,12 +7,14 @@ interface AvatarWithBadgeProps {
   avatar: string | StaticImageData;
   years: string;
   name: string;
+  priority?: boolean;
 }
 
 export const AvatarWithBadge = ({
   avatar,
   years,
   name,
+  priority = false,
 }: AvatarWithBadgeProps) => {
   const displayYears =
     TotalWorkSpanEnum[years as keyof typeof TotalWorkSpanEnum] ?? years;
@@ -25,6 +27,8 @@ export const AvatarWithBadge = ({
         fill
         sizes="(max-width: 768px) 334px, 413px"
         className="h-full object-cover"
+        priority={priority}
+        loading={priority ? 'eager' : 'lazy'}
       />
       <figcaption className="absolute bottom-[30px] right-[30px] rounded-lg bg-[#000000]/30 px-2.5 py-1 text-text-white">
         {displayYears}工作經驗

--- a/src/components/mentor-pool/mentor-card/index.tsx
+++ b/src/components/mentor-pool/mentor-card/index.tsx
@@ -14,6 +14,7 @@ export interface MentorCardProps {
   company: string;
   about: string;
   haveTopicLabels: string[];
+  priority?: boolean;
 }
 
 const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
@@ -27,6 +28,7 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
       company,
       about,
       haveTopicLabels,
+      priority = false,
     }: MentorCardProps,
     ref
   ) => {
@@ -40,7 +42,12 @@ const MentorCardBase = forwardRef<HTMLElement, MentorCardProps>(
           aria-label={`前往 ${name} 的個人頁面`}
           className="absolute bottom-0 left-0 right-0 top-0 z-10"
         ></Link>
-        <AvatarWithBadge avatar={avatar} years={years} name={name} />
+        <AvatarWithBadge
+          avatar={avatar}
+          years={years}
+          name={name}
+          priority={priority}
+        />
         <div className="px-4 pb-6 pt-4">
           <Information
             name={name}

--- a/src/instrumentation-client.ts
+++ b/src/instrumentation-client.ts
@@ -5,10 +5,19 @@
 import * as Sentry from '@sentry/nextjs';
 
 const sentryEnv = process.env.NEXT_PUBLIC_SENTRY_ENV;
+const sentryEnabled = sentryEnv === 'production' || sentryEnv === 'staging';
+
+// Replay sampling. Gate the lazyLoadIntegration call itself so unsampled
+// sessions never download replay.min.js (~40 kB). Sentry's
+// replaysSessionSampleRate only controls *recording*, not the script
+// download — without this gate, every user pays the bundle cost even if
+// 90% of sessions are never recorded. Trade-off: the on-error buffer
+// (replaysOnErrorSampleRate) is also unavailable for unsampled sessions.
+const REPLAY_SAMPLE_RATE = 0.05;
 
 Sentry.init({
   dsn: process.env.NEXT_PUBLIC_SENTRY_DSN,
-  enabled: sentryEnv === 'production' || sentryEnv === 'staging',
+  enabled: sentryEnabled,
   environment: sentryEnv ?? 'local',
 
   // Trace 10% of requests in production; increase temporarily for debugging
@@ -19,19 +28,19 @@ Sentry.init({
 
   // Do not send PII (IP addresses, user emails, etc.) automatically
   sendDefaultPii: false,
-
-  // Session Replay is lazy-loaded below to avoid adding ~50kB to the initial bundle.
-  // replaysSessionSampleRate and replaysOnErrorSampleRate are set on the integration itself.
 });
 
-// Lazy-load Replay after the page is interactive so it does not block initial load.
-Sentry.lazyLoadIntegration('replayIntegration').then((replayIntegration) => {
-  Sentry.addIntegration(
-    replayIntegration({
-      replaysSessionSampleRate: 0.1,
-      replaysOnErrorSampleRate: 1.0,
-    })
-  );
-});
+if (sentryEnabled && Math.random() < REPLAY_SAMPLE_RATE) {
+  Sentry.lazyLoadIntegration('replayIntegration').then((replayIntegration) => {
+    Sentry.addIntegration(
+      replayIntegration({
+        // Already gated above, so record this whole session and capture
+        // its on-error buffer if anything throws.
+        replaysSessionSampleRate: 1.0,
+        replaysOnErrorSampleRate: 1.0,
+      })
+    );
+  });
+}
 
 export const onRouterTransitionStart = Sentry.captureRouterTransitionStart;

--- a/src/lib/site-url.ts
+++ b/src/lib/site-url.ts
@@ -1,0 +1,16 @@
+/**
+ * Resolves the public site origin for absolute URLs (sitemap, robots, OG).
+ *
+ * Why: production prematurely fell back to `http://localhost:3000` when
+ * `NEXT_PUBLIC_SITE_URL` wasn't set on Vercel, leaking into robots.txt
+ * `Sitemap:` line and `metadataBase`. Vercel auto-provides
+ * `VERCEL_PROJECT_PRODUCTION_URL` (host only, no scheme) in every build,
+ * so use it as a fallback before localhost.
+ */
+export function getSiteUrl(): string {
+  if (process.env.NEXT_PUBLIC_SITE_URL) return process.env.NEXT_PUBLIC_SITE_URL;
+  if (process.env.VERCEL_PROJECT_PRODUCTION_URL) {
+    return `https://${process.env.VERCEL_PROJECT_PRODUCTION_URL}`;
+  }
+  return 'http://localhost:3000';
+}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -14,7 +14,9 @@
     --popover-foreground: 222.2 84% 4.9%;
 
     --primary: 180 64% 48%;
-    --primary-foreground: 210 40% 98%;
+    /* Dark foreground on the bright teal brand color: white-ish gives a
+       1.94:1 contrast ratio (WCAG AA fails). Dark gray gives ~9:1. */
+    --primary-foreground: 222.2 47.4% 11.2%;
 
     --secondary: 210 40% 96.1%;
     --secondary-foreground: 222.2 47.4% 11.2%;


### PR DESCRIPTION
## Summary

Concrete fixes for issues surfaced by a mobile Lighthouse run on
production (https://xtalent.xchange.com.tw). Reports stored locally in
`lighthouse-reports/` (gitignored).

| Page | Perf | A11y | Best Practices | SEO |
|------|------|------|----------------|-----|
| `/` | 85 | 100 | 79 | 100 |
| `/auth/signin` | 94 | **92 → 100 (this PR)** | 79 | 66\* |
| `/mentor-pool` | **63 → ~85 (this PR)** | 100 | 79 | 100 |

\* signin SEO 66 is from `robots.txt` `Disallow: /auth/`, intentional.

## Changes

**LCP — `/mentor-pool` 10.3s → ~3s.** First mentor card avatar was the
LCP element but had `loading=lazy`. Threaded a `priority` prop
through `MentorCardList → MentorCard → AvatarWithBadge` so only the
first card paints eagerly.

**Preconnect — saves ~743ms on `/mentor-pool`.** Added
`<link rel=preconnect>` for `clarity.ms`, `c.clarity.ms`, and
`browser.sentry-cdn.com`, gated on the same env vars that already gate
the corresponding `<Script>` tags.

**Sentry Replay bundle — drops ~40kB from 95% of sessions.**
`replaysSessionSampleRate` only controls *recording*, not script
download — `lazyLoadIntegration` was pulling `replay.min.js` for every
user. Gate the call itself behind a 5% sample. Trade-off documented
inline: on-error replay buffer is unavailable for those 95%.

**`robots.txt` / sitemap — fix prod sitemap pointing at localhost.**
Production was emitting `Sitemap: http://localhost:3000/sitemap.xml`
because `NEXT_PUBLIC_SITE_URL` wasn'\''t set on Vercel. Added shared
`lib/site-url.ts` that falls back to `VERCEL_PROJECT_PRODUCTION_URL`
before localhost. Used in `robots.ts`, `sitemap.ts`, root `layout.tsx`,
and the public profile page.

**A11y — signin 92 → 100.**
- Submit button: white on teal `#2CCBCB` was 1.94:1 (fails WCAG AA).
  Updated `--primary-foreground` to the dark token already used by
  `--secondary-foreground` — ~9:1 contrast. Affects every primary
  button consistently across the app.
- Password visibility toggle: 20×20 hit area failed `target-size`.
  Added `p-2` (effective 36×36) while keeping the icon visually in
  place via a compensating `right-1`.

## Test plan
- [x] `pnpm type-check` (passes)
- [x] `pnpm test` — 173/173 (pre-push hook)
- [ ] Visually verify primary buttons across the app (now have dark
  text on teal — confirm this matches design intent)
- [ ] Verify `/mentor-pool` first-card image still renders correctly
  on mobile and desktop grid layouts
- [ ] After merge: confirm production `robots.txt` shows the correct
  sitemap origin (requires `NEXT_PUBLIC_SITE_URL` *or* Vercel-set
  `VERCEL_PROJECT_PRODUCTION_URL` — the latter is automatic)
- [ ] After merge: re-run Lighthouse to confirm mentor-pool perf and
  signin a11y deltas land in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)