### PR TITLE
feat: add Business Logic reviewer to AI review pipeline

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -104,6 +104,35 @@ jobs:
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/correctness.mjs
 
+  business_logic:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Business Logic'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run business-logic agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/business-logic.mjs
+
   performance:
     needs: planner
     runs-on: ubuntu-latest
@@ -226,6 +255,7 @@ jobs:
         planner,
         security,
         correctness,
+        business_logic,
         performance,
         testing,
         architecture,
@@ -251,6 +281,7 @@ jobs:
           PLAN_B64: ${{ needs.planner.outputs.plan }}
           SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
           CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
+          BUSINESS_LOGIC_FINDINGS_B64: ${{ needs.business_logic.outputs.findings }}
           PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
           TESTING_FINDINGS_B64: ${{ needs.testing.outputs.findings }}
           ARCHITECTURE_FINDINGS_B64: ${{ needs.architecture.outputs.findings }}

--- a/scripts/ai-review/business-logic.mjs
+++ b/scripts/ai-review/business-logic.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/business-logic.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/generate-summary.mjs
+++ b/scripts/ai-review/generate-summary.mjs
@@ -23,6 +23,10 @@ function decodeUpstream(name, envVar) {
 const plan = decodeUpstream('plan', 'PLAN_B64');
 const security = decodeUpstream('security', 'SECURITY_FINDINGS_B64');
 const correctness = decodeUpstream('correctness', 'CORRECTNESS_FINDINGS_B64');
+const businessLogic = decodeUpstream(
+  'businessLogic',
+  'BUSINESS_LOGIC_FINDINGS_B64'
+);
 const performance = decodeUpstream('performance', 'PERFORMANCE_FINDINGS_B64');
 const testing = decodeUpstream('testing', 'TESTING_FINDINGS_B64');
 const architecture = decodeUpstream(
@@ -37,6 +41,11 @@ try {
     PLAN_JSON: JSON.stringify(plan ?? null, null, 2),
     SECURITY_FINDINGS_JSON: JSON.stringify(security ?? null, null, 2),
     CORRECTNESS_FINDINGS_JSON: JSON.stringify(correctness ?? null, null, 2),
+    BUSINESS_LOGIC_FINDINGS_JSON: JSON.stringify(
+      businessLogic ?? null,
+      null,
+      2
+    ),
     PERFORMANCE_FINDINGS_JSON: JSON.stringify(performance ?? null, null, 2),
     TESTING_FINDINGS_JSON: JSON.stringify(testing ?? null, null, 2),
     ARCHITECTURE_FINDINGS_JSON: JSON.stringify(architecture ?? null, null, 2),
@@ -57,6 +66,7 @@ const comment = formatComment({
   reviewGuide,
   security,
   correctness,
+  businessLogic,
   performance,
   testing,
   architecture,

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -85,12 +85,14 @@ export function formatComment({
   reviewGuide,
   security,
   correctness,
+  businessLogic,
   performance,
   testing,
   architecture,
   summary,
 }) {
   const sections = [
+    renderFindingsSection('🧭 Business Logic / Requirements', businessLogic),
     renderFindingsSection('🔒 Security', security),
     renderFindingsSection('🧩 Correctness / Regression', correctness),
     renderFindingsSection('⚡ Performance', performance),

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -197,6 +197,48 @@ describe('formatComment', () => {
     );
   });
 
+  it('renders Business Logic findings under their own section', () => {
+    const businessLogic = oneFinding({
+      summary: '發現 1 個業務規則違反',
+      findings: [
+        {
+          file: 'src/app/auth/(sign)/onboarding/container.tsx',
+          line: 115,
+          category: 'Unreachable Logic',
+          issue: 'onboarding 流程裡加了 isMentor 分支，但這裡永遠是 mentee',
+          why: 'onboarding 尚未完成前使用者不可能是 mentor，這段永遠不會執行',
+          fix: '移除此分支，mentor 專屬的頭像必填邏輯已在 profile/edit 實作',
+        },
+      ],
+    });
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      businessLogic,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧭 Business Logic / Requirements');
+    expect(comment).toContain('[Unreachable Logic]');
+    expect(comment).toContain(
+      'onboarding 流程裡加了 isMentor 分支，但這裡永遠是 mentee'
+    );
+  });
+
+  it('renders "not run" for Business Logic when it is undefined, without affecting other sections', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧭 Business Logic / Requirements\n_（未執行）_');
+  });
+
   it('falls back to a placeholder merge recommendation when the final-judgment summary is missing entirely (e.g. that Gemini call failed)', () => {
     const comment = formatComment({
       plan: basePlan,

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -236,7 +236,9 @@ describe('formatComment', () => {
       testing: noFindings,
       architecture: noFindings,
     });
-    expect(comment).toContain('### 🧭 Business Logic / Requirements\n_（未執行）_');
+    expect(comment).toContain(
+      '### 🧭 Business Logic / Requirements\n_（未執行）_'
+    );
   });
 
   it('falls back to a placeholder merge recommendation when the final-judgment summary is missing entirely (e.g. that Gemini call failed)', () => {

--- a/scripts/ai-review/lib/prompt.mjs
+++ b/scripts/ai-review/lib/prompt.mjs
@@ -12,6 +12,10 @@ function loadShared() {
       new URL('review-discipline.md', SHARED_DIR),
       'utf-8'
     ),
+    businessRules: readFileSync(
+      new URL('business-rules.md', SHARED_DIR),
+      'utf-8'
+    ),
   };
 }
 
@@ -21,12 +25,13 @@ function loadShared() {
  * Placeholders are `{{NAME}}` tokens; unknown placeholders are left as-is.
  */
 export function buildPrompt(templateUrl, replacements = {}) {
-  const { projectContext, reviewDiscipline } = loadShared();
+  const { projectContext, reviewDiscipline, businessRules } = loadShared();
   let template = readFileSync(templateUrl, 'utf-8');
 
   const all = {
     PROJECT_CONTEXT: projectContext,
     REVIEW_DISCIPLINE: reviewDiscipline,
+    BUSINESS_RULES: businessRules,
     ...replacements,
   };
   for (const [key, value] of Object.entries(all)) {

--- a/scripts/ai-review/prompts/_shared/business-rules.md
+++ b/scripts/ai-review/prompts/_shared/business-rules.md
@@ -12,3 +12,32 @@
   - **Reviewer 該做的事**：只要看到 onboarding 相關檔案裡出現 mentor-only 分支、或新增邏輯依賴 `isMentor`/`is_mentor` 為真，一律回報為「業務邏輯不成立，應移除或搬到 profile edit 流程」。
 
 - 角色專屬 UI 在角色 resolve 前不可 render（見 project context）是「時序」問題，跟上面「onboarding 裡沒有 mentor」是不同層次的規則——前者是「還不知道角色」，後者是「這個流程裡角色的答案永遠已知且固定」，兩者都要檢查，不要混為一談。
+
+- **「onboarding」在這個專案裡其實是兩個語意完全不同的入口，不能只看名字判斷。**
+  1. `/auth/(sign)/onboarding`（`src/app/auth/(sign)/onboarding/**`）—— 新用戶「註冊後」的初次填寫個人資料流程，就是上面那條規則講的、永遠是 mentee 的那個。
+  2. `/profile/[pageUserId]/edit?onboarding=true` —— 既有使用者「成為導師」的流程。所有「成為導師」按鈕（Header、HamburgerMenu、UserDropdown、MobileUserMenu）都導到這裡；`isMentorOnboarding` 這個 query flag 會傳進 `useEditProfileData` / `useProfileSubmit`，讓既有的 profile edit 頁面切換成「導師專屬必填欄位」模式。沒有任何入口導到 `/auth/onboarding`。
+  - **因此**：PR 描述或 ticket 只寫「onboarding」時不能假設是指哪一個，要看 diff 實際動到 `src/app/auth/(sign)/onboarding/**` 還是 `src/app/profile/[pageUserId]/edit/**` 才能判斷。
+  - **案例**：PR #641「mentor 需強制上傳頭像」正確位置是入口 2（`/profile/edit`，該 PR 也確實這樣做了），但同一份 PR 把同樣的邏輯又加了一份到入口 1（`/auth/onboarding`）——很可能就是把這兩個「onboarding」搞混了，這正是本文件最上面那條規則的真正成因。
+  - **Reviewer 該做的事**：如果同一個「只該屬於某一邊」的需求同時出現在兩個入口，視為 Misplaced Implementation。
+
+---
+
+## Mentor Profile 必填欄位
+
+- **Mentor 的個人檔案（profile edit）比 mentee 多一組必填欄位，而且已經有唯一正確的實作位置。** 在 `createProfileFormSchema(isMentor)`（`src/components/profile/edit/profileSchema.ts`）裡，只有 `isMentor === true` 時才透過 `superRefine` 強制要求：`about`、`industry`、`have_topic`（至少 1 個）、`have_skill`（至少 1 個）、`work_experiences`（至少 1 筆）、`educations`（至少 1 筆）。這些欄位對 mentee 都是選填或有預設值。
+  - **因此**：任何新的「mentor 才需要填 XXX」需求，正確做法是在這個 schema 裡加欄位或加 `superRefine` 分支，不該在 onboarding 或其他頁面另外刻一份驗證邏輯。
+  - **Reviewer 該做的事**：diff 若在 `profileSchema.ts` 以外的檔案新增「只有 mentor 才需要」的表單驗證，視為 Misplaced Implementation，應指向這個 schema。反過來，若 mentee 被要求填上面這些 mentor-only 欄位，視為 Business Rule Violation。
+
+---
+
+## 刪除帳號
+
+- **只有 3 個寫死的測試帳號能在 UI 上看到「刪除帳號」選項，這是刻意的權限限制，不是預設隱藏的一般 feature flag。** `canDeleteAccount` 寫死比對 3 個 email：`testing_visitor@xchange.com.tw`、`testing_mentee@xchange.com.tw`、`testing_mentor@xchange.com.tw`。這份清單在 `UserDropdown.tsx` 與 `MobileUserMenu.tsx` 各自維護一份**完全相同**的陣列，沒有共用常數。
+  - **因此**：一般使用者帳號目前完全看不到刪除帳號入口；這份清單的存在本身就是業務規則，不是待清理的技術債。
+  - **Reviewer 該做的事**：
+    1. diff 改了這份允許清單（新增/移除 email、或改成對所有人開放）——視為業務規則變更，必須有對應 ticket／需求依據，不能是附帶改動。
+    2. diff 只改了 `UserDropdown.tsx` 或 `MobileUserMenu.tsx` 其中一份清單、沒有同步改另一份——兩處會不一致（例如手機版能刪、桌面版不能刪），視為 Business Rule Violation，不是單純 code smell。
+
+- **使用者有未完成或未來的預約時，刪除帳號會被擋下，且這個狀態必須獨立處理，不能併入一般錯誤訊息。** 呼叫刪除帳號 API 後，若後端回傳 `status === 'blocked_reservations'`，前端要顯示「您目前有未完成或未來的預約，請先處理後再刪除帳號」並附上前往預約管理的連結（`src/hooks/auth/useDeleteAccountForm.ts` 的 `blockedByReservations` state、`src/components/auth/DeleteAccountDialog.tsx` 對應 UI），不會走登出/刪除流程。
+  - **因此**：這是獨立於「成功／一般失敗」的第三種結果，UI 必須給出可操作的下一步，不能被靜默吞掉或改成一般錯誤 toast。
+  - **Reviewer 該做的事**：diff 修改刪除帳號的 submit 流程時，確認 `blocked_reservations` 分支還在、仍獨立於 success/一般 error 處理，訊息與導頁行為沒有被移除或跟一般錯誤訊息混在一起。

--- a/scripts/ai-review/prompts/_shared/business-rules.md
+++ b/scripts/ai-review/prompts/_shared/business-rules.md
@@ -1,0 +1,14 @@
+這份文件收錄「不會寫在單一 ticket 裡、但整個平台都要遵守」的業務規則（domain invariants）。目的是讓 Business Logic Reviewer 不需要靠 tribal knowledge，也能判斷一個 PR 是不是做了「技術上邏輯正確、但業務上根本不該存在」的事。
+
+**維護方式**：只要 AI reviewer（或人類 reviewer）事後發現漏掉一個「因為不懂平台業務規則而犯的錯」，就把那條規則寫進來，避免同一類錯誤在下一個 PR 又發生一次。每條規則都要附上「為什麼」跟「reviewer 該怎麼做」，單純條列規則但沒有依據，之後很容易被誤用或誤判成過時。
+
+---
+
+## 角色與 Onboarding
+
+- **Onboarding 流程（`src/app/auth/(sign)/onboarding/**`、`src/components/onboarding/**`）永遠只有 mentee 會走過。** 使用者在完成 onboarding 之前不可能是 mentor —— `session.user.isMentor` / DTO 的 `is_mentor` 在這個流程裡永遠是 `false`（`buildOnboardingDtoStub` 也是以此為前提，預設 `isMentor: false`）。
+  - **因此**：onboarding 相關檔案裡任何依賴 `isMentor` / `is_mentor` 為 `true` 的分支，都是永遠不會執行的死路（unreachable code）。
+  - **案例**：PR #641「mentor 需強制上傳頭像」在 `src/app/auth/(sign)/onboarding/container.tsx` 加了 `if (isMentor && !avatar)` 檢查，這段永遠不會觸發；正確的位置是 `/profile/[pageUserId]/edit`（該 PR 也確實同時改了 `profile/edit/container.tsx` 與 `profileSchema.ts`，onboarding 那份是多餘的實作）。
+  - **Reviewer 該做的事**：只要看到 onboarding 相關檔案裡出現 mentor-only 分支、或新增邏輯依賴 `isMentor`/`is_mentor` 為真，一律回報為「業務邏輯不成立，應移除或搬到 profile edit 流程」。
+
+- 角色專屬 UI 在角色 resolve 前不可 render（見 project context）是「時序」問題，跟上面「onboarding 裡沒有 mentor」是不同層次的規則——前者是「還不知道角色」，後者是「這個流程裡角色的答案永遠已知且固定」，兩者都要檢查，不要混為一談。

--- a/scripts/ai-review/prompts/business-logic.md
+++ b/scripts/ai-review/prompts/business-logic.md
@@ -1,0 +1,50 @@
+你是 multi-agent PR review pipeline 裡的 **Business Logic / Requirements Reviewer**。你跟 Security、Correctness / Regression、Performance、Testing、Architecture Reviewer 是平行執行的，彼此看不到對方的發現，只共用 Planner 的審查計畫。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+## 平台業務規則（domain invariants）
+
+{{BUSINESS_RULES}}
+
+## Planner 提供的審查計畫
+
+```json
+{{PLAN_JSON}}
+```
+
+## PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+其他 agent 檢查的是「這段程式碼寫得對不對」，你檢查的是「這段程式碼在業務邏輯上該不該存在、或做在對的地方」。只檢查以下面向：
+
+- **違反已知業務規則**：diff 是否新增了違反上面「平台業務規則」清單的邏輯（例如在規則明說不可能出現某角色/某狀態的流程裡，加了針對該角色/狀態的分支）。`category` 標成 `"Business Rule Violation"`
+- **Dead / unreachable 邏輯**：因為業務規則保證某個條件永遠不成立（角色、狀態機階段等），導致新增的分支永遠不會被執行，屬於白做工。`category` 標成 `"Unreachable Logic"`
+- **需求範圍錯誤**：對照 Planner 的 `requirementSummary` / `acceptanceCriteria`，這次實作是否做在錯誤的流程/頁面/角色上——功能本身沒錯，但放錯地方，導致沒有真正滿足需求，或做了需求沒要求的事。`category` 標成 `"Misplaced Implementation"`
+
+不要重複其他 agent 的工作：不評論程式碼風格、效能、測試覆蓋、一般架構慣例（layer 分層、apiClient 用法等）；只把關「這段邏輯有沒有業務上的存在理由、放在對的地方」。「平台業務規則」清單沒有涵蓋到、且 Planner 的 ticket 資訊也看不出依據的情況，不要用猜測硬套規則——找不到明確違反的規則就不要回報。
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "hasFindings": boolean,
+  "summary": "一句話總結，例如「無業務邏輯疑慮」或「發現 1 個業務規則違反」",
+  "findings": [
+    {
+      "file": "檔案路徑",
+      "line": number | null,
+      "category": "Business Rule Violation / Unreachable Logic / Misplaced Implementation 三選一",
+      "issue": "一句話描述問題",
+      "why": "違反了哪一條業務規則、為什麼這很重要",
+      "fix": "具體修法（例如應該搬到哪個檔案/流程）"
+    }
+  ]
+}
+```

--- a/scripts/ai-review/prompts/summary.md
+++ b/scripts/ai-review/prompts/summary.md
@@ -1,4 +1,4 @@
-你是 multi-agent PR review pipeline 的最後一站，負責綜合 Planner 與全部 5 個 Reviewer（Security、Correctness / Regression、Performance、Testing、Architecture）的結果，給出最終的整體判斷。你不需要重新分析程式碼本身，只需要根據下面已經產出的結果做綜合判斷。
+你是 multi-agent PR review pipeline 的最後一站，負責綜合 Planner 與全部 6 個 Reviewer（Security、Correctness / Regression、Business Logic / Requirements、Performance、Testing、Architecture）的結果，給出最終的整體判斷。你不需要重新分析程式碼本身，只需要根據下面已經產出的結果做綜合判斷。
 
 {{PROJECT_CONTEXT}}
 
@@ -22,6 +22,12 @@
 {{CORRECTNESS_FINDINGS_JSON}}
 ```
 
+## Business Logic / Requirements Reviewer 的發現
+
+```json
+{{BUSINESS_LOGIC_FINDINGS_JSON}}
+```
+
 ## Performance Reviewer 的發現
 
 ```json
@@ -43,7 +49,7 @@
 ## 你的任務
 
 1. **Requirement coverage**：對照 Planner 整理的 `acceptanceCriteria`，逐條判斷這次 diff 有沒有覆蓋到。若 Planner 的 `ticketFound` 為 false 或 `acceptanceCriteria` 為空陣列，回傳空陣列即可
-2. **Overall risk**：綜合以上 5 個 Reviewer 全部的 findings，給一個整體風險等級（`low` / `medium` / `high`）與一句話理由。判斷原則：只要有任何一個 agent 回報了 `hasFindings: true` 且問題看起來嚴重（例如安全性問題、會導致流程中斷的錯誤處理缺漏），風險就不該是 `low`；若某個 agent 的結果標記為「未執行」或缺失，也要在理由中提及，因為代表這次審查不完整
+2. **Overall risk**：綜合以上 6 個 Reviewer 全部的 findings，給一個整體風險等級（`low` / `medium` / `high`）與一句話理由。判斷原則：只要有任何一個 agent 回報了 `hasFindings: true` 且問題看起來嚴重（例如安全性問題、會導致流程中斷的錯誤處理缺漏、Business Logic Reviewer 回報的業務規則違反或做在錯誤流程），風險就不該是 `low`；若某個 agent 的結果標記為「未執行」或缺失，也要在理由中提及，因為代表這次審查不完整
 3. **Merge recommendation**：給審查者一句話建議（例如「可合併」「建議先補測試」「建議人工複查安全性問題」）。這只是給人看的參考意見，不代表任何強制的 merge gate
 
 請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：


### PR DESCRIPTION
## What Does This PR Do?

- Adds a Business Logic / Requirements reviewer agent to the AI review pipeline, parallel to Security / Correctness / Performance / Testing / Architecture, focused on whether a diff should exist or is placed in the right flow - not whether it is implemented correctly
- Adds `scripts/ai-review/prompts/_shared/business-rules.md`, a maintainable domain-invariants doc the new agent checks diffs against, seeded with the rule PR #641 violated (onboarding is mentee-only; `isMentor` is always `false` there, so mentor branches added inside onboarding files are unreachable dead code)
- Wires the new agent's findings into the final PR summary comment and overall risk judgment

## Demo

N/A (CI pipeline change; runs on the next PR opened against this repo)

## Screenshot

N/A

## Anything to Note?

`business-rules.md` only has one entry so far - it is meant to grow every time a reviewer (human or AI) catches a domain-knowledge mistake like this one, so the same class of error does not slip through again.