### PR TITLE
perf: restore 30-day Image Optimizer cache for avatars

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -78,17 +78,11 @@ function buildCsp() {
 
 const nextConfig = {
   images: {
-    // TEMP: disabled the 30-day Image Optimizer cache.
-    // Avatar URLs from the profile API are stable keys (re-uploads overwrite
-    // the same S3 object), and `MentorProfileVO` does not yet return an
-    // `updated_at` we can append as `?cb=`. Caching long-term means visitors
-    // see stale avatars after another user updates theirs. Setting TTL to 0
-    // makes the optimizer revalidate every request — accepts higher S3
-    // egress in exchange for correctness.
-    // Revert to `60 * 60 * 24 * 30` once the backend adds `updated_at` to
-    // `MentorProfileVO` and profile pages can use `?cb=${updated_at}` like
-    // mentor-pool already does (see `MentorPoolWithData.tsx:resolveAvatar`).
-    minimumCacheTTL: 0,
+    // Avatar URLs are versioned at write time (`?v=` baked in by
+    // `updateAvatar.ts:buildS3ObjectUrl`, `?cb=` appended from
+    // `SearchMentorProfileVO.updated_at` in `MentorPoolWithData.tsx`), so a
+    // new avatar always resolves to a new cache key — safe to cache long.
+    minimumCacheTTL: 60 * 60 * 24 * 30,
     remotePatterns: [
       {
         protocol: 'https',


### PR DESCRIPTION
## What Does This PR Do?

- Restores `images.minimumCacheTTL` in `next.config.js` from `0` back to 30 days (`60 * 60 * 24 * 30`)
- Removes the stale TEMP comment explaining the previous workaround
- Avatar URLs are now versioned at write time (`?v=` baked in by `updateAvatar.ts:buildS3ObjectUrl`, `?cb=` appended from `SearchMentorProfileVO.updated_at` in `MentorPoolWithData.tsx`), so a new avatar always resolves to a new cache key and long-lived caching no longer risks stale images

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

Closes Xchange-Taiwan/X-Talent-Tracker#279

Verified: `pnpm type-check`, `pnpm lint` (no new errors on changed files), `pnpm build` all pass. Manual verification of avatar update propagation across profile page / mentor-pool / header, and the rollback-on-cancel path, still needs to be done against a running environment.
