### PR TITLE
feat: AI Review Pipeline — Security Reviewer Agent

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -45,3 +45,32 @@ jobs:
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: node scripts/ai-review/planner.mjs
+
+  security:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Security'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run security agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/security.mjs

--- a/scripts/ai-review/lib/run-agent.mjs
+++ b/scripts/ai-review/lib/run-agent.mjs
@@ -1,0 +1,46 @@
+import { callGemini } from './gemini.mjs';
+import { getDiff } from './diff.mjs';
+import { buildPrompt } from './prompt.mjs';
+import {
+  encodeContext,
+  decodeContext,
+  writeGithubOutput,
+} from './context-io.mjs';
+
+/**
+ * Runs one downstream review-agent stage: recomputes the PR diff, decodes the
+ * upstream job outputs it depends on, builds this agent's prompt, calls
+ * Gemini, and writes the structured result to $GITHUB_OUTPUT under
+ * `outputName` so the next stage in the pipeline can read it via
+ * `needs.<job>.outputs.<outputName>`.
+ */
+export async function runAgent({ promptUrl, upstreamEnvVars, outputName }) {
+  const baseRef = process.env.BASE_REF;
+  if (!baseRef) {
+    throw new Error('BASE_REF env var is required');
+  }
+
+  const { diff, truncated } = getDiff(baseRef);
+
+  const upstreamReplacements = {};
+  for (const [placeholder, envVar] of Object.entries(upstreamEnvVars)) {
+    const value = decodeContext(process.env[envVar]);
+    if (!value) {
+      throw new Error(
+        `${envVar} env var is required (missing upstream job output)`
+      );
+    }
+    upstreamReplacements[placeholder] = JSON.stringify(value, null, 2);
+  }
+
+  const prompt = buildPrompt(promptUrl, {
+    DIFF: diff,
+    TRUNCATED_NOTE: truncated ? '（注意：diff 過大，內容已截斷）' : '',
+    ...upstreamReplacements,
+  });
+
+  const result = await callGemini(prompt);
+  console.log(`[${outputName}] result:`, JSON.stringify(result, null, 2));
+  writeGithubOutput(outputName, encodeContext(result));
+  return result;
+}

--- a/scripts/ai-review/prompts/security.md
+++ b/scripts/ai-review/prompts/security.md
@@ -1,0 +1,45 @@
+你是 multi-agent PR review pipeline 裡的 **Security Reviewer**，接在 Planner 之後。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+只檢查以下面向，其他問題（格式、型別、效能、測試覆蓋、架構慣例）不用理會，因為有其他 agent 專門負責：
+
+- PII 外洩（log、analytics/monitoring payload 是否包含 email、密碼、token 等）
+- 輸入驗證缺失（表單邊界、API 參數）
+- XSS / injection 風險
+- Secrets 是否寫死在程式碼裡，或有被 log 出來的風險
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "hasFindings": boolean,
+  "summary": "一句話總結，例如「無安全疑慮」或「發現 2 個問題」",
+  "findings": [
+    {
+      "file": "檔案路徑",
+      "line": number | null,
+      "category": "簡短分類，例如 PII / Input Validation / XSS / Secrets",
+      "issue": "一句話描述問題",
+      "why": "為什麼這很重要",
+      "fix": "具體修法"
+    }
+  ]
+}
+```

--- a/scripts/ai-review/security.mjs
+++ b/scripts/ai-review/security.mjs
@@ -1,0 +1,7 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/security.md', import.meta.url),
+  upstreamEnvVars: { PLAN_JSON: 'PLAN_B64' },
+  outputName: 'findings',
+});


### PR DESCRIPTION
## What Does This PR Do?
Stage 2 of the multi-agent AI PR review pipeline (Xchange-Taiwan/X-Talent-Tracker#289, part of epic Xchange-Taiwan/X-Talent-Tracker#287).

- Adds the `security` job to `.github/workflows/ai-review.yml` (`needs: planner`)
- Adds `lib/run-agent.mjs`: shared helper the remaining downstream stages (Correctness, Performance, Testing) will reuse — recomputes the diff, decodes upstream job outputs, builds the prompt, calls Gemini, writes the result to `$GITHUB_OUTPUT`
- Adds `security.mjs` + `prompts/security.md`: checks PII leakage, missing input validation, XSS/injection risk, and hardcoded secrets. Scoped narrowly — explicitly told not to comment on formatting/type/perf/test/architecture since other agents own those
- Output schema (`{ hasFindings, summary, findings: [{ file, line, category, issue, why, fix }] }`) is the shared shape the rest of the pipeline's findings-producing agents will follow

## Demo
N/A — no UI change.

## Screenshot
N/A

## Anything to Note?
- Base branch is `feat/288-ai-review-planner-agent` (stacked), not `develop` — merge #643 first.
- Same secrets dependency as #643 (`GEMINI_API_KEY`); non-blocking if missing.