### PR TITLE
feat(header): render header instantly via middleware session hint cookie

### DIFF
--- a/src/components/layout/Header/DisabledAwareLink.test.tsx
+++ b/src/components/layout/Header/DisabledAwareLink.test.tsx
@@ -1,0 +1,35 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { DisabledAwareLink } from './DisabledAwareLink';
+
+describe('DisabledAwareLink', () => {
+  it('renders a normal, focusable link when not disabled', () => {
+    render(
+      <DisabledAwareLink href="/profile/user-123">Profile</DisabledAwareLink>
+    );
+
+    const link = screen.getByRole('link', { name: 'Profile' });
+    expect(link).toHaveAttribute('href', '/profile/user-123');
+    expect(link).toHaveAttribute('aria-disabled', 'false');
+    expect(link).not.toHaveAttribute('tabindex', '-1');
+  });
+
+  it('renders inert — href, tabIndex, and click all neutralized — when disabled', () => {
+    const onClick = vi.fn();
+    render(
+      <DisabledAwareLink href="/profile/user-123" disabled onClick={onClick}>
+        Profile
+      </DisabledAwareLink>
+    );
+
+    const link = screen.getByRole('link', { name: 'Profile' });
+    expect(link).toHaveAttribute('href', '#');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+    expect(link).toHaveAttribute('tabindex', '-1');
+
+    const notPrevented = fireEvent.click(link);
+    expect(notPrevented).toBe(false);
+    expect(onClick).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/layout/Header/DisabledAwareLink.tsx
+++ b/src/components/layout/Header/DisabledAwareLink.tsx
@@ -21,12 +21,17 @@ export function DisabledAwareLink({
   href,
   onClick,
   className,
+  tabIndex,
   ...props
 }: DisabledAwareLinkProps): JSX.Element {
   return (
     <Link
       href={disabled ? '#' : href}
       aria-disabled={disabled}
+      // `href` keeps the element focusable even with pointer-events-none, so
+      // keyboard/screen-reader users would still tab onto an inert link
+      // without this — remove it from the tab order while disabled.
+      tabIndex={disabled ? -1 : tabIndex}
       onClick={
         disabled
           ? (e: MouseEvent<HTMLAnchorElement>) => e.preventDefault()

--- a/src/components/layout/Header/DisabledAwareLink.tsx
+++ b/src/components/layout/Header/DisabledAwareLink.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import Link from 'next/link';
+import type { ComponentProps, MouseEvent } from 'react';
+
+import { cn } from '@/lib/utils';
+
+export interface DisabledAwareLinkProps extends ComponentProps<typeof Link> {
+  /** While true, the link renders inert instead of navigating anywhere. */
+  disabled?: boolean;
+}
+
+/**
+ * A `next/link` that can be temporarily disabled without swapping in a
+ * placeholder destination (`/auth/signup`, `/`, …). Used while auth state is
+ * still resolving so a link's label can be shown correctly before it's safe
+ * to know where it should actually go.
+ */
+export function DisabledAwareLink({
+  disabled = false,
+  href,
+  onClick,
+  className,
+  ...props
+}: DisabledAwareLinkProps): JSX.Element {
+  return (
+    <Link
+      href={disabled ? '#' : href}
+      aria-disabled={disabled}
+      onClick={
+        disabled
+          ? (e: MouseEvent<HTMLAnchorElement>) => e.preventDefault()
+          : onClick
+      }
+      className={cn(className, disabled && 'pointer-events-none opacity-50')}
+      {...props}
+    />
+  );
+}

--- a/src/components/layout/Header/HamburgerMenu.test.tsx
+++ b/src/components/layout/Header/HamburgerMenu.test.tsx
@@ -1,0 +1,76 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { HamburgerMenu } from './HamburgerMenu';
+
+function openMenu(): void {
+  fireEvent.click(screen.getByRole('button', { name: '開啟導航選單' }));
+}
+
+describe('HamburgerMenu', () => {
+  it('disables "成為導師" while resolving a mentee user and does not close the sheet on click', () => {
+    render(
+      <HamburgerMenu
+        isLoggedIn
+        isMentor={false}
+        userId={undefined}
+        isResolvingUser
+      />
+    );
+    openMenu();
+
+    const link = screen.getByRole('link', { name: '成為導師' });
+    expect(link).toHaveAttribute('href', '#');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+
+    fireEvent.click(link);
+
+    // A disabled link must not run the `close` handler — the sheet stays open.
+    expect(screen.getByRole('link', { name: '成為導師' })).toBeInTheDocument();
+  });
+
+  it('disables "我的導師頁面" while resolving a mentor user, never falling back to "/"', () => {
+    render(
+      <HamburgerMenu isLoggedIn isMentor userId={undefined} isResolvingUser />
+    );
+    openMenu();
+
+    const link = screen.getByRole('link', { name: '我的導師頁面' });
+    expect(link).toHaveAttribute('href', '#');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('links to the real profile once userId has landed and isResolvingUser is false', () => {
+    render(
+      <HamburgerMenu
+        isLoggedIn
+        isMentor
+        userId="user-123"
+        isResolvingUser={false}
+      />
+    );
+    openMenu();
+
+    const link = screen.getByRole('link', { name: '我的導師頁面' });
+    expect(link).toHaveAttribute('href', '/profile/user-123');
+    expect(link).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('closes the sheet when a normal (non-disabled) link is clicked', () => {
+    render(
+      <HamburgerMenu
+        isLoggedIn
+        isMentor
+        userId="user-123"
+        isResolvingUser={false}
+      />
+    );
+    openMenu();
+
+    fireEvent.click(screen.getByRole('link', { name: '我的導師頁面' }));
+
+    expect(
+      screen.queryByRole('link', { name: '我的導師頁面' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -13,29 +13,31 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { trackEvent } from '@/lib/analytics';
-import { cn } from '@/lib/utils';
 
 import { FEEDBACK_FORM_URL } from './constants';
+import { DisabledAwareLink } from './DisabledAwareLink';
 
 export type HamburgerMenuProps = {
   isLoggedIn: boolean;
   isMentor: boolean;
   userId?: string;
+  /**
+   * Logged in per the fast session hint, but `userId` hasn't landed yet —
+   * owned by Header's `useAuthStatus()`, passed down rather than re-derived
+   * here so the two never drift out of sync.
+   */
+  isResolvingUser: boolean;
 };
 
 export function HamburgerMenu({
   isLoggedIn,
   isMentor,
   userId,
+  isResolvingUser,
 }: HamburgerMenuProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const close = (): void => setOpen(false);
 
-  // `isLoggedIn` can be true from the fast session hint before `userId` has
-  // loaded. During that window neither `/profile/${userId}` nor a
-  // signed-out fallback (`/`, `/auth/signup`) is correct, so the link is
-  // disabled instead of navigating anywhere.
-  const isResolvingUser = isLoggedIn && !userId;
   const profilePath = userId ? `/profile/${userId}` : '/';
   const becomeMentorPath = userId
     ? `/profile/${userId}/edit?onboarding=true`
@@ -67,29 +69,23 @@ export function HamburgerMenu({
             </Link>
 
             {isMentor ? (
-              <Link
-                href={isResolvingUser ? '#' : profilePath}
-                onClick={isResolvingUser ? (e) => e.preventDefault() : close}
-                aria-disabled={isResolvingUser}
-                className={cn(
-                  'text-black',
-                  isResolvingUser && 'pointer-events-none opacity-50'
-                )}
+              <DisabledAwareLink
+                href={profilePath}
+                onClick={close}
+                disabled={isResolvingUser}
+                className="text-black"
               >
                 我的導師頁面
-              </Link>
+              </DisabledAwareLink>
             ) : (
-              <Link
-                href={isResolvingUser ? '#' : becomeMentorPath}
-                onClick={isResolvingUser ? (e) => e.preventDefault() : close}
-                aria-disabled={isResolvingUser}
-                className={cn(
-                  'text-black',
-                  isResolvingUser && 'pointer-events-none opacity-50'
-                )}
+              <DisabledAwareLink
+                href={becomeMentorPath}
+                onClick={close}
+                disabled={isResolvingUser}
+                className="text-black"
               >
                 成為導師
-              </Link>
+              </DisabledAwareLink>
             )}
 
             <Link href="/about" onClick={close} className="text-black">

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -13,6 +13,7 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
 
 import { FEEDBACK_FORM_URL } from './constants';
 
@@ -30,10 +31,12 @@ export function HamburgerMenu({
   const [open, setOpen] = React.useState(false);
   const close = (): void => setOpen(false);
 
+  // `isLoggedIn` can be true from the fast session hint before `userId` has
+  // loaded. During that window neither `/profile/${userId}` nor a
+  // signed-out fallback (`/`, `/auth/signup`) is correct, so the link is
+  // disabled instead of navigating anywhere.
+  const isResolvingUser = isLoggedIn && !userId;
   const profilePath = userId ? `/profile/${userId}` : '/';
-  // Keyed on `userId` (not `isLoggedIn`) — `isLoggedIn` can be true from the
-  // fast session hint before the real user id has loaded, which would
-  // otherwise build a `/profile/undefined/...` URL.
   const becomeMentorPath = userId
     ? `/profile/${userId}/edit?onboarding=true`
     : '/auth/signup';
@@ -64,14 +67,26 @@ export function HamburgerMenu({
             </Link>
 
             {isMentor ? (
-              <Link href={profilePath} onClick={close} className="text-black">
+              <Link
+                href={isResolvingUser ? '#' : profilePath}
+                onClick={isResolvingUser ? (e) => e.preventDefault() : close}
+                aria-disabled={isResolvingUser}
+                className={cn(
+                  'text-black',
+                  isResolvingUser && 'pointer-events-none opacity-50'
+                )}
+              >
                 我的導師頁面
               </Link>
             ) : (
               <Link
-                href={becomeMentorPath}
-                onClick={close}
-                className="text-black"
+                href={isResolvingUser ? '#' : becomeMentorPath}
+                onClick={isResolvingUser ? (e) => e.preventDefault() : close}
+                aria-disabled={isResolvingUser}
+                className={cn(
+                  'text-black',
+                  isResolvingUser && 'pointer-events-none opacity-50'
+                )}
               >
                 成為導師
               </Link>

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -16,6 +16,7 @@ import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
 import { DisabledAwareLink } from './DisabledAwareLink';
+import { getBecomeMentorHref, getProfileHref } from './navHrefs';
 
 export type HamburgerMenuProps = {
   isLoggedIn: boolean;
@@ -38,10 +39,8 @@ export function HamburgerMenu({
   const [open, setOpen] = React.useState(false);
   const close = (): void => setOpen(false);
 
-  const profilePath = userId ? `/profile/${userId}` : '/';
-  const becomeMentorPath = userId
-    ? `/profile/${userId}/edit?onboarding=true`
-    : '/auth/signup';
+  const profilePath = getProfileHref(userId);
+  const becomeMentorPath = getBecomeMentorHref(userId);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -31,9 +31,12 @@ export function HamburgerMenu({
   const close = (): void => setOpen(false);
 
   const profilePath = userId ? `/profile/${userId}` : '/';
-  const becomeMentorPath = !isLoggedIn
-    ? '/auth/signup'
-    : `/profile/${userId}/edit?onboarding=true`;
+  // Keyed on `userId` (not `isLoggedIn`) — `isLoggedIn` can be true from the
+  // fast session hint before the real user id has loaded, which would
+  // otherwise build a `/profile/undefined/...` URL.
+  const becomeMentorPath = userId
+    ? `/profile/${userId}/edit?onboarding=true`
+    : '/auth/signup';
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -1,0 +1,117 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/image', () => ({
+  // next/image requires width/height derived from a static-import object
+  // shape that Vitest's asset transform doesn't produce; not relevant to
+  // the auth-status link logic under test here.
+  default: ({ src, alt }: { src: string | { src: string }; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={typeof src === 'string' ? src : src.src} alt={alt} />
+  ),
+}));
+
+vi.mock('next-auth/react', async () => {
+  const { nextAuthMockFactory } = await import('@/test/mocks/nextAuth');
+  return nextAuthMockFactory();
+});
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+const mockUseAuthStatus = vi.fn();
+vi.mock('@/hooks/user/auth/useAuthStatus', () => ({
+  useAuthStatus: () => mockUseAuthStatus(),
+}));
+
+import { mockSession, mockUseSession } from '@/test/mocks/nextAuth';
+
+import { Header } from './Header';
+
+describe('Header', () => {
+  it('disables the second nav link while resolving a logged-in user, instead of falling back to /auth/signup or /', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: true,
+    });
+
+    render(<Header />);
+
+    const link = screen.getByRole('link', { name: '成為導師' });
+    expect(link).toHaveAttribute('href', '#');
+    expect(link).toHaveAttribute('aria-disabled', 'true');
+
+    // dispatchEvent() returns false when a handler called preventDefault().
+    const notPrevented = fireEvent.click(link);
+    expect(notPrevented).toBe(false);
+  });
+
+  it('links straight to the profile edit page once userId has landed and isResolvingUser is false', () => {
+    mockUseSession.mockReturnValue({
+      data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
+      status: 'authenticated',
+    });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: 'user-123',
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    const link = screen.getByRole('link', { name: '成為導師' });
+    expect(link).toHaveAttribute(
+      'href',
+      '/profile/user-123/edit?onboarding=true'
+    );
+    expect(link).toHaveAttribute('aria-disabled', 'false');
+  });
+
+  it('shows guest sign-in/sign-up actions once auth is known and the user is not logged in', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    expect(screen.getByRole('link', { name: '註冊' })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '登入' })).toBeInTheDocument();
+  });
+
+  it('shows a loading skeleton, not guest actions, before auth is known at all', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: false,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.queryByRole('link', { name: '登入' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: '註冊' })
+    ).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -114,4 +114,28 @@ describe('Header', () => {
       screen.queryByRole('link', { name: '註冊' })
     ).not.toBeInTheDocument();
   });
+
+  it('does not flash the mentee-default "成為導師" label for a mentor before auth is known', () => {
+    // `useAuthStatus` defaults `isMentor` to false until it can be
+    // determined — this must not leak into the rendered nav link before
+    // `authKnown` is true, or a mentor briefly sees the wrong role's label.
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: false,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.queryByRole('link', { name: '成為導師' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: '我的導師頁面' })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -8,8 +8,9 @@ import { memo } from 'react';
 import LogoImgUrl from '@/assets/logo.svg';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
-import { useSessionHint } from '@/hooks/user/auth/useSessionHint';
+import { useAuthStatus } from '@/hooks/user/auth/useAuthStatus';
 import { trackEvent } from '@/lib/analytics';
+import { cn } from '@/lib/utils';
 
 import { FEEDBACK_FORM_URL } from './constants';
 import { HamburgerMenu } from './HamburgerMenu';
@@ -18,27 +19,19 @@ import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
   const { data: session } = useSession();
-  const hint = useSessionHint();
-
-  // `session` (from useSession) is the only source ever used for hrefs that
-  // need a real user id — the hint cookie intentionally carries no id, so a
-  // hint-only "logged in" state must never build a `/profile/${userId}` URL.
-  const userId = session?.user?.id;
-  const hasFullUser = Boolean(userId);
-
-  // Before the full session lands, fall back to the hint cookie (written by
-  // middleware from a fast local JWT check) so the header doesn't sit blank
-  // for the length of the /api/auth/session round trip — which can itself be
-  // blocked on a backend token-refresh call. Once the real session resolves
-  // it always wins over a possibly-stale hint.
-  const authKnown = hasFullUser || hint.status !== 'unknown';
-  const isLoggedIn = hasFullUser ? true : hint.status === 'authenticated';
-  const isMentor = hasFullUser
-    ? Boolean(session?.user?.isMentor)
-    : hint.status === 'authenticated' && hint.isMentor;
+  const {
+    authKnown,
+    isLoggedIn,
+    isMentor,
+    userId,
+    hasFullUser,
+    isResolvingUser,
+  } = useAuthStatus();
 
   const findMentorHref = '/mentor-pool';
 
+  // `userId` only ever comes from the real session, never the hint — while
+  // isResolvingUser is true these hrefs are unused (the link is disabled).
   const becomeMentorHref = userId
     ? `/profile/${userId}/edit?onboarding=true`
     : '/auth/signup';
@@ -66,8 +59,13 @@ function HeaderComponent(): JSX.Element {
             </Link>
 
             <Link
-              href={leftSecondNav.href}
-              className="text-black font-['Open_Sans'] text-base"
+              href={isResolvingUser ? '#' : leftSecondNav.href}
+              aria-disabled={isResolvingUser}
+              onClick={isResolvingUser ? (e) => e.preventDefault() : undefined}
+              className={cn(
+                "text-black font-['Open_Sans'] text-base",
+                isResolvingUser && 'pointer-events-none opacity-50'
+              )}
             >
               {leftSecondNav.label}
             </Link>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -15,6 +15,7 @@ import { FEEDBACK_FORM_URL } from './constants';
 import { DisabledAwareLink } from './DisabledAwareLink';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
+import { getBecomeMentorHref, getProfileHref } from './navHrefs';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
@@ -32,15 +33,9 @@ function HeaderComponent(): JSX.Element {
 
   // `userId` only ever comes from the real session, never the hint — while
   // isResolvingUser is true these hrefs are unused (the link is disabled).
-  const becomeMentorHref = userId
-    ? `/profile/${userId}/edit?onboarding=true`
-    : '/auth/signup';
-
-  const profileHref = userId ? `/profile/${userId}` : '/';
-
   const leftSecondNav = isMentor
-    ? { label: '我的導師頁面', href: profileHref }
-    : { label: '成為導師', href: becomeMentorHref };
+    ? { label: '我的導師頁面', href: getProfileHref(userId) }
+    : { label: '成為導師', href: getBecomeMentorHref(userId) };
 
   return (
     <header className="fixed inset-x-0 z-50 bg-light px-5">

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -3,10 +3,12 @@
 import Image from 'next/image';
 import Link from 'next/link';
 import { useSession } from 'next-auth/react';
-import { memo, useRef } from 'react';
+import { memo } from 'react';
 
 import LogoImgUrl from '@/assets/logo.svg';
 import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+import { useSessionHint } from '@/hooks/user/auth/useSessionHint';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
@@ -15,20 +17,31 @@ import { MobileUserMenu } from './MobileUserMenu';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
-  const { data: session, status } = useSession();
-  const wasAuthenticated = useRef(false);
-  if (status === 'authenticated') wasAuthenticated.current = true;
-  const isLoading = status === 'loading' && !wasAuthenticated.current;
+  const { data: session } = useSession();
+  const hint = useSessionHint();
 
-  const isLoggedIn = Boolean(session?.user?.id);
-  const isMentor = Boolean(session?.user?.isMentor);
+  // `session` (from useSession) is the only source ever used for hrefs that
+  // need a real user id — the hint cookie intentionally carries no id, so a
+  // hint-only "logged in" state must never build a `/profile/${userId}` URL.
   const userId = session?.user?.id;
+  const hasFullUser = Boolean(userId);
+
+  // Before the full session lands, fall back to the hint cookie (written by
+  // middleware from a fast local JWT check) so the header doesn't sit blank
+  // for the length of the /api/auth/session round trip — which can itself be
+  // blocked on a backend token-refresh call. Once the real session resolves
+  // it always wins over a possibly-stale hint.
+  const authKnown = hasFullUser || hint.status !== 'unknown';
+  const isLoggedIn = hasFullUser ? true : hint.status === 'authenticated';
+  const isMentor = hasFullUser
+    ? Boolean(session?.user?.isMentor)
+    : hint.status === 'authenticated' && hint.isMentor;
 
   const findMentorHref = '/mentor-pool';
 
-  const becomeMentorHref = !isLoggedIn
-    ? '/auth/signup'
-    : `/profile/${userId}/edit?onboarding=true`;
+  const becomeMentorHref = userId
+    ? `/profile/${userId}/edit?onboarding=true`
+    : '/auth/signup';
 
   const profileHref = userId ? `/profile/${userId}` : '/';
 
@@ -39,83 +52,81 @@ function HeaderComponent(): JSX.Element {
   return (
     <header className="fixed inset-x-0 z-50 bg-light px-5">
       <div className="flex h-[70px] items-center justify-between">
-        {!isLoading && (
-          <>
-            <div className="flex items-center gap-10">
-              <Link href="/" aria-label="Go to homepage">
-                <Image src={LogoImgUrl} alt="logo" />
-              </Link>
+        <div className="flex items-center gap-10">
+          <Link href="/" aria-label="Go to homepage">
+            <Image src={LogoImgUrl} alt="logo" />
+          </Link>
 
-              <nav className="hidden items-center gap-7 md:flex">
-                <Link
-                  href={findMentorHref}
-                  className="text-black font-['Open_Sans'] text-base"
-                >
-                  尋找導師
+          <nav className="hidden items-center gap-7 md:flex">
+            <Link
+              href={findMentorHref}
+              className="text-black font-['Open_Sans'] text-base"
+            >
+              尋找導師
+            </Link>
+
+            <Link
+              href={leftSecondNav.href}
+              className="text-black font-['Open_Sans'] text-base"
+            >
+              {leftSecondNav.label}
+            </Link>
+
+            <Link
+              href="/about"
+              className="text-black font-['Open_Sans'] text-base"
+            >
+              關於 X-Talent
+            </Link>
+
+            <a
+              href={FEEDBACK_FORM_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              aria-label="提供回饋（另開新分頁）"
+              onClick={() => trackEvent({ name: 'feedback_open' })}
+              className="text-black font-['Open_Sans'] text-base"
+            >
+              提供回饋
+            </a>
+          </nav>
+        </div>
+
+        <div className="flex items-center gap-3 md:mr-20">
+          <div className="hidden items-center gap-3 md:flex">
+            {!authKnown ? (
+              <Skeleton className="h-9 w-9 rounded-full" />
+            ) : !isLoggedIn ? (
+              <>
+                <Link href="/auth/signup">
+                  <Button
+                    variant="outline"
+                    className="border-primary text-primary hover:text-primary"
+                  >
+                    註冊
+                  </Button>
                 </Link>
 
-                <Link
-                  href={leftSecondNav.href}
-                  className="text-black font-['Open_Sans'] text-base"
-                >
-                  {leftSecondNav.label}
+                <Link href="/auth/signin">
+                  <Button className="bg-primary hover:bg-primary">登入</Button>
                 </Link>
+              </>
+            ) : hasFullUser ? (
+              <UserDropdown user={session!.user} />
+            ) : (
+              <Skeleton className="h-9 w-9 rounded-full" />
+            )}
+          </div>
 
-                <Link
-                  href="/about"
-                  className="text-black font-['Open_Sans'] text-base"
-                >
-                  關於 X-Talent
-                </Link>
-
-                <a
-                  href={FEEDBACK_FORM_URL}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  aria-label="提供回饋（另開新分頁）"
-                  onClick={() => trackEvent({ name: 'feedback_open' })}
-                  className="text-black font-['Open_Sans'] text-base"
-                >
-                  提供回饋
-                </a>
-              </nav>
-            </div>
-
-            <div className="flex items-center gap-3 md:mr-20">
-              <div className="hidden items-center gap-3 md:flex">
-                {!isLoggedIn ? (
-                  <>
-                    <Link href="/auth/signup">
-                      <Button
-                        variant="outline"
-                        className="border-primary text-primary hover:text-primary"
-                      >
-                        註冊
-                      </Button>
-                    </Link>
-
-                    <Link href="/auth/signin">
-                      <Button className="bg-primary hover:bg-primary">
-                        登入
-                      </Button>
-                    </Link>
-                  </>
-                ) : (
-                  <UserDropdown user={session!.user} />
-                )}
-              </div>
-
-              <div className="flex items-center gap-3 md:hidden">
-                {isLoggedIn ? <MobileUserMenu user={session!.user} /> : null}
-                <HamburgerMenu
-                  isLoggedIn={isLoggedIn}
-                  isMentor={isMentor}
-                  userId={userId}
-                />
-              </div>
-            </div>
-          </>
-        )}
+          <div className="flex items-center gap-3 md:hidden">
+            {hasFullUser ? <MobileUserMenu user={session!.user} /> : null}
+            <HamburgerMenu
+              isLoggedIn={isLoggedIn}
+              isMentor={isMentor}
+              userId={userId}
+            />
+          </div>
+        </div>
       </div>
     </header>
   );

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -53,13 +53,17 @@ function HeaderComponent(): JSX.Element {
               尋找導師
             </Link>
 
-            <DisabledAwareLink
-              href={leftSecondNav.href}
-              disabled={isResolvingUser}
-              className="text-black font-['Open_Sans'] text-base"
-            >
-              {leftSecondNav.label}
-            </DisabledAwareLink>
+            {!authKnown ? (
+              <Skeleton className="h-6 w-24" />
+            ) : (
+              <DisabledAwareLink
+                href={leftSecondNav.href}
+                disabled={isResolvingUser}
+                className="text-black font-['Open_Sans'] text-base"
+              >
+                {leftSecondNav.label}
+              </DisabledAwareLink>
+            )}
 
             <Link
               href="/about"

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -10,9 +10,9 @@ import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAuthStatus } from '@/hooks/user/auth/useAuthStatus';
 import { trackEvent } from '@/lib/analytics';
-import { cn } from '@/lib/utils';
 
 import { FEEDBACK_FORM_URL } from './constants';
+import { DisabledAwareLink } from './DisabledAwareLink';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
 import { UserDropdown } from './UserDropdown';
@@ -58,17 +58,13 @@ function HeaderComponent(): JSX.Element {
               尋找導師
             </Link>
 
-            <Link
-              href={isResolvingUser ? '#' : leftSecondNav.href}
-              aria-disabled={isResolvingUser}
-              onClick={isResolvingUser ? (e) => e.preventDefault() : undefined}
-              className={cn(
-                "text-black font-['Open_Sans'] text-base",
-                isResolvingUser && 'pointer-events-none opacity-50'
-              )}
+            <DisabledAwareLink
+              href={leftSecondNav.href}
+              disabled={isResolvingUser}
+              className="text-black font-['Open_Sans'] text-base"
             >
               {leftSecondNav.label}
-            </Link>
+            </DisabledAwareLink>
 
             <Link
               href="/about"
@@ -122,6 +118,7 @@ function HeaderComponent(): JSX.Element {
               isLoggedIn={isLoggedIn}
               isMentor={isMentor}
               userId={userId}
+              isResolvingUser={isResolvingUser}
             />
           </div>
         </div>

--- a/src/components/layout/Header/navHrefs.test.ts
+++ b/src/components/layout/Header/navHrefs.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { getBecomeMentorHref, getProfileHref } from './navHrefs';
+
+describe('navHrefs', () => {
+  describe('getProfileHref', () => {
+    it('returns the profile URL when userId is present', () => {
+      expect(getProfileHref('user-123')).toBe('/profile/user-123');
+    });
+
+    it('falls back to "/" when userId is undefined', () => {
+      expect(getProfileHref(undefined)).toBe('/');
+    });
+  });
+
+  describe('getBecomeMentorHref', () => {
+    it('returns the onboarding edit URL when userId is present', () => {
+      expect(getBecomeMentorHref('user-123')).toBe(
+        '/profile/user-123/edit?onboarding=true'
+      );
+    });
+
+    it('falls back to signup when userId is undefined', () => {
+      expect(getBecomeMentorHref(undefined)).toBe('/auth/signup');
+    });
+  });
+});

--- a/src/components/layout/Header/navHrefs.ts
+++ b/src/components/layout/Header/navHrefs.ts
@@ -1,0 +1,10 @@
+// Single source of truth for the userId-dependent nav destinations shared by
+// Header.tsx and HamburgerMenu.tsx, so the two never drift out of sync.
+
+export function getProfileHref(userId: string | undefined): string {
+  return userId ? `/profile/${userId}` : '/';
+}
+
+export function getBecomeMentorHref(userId: string | undefined): string {
+  return userId ? `/profile/${userId}/edit?onboarding=true` : '/auth/signup';
+}

--- a/src/hooks/user/auth/useAuthStatus.test.ts
+++ b/src/hooks/user/auth/useAuthStatus.test.ts
@@ -1,0 +1,121 @@
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-auth/react', async () => {
+  const { nextAuthMockFactory } = await import('@/test/mocks/nextAuth');
+  return nextAuthMockFactory();
+});
+
+const mockUseSessionHint = vi.fn();
+vi.mock('./useSessionHint', () => ({
+  useSessionHint: () => mockUseSessionHint(),
+}));
+
+import { mockSession, mockUseSession } from '@/test/mocks/nextAuth';
+
+import { useAuthStatus } from './useAuthStatus';
+
+describe('useAuthStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is unresolved while both the session and the hint are still loading', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseSessionHint.mockReturnValue({ status: 'unknown' });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toMatchObject({
+      authKnown: false,
+      isLoggedIn: false,
+      isResolvingUser: false,
+      userId: undefined,
+      hasFullUser: false,
+    });
+  });
+
+  it('renders as guest immediately once the hint resolves, even before the session does', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseSessionHint.mockReturnValue({ status: 'guest' });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toMatchObject({
+      authKnown: true,
+      isLoggedIn: false,
+      isResolvingUser: false,
+    });
+  });
+
+  it('flags isResolvingUser when the hint says authenticated but the full session has not landed — must not expose a userId', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseSessionHint.mockReturnValue({
+      status: 'authenticated',
+      isMentor: true,
+    });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toEqual({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: true,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: true,
+    });
+  });
+
+  it('prefers the real session over a stale "authenticated" hint once the session resolves to logged out', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    mockUseSessionHint.mockReturnValue({
+      status: 'authenticated',
+      isMentor: true,
+    });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toMatchObject({
+      isLoggedIn: false,
+      isResolvingUser: false,
+    });
+  });
+
+  it('keeps showing the cached user during a NextAuth update() call — status flips to "loading" but data is retained', () => {
+    // Mirrors NextAuth v4: calling session.update() sets status back to
+    // "loading" while `data` still holds the previous session.
+    mockUseSession.mockReturnValue({ data: mockSession, status: 'loading' });
+    mockUseSessionHint.mockReturnValue({ status: 'unknown' });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toEqual({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: mockSession.user.id,
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+  });
+
+  it('uses the real session data once it lands, ignoring the hint', () => {
+    mockUseSession.mockReturnValue({
+      data: mockSession,
+      status: 'authenticated',
+    });
+    mockUseSessionHint.mockReturnValue({ status: 'unknown' });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toEqual({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: mockSession.user.id,
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+  });
+});

--- a/src/hooks/user/auth/useAuthStatus.ts
+++ b/src/hooks/user/auth/useAuthStatus.ts
@@ -1,0 +1,62 @@
+'use client';
+
+import { useSession } from 'next-auth/react';
+
+import { useSessionHint } from './useSessionHint';
+
+export interface AuthStatus {
+  /** Whether we know anything at all (from hint or real session) yet. */
+  authKnown: boolean;
+  isLoggedIn: boolean;
+  isMentor: boolean;
+  userId: string | undefined;
+  /** Whether the full `useSession()` payload (id, avatar, email, …) has landed. */
+  hasFullUser: boolean;
+  /**
+   * Logged in per the fast hint cookie, but the full session — and with it
+   * `userId` — hasn't arrived yet. Any link that needs `userId` must be
+   * disabled during this window rather than falling back to a signed-out
+   * destination like `/auth/signup` or `/`.
+   */
+  isResolvingUser: boolean;
+}
+
+/**
+ * Combines `useSession()` with the fast `useSessionHint()` fallback so
+ * layout that needs to know the auth/mentor state doesn't have to wait on
+ * the `/api/auth/session` round trip before rendering. The real session
+ * always wins once it lands.
+ */
+export function useAuthStatus(): AuthStatus {
+  const { data: session, status } = useSession();
+  const hint = useSessionHint();
+
+  const userId = session?.user?.id;
+  const hasFullUser = Boolean(userId);
+  // `status` only reliably means "no session data at all" when there is no
+  // cached session yet — during a NextAuth `update()` call `status` flips
+  // back to "loading" while `data` still holds the previous session. Gate on
+  // `hasFullUser` first so an in-flight `update()` doesn't fall back to a
+  // (possibly stale) hint; only once neither is available do we consult it.
+  const sessionSettled = hasFullUser || status !== 'loading';
+
+  const authKnown = sessionSettled || hint.status !== 'unknown';
+  const isLoggedIn = sessionSettled
+    ? hasFullUser
+    : hint.status === 'authenticated';
+  const isMentor = hasFullUser
+    ? Boolean(session?.user?.isMentor)
+    : sessionSettled
+      ? false
+      : hint.status === 'authenticated' && hint.isMentor;
+  const isResolvingUser = isLoggedIn && !hasFullUser;
+
+  return {
+    authKnown,
+    isLoggedIn,
+    isMentor,
+    userId,
+    hasFullUser,
+    isResolvingUser,
+  };
+}

--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -1,0 +1,53 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { SESSION_HINT_COOKIE } from '@/lib/auth/sessionHint';
+
+import { useSessionHint } from './useSessionHint';
+
+function setCookie(value: string | undefined): void {
+  if (value === undefined) {
+    document.cookie = `${SESSION_HINT_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+    return;
+  }
+  document.cookie = `${SESSION_HINT_COOKIE}=${value}`;
+}
+
+describe('useSessionHint', () => {
+  afterEach(() => {
+    setCookie(undefined);
+  });
+
+  it('resolves to guest when no hint cookie is present', async () => {
+    const { result } = renderHook(() => useSessionHint());
+    await waitFor(() => expect(result.current.status).toBe('guest'));
+  });
+
+  it('resolves to authenticated mentor when cookie value is "1"', async () => {
+    setCookie('1');
+    const { result } = renderHook(() => useSessionHint());
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'authenticated',
+        isMentor: true,
+      })
+    );
+  });
+
+  it('resolves to authenticated non-mentor when cookie value is "0"', async () => {
+    setCookie('0');
+    const { result } = renderHook(() => useSessionHint());
+    await waitFor(() =>
+      expect(result.current).toEqual({
+        status: 'authenticated',
+        isMentor: false,
+      })
+    );
+  });
+
+  it('treats an unrecognized cookie value as guest', async () => {
+    setCookie('garbage');
+    const { result } = renderHook(() => useSessionHint());
+    await waitFor(() => expect(result.current.status).toBe('guest'));
+  });
+});

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -1,0 +1,44 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import {
+  decodeSessionHint,
+  SESSION_HINT_COOKIE,
+  type SessionHint,
+} from '@/lib/auth/sessionHint';
+
+function readCookie(name: string): string | undefined {
+  return document.cookie
+    .split('; ')
+    .find((row) => row.startsWith(`${name}=`))
+    ?.slice(name.length + 1);
+}
+
+export type SessionHintState =
+  | { status: 'unknown' }
+  | { status: 'guest' }
+  | { status: 'authenticated'; isMentor: boolean };
+
+/**
+ * Reads the middleware-written hint cookie so the header can render the
+ * right shape before `useSession()` resolves. Deferred to an effect (rather
+ * than a lazy useState initializer) because the server render has no cookie
+ * access — reading it during the first client render would mismatch.
+ */
+export function useSessionHint(): SessionHintState {
+  const [state, setState] = useState<SessionHintState>({ status: 'unknown' });
+
+  useEffect(() => {
+    const hint: SessionHint | null = decodeSessionHint(
+      readCookie(SESSION_HINT_COOKIE)
+    );
+    setState(
+      hint
+        ? { status: 'authenticated', isMentor: hint.isMentor }
+        : { status: 'guest' }
+    );
+  }, []);
+
+  return state;
+}

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -1,0 +1,34 @@
+// Non-sensitive UI hint, written by middleware from a token already verified
+// via `getToken()` (local JWT signature check, no network call). Lets the
+// client render the correct header shape before the slower `useSession()`
+// round trip (which can be blocked on a backend token-refresh call) resolves.
+// Never trust this cookie for authorization — it is readable/writable by
+// client JS and carries no signature of its own.
+export const SESSION_HINT_COOKIE = 'session-hint';
+
+export const SESSION_HINT_COOKIE_OPTIONS = {
+  httpOnly: false,
+  secure: process.env.NODE_ENV === 'production',
+  sameSite: 'lax' as const,
+  path: '/',
+  maxAge: 60 * 60 * 24 * 30,
+};
+
+export interface SessionHint {
+  isMentor: boolean;
+}
+
+const MENTOR_VALUE = '1';
+const NON_MENTOR_VALUE = '0';
+
+export function encodeSessionHint(hint: SessionHint): string {
+  return hint.isMentor ? MENTOR_VALUE : NON_MENTOR_VALUE;
+}
+
+export function decodeSessionHint(
+  value: string | undefined | null
+): SessionHint | null {
+  if (value === MENTOR_VALUE) return { isMentor: true };
+  if (value === NON_MENTOR_VALUE) return { isMentor: false };
+  return null;
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -12,8 +12,12 @@ import { middleware } from './middleware';
 
 const mockGetToken = vi.mocked(getToken);
 
-function makeRequest(pathname: string): NextRequest {
-  return new NextRequest(`https://example.com${pathname}`);
+function makeRequest(pathname: string, existingHint?: string): NextRequest {
+  return new NextRequest(`https://example.com${pathname}`, {
+    headers: existingHint
+      ? { cookie: `${SESSION_HINT_COOKIE}=${existingHint}` }
+      : undefined,
+  });
 }
 
 describe('middleware session hint cookie', () => {
@@ -21,7 +25,7 @@ describe('middleware session hint cookie', () => {
     vi.clearAllMocks();
   });
 
-  it('sets isMentor=1 for a logged-in mentor on a public route', async () => {
+  it('sets isMentor=1 for a logged-in mentor with no existing hint cookie', async () => {
     mockGetToken.mockResolvedValue({ isMentor: true } as never);
 
     const response = await middleware(makeRequest('/'));
@@ -29,7 +33,7 @@ describe('middleware session hint cookie', () => {
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
   });
 
-  it('sets isMentor=0 for a logged-in mentee on a public route', async () => {
+  it('sets isMentor=0 for a logged-in mentee with no existing hint cookie', async () => {
     mockGetToken.mockResolvedValue({ isMentor: false } as never);
 
     const response = await middleware(makeRequest('/'));
@@ -37,27 +41,60 @@ describe('middleware session hint cookie', () => {
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('0');
   });
 
-  it('clears the hint cookie for a logged-out visitor on a public route', async () => {
+  it('does not re-emit Set-Cookie when the stored hint already matches the verified token', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true } as never);
+
+    const response = await middleware(makeRequest('/', '1'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)).toBeUndefined();
+  });
+
+  it('updates the hint cookie when the stored value no longer matches the verified token', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true } as never);
+
+    const response = await middleware(makeRequest('/', '0'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
+  });
+
+  it('does not emit a Set-Cookie for a guest with no existing hint cookie — keeps public routes cacheable', async () => {
     mockGetToken.mockResolvedValue(null);
 
     const response = await middleware(makeRequest('/'));
 
+    expect(response.cookies.get(SESSION_HINT_COOKIE)).toBeUndefined();
+  });
+
+  it('clears a stale hint cookie for a guest who previously had one', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(makeRequest('/', '1'));
+
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');
   });
 
-  it('clears the hint cookie when redirecting an unauthenticated user off a protected route', async () => {
+  it('does not emit a Set-Cookie when redirecting an unauthenticated user with no existing hint cookie', async () => {
     mockGetToken.mockResolvedValue(null);
 
     const response = await middleware(makeRequest('/reservation/mentee'));
 
     expect(response.status).toBe(307);
+    expect(response.cookies.get(SESSION_HINT_COOKIE)).toBeUndefined();
+  });
+
+  it('clears a stale hint cookie when redirecting an unauthenticated user off a protected route', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(makeRequest('/reservation/mentee', '1'));
+
+    expect(response.status).toBe(307);
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');
   });
 
-  it('clears the hint cookie when the token has a RefreshTokenError', async () => {
+  it('clears a stale hint cookie when the token has a RefreshTokenError', async () => {
     mockGetToken.mockResolvedValue({ error: 'RefreshTokenError' } as never);
 
-    const response = await middleware(makeRequest('/reservation/mentee'));
+    const response = await middleware(makeRequest('/reservation/mentee', '1'));
 
     expect(response.status).toBe(307);
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,73 @@
+import { NextRequest } from 'next/server';
+import { getToken } from 'next-auth/jwt';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next-auth/jwt', () => ({
+  getToken: vi.fn(),
+}));
+
+import { SESSION_HINT_COOKIE } from '@/lib/auth/sessionHint';
+
+import { middleware } from './middleware';
+
+const mockGetToken = vi.mocked(getToken);
+
+function makeRequest(pathname: string): NextRequest {
+  return new NextRequest(`https://example.com${pathname}`);
+}
+
+describe('middleware session hint cookie', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('sets isMentor=1 for a logged-in mentor on a public route', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
+  });
+
+  it('sets isMentor=0 for a logged-in mentee on a public route', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: false } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('0');
+  });
+
+  it('clears the hint cookie for a logged-out visitor on a public route', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');
+  });
+
+  it('clears the hint cookie when redirecting an unauthenticated user off a protected route', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(makeRequest('/reservation/mentee'));
+
+    expect(response.status).toBe(307);
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');
+  });
+
+  it('clears the hint cookie when the token has a RefreshTokenError', async () => {
+    mockGetToken.mockResolvedValue({ error: 'RefreshTokenError' } as never);
+
+    const response = await middleware(makeRequest('/reservation/mentee'));
+
+    expect(response.status).toBe(307);
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('');
+  });
+
+  it('does not set the hint cookie for NextAuth API routes', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true } as never);
+
+    const response = await middleware(makeRequest('/api/auth/session'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)).toBeUndefined();
+  });
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -33,6 +33,7 @@ export async function middleware(req: NextRequest) {
 
   const hasRefreshError = token?.error === 'RefreshTokenError';
   const isLoggedIn = !!token && !hasRefreshError;
+  const currentHint = req.cookies.get(SESSION_HINT_COOKIE)?.value;
 
   // -------- 2. Allow NextAuth API routes through unconditionally --------
   const isApiAuthRoute = pathname.startsWith(apiAuthPrefix);
@@ -65,21 +66,29 @@ export async function middleware(req: NextRequest) {
       response.cookies.delete('__Secure-next-auth.session-token');
     }
 
-    response.cookies.delete(SESSION_HINT_COOKIE);
+    if (currentHint !== undefined) {
+      response.cookies.delete(SESSION_HINT_COOKIE);
+    }
     return response;
   }
 
   // -------- 5. Keep the client-readable hint in sync with the verified token --------
   // UI-only signal for instant header rendering — never used for auth decisions.
+  // Only emit Set-Cookie when the value actually changes: writing on every
+  // request would mark otherwise-cacheable public responses (e.g. `/`)
+  // as uncacheable for CDNs and Next's route cache.
   const response = NextResponse.next();
 
   if (isLoggedIn) {
-    response.cookies.set(
-      SESSION_HINT_COOKIE,
-      encodeSessionHint({ isMentor: Boolean(token?.isMentor) }),
-      SESSION_HINT_COOKIE_OPTIONS
-    );
-  } else {
+    const nextHint = encodeSessionHint({ isMentor: Boolean(token?.isMentor) });
+    if (currentHint !== nextHint) {
+      response.cookies.set(
+        SESSION_HINT_COOKIE,
+        nextHint,
+        SESSION_HINT_COOKIE_OPTIONS
+      );
+    }
+  } else if (currentHint !== undefined) {
     response.cookies.delete(SESSION_HINT_COOKIE);
   }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -2,6 +2,11 @@ import { NextRequest, NextResponse } from 'next/server';
 import { getToken } from 'next-auth/jwt';
 import { match } from 'path-to-regexp';
 
+import {
+  encodeSessionHint,
+  SESSION_HINT_COOKIE,
+  SESSION_HINT_COOKIE_OPTIONS,
+} from '@/lib/auth/sessionHint';
 import { apiAuthPrefix, DEFAULT_LOGIN, publicRoutes } from '@/routes';
 
 // Convert Next.js dynamic route → express style (:id)
@@ -60,10 +65,25 @@ export async function middleware(req: NextRequest) {
       response.cookies.delete('__Secure-next-auth.session-token');
     }
 
+    response.cookies.delete(SESSION_HINT_COOKIE);
     return response;
   }
 
-  return NextResponse.next();
+  // -------- 5. Keep the client-readable hint in sync with the verified token --------
+  // UI-only signal for instant header rendering — never used for auth decisions.
+  const response = NextResponse.next();
+
+  if (isLoggedIn) {
+    response.cookies.set(
+      SESSION_HINT_COOKIE,
+      encodeSessionHint({ isMentor: Boolean(token?.isMentor) }),
+      SESSION_HINT_COOKIE_OPTIONS
+    );
+  } else {
+    response.cookies.delete(SESSION_HINT_COOKIE);
+  }
+
+  return response;
 }
 
 export const config = {


### PR DESCRIPTION
## What Does This PR Do?

- Adds `session-hint`, a non-sensitive cookie written by `middleware.ts` from the token it already verifies locally via `getToken()` (no network call). It only carries `isLoggedIn` (cookie presence) + `isMentor`.
- `Header.tsx` no longer waits on `useSession()` before rendering the logo/nav - those render immediately. The login-state section now has 4 states: unknown (skeleton) to guest (buttons) to logged in but full session not loaded yet (skeleton) to full session (UserDropdown/MobileUserMenu).
- Adds `useSessionHint()` hook (reads the cookie in a `useEffect`, not a lazy state initializer, to avoid hydration mismatch - the server has no cookie access).
- Fixes a latent bug in `HamburgerMenu.tsx`: `becomeMentorPath` was keyed on `isLoggedIn`, which can now be true from the hint before `userId` arrives, producing `/profile/undefined/edit...`. Keyed on `userId` presence instead.

This addresses the root cause behind #295: `useSession()`'s `/api/auth/session` call runs the `jwt` callback, which can synchronously call the backend to refresh an expiring token - if that call is slow, the whole header used to stay blank for the length of the wait.

## How to Test

pnpm install
pnpm dev

- Guest: open `/` in an incognito window - logo/nav should appear instantly, register/login buttons should not wait on any visible delay.
- Logged in (mentor and mentee): sign in, hard-refresh a page - header shape (nav label, avatar slot) should resolve near-instantly instead of blanking out; full dropdown still fills in once `useSession()` resolves.
- Confirm `pnpm build` still marks `/` as static (circle symbol), i.e. this change does not force dynamic rendering.
- `pnpm test` - includes new `src/middleware.test.ts` and `src/hooks/user/auth/useSessionHint.test.ts`.

## Anything to Note?

- The hint cookie is intentionally minimal (no user id, name, or avatar) and must never be used for server-side authorization - it is UI-only, cleared on logout/redirect/RefreshTokenError alongside the existing session-token cookie cleanup.
- Does not touch the refresh-token logic in `auth.config.ts` itself - if the backend refresh call is genuinely slow, `useSession()` will still take that long to fully resolve; this change stops that delay from blanking the header.
- Fixes Xchange-Taiwan/X-Talent-Tracker#295

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
