### PR TITLE
fix: prevent duplicate-click history collapse on mentor card navigation

### DIFF
--- a/src/components/NavigationClickGuard.tsx
+++ b/src/components/NavigationClickGuard.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+// Some iOS WebKit browsers (Safari, and every iOS browser — they all share
+// the same engine) occasionally dispatch two click events for a single tap
+// on an anchor. When both reach the same next/link, App Router's history
+// logic (HistoryUpdater in next/dist/client/components/app-router.js)
+// pushes a history entry for the first navigation, then treats the second
+// push to the now-current URL as a no-op and replaces it instead — silently
+// dropping the entry that should exist for the page the user tapped from.
+// A single "back" then skips over it. Swallowing the duplicate click here,
+// before it reaches React/Link, stops the second navigation from ever
+// firing. Mounted once in Providers so it covers every link in the app.
+import { useEffect } from 'react';
+
+const DUPLICATE_CLICK_WINDOW_MS = 700;
+
+export default function NavigationClickGuard() {
+  useEffect(() => {
+    let lastHref: string | null = null;
+    let lastTime = 0;
+
+    function handleClick(event: MouseEvent): void {
+      if (event.defaultPrevented) return;
+      if (!(event.target instanceof Element)) return;
+
+      const anchor = event.target.closest('a[href]');
+      if (!(anchor instanceof HTMLAnchorElement)) return;
+
+      const href = anchor.href;
+      const now = Date.now();
+
+      if (href === lastHref && now - lastTime < DUPLICATE_CLICK_WINDOW_MS) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        return;
+      }
+
+      lastHref = href;
+      lastTime = now;
+    }
+
+    document.addEventListener('click', handleClick, { capture: true });
+    return () =>
+      document.removeEventListener('click', handleClick, { capture: true });
+  }, []);
+
+  return null;
+}

--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -4,6 +4,7 @@ import { SessionProvider } from 'next-auth/react';
 
 import ErrorBoundary from '@/components/ErrorBoundary';
 import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
+import NavigationClickGuard from '@/components/NavigationClickGuard';
 import PageViewTracker from '@/components/PageViewTracker';
 import SessionErrorWatcher from '@/components/SessionErrorWatcher';
 
@@ -11,6 +12,7 @@ export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
       <GlobalErrorMonitor />
+      <NavigationClickGuard />
       <PageViewTracker />
       <SessionErrorWatcher />
       <ErrorBoundary>{children}</ErrorBoundary>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,6 +76,14 @@
   body {
     @apply bg-background text-foreground;
   }
+
+  /* iOS WebKit can dispatch duplicate synthetic click events for a single
+     tap on an anchor/button; manipulation disables double-tap-to-zoom
+     handling on the tap target, which is the primary source of that. */
+  a,
+  button {
+    touch-action: manipulation;
+  }
 }
 
 /* =========================


### PR DESCRIPTION
## What Does This PR Do?

- Adds `touch-action: manipulation` globally to `a`/`button` in `global.css`, reducing iOS WebKit's tendency to dispatch duplicate synthetic click events for a single tap (its double-tap-to-zoom gesture disambiguation is the primary source)
- Adds `NavigationClickGuard`, mounted once in `Providers.tsx`, which intercepts (in the capture phase) a second click on the same `href` within 700ms and swallows it before it reaches Next.js Link/App Router
- Root cause: on iPhone Chrome (WebKit engine), a duplicate click on a mentor card in `/mentor-pool` could fire two `router.push` calls to the same `/profile/[id]` target. Next.js App Router`s `HistoryUpdater` (next/dist/client/components/app-router.js) treats a second push to the already-current URL as a no-op and uses `replaceState` instead of `pushState`, silently dropping the `/mentor-pool` history entry - so a single browser back tap skipped straight past it to home or a previously visited profile
- Does not reproduce on desktop Chrome; isolated to iOS WebKit browsers

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Mitigates the triggering mechanism (duplicate/rapid clicks) rather than changing Next.js's internal push/replace logic itself, since that behavior is intentional framework code
- Global fix - covers every link/button in the app, not just the mentor card
- Verified via `pnpm type-check`, `pnpm lint` (no new errors), and `pnpm build` (all pass); could not verify live on an iOS device in this environment - recommend confirming on a real iPhone Chrome/Safari session using the original repro (mentor-pool -> tap a mentor card -> profile -> back)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
