### PR TITLE
feat: move privacy/terms links to footer about section (#269)

### DIFF
--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -55,6 +55,22 @@ export const Footer: FC = () => {
 
         <div className="mt-8 flex flex-col gap-8 text-[#FFFFFF] md:mt-0 md:flex-row md:gap-x-16">
           <div className="flex flex-col items-center md:items-start">
+            <p className="mb-5 text-xl font-bold tracking-[0.085em]">關於</p>
+
+            <div className="flex flex-col items-center gap-3 md:items-start">
+              {LEGAL_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="block font-normal hover:underline"
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center md:items-start">
             <p className="mb-5 text-xl font-bold tracking-[0.085em]">
               相關連結
             </p>
@@ -70,22 +86,6 @@ export const Footer: FC = () => {
                 >
                   {link.label}
                 </a>
-              ))}
-            </div>
-          </div>
-
-          <div className="flex flex-col items-center md:items-start">
-            <p className="mb-5 text-xl font-bold tracking-[0.085em]">關於</p>
-
-            <div className="flex flex-col items-center gap-3 md:items-start">
-              {LEGAL_LINKS.map((link) => (
-                <Link
-                  key={link.href}
-                  href={link.href}
-                  className="block font-normal hover:underline"
-                >
-                  {link.label}
-                </Link>
               ))}
             </div>
           </div>

--- a/src/components/layout/Footer/Footer.tsx
+++ b/src/components/layout/Footer/Footer.tsx
@@ -51,18 +51,6 @@ export const Footer: FC = () => {
             sizes="146px"
             className="h-[39px] w-[146px]"
           />
-
-          <div className="mt-6 flex flex-col items-center gap-3 text-[#FFFFFF] md:items-start">
-            {LEGAL_LINKS.map((link) => (
-              <Link
-                key={link.href}
-                href={link.href}
-                className="block font-normal hover:underline"
-              >
-                {link.label}
-              </Link>
-            ))}
-          </div>
         </div>
 
         <div className="mt-8 flex flex-col gap-8 text-[#FFFFFF] md:mt-0 md:flex-row md:gap-x-16">
@@ -82,6 +70,22 @@ export const Footer: FC = () => {
                 >
                   {link.label}
                 </a>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex flex-col items-center md:items-start">
+            <p className="mb-5 text-xl font-bold tracking-[0.085em]">關於</p>
+
+            <div className="flex flex-col items-center gap-3 md:items-start">
+              {LEGAL_LINKS.map((link) => (
+                <Link
+                  key={link.href}
+                  href={link.href}
+                  className="block font-normal hover:underline"
+                >
+                  {link.label}
+                </Link>
               ))}
             </div>
           </div>


### PR DESCRIPTION
## What Does This PR Do?

- Move the privacy/terms legal links out from under the footer logo
- Add a new "關於" column between "相關連結" and "XChange 社群連結"
- Keep links as internal Next.js <Link> (no new tab), reusing existing column styles and RWD behavior

## Demo

http://localhost:3000

## Screenshot

N/A

## Anything to Note?

- Per Julie-Su PM feedback on issue #269, links now sit next to the related-links column as an "About" category instead of under the logo
- Privacy/Terms pages already carry a consistent "Last updated" date, so no page content changed

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
