### PR TITLE
fix: log dev-agent tool calls per turn in ai:dev orchestrator

### DIFF
--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -166,6 +166,7 @@ async function runDevAgentTurn({ systemPrompt, task }) {
 
     const calls = extractFunctionCalls(candidate);
     if (calls.length === 0) {
+      log(`  turn ${turn}/${MAX_TURNS_PER_ITERATION}: no tool call — nudging`);
       contents.push(
         userTurn(
           'You must call a tool to make progress; plain text is not read by anyone. Call submitForReview when your changes are complete.'
@@ -173,6 +174,10 @@ async function runDevAgentTurn({ systemPrompt, task }) {
       );
       continue;
     }
+    log(
+      `  turn ${turn}/${MAX_TURNS_PER_ITERATION}: ` +
+        calls.map((c) => `${c.name}(${summarizeCallArgs(c)})`).join(', ')
+    );
 
     // Round 8: if the model returns multiple parallel calls in one turn, run
     // every non-submit call first so all edits land before we hand off — and
@@ -193,6 +198,7 @@ async function runDevAgentTurn({ systemPrompt, task }) {
         }
       } catch (err) {
         if (err instanceof FileTooLargeError) throw err; // Round 10: abort the whole run, don't loop on it
+        log(`    ${call.name} failed: ${err.message}`);
         results.push({ name: call.name, response: { error: err.message } });
       }
     }
@@ -209,6 +215,14 @@ async function runDevAgentTurn({ systemPrompt, task }) {
   throw new Error(
     `Dev agent exceeded ${MAX_TURNS_PER_ITERATION} tool-call turns without calling submitForReview.`
   );
+}
+
+function summarizeCallArgs(call) {
+  const { path, command, pattern } = call.args ?? {};
+  if (path) return path;
+  if (command) return command;
+  if (pattern) return pattern;
+  return '';
 }
 
 function diffHash(baseRef) {


### PR DESCRIPTION
## What Does This PR Do?

- `runDevAgentTurn` in `scripts/ai-dev/orchestrator.mjs` ran up to 25 turns
  per iteration with zero console output — a long-running turn was
  indistinguishable from a hung process, and a run that eventually failed
  with "Dev agent exceeded 25 tool-call turns without calling
  submitForReview" gave no clue which tool calls it made or where it got stuck
- Added a log line per turn showing which tool(s) the dev agent called (and
  the target path/command/pattern), a log line when a turn produces no tool
  call (the "nudge" case), and a log line when an individual tool call fails

## Demo

N/A (local CLI script — `pnpm ai:dev <ticket-number>`)

## Screenshot

N/A

## Anything to Note?

Purely additive logging, no behavior change.
