### PR TITLE
perf: remove getServerSession from root layout to unblock ISR

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,9 +3,7 @@ import '../styles/global.css';
 import * as Sentry from '@sentry/nextjs';
 import type { Metadata } from 'next';
 import Script from 'next/script';
-import { getServerSession } from 'next-auth/next';
 
-import authOptions from '@/auth.config';
 import { Footer } from '@/components/layout/Footer';
 import { Header } from '@/components/layout/Header';
 import Providers from '@/components/Providers';
@@ -49,42 +47,14 @@ export function generateMetadata(): Metadata {
   };
 }
 
-export default async function RootLayout({
+export default function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
-  const session = await getServerSession(authOptions);
-
-  // Preload the logged-in user's avatar through the next/image optimizer so the
-  // profile view / edit page's first paint does not wait on a cold S3 fetch.
-  // imageSrcSet + imageSizes lets the browser pick the same width that
-  // <Image sizes="150-160px" /> will request (w=256 at 1x DPR, w=384 at 2x),
-  // avoiding the cache-miss caused by a fixed-width preload.
-  // Skip preload entirely when the avatar URL carries no `?v=` query — the
-  // upload pipeline always bakes in a cache buster, so a bare URL means
-  // legacy data we'd rather refetch live than cache for 30 days.
-  const sessionAvatar = session?.user?.avatar ?? null;
-  const avatarSrc =
-    sessionAvatar && sessionAvatar.includes('?v=') ? sessionAvatar : null;
-  const buildOptimizerUrl = (w: number) =>
-    `/_next/image?url=${encodeURIComponent(avatarSrc ?? '')}&w=${w}&q=75`;
-  const avatarSrcSet = avatarSrc
-    ? `${buildOptimizerUrl(256)} 256w, ${buildOptimizerUrl(384)} 384w`
-    : null;
-
   return (
     <html lang="zh-TW" className={notoSansTC.className}>
       <head>
-        {avatarSrcSet && (
-          <link
-            rel="preload"
-            as="image"
-            imageSrcSet={avatarSrcSet}
-            imageSizes="160px"
-            fetchPriority="high"
-          />
-        )}
         {/* Preconnect to third-party origins so the TLS handshake overlaps with
             HTML parse instead of blocking the first script byte. crossOrigin
             is required so the warmed connection is reused for the actual
@@ -158,7 +128,7 @@ export default async function RootLayout({
             }}
           />
         )}
-        <Providers session={session}>
+        <Providers>
           <div className="flex min-h-screen flex-col">
             <Header />
             <main

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { Session } from 'next-auth';
 import { SessionProvider } from 'next-auth/react';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
@@ -8,15 +7,9 @@ import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
 import PageViewTracker from '@/components/PageViewTracker';
 import SessionErrorWatcher from '@/components/SessionErrorWatcher';
 
-export default function Providers({
-  children,
-  session,
-}: {
-  children: React.ReactNode;
-  session: Session | null;
-}) {
+export default function Providers({ children }: { children: React.ReactNode }) {
   return (
-    <SessionProvider session={session}>
+    <SessionProvider>
       <GlobalErrorMonitor />
       <PageViewTracker />
       <SessionErrorWatcher />


### PR DESCRIPTION
## What Does This PR Do?

- Removes `await getServerSession(authOptions)` from `src/app/layout.tsx` — reading `cookies()` in the root layout was forcing every route in the app into per-request dynamic rendering, blocking ISR/static generation site-wide (confirmed via `pnpm build`: ~14 routes flip from `ƒ Dynamic` to `○ Static` after this change)
- Removes the session-dependent avatar `<link rel="preload">` block, which duplicated the preload `UserDropdown.tsx` already gets for free via `<Image priority>`
- Updates `Providers.tsx` to stop accepting a `session` prop — `SessionProvider` now receives no initial session (`undefined`), so it correctly runs its own client-side session fetch on mount instead of treating `null` as "definitely logged out"
- `/mentor-pool` and `/profile/[pageUserId]` intentionally still render dynamically — each has its own independent reason (searchParams-driven server fetch, and a page-level `getServerSession` call) tracked as follow-up in the linked issue

## Demo

http://localhost:3000/

## Screenshot

N/A

## Anything to Note?

Verified `pnpm type-check`, `pnpm lint` (no new errors), and `pnpm build` (rendering mode diff matches investigation). Could not run a full browser-based login QA pass (mentor/mentee) in this environment — SSR output confirms Header renders its existing loading skeleton correctly (no flash of wrong auth state), but a manual pass logging in as both roles is recommended before merge.

Closes Xchange-Taiwan/X-Talent-Tracker#282
