### PR TITLE
fix: auto-collapse WIP commits at the end of an ai:dev run

### DIFF
--- a/scripts/ai-dev/lib/git.mjs
+++ b/scripts/ai-dev/lib/git.mjs
@@ -123,6 +123,11 @@ export function commitWip(message) {
   run(['commit', '-m', message, '--no-verify']);
 }
 
+/** Collapses every WIP commit back into uncommitted (staged) changes against `ref`, leaving HEAD at `ref`. */
+export function resetSoft(ref) {
+  run(['reset', '--soft', ref]);
+}
+
 /** Files changed between baseRef and HEAD (committed history only — WIP commits included). */
 export function diffNameOnly(baseRef) {
   const out = run(['diff', '--name-only', '-z', `${baseRef}...HEAD`]);

--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -29,6 +29,7 @@ import {
   mergeBase,
   parseOwnerRepo,
   remoteOriginUrl,
+  resetSoft,
   stageAll,
   updateDevelopFastForward,
 } from './lib/git.mjs';
@@ -272,11 +273,14 @@ function printFinalReport(finalState) {
       );
     }
   }
-  console.log(
-    `\n[ai:dev] WIP commits are on branch "${currentBranch()}". Next step:\n` +
-      `  git reset --soft ${resolvedBaseRef}\n` +
-      '  # review the diff, then commit it yourself (ai:dev never pushes or commits for real)'
-  );
+  if (hasCommittedThisRun) {
+    console.log(
+      `\n[ai:dev] collapsed the WIP commit(s) back onto branch "${currentBranch()}" — ` +
+        'your changes are staged and uncommitted, ready to review.\n' +
+        '  git diff --cached   # review before committing\n' +
+        '  # ai:dev never commits or pushes anything real — that part is still on you'
+    );
+  }
 }
 
 async function main() {
@@ -444,6 +448,13 @@ async function main() {
 
   if (!finalState) {
     finalState = { status: 'iteration-cap-reached', iteration: MAX_ITERATIONS };
+  }
+
+  // Collapse the per-iteration WIP commits back into uncommitted staged
+  // changes so the run ends with something ready to review, not a WIP commit
+  // you have to manually reset yourself every time.
+  if (hasCommittedThisRun) {
+    resetSoft(resolvedBaseRef);
   }
 
   printFinalReport(finalState);


### PR DESCRIPTION
## What Does This PR Do?

- Every iteration of `ai:dev` creates a `wip: ai:dev iteration N` commit so
  the reviewer's diff logic (`git diff baseRef...HEAD`, shared with the CI
  ai-review pipeline) has something to compare against `HEAD`, and so a
  bad iteration has a rollback point. Previously the run ended by just
  printing `git reset --soft <baseRef>` and expecting you to run it
  yourself every single time
- Added `resetSoft(ref)` to `lib/git.mjs`. `main()` now runs it
  automatically once the iteration loop ends (pass, stuck, or iteration cap)
  and there's at least one WIP commit — collapsing them back into staged,
  uncommitted changes on the branch. The final report reflects this: it
  tells you to `git diff --cached` and commit yourself, instead of telling
  you to run the reset

## Demo

N/A (local CLI script — `pnpm ai:dev <ticket-number>`)

## Screenshot

N/A

## Anything to Note?

- Only removes a manual step at the very end of a *completed* run — the
  per-iteration WIP commits still happen during the run itself (still
  required for the reviewer's diff and the per-round rollback point)
- The SIGINT (Ctrl+C) handler still prints the manual `git reset --soft`
  instruction rather than auto-resetting, since an interrupt can land
  mid-tool-call and auto-running further git operations at that point felt
  riskier than just telling the user what to do
- Still never creates a "real" commit or pushes anything — that boundary is
  unchanged, only the last mechanical step (turning WIP commits back into a
  diff you can review) is now automatic
