### PR TITLE
fix: reversed appointment history order

### DIFF
--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -115,16 +115,17 @@ export default function ReservationConversationDialog({
               尚無對話內容
             </p>
           ) : (
-            reservation.messages.map((message, index) => (
-              <MessageBubble
-                key={index}
-                message={message}
-                isPrevSameRole={
-                  index > 0 &&
-                  reservation.messages[index - 1].role === message.role
-                }
-              />
-            ))
+            [...reservation.messages]
+              .reverse()
+              .map((message, index, array) => (
+                <MessageBubble
+                  key={index}
+                  message={message}
+                  isPrevSameRole={
+                    index > 0 && array[index - 1].role === message.role
+                  }
+                />
+              ))
           )}
         </div>
       </DialogContent>


### PR DESCRIPTION
## What Does This PR Do?
Fix appointment history ordering
<!-- The fixes & changes you made -->

## Demo

http://localhost:3000/reservation/mentee

## Screenshot
before:
<img width="724" height="783" alt="image" src="https://github.com/user-attachments/assets/9027eea0-1e04-4f11-a7f2-8e365c11b3f3" />

after: 
<img width="1416" height="802" alt="image" src="https://github.com/user-attachments/assets/fde02e6e-7222-4839-9808-e907265378d5" />

case 2
<img width="1414" height="790" alt="image" src="https://github.com/user-attachments/assets/e1c66068-2fc6-4a18-8166-fbd3060fd10e" />


## Anything to Note?

N/A
