### PR TITLE
feat: require avatar upload for mentor profile

### DIFF
--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -2,7 +2,7 @@
 
 import { useSession } from 'next-auth/react';
 import React from 'react';
-import { Control, FieldValues, Path } from 'react-hook-form';
+import { Control, FieldValues, Path, useController } from 'react-hook-form';
 
 import AvatarUpload from '@/components/ui/avatar-upload';
 
@@ -11,27 +11,46 @@ import { Section } from './Section';
 interface AvatarSectionProps<T extends FieldValues> {
   control: Control<T>;
   name: Path<T>;
+  isMentor?: boolean;
   onFileChange?: (file: File) => void;
 }
 
 export const AvatarSection = <T extends FieldValues>({
   control,
   name,
+  isMentor,
   onFileChange,
 }: AvatarSectionProps<T>) => {
   const { data: session } = useSession();
+  const {
+    fieldState: { error },
+  } = useController({ control, name });
+
   // Avatar URLs already carry their own `?v=` cache buster from upload time,
   // so render the session value as-is — no post-hoc version stitching.
   const avatarUrl = session?.user?.avatar ?? '';
 
   return (
-    <Section title="個人頭像">
+    <Section
+      id="avatarFile"
+      title={
+        <>
+          {isMentor && <span className="text-status-200">* </span>}
+          個人頭像
+        </>
+      }
+    >
       <AvatarUpload
         control={control}
         name={name}
         avatarUrl={avatarUrl}
         onFileChange={onFileChange}
       />
+      {error && (
+        <p className="mt-2 text-sm font-medium text-destructive">
+          {error.message}
+        </p>
+      )}
     </Section>
   );
 };

--- a/src/components/profile/edit/profileSchema.ts
+++ b/src/components/profile/edit/profileSchema.ts
@@ -133,6 +133,13 @@ export const createProfileFormSchema = (isMentor: boolean) =>
     })
     .superRefine((data, ctx) => {
       if (isMentor) {
+        if (!data.avatar && !data.avatarFile) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            path: ['avatarFile'],
+            message: '請上傳大頭貼以完成導師註冊',
+          });
+        }
         if (data.work_experiences.length < 1) {
           ctx.addIssue({
             code: z.ZodIssueCode.custom,


### PR DESCRIPTION
## What Does This PR Do?

- Marks avatar as required for mentors during profile edit, with an asterisk on the section title
- Adds Zod validation so mentors must set an avatar (existing or newly uploaded) before submitting
- Surfaces an inline error message under the avatar upload when validation fails

## Demo

http://localhost:3000/profile

## Screenshot

N/A

## Anything to Note?

N/A
