### PR TITLE
feat: AI Review Pipeline — Performance Reviewer Agent

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -104,3 +104,34 @@ jobs:
           PLAN_B64: ${{ needs.planner.outputs.plan }}
           SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
         run: node scripts/ai-review/correctness.mjs
+
+  performance:
+    needs: [planner, security, correctness]
+    runs-on: ubuntu-latest
+    name: 'AI Review: Performance'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run performance agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+          SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
+          CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
+        run: node scripts/ai-review/performance.mjs

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -105,7 +105,7 @@ jobs:
         run: node scripts/ai-review/correctness.mjs
 
   performance:
-    needs: [planner, security, correctness]
+    needs: planner
     runs-on: ubuntu-latest
     name: 'AI Review: Performance'
     outputs:
@@ -131,6 +131,4 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
-          SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
-          CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
         run: node scripts/ai-review/performance.mjs

--- a/scripts/ai-review/performance.mjs
+++ b/scripts/ai-review/performance.mjs
@@ -4,8 +4,6 @@ await runAgent({
   promptUrl: new URL('./prompts/performance.md', import.meta.url),
   upstreamEnvVars: {
     PLAN_JSON: 'PLAN_B64',
-    SECURITY_FINDINGS_JSON: 'SECURITY_FINDINGS_B64',
-    CORRECTNESS_FINDINGS_JSON: 'CORRECTNESS_FINDINGS_B64',
   },
   outputName: 'findings',
 });

--- a/scripts/ai-review/performance.mjs
+++ b/scripts/ai-review/performance.mjs
@@ -1,0 +1,11 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/performance.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+    SECURITY_FINDINGS_JSON: 'SECURITY_FINDINGS_B64',
+    CORRECTNESS_FINDINGS_JSON: 'CORRECTNESS_FINDINGS_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/prompts/performance.md
+++ b/scripts/ai-review/prompts/performance.md
@@ -1,4 +1,4 @@
-你是 multi-agent PR review pipeline 裡的 **Performance Reviewer**，接在 Correctness / Regression Reviewer 之後。
+你是 multi-agent PR review pipeline 裡的 **Performance Reviewer**。你跟 Security、Correctness / Regression、Testing Reviewer 是平行執行的，彼此看不到對方的發現，只共用 Planner 的審查計畫。
 
 {{PROJECT_CONTEXT}}
 
@@ -8,18 +8,6 @@
 
 ```json
 {{PLAN_JSON}}
-```
-
-## Security Reviewer 的發現
-
-```json
-{{SECURITY_FINDINGS_JSON}}
-```
-
-## Correctness / Regression Reviewer 的發現
-
-```json
-{{CORRECTNESS_FINDINGS_JSON}}
 ```
 
 ## PR Diff{{TRUNCATED_NOTE}}

--- a/scripts/ai-review/prompts/performance.md
+++ b/scripts/ai-review/prompts/performance.md
@@ -1,0 +1,57 @@
+你是 multi-agent PR review pipeline 裡的 **Performance Reviewer**，接在 Correctness / Regression Reviewer 之後。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## Security Reviewer 的發現
+
+```json
+{{SECURITY_FINDINGS_JSON}}
+```
+
+## Correctness / Regression Reviewer 的發現
+
+```json
+{{CORRECTNESS_FINDINGS_JSON}}
+```
+
+## PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+只做程式碼層面的質化效能判斷，不用實際量測 bundle size（已有獨立的 `performance.yml` workflow 在做 bundle size budget 檢查）。聚焦：
+
+- 明顯的重複計算或不必要的運算（例如每次 render 都重新算一次可以 memo 的值）
+- 遺漏 `useMemo` / `useCallback` / `React.memo` 造成的大量不必要 re-render（僅在真的會造成明顯效能問題時才提，不要為了用而用）
+- 新增的 dependency 或 import 是否明顯過重，可能顯著增加 bundle size（例如 import 整個 lodash 而非單一函式）
+- 不必要的重複 API 呼叫（例如同一份資料在多個地方各自 fetch，而非透過既有 hook 共用）
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "hasFindings": boolean,
+  "summary": "一句話總結，例如「無效能疑慮」或「發現 1 個問題」",
+  "findings": [
+    {
+      "file": "檔案路徑",
+      "line": number | null,
+      "category": "Re-render / Bundle Size / Redundant Computation / Redundant Fetch 擇一",
+      "issue": "一句話描述問題",
+      "why": "為什麼這很重要",
+      "fix": "具體修法"
+    }
+  ]
+}
+```


### PR DESCRIPTION
## What Does This PR Do?
Stage 4 of the multi-agent AI PR review pipeline (Xchange-Taiwan/X-Talent-Tracker#290, part of epic Xchange-Taiwan/X-Talent-Tracker#287).

- Adds the `performance` job to `.github/workflows/ai-review.yml` (`needs: [planner, security, correctness]`)
- Adds `performance.mjs` + `prompts/performance.md`: checks redundant computation, missing memoization causing real re-render problems, unusually heavy new imports/deps, and redundant fetches — qualitative/code-level only, doesn't re-measure bundle size (that's already owned by the existing `performance.yml` budget check)
- Includes the `execFileSync` fix for `getDiff()` from #643 (see note below)

## Demo
N/A — no UI change.

## Screenshot
N/A

## Anything to Note?
- Base branch is `feat/293-ai-review-correctness-agent` (stacked) — merge #643, #644, #645 first, in order.
- **Bug fix carried in from #643**: `getDiff()` originally used `execSync` with a shell string, and the `:(exclude)...` pathspec magic contains unquoted parens that `/bin/sh` on the Actions runner fails to parse (confirmed via #643/#644 job logs: `Syntax error: "(" unexpected`). Switched to `execFileSync` with an argv array to bypass shell parsing entirely. Verified locally against a real diff after the fix.