### PR TITLE
feat: AI Review Pipeline — Review Guide Agent

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -191,8 +191,46 @@ jobs:
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/architecture.mjs
 
+  review_guide:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Review Guide'
+    outputs:
+      guide: ${{ steps.run.outputs.guide }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run review-guide agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/review-guide.mjs
+
   summary:
-    needs: [planner, security, correctness, performance, testing, architecture]
+    needs:
+      [
+        planner,
+        security,
+        correctness,
+        performance,
+        testing,
+        architecture,
+        review_guide,
+      ]
     runs-on: ubuntu-latest
     name: 'AI Review: Final Summary'
     steps:
@@ -216,6 +254,7 @@ jobs:
           PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
           TESTING_FINDINGS_B64: ${{ needs.testing.outputs.findings }}
           ARCHITECTURE_FINDINGS_B64: ${{ needs.architecture.outputs.findings }}
+          REVIEW_GUIDE_B64: ${{ needs.review_guide.outputs.guide }}
         run: node scripts/ai-review/generate-summary.mjs
 
       - name: Post PR comment

--- a/scripts/ai-review/generate-summary.mjs
+++ b/scripts/ai-review/generate-summary.mjs
@@ -29,6 +29,7 @@ const architecture = decodeUpstream(
   'architecture',
   'ARCHITECTURE_FINDINGS_B64'
 );
+const reviewGuide = decodeUpstream('reviewGuide', 'REVIEW_GUIDE_B64');
 
 let summary;
 try {
@@ -53,6 +54,7 @@ try {
 
 const comment = formatComment({
   plan,
+  reviewGuide,
   security,
   correctness,
   performance,

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -46,8 +46,31 @@ function renderMissingTests(testing) {
     .join('\n');
 }
 
+function renderReviewGuide(reviewGuide) {
+  if (!reviewGuide) {
+    return null;
+  }
+
+  const order = reviewGuide.readingOrder?.length
+    ? reviewGuide.readingOrder
+        .slice()
+        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+        .map((f) => `${f.order}. \`${f.file}\` — ${f.why}`)
+        .join('\n')
+    : null;
+
+  return [
+    '### 🧭 Review Guide',
+    reviewGuide.overview ?? '',
+    order ? '\n**建議閱讀順序：**\n' + order : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
 /**
- * Assembles the single PR comment the pipeline posts: Planner's requirement
+ * Assembles the single PR comment the pipeline posts: a review guide
+ * (overview + suggested reading order) up top, Planner's requirement
  * summary, each agent's findings, then the final Requirement Coverage /
  * Overall Risk / Missing Tests / Merge Recommendation block.
  *
@@ -58,6 +81,7 @@ function renderMissingTests(testing) {
  */
 export function formatComment({
   plan,
+  reviewGuide,
   security,
   correctness,
   performance,
@@ -78,12 +102,17 @@ export function formatComment({
     : '_（未提供）_';
 
   const mergeRecommendation = summary?.mergeRecommendation ?? '_（未提供）_';
+  const guideSection = renderReviewGuide(reviewGuide);
 
   return [
     AI_REVIEW_COMMENT_MARKER,
     '## 🤖 AI Review Pipeline',
     '',
     plan?.requirementSummary ? `> ${plan.requirementSummary}` : '',
+    '',
+    guideSection ?? '### 🧭 Review Guide\n_（未執行）_',
+    '',
+    '---',
     '',
     sections.join('\n\n'),
     '',

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -51,13 +51,14 @@ function renderReviewGuide(reviewGuide) {
     return null;
   }
 
-  const order = reviewGuide.readingOrder?.length
-    ? reviewGuide.readingOrder
-        .slice()
-        .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
-        .map((f) => `${f.order}. \`${f.file}\` — ${f.why}`)
-        .join('\n')
-    : null;
+  const order =
+    Array.isArray(reviewGuide.readingOrder) && reviewGuide.readingOrder.length
+      ? reviewGuide.readingOrder
+          .slice()
+          .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+          .map((f) => `${f.order}. \`${f.file}\` — ${f.why}`)
+          .join('\n')
+      : null;
 
   return [
     '### 🧭 Review Guide',

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -212,4 +212,52 @@ describe('formatComment', () => {
     // the rest of the comment (each agent's own findings) must still render
     expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
   });
+
+  it('renders the review guide overview and reading order, sorted by the declared order field', () => {
+    const reviewGuide = {
+      overview: '這次變更把 X 功能拆成三層。',
+      readingOrder: [
+        {
+          file: 'src/components/Foo.tsx',
+          order: 3,
+          why: '最後看畫面怎麼消費資料',
+        },
+        { file: 'src/schemas/foo.ts', order: 1, why: '先看資料形狀' },
+        { file: 'src/hooks/useFoo.ts', order: 2, why: '再看怎麼用 schema' },
+      ],
+    };
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+
+    expect(comment).toContain('### 🧭 Review Guide');
+    expect(comment).toContain('這次變更把 X 功能拆成三層。');
+
+    const order1 = comment.indexOf('1. `src/schemas/foo.ts`');
+    const order2 = comment.indexOf('2. `src/hooks/useFoo.ts`');
+    const order3 = comment.indexOf('3. `src/components/Foo.tsx`');
+    expect(order1).toBeGreaterThan(-1);
+    expect(order1).toBeLessThan(order2);
+    expect(order2).toBeLessThan(order3);
+  });
+
+  it('renders a "not run" placeholder for the review guide when it is missing, without affecting the rest of the comment', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide: undefined,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧭 Review Guide\n_（未執行）_');
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
+  });
 });

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -260,4 +260,35 @@ describe('formatComment', () => {
     expect(comment).toContain('### 🧭 Review Guide\n_（未執行）_');
     expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
   });
+
+  it('does not crash when the LLM returns readingOrder as a non-array (e.g. a string) instead of following the schema', () => {
+    const reviewGuide = {
+      overview: '這次變更把 X 功能拆成三層。',
+      readingOrder: 'src/schemas/foo.ts, src/hooks/useFoo.ts',
+    };
+
+    expect(() =>
+      formatComment({
+        plan: basePlan,
+        reviewGuide,
+        security: noFindings,
+        correctness: noFindings,
+        performance: noFindings,
+        testing: noFindings,
+        architecture: noFindings,
+      })
+    ).not.toThrow();
+
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('這次變更把 X 功能拆成三層。');
+    expect(comment).not.toContain('建議閱讀順序');
+  });
 });

--- a/scripts/ai-review/prompts/review-guide.md
+++ b/scripts/ai-review/prompts/review-guide.md
@@ -1,0 +1,42 @@
+你是 multi-agent PR review pipeline 裡的 **Review Guide**。你的工作不是找 bug，而是幫真人 reviewer 節省「打開一堆檔案卻不知道從哪看起」的時間。你跟 Security、Correctness / Regression、Performance、Testing、Architecture Reviewer 是平行執行的，彼此看不到對方的發現，只共用 Planner 的審查計畫。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+1. **Overview**：用一段話（2-4 句）總結這次變更的整體樣貌，讓 reviewer 在看任何檔案之前，先在腦中建立一個「這次改動大概長怎樣」的心智模型
+2. **Reading order**：把這次 diff 觸碰到的檔案排出建議的閱讀順序，並為每個檔案寫一句話理由。排序原則：
+   - 先看「定義資料形狀/約定」的檔案（例如 type、schema、interface），再看「使用它們」的檔案（hook、service），最後看「呈現」的檔案（component、UI）
+   - 如果有共用的 helper/util 被多處呼叫，通常也適合排在前面
+   - 設定檔、workflow YAML、測試檔通常適合排在最後，除非測試本身就是最能說明這次改動意圖的地方
+   - 每個理由要具體到「看這個檔案時應該注意什麼」，而不是空泛的「這是核心邏輯」
+   - 不用把每個檔案都硬湊一個很長的理由，簡短、有資訊量就好
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "overview": "2-4 句話，總結這次變更的整體樣貌",
+  "readingOrder": [
+    {
+      "file": "檔案路徑",
+      "order": 1,
+      "why": "為什麼建議在這個順位看這個檔案、看的時候要注意什麼"
+    }
+  ]
+}
+```

--- a/scripts/ai-review/review-guide.mjs
+++ b/scripts/ai-review/review-guide.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/review-guide.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'guide',
+});


### PR DESCRIPTION
## What Does This PR Do?
New pipeline stage (Xchange-Taiwan/X-Talent-Tracker#294, part of epic Xchange-Taiwan/X-Talent-Tracker#287): a **Review Guide** agent that doesn't hunt for bugs — it exists purely to save a human reviewer the "which file do I even open first" problem.

- New `review_guide` job (`needs: planner`, parallel with Security/Correctness/Performance/Testing/Architecture — same shape, just a different job of work)
- `prompts/review-guide.md` + `review-guide.mjs`: produces an `overview` (2-4 sentences on the overall shape of the change) and a `readingOrder` (files ranked with a short reason each — schema before the hook that consumes it, before the component that renders it, config/tests usually last)
- `generate-summary.mjs` decodes this alongside the 5 findings outputs, same tolerant `decodeUpstream()` pattern — a missing guide degrades gracefully
- `format-comment.mjs` renders it at the very top of the comment, before any findings section, sorted by the declared reading order

## Demo
N/A — no UI change.

## Screenshot
N/A

## Anything to Note?
- Base branch is `feat/292-ai-review-architecture-agent` (stacked) — merge #643–#648 first, in order.
- Named the job `review_guide` (underscore), not `review-guide` — GitHub Actions expressions parse `-` as subtraction, so `needs.review-guide.outputs.guide` would silently misparse. Caught this before pushing.
- 2 new test cases added to `format-comment.test.mjs` (sorted rendering + "not run" fallback). `pnpm test`: 25 files / 193 tests.