### PR TITLE
feat: AI Review Pipeline — Architecture Reviewer Agent (+ Final Aggregation)

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -205,7 +205,7 @@ jobs:
             const fs = require('fs');
             const body = fs.readFileSync('ai-review-comment.md', 'utf8');
 
-            const { data: comments } = await github.rest.issues.listComments({
+            const comments = await github.paginate(github.rest.issues.listComments, {
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -163,9 +163,11 @@ jobs:
         run: node scripts/ai-review/testing.mjs
 
   architecture:
-    needs: [planner, security, correctness, performance, testing]
+    needs: planner
     runs-on: ubuntu-latest
-    name: 'AI Review: Architecture (+ Final Summary)'
+    name: 'AI Review: Architecture'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -182,15 +184,39 @@ jobs:
           node-version: 20
 
       - name: Run architecture agent
+        id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/architecture.mjs
+
+  summary:
+    needs: [planner, security, correctness, performance, testing, architecture]
+    runs-on: ubuntu-latest
+    name: 'AI Review: Final Summary'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate final summary comment
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
           SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
           CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
           PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
           TESTING_FINDINGS_B64: ${{ needs.testing.outputs.findings }}
-        run: node scripts/ai-review/architecture.mjs
+          ARCHITECTURE_FINDINGS_B64: ${{ needs.architecture.outputs.findings }}
+        run: node scripts/ai-review/generate-summary.mjs
 
       - name: Post PR comment
         env:

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -167,3 +167,66 @@ jobs:
           CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
           PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
         run: node scripts/ai-review/testing.mjs
+
+  architecture:
+    needs: [planner, security, correctness, performance, testing]
+    runs-on: ubuntu-latest
+    name: 'AI Review: Architecture (+ Final Summary)'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run architecture agent
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+          SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
+          CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
+          PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
+          TESTING_FINDINGS_B64: ${{ needs.testing.outputs.findings }}
+        run: node scripts/ai-review/architecture.mjs
+
+      - name: Post PR comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const body = fs.readFileSync('ai-review-comment.md', 'utf8');
+
+            const { data: comments } = await github.rest.issues.listComments({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+            });
+
+            const existing = comments.find(
+              (c) => c.user.login === 'github-actions[bot]' && c.body.includes('<!-- ai-review-pipeline -->')
+            );
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                comment_id: existing.id,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body,
+              });
+            }

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -199,34 +199,7 @@ jobs:
         run: node scripts/ai-review/architecture.mjs
 
       - name: Post PR comment
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const body = fs.readFileSync('ai-review-comment.md', 'utf8');
-
-            const comments = await github.paginate(github.rest.issues.listComments, {
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-            });
-
-            const existing = comments.find(
-              (c) => c.user.login === 'github-actions[bot]' && c.body.includes('<!-- ai-review-pipeline -->')
-            );
-
-            if (existing) {
-              await github.rest.issues.updateComment({
-                comment_id: existing.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
-                issue_number: context.issue.number,
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                body,
-              });
-            }
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/ai-review/post-comment.mjs

--- a/scripts/ai-review/architecture.mjs
+++ b/scripts/ai-review/architecture.mjs
@@ -1,0 +1,57 @@
+import { writeFileSync } from 'node:fs';
+import { callGemini } from './lib/gemini.mjs';
+import { getDiff } from './lib/diff.mjs';
+import { buildPrompt } from './lib/prompt.mjs';
+import { decodeContext } from './lib/context-io.mjs';
+import { formatComment } from './lib/format-comment.mjs';
+
+const baseRef = process.env.BASE_REF;
+if (!baseRef) {
+  throw new Error('BASE_REF env var is required');
+}
+
+const plan = decodeContext(process.env.PLAN_B64);
+const security = decodeContext(process.env.SECURITY_FINDINGS_B64);
+const correctness = decodeContext(process.env.CORRECTNESS_FINDINGS_B64);
+const performance = decodeContext(process.env.PERFORMANCE_FINDINGS_B64);
+const testing = decodeContext(process.env.TESTING_FINDINGS_B64);
+
+for (const [name, value] of Object.entries({
+  plan,
+  security,
+  correctness,
+  performance,
+  testing,
+})) {
+  if (!value) {
+    throw new Error(`missing upstream job output: ${name}`);
+  }
+}
+
+const { diff, truncated } = getDiff(baseRef);
+
+const prompt = buildPrompt(
+  new URL('./prompts/architecture.md', import.meta.url),
+  {
+    PLAN_JSON: JSON.stringify(plan, null, 2),
+    SECURITY_FINDINGS_JSON: JSON.stringify(security, null, 2),
+    CORRECTNESS_FINDINGS_JSON: JSON.stringify(correctness, null, 2),
+    PERFORMANCE_FINDINGS_JSON: JSON.stringify(performance, null, 2),
+    TESTING_FINDINGS_JSON: JSON.stringify(testing, null, 2),
+    DIFF: diff,
+    TRUNCATED_NOTE: truncated ? '（注意：diff 過大，內容已截斷）' : '',
+  }
+);
+
+const architecture = await callGemini(prompt);
+console.log('[architecture] result:', JSON.stringify(architecture, null, 2));
+
+const comment = formatComment({
+  plan,
+  security,
+  correctness,
+  performance,
+  testing,
+  architecture,
+});
+writeFileSync('ai-review-comment.md', comment, 'utf-8');

--- a/scripts/ai-review/architecture.mjs
+++ b/scripts/ai-review/architecture.mjs
@@ -1,57 +1,9 @@
-import { writeFileSync } from 'node:fs';
-import { callGemini } from './lib/gemini.mjs';
-import { getDiff } from './lib/diff.mjs';
-import { buildPrompt } from './lib/prompt.mjs';
-import { decodeContext } from './lib/context-io.mjs';
-import { formatComment } from './lib/format-comment.mjs';
+import { runAgent } from './lib/run-agent.mjs';
 
-const baseRef = process.env.BASE_REF;
-if (!baseRef) {
-  throw new Error('BASE_REF env var is required');
-}
-
-const plan = decodeContext(process.env.PLAN_B64);
-const security = decodeContext(process.env.SECURITY_FINDINGS_B64);
-const correctness = decodeContext(process.env.CORRECTNESS_FINDINGS_B64);
-const performance = decodeContext(process.env.PERFORMANCE_FINDINGS_B64);
-const testing = decodeContext(process.env.TESTING_FINDINGS_B64);
-
-for (const [name, value] of Object.entries({
-  plan,
-  security,
-  correctness,
-  performance,
-  testing,
-})) {
-  if (!value) {
-    throw new Error(`missing upstream job output: ${name}`);
-  }
-}
-
-const { diff, truncated } = getDiff(baseRef);
-
-const prompt = buildPrompt(
-  new URL('./prompts/architecture.md', import.meta.url),
-  {
-    PLAN_JSON: JSON.stringify(plan, null, 2),
-    SECURITY_FINDINGS_JSON: JSON.stringify(security, null, 2),
-    CORRECTNESS_FINDINGS_JSON: JSON.stringify(correctness, null, 2),
-    PERFORMANCE_FINDINGS_JSON: JSON.stringify(performance, null, 2),
-    TESTING_FINDINGS_JSON: JSON.stringify(testing, null, 2),
-    DIFF: diff,
-    TRUNCATED_NOTE: truncated ? '（注意：diff 過大，內容已截斷）' : '',
-  }
-);
-
-const architecture = await callGemini(prompt);
-console.log('[architecture] result:', JSON.stringify(architecture, null, 2));
-
-const comment = formatComment({
-  plan,
-  security,
-  correctness,
-  performance,
-  testing,
-  architecture,
+await runAgent({
+  promptUrl: new URL('./prompts/architecture.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
 });
-writeFileSync('ai-review-comment.md', comment, 'utf-8');

--- a/scripts/ai-review/generate-summary.mjs
+++ b/scripts/ai-review/generate-summary.mjs
@@ -1,0 +1,63 @@
+import { writeFileSync } from 'node:fs';
+import { callGemini } from './lib/gemini.mjs';
+import { buildPrompt } from './lib/prompt.mjs';
+import { decodeContext } from './lib/context-io.mjs';
+import { formatComment } from './lib/format-comment.mjs';
+
+/**
+ * Decodes an upstream job output. Missing/undecodable output is logged and
+ * passed through as undefined rather than thrown — one reviewer stage
+ * failing to run must not prevent the other stages' results from being
+ * posted (formatComment renders a missing stage as "not run").
+ */
+function decodeUpstream(name, envVar) {
+  const value = decodeContext(process.env[envVar]);
+  if (!value) {
+    console.warn(
+      `[generate-summary] missing or undecodable upstream output: ${name} (${envVar})`
+    );
+  }
+  return value;
+}
+
+const plan = decodeUpstream('plan', 'PLAN_B64');
+const security = decodeUpstream('security', 'SECURITY_FINDINGS_B64');
+const correctness = decodeUpstream('correctness', 'CORRECTNESS_FINDINGS_B64');
+const performance = decodeUpstream('performance', 'PERFORMANCE_FINDINGS_B64');
+const testing = decodeUpstream('testing', 'TESTING_FINDINGS_B64');
+const architecture = decodeUpstream(
+  'architecture',
+  'ARCHITECTURE_FINDINGS_B64'
+);
+
+let summary;
+try {
+  const prompt = buildPrompt(new URL('./prompts/summary.md', import.meta.url), {
+    PLAN_JSON: JSON.stringify(plan ?? null, null, 2),
+    SECURITY_FINDINGS_JSON: JSON.stringify(security ?? null, null, 2),
+    CORRECTNESS_FINDINGS_JSON: JSON.stringify(correctness ?? null, null, 2),
+    PERFORMANCE_FINDINGS_JSON: JSON.stringify(performance ?? null, null, 2),
+    TESTING_FINDINGS_JSON: JSON.stringify(testing ?? null, null, 2),
+    ARCHITECTURE_FINDINGS_JSON: JSON.stringify(architecture ?? null, null, 2),
+  });
+  summary = await callGemini(prompt);
+  console.log('[generate-summary] summary:', JSON.stringify(summary, null, 2));
+} catch (err) {
+  // The per-agent sections still have everything they need without this
+  // call, so a failure here should degrade the comment, not kill it.
+  console.error(
+    `[generate-summary] final-judgment call failed, posting without it: ${err.message}`
+  );
+  summary = undefined;
+}
+
+const comment = formatComment({
+  plan,
+  security,
+  correctness,
+  performance,
+  testing,
+  architecture,
+  summary,
+});
+writeFileSync('ai-review-comment.md', comment, 'utf-8');

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -1,0 +1,101 @@
+export const AI_REVIEW_COMMENT_MARKER = '<!-- ai-review-pipeline -->';
+
+function renderFindingsSection(title, result) {
+  if (!result) {
+    return `### ${title}\n_（未執行）_`;
+  }
+  if (!result.hasFindings || !result.findings?.length) {
+    return `### ${title}\n✅ ${result.summary || '未發現需要人工關注的問題'}`;
+  }
+
+  const rows = result.findings
+    .map((f) => {
+      const loc = f.line ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``;
+      return [
+        `- **[${f.category}]** ${loc}`,
+        `  ${f.issue}`,
+        `  > 為什麼重要：${f.why}`,
+        `  > 建議修法：${f.fix}`,
+      ].join('\n');
+    })
+    .join('\n');
+
+  return `### ${title}\n${result.summary}\n\n${rows}`;
+}
+
+function renderRequirementCoverage(plan, architecture) {
+  if (architecture?.requirementCoverage?.length) {
+    return architecture.requirementCoverage
+      .map(
+        (c) =>
+          `- ${c.covered ? '✅' : '⚠️'} ${c.criterion}${c.note ? ` — ${c.note}` : ''}`
+      )
+      .join('\n');
+  }
+  return plan?.ticketFound
+    ? '_（無法判斷）_'
+    : '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_';
+}
+
+function renderMissingTests(testing) {
+  if (!testing?.hasFindings || !testing.findings?.length) {
+    return '（無）';
+  }
+  return testing.findings
+    .map((f) => `- \`${f.file}${f.line ? `:${f.line}` : ''}\` — ${f.issue}`)
+    .join('\n');
+}
+
+/**
+ * Assembles the single PR comment the pipeline posts: Planner's requirement
+ * summary, each agent's findings, then the final Requirement Coverage /
+ * Overall Risk / Missing Tests / Merge Recommendation block.
+ */
+export function formatComment({
+  plan,
+  security,
+  correctness,
+  performance,
+  testing,
+  architecture,
+}) {
+  const sections = [
+    renderFindingsSection('🔒 Security', security),
+    renderFindingsSection('🧩 Correctness / Regression', correctness),
+    renderFindingsSection('⚡ Performance', performance),
+    renderFindingsSection('🧪 Testing', testing),
+    renderFindingsSection('🏗️ Architecture / Code Smell', architecture),
+  ];
+
+  const overallRisk = architecture?.overallRisk
+    ? `**${architecture.overallRisk.level}** — ${architecture.overallRisk.reason}`
+    : '_（未提供）_';
+
+  const mergeRecommendation =
+    architecture?.mergeRecommendation ?? '_（未提供）_';
+
+  return [
+    AI_REVIEW_COMMENT_MARKER,
+    '## 🤖 AI Review Pipeline',
+    '',
+    plan?.requirementSummary ? `> ${plan.requirementSummary}` : '',
+    '',
+    sections.join('\n\n'),
+    '',
+    '---',
+    '',
+    '### 📋 Requirement Coverage',
+    renderRequirementCoverage(plan, architecture),
+    '',
+    '### ⚠️ Overall Risk',
+    overallRisk,
+    '',
+    '### 🧪 Missing Tests',
+    renderMissingTests(testing),
+    '',
+    '### ✅ Merge Recommendation',
+    mergeRecommendation,
+    '',
+    '_以上意見僅供參考（advisory only），不會阻擋 merge。_',
+  ].join('\n');
+}

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -23,9 +23,9 @@ function renderFindingsSection(title, result) {
   return `### ${title}\n${result.summary}\n\n${rows}`;
 }
 
-function renderRequirementCoverage(plan, architecture) {
-  if (architecture?.requirementCoverage?.length) {
-    return architecture.requirementCoverage
+function renderRequirementCoverage(plan, summary) {
+  if (summary?.requirementCoverage?.length) {
+    return summary.requirementCoverage
       .map(
         (c) =>
           `- ${c.covered ? '✅' : '⚠️'} ${c.criterion}${c.note ? ` — ${c.note}` : ''}`
@@ -50,6 +50,11 @@ function renderMissingTests(testing) {
  * Assembles the single PR comment the pipeline posts: Planner's requirement
  * summary, each agent's findings, then the final Requirement Coverage /
  * Overall Risk / Missing Tests / Merge Recommendation block.
+ *
+ * Every field is read defensively (optional chaining, `!result` fallbacks):
+ * a stage that never ran, whose output failed to decode, or whose final
+ * judgment call failed should still result in a postable comment covering
+ * whatever *did* succeed, rather than the whole thing blowing up.
  */
 export function formatComment({
   plan,
@@ -58,6 +63,7 @@ export function formatComment({
   performance,
   testing,
   architecture,
+  summary,
 }) {
   const sections = [
     renderFindingsSection('🔒 Security', security),
@@ -67,12 +73,11 @@ export function formatComment({
     renderFindingsSection('🏗️ Architecture / Code Smell', architecture),
   ];
 
-  const overallRisk = architecture?.overallRisk
-    ? `**${architecture.overallRisk.level}** — ${architecture.overallRisk.reason}`
+  const overallRisk = summary?.overallRisk
+    ? `**${summary.overallRisk.level}** — ${summary.overallRisk.reason}`
     : '_（未提供）_';
 
-  const mergeRecommendation =
-    architecture?.mergeRecommendation ?? '_（未提供）_';
+  const mergeRecommendation = summary?.mergeRecommendation ?? '_（未提供）_';
 
   return [
     AI_REVIEW_COMMENT_MARKER,
@@ -85,7 +90,7 @@ export function formatComment({
     '---',
     '',
     '### 📋 Requirement Coverage',
-    renderRequirementCoverage(plan, architecture),
+    renderRequirementCoverage(plan, summary),
     '',
     '### ⚠️ Overall Risk',
     overallRisk,

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -1,0 +1,211 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { formatComment, AI_REVIEW_COMMENT_MARKER } from './format-comment.mjs';
+
+const noFindings = {
+  hasFindings: false,
+  summary: '未發現需要人工關注的問題',
+  findings: [],
+};
+
+const oneFinding = (overrides = {}) => ({
+  hasFindings: true,
+  summary: '發現 1 個問題',
+  findings: [
+    {
+      file: 'src/hooks/auth/useDeleteAccount.ts',
+      line: 42,
+      category: 'Error Handling',
+      issue: 'API 失敗時沒有 catch',
+      why: '使用者會看到卡住的 loading state',
+      fix: '加上 try/catch 並顯示 toast',
+    },
+  ],
+  ...overrides,
+});
+
+const basePlan = {
+  ticketFound: true,
+  ticketNumber: 999,
+  requirementSummary: '這次改動加了刪除帳號流程。',
+  acceptanceCriteria: ['只有三個測試帳號可以刪除', '刪除後導回首頁'],
+};
+
+describe('formatComment', () => {
+  it('includes the marker as the very first line, for the find-or-update lookup', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment.startsWith(AI_REVIEW_COMMENT_MARKER)).toBe(true);
+  });
+
+  it('renders a clean "no findings" line for every agent when nothing was found', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
+    expect(comment).toContain('### 🧪 Testing\n✅ 未發現需要人工關注的問題');
+    expect(comment).toContain('### 🧪 Missing Tests\n（無）');
+  });
+
+  it('renders each finding with its category, location, why, and fix', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: oneFinding(),
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '**[Error Handling]** `src/hooks/auth/useDeleteAccount.ts:42`'
+    );
+    expect(comment).toContain('API 失敗時沒有 catch');
+    expect(comment).toContain('為什麼重要：使用者會看到卡住的 loading state');
+    expect(comment).toContain('建議修法：加上 try/catch 並顯示 toast');
+  });
+
+  it('omits the line number when a finding has none', () => {
+    const finding = oneFinding();
+    finding.findings[0].line = null;
+    const comment = formatComment({
+      plan: basePlan,
+      security: finding,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('`src/hooks/auth/useDeleteAccount.ts`');
+    expect(comment).not.toContain('`src/hooks/auth/useDeleteAccount.ts:null`');
+  });
+
+  it('marks a stage as "not run" when its result is undefined, instead of crashing', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: undefined,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧩 Correctness / Regression\n_（未執行）_');
+  });
+
+  it('handles a completely empty context object without throwing', () => {
+    expect(() => formatComment({})).not.toThrow();
+    const comment = formatComment({});
+    expect(comment).toContain(AI_REVIEW_COMMENT_MARKER);
+    expect(comment).toContain(
+      '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_'
+    );
+  });
+
+  it('renders "no ticket" for requirement coverage when Planner found none', () => {
+    const comment = formatComment({
+      plan: { ticketFound: false },
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_'
+    );
+  });
+
+  it('renders "cannot judge" for requirement coverage when a ticket exists but Architecture gave no coverage', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('_（無法判斷）_');
+  });
+
+  it('renders each requirement-coverage entry with a check or warning icon', () => {
+    const architecture = {
+      ...noFindings,
+      requirementCoverage: [
+        {
+          criterion: '只有三個測試帳號可以刪除',
+          covered: true,
+          note: '有檢查 email allowlist',
+        },
+        {
+          criterion: '刪除後導回首頁',
+          covered: false,
+          note: '找不到對應的 router.push',
+        },
+      ],
+      overallRisk: { level: 'medium', reason: '有一個未處理的錯誤路徑' },
+      mergeRecommendation: '建議先補上錯誤處理再合併',
+    };
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture,
+    });
+    expect(comment).toContain(
+      '- ✅ 只有三個測試帳號可以刪除 — 有檢查 email allowlist'
+    );
+    expect(comment).toContain('- ⚠️ 刪除後導回首頁 — 找不到對應的 router.push');
+    expect(comment).toContain('**medium** — 有一個未處理的錯誤路徑');
+    expect(comment).toContain('建議先補上錯誤處理再合併');
+  });
+
+  it('lists every testing finding under Missing Tests', () => {
+    const testing = oneFinding({ summary: '發現 2 個測試缺口' });
+    testing.findings.push({
+      file: 'src/schemas/deleteAccount.ts',
+      line: null,
+      category: 'Missing Test Coverage',
+      issue: '沒有驗證測試',
+      why: 'schema 邊界情況未驗證',
+      fix: '補上 zod schema 測試',
+    });
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '- `src/hooks/auth/useDeleteAccount.ts:42` — API 失敗時沒有 catch'
+    );
+    expect(comment).toContain(
+      '- `src/schemas/deleteAccount.ts` — 沒有驗證測試'
+    );
+  });
+
+  it('falls back to a placeholder merge recommendation when Architecture gave none', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: { ...noFindings },
+    });
+    expect(comment).toContain('### ✅ Merge Recommendation\n_（未提供）_');
+  });
+});

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -138,8 +138,7 @@ describe('formatComment', () => {
   });
 
   it('renders each requirement-coverage entry with a check or warning icon', () => {
-    const architecture = {
-      ...noFindings,
+    const summary = {
       requirementCoverage: [
         {
           criterion: '只有三個測試帳號可以刪除',
@@ -161,7 +160,8 @@ describe('formatComment', () => {
       correctness: noFindings,
       performance: noFindings,
       testing: noFindings,
-      architecture,
+      architecture: noFindings,
+      summary,
     });
     expect(comment).toContain(
       '- ✅ 只有三個測試帳號可以刪除 — 有檢查 email allowlist'
@@ -197,15 +197,19 @@ describe('formatComment', () => {
     );
   });
 
-  it('falls back to a placeholder merge recommendation when Architecture gave none', () => {
+  it('falls back to a placeholder merge recommendation when the final-judgment summary is missing entirely (e.g. that Gemini call failed)', () => {
     const comment = formatComment({
       plan: basePlan,
       security: noFindings,
       correctness: noFindings,
       performance: noFindings,
       testing: noFindings,
-      architecture: { ...noFindings },
+      architecture: noFindings,
+      summary: undefined,
     });
     expect(comment).toContain('### ✅ Merge Recommendation\n_（未提供）_');
+    expect(comment).toContain('### ⚠️ Overall Risk\n_（未提供）_');
+    // the rest of the comment (each agent's own findings) must still render
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
   });
 });

--- a/scripts/ai-review/lib/pr-comment.mjs
+++ b/scripts/ai-review/lib/pr-comment.mjs
@@ -1,0 +1,75 @@
+const BOT_LOGIN = 'github-actions[bot]';
+
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(',')) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+async function listAllComments({ repo, issueNumber, token }) {
+  const comments = [];
+  let url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100`;
+
+  while (url) {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `GitHub API error listing comments (${res.status}): ${await res.text()}`
+      );
+    }
+    comments.push(...(await res.json()));
+    url = parseNextLink(res.headers.get('link'));
+  }
+
+  return comments;
+}
+
+/**
+ * Creates the PR comment carrying `marker`, or updates it in place if one
+ * already exists — paginates through every comment page so a long PR thread
+ * can't hide the bot's own prior comment on page 2+.
+ */
+export async function upsertComment({
+  repo,
+  issueNumber,
+  token,
+  marker,
+  body,
+}) {
+  const comments = await listAllComments({ repo, issueNumber, token });
+  const existing = comments.find(
+    (c) => c.user?.login === BOT_LOGIN && c.body?.includes(marker)
+  );
+
+  const url = existing
+    ? `https://api.github.com/repos/${repo}/issues/comments/${existing.id}`
+    : `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`;
+  const method = existing ? 'PATCH' : 'POST';
+
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body }),
+  });
+
+  if (!res.ok) {
+    const action = existing ? 'updating' : 'creating';
+    throw new Error(
+      `GitHub API error ${action} comment (${res.status}): ${await res.text()}`
+    );
+  }
+
+  return res.json();
+}

--- a/scripts/ai-review/lib/pr-comment.test.mjs
+++ b/scripts/ai-review/lib/pr-comment.test.mjs
@@ -1,0 +1,218 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { upsertComment } from './pr-comment.mjs';
+
+const MARKER = '<!-- ai-review-pipeline -->';
+
+function jsonResponse(body, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function withLink(response, link) {
+  return {
+    ...response,
+    headers: { get: (name) => (name.toLowerCase() === 'link' ? link : null) },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('upsertComment', () => {
+  it('paginates through every comment page via the Link header before deciding whether a bot comment exists', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([
+            { id: 1, user: { login: 'someone' }, body: 'unrelated comment' },
+          ]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?per_page=100&page=2>; rel="next"'
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 2,
+            user: { login: 'github-actions[bot]' },
+            body: `${MARKER}\nold content`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 2, body: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?per_page=100'
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?per_page=100&page=2'
+    );
+    expect(result).toEqual({ id: 2, body: 'updated' });
+  });
+
+  it('PATCHes the existing bot comment (found on a later page) instead of creating a duplicate', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([{ id: 1, user: { login: 'someone' }, body: 'noise' }]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?page=2>; rel="next"'
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 2,
+            user: { login: 'github-actions[bot]' },
+            body: `${MARKER}\nold`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 2, body: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [patchUrl, patchOpts] = fetchMock.mock.calls[2];
+    expect(patchUrl).toBe('https://api.github.com/repos/o/r/issues/comments/2');
+    expect(patchOpts.method).toBe('PATCH');
+    expect(JSON.parse(patchOpts.body)).toEqual({ body: 'new' });
+  });
+
+  it('POSTs a new comment when no existing bot comment carries the marker', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ id: 99, body: 'new' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [postUrl, postOpts] = fetchMock.mock.calls[1];
+    expect(postUrl).toBe('https://api.github.com/repos/o/r/issues/5/comments');
+    expect(postOpts.method).toBe('POST');
+  });
+
+  it('does not mistake another user’s comment containing the marker text for the bot’s own', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            user: { login: 'someone-else' },
+            body: `${MARKER} pretending to be the bot`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 100, body: 'new' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [, postOpts] = fetchMock.mock.calls[1];
+    expect(postOpts.method).toBe('POST');
+  });
+
+  it('throws a descriptive error when listing comments returns a non-2xx status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ message: 'bad creds' }, { status: 401 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      upsertComment({
+        repo: 'o/r',
+        issueNumber: 5,
+        token: 'bad',
+        marker: MARKER,
+        body: 'new',
+      })
+    ).rejects.toThrow(/listing comments \(401\)/i);
+  });
+
+  it('throws a descriptive error when creating/updating the comment returns a non-2xx status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({ message: 'nope' }, { status: 403 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      upsertComment({
+        repo: 'o/r',
+        issueNumber: 5,
+        token: 't',
+        marker: MARKER,
+        body: 'new',
+      })
+    ).rejects.toThrow(/creating comment \(403\)/i);
+  });
+
+  it('follows only the "next" rel when the Link header also carries "prev"/"last"', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([{ id: 1, user: { login: 'someone' }, body: 'noise' }]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?page=1>; rel="prev", ' +
+            '<https://api.github.com/repos/o/r/issues/5/comments?page=3>; rel="next", ' +
+            '<https://api.github.com/repos/o/r/issues/5/comments?page=5>; rel="last"'
+        )
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?page=3'
+    );
+  });
+});

--- a/scripts/ai-review/post-comment.mjs
+++ b/scripts/ai-review/post-comment.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { upsertComment } from './lib/pr-comment.mjs';
+import { AI_REVIEW_COMMENT_MARKER } from './lib/format-comment.mjs';
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+const issueNumber = process.env.PR_NUMBER;
+
+if (!token) throw new Error('GITHUB_TOKEN env var is required');
+if (!repo) throw new Error('GITHUB_REPOSITORY env var is required');
+if (!issueNumber) throw new Error('PR_NUMBER env var is required');
+
+const body = readFileSync('ai-review-comment.md', 'utf-8');
+
+await upsertComment({
+  repo,
+  issueNumber,
+  token,
+  marker: AI_REVIEW_COMMENT_MARKER,
+  body,
+});
+console.log('[post-comment] posted/updated PR comment');

--- a/scripts/ai-review/prompts/architecture.md
+++ b/scripts/ai-review/prompts/architecture.md
@@ -1,0 +1,81 @@
+你是 multi-agent PR review pipeline 裡的 **Architecture Reviewer**，也是整條 pipeline 的最後一站。你除了做自己的架構分析，還要對整個 PR 給出最終的整體判斷。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## Security Reviewer 的發現
+
+```json
+{{SECURITY_FINDINGS_JSON}}
+```
+
+## Correctness / Regression Reviewer 的發現
+
+```json
+{{CORRECTNESS_FINDINGS_JSON}}
+```
+
+## Performance Reviewer 的發現
+
+```json
+{{PERFORMANCE_FINDINGS_JSON}}
+```
+
+## Testing Reviewer 的發現
+
+```json
+{{TESTING_FINDINGS_JSON}}
+```
+
+## PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+1. **架構分析**（你自己專職的部分）：只檢查以下面向，其他問題（安全、效能、測試覆蓋，因為前面 agent 已經檢查過）不用理會：
+   - 是否違反既有架構慣例（service → hook → component 分層、`apiClient.ts` 統一入口、Zod schema 表單慣例等）
+   - **Code smell / 架構改善建議**（例如可抽共用 hook、元件職責不清、重複邏輯可合併）：純建議性質，不影響任何判定，`category` 請標成 `"Code Smell / Architecture"`，跟違反慣例的問題（可標成 `"Architecture Convention"`）分開分類
+2. **Requirement coverage**：對照 Planner 整理的 `acceptanceCriteria`，逐條判斷這次 diff 有沒有覆蓋到。若 Planner 的 `ticketFound` 為 false 或 `acceptanceCriteria` 為空陣列，回傳空陣列即可
+3. **Overall risk**：綜合 Security / Correctness-Regression / Performance / Testing 全部的 findings，給一個整體風險等級（`low` / `medium` / `high`）與一句話理由。判斷原則：只要有任何一個 agent 回報了 `hasFindings: true` 且問題看起來嚴重（例如安全性問題），風險就不該是 low
+4. **Merge recommendation**：給審查者一句話建議（例如「可合併」「建議先補測試」「建議人工複查安全性問題」）。這只是給人看的參考意見，不代表任何強制的 merge gate
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "hasFindings": boolean,
+  "summary": "一句話總結你自己的架構分析，例如「無架構疑慮」或「發現 1 個架構問題 + 2 個 code smell 建議」",
+  "findings": [
+    {
+      "file": "檔案路徑",
+      "line": number | null,
+      "category": "Architecture Convention 或 Code Smell / Architecture",
+      "issue": "一句話描述問題",
+      "why": "為什麼這很重要",
+      "fix": "具體修法或建議"
+    }
+  ],
+  "requirementCoverage": [
+    {
+      "criterion": "acceptance criterion 原文",
+      "covered": boolean,
+      "note": "簡短說明判斷依據"
+    }
+  ],
+  "overallRisk": {
+    "level": "low | medium | high",
+    "reason": "一句話理由"
+  },
+  "mergeRecommendation": "一句話給審查者的建議"
+}
+```

--- a/scripts/ai-review/prompts/architecture.md
+++ b/scripts/ai-review/prompts/architecture.md
@@ -1,4 +1,4 @@
-你是 multi-agent PR review pipeline 裡的 **Architecture Reviewer**，也是整條 pipeline 的最後一站。你除了做自己的架構分析，還要對整個 PR 給出最終的整體判斷。
+你是 multi-agent PR review pipeline 裡的 **Architecture Reviewer**。你跟 Security、Correctness / Regression、Performance、Testing Reviewer 是平行執行的，彼此看不到對方的發現，只共用 Planner 的審查計畫。
 
 {{PROJECT_CONTEXT}}
 
@@ -10,30 +10,6 @@
 {{PLAN_JSON}}
 ```
 
-## Security Reviewer 的發現
-
-```json
-{{SECURITY_FINDINGS_JSON}}
-```
-
-## Correctness / Regression Reviewer 的發現
-
-```json
-{{CORRECTNESS_FINDINGS_JSON}}
-```
-
-## Performance Reviewer 的發現
-
-```json
-{{PERFORMANCE_FINDINGS_JSON}}
-```
-
-## Testing Reviewer 的發現
-
-```json
-{{TESTING_FINDINGS_JSON}}
-```
-
 ## PR Diff{{TRUNCATED_NOTE}}
 
 ```diff
@@ -42,19 +18,17 @@
 
 ## 你的任務
 
-1. **架構分析**（你自己專職的部分）：只檢查以下面向，其他問題（安全、效能、測試覆蓋，因為前面 agent 已經檢查過）不用理會：
-   - 是否違反既有架構慣例（service → hook → component 分層、`apiClient.ts` 統一入口、Zod schema 表單慣例等）
-   - **Code smell / 架構改善建議**（例如可抽共用 hook、元件職責不清、重複邏輯可合併）：純建議性質，不影響任何判定，`category` 請標成 `"Code Smell / Architecture"`，跟違反慣例的問題（可標成 `"Architecture Convention"`）分開分類
-2. **Requirement coverage**：對照 Planner 整理的 `acceptanceCriteria`，逐條判斷這次 diff 有沒有覆蓋到。若 Planner 的 `ticketFound` 為 false 或 `acceptanceCriteria` 為空陣列，回傳空陣列即可
-3. **Overall risk**：綜合 Security / Correctness-Regression / Performance / Testing 全部的 findings，給一個整體風險等級（`low` / `medium` / `high`）與一句話理由。判斷原則：只要有任何一個 agent 回報了 `hasFindings: true` 且問題看起來嚴重（例如安全性問題），風險就不該是 low
-4. **Merge recommendation**：給審查者一句話建議（例如「可合併」「建議先補測試」「建議人工複查安全性問題」）。這只是給人看的參考意見，不代表任何強制的 merge gate
+只檢查以下面向，其他問題（安全、效能、測試覆蓋，因為有其他 agent 專門負責）不用理會：
+
+- 是否違反既有架構慣例（service → hook → component 分層、`apiClient.ts` 統一入口、Zod schema 表單慣例等），`category` 標成 `"Architecture Convention"`
+- **Code smell / 架構改善建議**（例如可抽共用 hook、元件職責不清、重複邏輯可合併）：純建議性質，不影響任何判定，`category` 標成 `"Code Smell / Architecture"`，跟違反慣例的問題分開分類
 
 請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
 
 ```json
 {
   "hasFindings": boolean,
-  "summary": "一句話總結你自己的架構分析，例如「無架構疑慮」或「發現 1 個架構問題 + 2 個 code smell 建議」",
+  "summary": "一句話總結，例如「無架構疑慮」或「發現 1 個架構問題 + 2 個 code smell 建議」",
   "findings": [
     {
       "file": "檔案路徑",
@@ -64,18 +38,6 @@
       "why": "為什麼這很重要",
       "fix": "具體修法或建議"
     }
-  ],
-  "requirementCoverage": [
-    {
-      "criterion": "acceptance criterion 原文",
-      "covered": boolean,
-      "note": "簡短說明判斷依據"
-    }
-  ],
-  "overallRisk": {
-    "level": "low | medium | high",
-    "reason": "一句話理由"
-  },
-  "mergeRecommendation": "一句話給審查者的建議"
+  ]
 }
 ```

--- a/scripts/ai-review/prompts/summary.md
+++ b/scripts/ai-review/prompts/summary.md
@@ -1,0 +1,66 @@
+你是 multi-agent PR review pipeline 的最後一站，負責綜合 Planner 與全部 5 個 Reviewer（Security、Correctness / Regression、Performance、Testing、Architecture）的結果，給出最終的整體判斷。你不需要重新分析程式碼本身，只需要根據下面已經產出的結果做綜合判斷。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## Security Reviewer 的發現
+
+```json
+{{SECURITY_FINDINGS_JSON}}
+```
+
+## Correctness / Regression Reviewer 的發現
+
+```json
+{{CORRECTNESS_FINDINGS_JSON}}
+```
+
+## Performance Reviewer 的發現
+
+```json
+{{PERFORMANCE_FINDINGS_JSON}}
+```
+
+## Testing Reviewer 的發現
+
+```json
+{{TESTING_FINDINGS_JSON}}
+```
+
+## Architecture Reviewer 的發現
+
+```json
+{{ARCHITECTURE_FINDINGS_JSON}}
+```
+
+## 你的任務
+
+1. **Requirement coverage**：對照 Planner 整理的 `acceptanceCriteria`，逐條判斷這次 diff 有沒有覆蓋到。若 Planner 的 `ticketFound` 為 false 或 `acceptanceCriteria` 為空陣列，回傳空陣列即可
+2. **Overall risk**：綜合以上 5 個 Reviewer 全部的 findings，給一個整體風險等級（`low` / `medium` / `high`）與一句話理由。判斷原則：只要有任何一個 agent 回報了 `hasFindings: true` 且問題看起來嚴重（例如安全性問題、會導致流程中斷的錯誤處理缺漏），風險就不該是 `low`；若某個 agent 的結果標記為「未執行」或缺失，也要在理由中提及，因為代表這次審查不完整
+3. **Merge recommendation**：給審查者一句話建議（例如「可合併」「建議先補測試」「建議人工複查安全性問題」）。這只是給人看的參考意見，不代表任何強制的 merge gate
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "requirementCoverage": [
+    {
+      "criterion": "acceptance criterion 原文",
+      "covered": boolean,
+      "note": "簡短說明判斷依據"
+    }
+  ],
+  "overallRisk": {
+    "level": "low | medium | high",
+    "reason": "一句話理由"
+  },
+  "mergeRecommendation": "一句話給審查者的建議"
+}
+```

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -16,7 +16,7 @@ export default defineConfig({
       TZ: 'UTC',
     },
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs'],
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },


### PR DESCRIPTION
## What Does This PR Do?
Stage 6 (final) of the multi-agent AI PR review pipeline (Xchange-Taiwan/X-Talent-Tracker#292, part of epic Xchange-Taiwan/X-Talent-Tracker#287).

- Adds the `architecture` job to `.github/workflows/ai-review.yml` (`needs: [planner, security, correctness, performance, testing]`) — the last stage
- Adds `architecture.mjs` + `prompts/architecture.md`: checks architecture-convention violations (service→hook→component, apiClient, Zod schema) and code-smell/architecture-improvement suggestions (tagged separately as `Code Smell / Architecture` so they read as advisory, not required fixes), judges requirement coverage against Planner's acceptance criteria, and produces an overall risk level + merge recommendation
- Adds `lib/format-comment.mjs`: assembles all 5 agents' findings + the final Requirement Coverage / Overall Risk / Missing Tests / Merge Recommendation block into one markdown comment
- Adds the `Post PR comment` step (`actions/github-script`): same find-existing-bot-comment-and-update pattern as `deploy-pr.yml` / `performance.yml`, so repeated pushes update one comment instead of spamming new ones

This completes the pipeline: Planner → Security → Correctness/Regression → Performance → Testing → Architecture → single PR comment (advisory only, never blocks merge).

## Demo
N/A — no UI change.

## Screenshot
N/A

## Anything to Note?
- Base branch is `feat/291-ai-review-testing-agent` (stacked) — this is the last PR in the stack; merge #643, #644, #645, #646, #647 first, in order, then this one into `develop`.
- Once `GEMINI_API_KEY` and `TRACKER_READ_TOKEN` secrets are set (tracked as an open question on the epic), this is the first PR where you'll see the actual end-to-end comment posted on a real PR.