### PR TITLE
refactor: replace force-dynamic with Suspense on email-verified page

### DIFF
--- a/src/app/auth/email-verified/page.tsx
+++ b/src/app/auth/email-verified/page.tsx
@@ -1,7 +1,11 @@
-export const dynamic = 'force-dynamic';
+import { Suspense } from 'react';
 
 import EmailVerifiedContainer from './container';
 
 export default function Page() {
-  return <EmailVerifiedContainer />;
+  return (
+    <Suspense>
+      <EmailVerifiedContainer />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## What Does This PR Do?

- Removes `export const dynamic = 'force-dynamic'` from `src/app/auth/email-verified/page.tsx`
- Wraps `<EmailVerifiedContainer />` in a `<Suspense>` boundary, following the existing pattern used in `src/app/auth/password-reset/page.tsx`
- `EmailVerifiedContainer` uses `useSearchParams()` client-side to read the verification token and call `confirmRegister`; `Suspense` is the correct fix for this instead of forcing SSR on every request

## Demo

http://localhost:3000/auth/email-verified?token=<token>

## Screenshot

N/A

## Anything to Note?

- `pnpm build`, `pnpm lint`, and `pnpm type-check` all pass with no `useSearchParams`/Suspense warnings
- Note: the page still renders as `ƒ (Dynamic)` in the build output, not `○ (Static)`. This is because the root layout (`src/app/layout.tsx`) calls `getServerSession(authOptions)` on every request, which reads cookies and forces dynamic rendering site-wide (see `/auth/password-reset`, which also has no `force-dynamic` and already uses `Suspense`, yet is still `ƒ Dynamic`). This is a pre-existing site-wide constraint, not something introduced or fixable by this change alone.
