### PR TITLE
feat: add feedback form button to header

### DIFF
--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -13,6 +13,9 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { Skeleton } from '@/components/ui/skeleton';
+import { trackEvent } from '@/lib/analytics';
+
+import { FEEDBACK_FORM_URL } from './constants';
 
 export type HamburgerMenuProps = {
   isLoading: boolean;
@@ -79,6 +82,20 @@ export function HamburgerMenu({
             <Link href="/about" onClick={close} className="text-black">
               關於 X-Talent
             </Link>
+
+            <a
+              href={FEEDBACK_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="提供回饋（另開新分頁）"
+              onClick={() => {
+                trackEvent({ name: 'feedback_open' });
+                close();
+              }}
+              className="text-black"
+            >
+              提供回饋
+            </a>
           </div>
 
           {!isLoggedIn && (

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -8,7 +8,9 @@ import { memo, useRef } from 'react';
 import LogoImgUrl from '@/assets/logo.svg';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL } from './constants';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
 import { UserDropdown } from './UserDropdown';
@@ -68,6 +70,17 @@ function HeaderComponent(): JSX.Element {
             >
               關於 X-Talent
             </Link>
+
+            <a
+              href={FEEDBACK_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="提供回饋（另開新分頁）"
+              onClick={() => trackEvent({ name: 'feedback_open' })}
+              className="text-black font-['Open_Sans'] text-base"
+            >
+              提供回饋
+            </a>
           </nav>
         </div>
 

--- a/src/components/layout/Header/constants.ts
+++ b/src/components/layout/Header/constants.ts
@@ -1,0 +1,2 @@
+/** Google Form for collecting user feedback (issue #268). */
+export const FEEDBACK_FORM_URL = 'https://forms.gle/594hMVdTyoR3Pgtg9';


### PR DESCRIPTION
## What Does This PR Do?

- Add a "提供回饋" link in the header that opens a Google feedback form in a new tab (issue #268)
- Show it in both the desktop nav and the mobile hamburger drawer (closes the drawer on click) for consistent RWD behavior
- Use `<a target="_blank" rel="noopener noreferrer">` with an aria-label for accessibility; fire a `feedback_open` analytics event on click (no PII)
- Extract the form URL into a shared `constants.ts` to avoid duplication

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

Pure UI external link — no data-flow, service, hook, or schema changes. Role/auth independent, so no layout shift during session resolution.
