### PR TITLE
fix: load .env / .env.development.local in ai:dev orchestrator

### DIFF
--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -2,6 +2,8 @@
 import { execFileSync } from 'node:child_process';
 import { createHash } from 'node:crypto';
 
+import { config } from 'dotenv';
+
 import { getDiff } from '../ai-review/lib/diff.mjs';
 import { buildPrompt } from '../ai-review/lib/prompt.mjs';
 import {
@@ -39,6 +41,9 @@ import {
   SUBMIT_FOR_REVIEW_TOOL,
   TOOL_DECLARATIONS,
 } from './lib/tools.mjs';
+
+config();
+config({ path: '.env.development.local', override: true });
 
 const MAX_ITERATIONS = 10;
 const MAX_TURNS_PER_ITERATION = 25;


### PR DESCRIPTION
## What Does This PR Do?

- `scripts/ai-dev/orchestrator.mjs` never loaded any `.env` file — it only
  read `process.env` directly, so `GEMINI_API_KEY` set in `.env` or
  `.env.development.local` was silently ignored and preflight always failed
  with "GEMINI_API_KEY is not set" unless the var was exported in the shell
- Added `dotenv` loading (`config()` then `config({ path: '.env.development.local', override: true })`),
  matching the existing pattern in `scripts/generate-types.mjs`

## Demo

N/A (local CLI script — `pnpm ai:dev <ticket-number>`)

## Screenshot

N/A

## Anything to Note?

`dotenv` was already a project dependency, just unused by this script.
