### PR TITLE
fix: remove force-dynamic from google oauth redirect page

### DIFF
--- a/src/app/auth/google/callback/redirect/page.tsx
+++ b/src/app/auth/google/callback/redirect/page.tsx
@@ -1,7 +1,11 @@
-export const dynamic = 'force-dynamic';
+import { Suspense } from 'react';
 
 import GoogleOAuthRedirectPage from './container';
 
 export default function Page() {
-  return <GoogleOAuthRedirectPage />;
+  return (
+    <Suspense>
+      <GoogleOAuthRedirectPage />
+    </Suspense>
+  );
 }


### PR DESCRIPTION
## What Does This PR Do?

- Removes the unnecessary `export const dynamic = 'force-dynamic'` from `/auth/google/callback/redirect`
- Wraps `<GoogleOAuthRedirectPage />` in a `<Suspense>` boundary so `useSearchParams()` no longer requires `force-dynamic` to satisfy the build
- `pnpm build` completes with no `useSearchParams`/missing-Suspense warnings

## Demo

http://localhost:3000/auth/google/callback/redirect

## Screenshot

N/A

## Anything to Note?

The route still builds as dynamic (`ƒ`) rather than static (`○`) because the root layout (`src/app/layout.tsx`) calls `getServerSession()` on every request to preload the user's avatar, which forces dynamic rendering across nearly all routes in the app (not specific to this page). Full static generation for this page would require addressing that separately.
