### PR TITLE
chore: raise ai:dev MAX_TURNS_PER_ITERATION from 40 to 200

### DIFF
--- a/scripts/ai-dev/lib/review-bridge.mjs
+++ b/scripts/ai-dev/lib/review-bridge.mjs
@@ -57,7 +57,9 @@ async function runSpecialist(key, title, plan, diff, truncatedNote) {
       TRUNCATED_NOTE: truncatedNote,
     });
     const result = await callGemini(prompt);
-    const findingsCount = result?.hasFindings ? (result.findings ?? []).length : 0;
+    const findingsCount = result?.hasFindings
+      ? (result.findings ?? []).length
+      : 0;
     console.log(`[review] ${title}: done (${findingsCount} finding(s))`);
     return result;
   } catch (err) {

--- a/scripts/ai-dev/lib/review-bridge.mjs
+++ b/scripts/ai-dev/lib/review-bridge.mjs
@@ -37,22 +37,29 @@ function formatTicketSection(ticket) {
 const DIFF_SIZE_WARNING_THRESHOLD = 40_000;
 
 async function runPlanner({ ticketSection, diff, truncatedNote }) {
+  console.log('[review] planner: analyzing ticket + diff...');
   const prompt = buildPrompt(new URL('planner.md', PROMPTS_DIR), {
     TICKET_SECTION: ticketSection,
     DIFF: diff,
     TRUNCATED_NOTE: truncatedNote,
   });
-  return callGemini(prompt);
+  const plan = await callGemini(prompt);
+  console.log('[review] planner: done');
+  return plan;
 }
 
-async function runSpecialist(key, plan, diff, truncatedNote) {
+async function runSpecialist(key, title, plan, diff, truncatedNote) {
+  console.log(`[review] ${title}: running...`);
   try {
     const prompt = buildPrompt(new URL(`${key}.md`, PROMPTS_DIR), {
       PLAN_JSON: JSON.stringify(plan, null, 2),
       DIFF: diff,
       TRUNCATED_NOTE: truncatedNote,
     });
-    return await callGemini(prompt);
+    const result = await callGemini(prompt);
+    const findingsCount = result?.hasFindings ? (result.findings ?? []).length : 0;
+    console.log(`[review] ${title}: done (${findingsCount} finding(s))`);
+    return result;
   } catch (err) {
     // One specialist failing must not kill the whole review round — the
     // others still have useful findings, and this one shows up as "not run".
@@ -62,6 +69,7 @@ async function runSpecialist(key, plan, diff, truncatedNote) {
 }
 
 async function runSummary(plan, findingsByKey) {
+  console.log('[review] summary: judging overall risk...');
   try {
     const replacements = { PLAN_JSON: JSON.stringify(plan, null, 2) };
     for (const { key } of SPECIALISTS) {
@@ -77,7 +85,11 @@ async function runSummary(plan, findingsByKey) {
       new URL('summary.md', PROMPTS_DIR),
       replacements
     );
-    return await callGemini(prompt);
+    const summary = await callGemini(prompt);
+    console.log(
+      `[review] summary: done (overall risk: ${summary?.overallRisk?.level ?? 'unknown'})`
+    );
+    return summary;
   } catch (err) {
     console.warn(`[review-bridge] summary judgment failed: ${err.message}`);
     return null;
@@ -110,7 +122,9 @@ export async function reviewDiff({ baseRef, ticket }) {
   });
 
   const results = await Promise.all(
-    SPECIALISTS.map(({ key }) => runSpecialist(key, plan, diff, truncatedNote))
+    SPECIALISTS.map(({ key, title }) =>
+      runSpecialist(key, title, plan, diff, truncatedNote)
+    )
   );
   const findingsByKey = Object.fromEntries(
     SPECIALISTS.map(({ key }, i) => [key, results[i]])

--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -48,10 +48,10 @@ config();
 config({ path: '.env.development.local', override: true });
 
 const MAX_ITERATIONS = 10;
-const MAX_TURNS_PER_ITERATION = 40;
+const MAX_TURNS_PER_ITERATION = 200;
 // When this few turns remain, nudge the agent to wrap up instead of letting
 // it keep investigating until the hard cutoff.
-const WRAP_UP_WARNING_TURNS_REMAINING = 5;
+const WRAP_UP_WARNING_TURNS_REMAINING = 25;
 const EXPECTED_ORG = 'Xchange-Taiwan';
 const SYSTEM_PROMPT_URL = new URL(
   './prompts/dev-agent-system.md',


### PR DESCRIPTION
## What Does This PR Do?

- Raises `MAX_TURNS_PER_ITERATION` in `scripts/ai-dev/orchestrator.mjs` from 40 to 200 so complex tickets no longer get cut off mid-investigation before the dev agent calls `submitForReview`
- Scales `WRAP_UP_WARNING_TURNS_REMAINING` from 5 to 25 to keep the same ~12.5% wrap-up buffer ratio at the new turn budget
- Adds real-time progress logging to the local review pipeline (`scripts/ai-dev/lib/review-bridge.mjs`) — Planner, each of the 6 specialist reviewers, and the Summary judgment now each log when they start and finish, instead of the whole `reviewDiff` call being a silent black box until it returns

## Demo

N/A — internal `pnpm ai:dev` CLI tooling, no user-facing UI

## Screenshot

N/A

## Anything to Note?

Closes Xchange-Taiwan/X-Talent-Tracker#310. Verified with `pnpm lint`, `pnpm type-check`, `pnpm test` (157 tests passing), and `pnpm build`.
