### PR TITLE
fix: repair pre-existing E2E test bugs unmasked by next-auth login fix

### DIFF
--- a/e2e/tests/authenticated/smoke.spec.ts
+++ b/e2e/tests/authenticated/smoke.spec.ts
@@ -7,9 +7,7 @@ import { expect, test } from '@playwright/test';
 test('logged-in user sees the user menu on the homepage', async ({ page }) => {
   await page.goto('/');
 
-  await expect(
-    page.getByRole('button', { name: /open user menu/i })
-  ).toBeVisible({
+  await expect(page.getByRole('button', { name: /開啟用戶選單/ })).toBeVisible({
     timeout: 15_000,
   });
   await expect(page.getByRole('link', { name: /^登入$/ })).toHaveCount(0);
@@ -22,9 +20,7 @@ test('logged-in user can open the mentor pool without redirect', async ({
   await page.goto('/mentor-pool');
 
   await expect(page).toHaveURL(/\/mentor-pool/);
-  await expect(
-    page.getByRole('button', { name: /open user menu/i })
-  ).toBeVisible({
+  await expect(page.getByRole('button', { name: /開啟用戶選單/ })).toBeVisible({
     timeout: 15_000,
   });
 });

--- a/e2e/tests/onboarding/onboarding.spec.ts
+++ b/e2e/tests/onboarding/onboarding.spec.ts
@@ -1,7 +1,7 @@
 import { expect, Page, test } from '@playwright/test';
 
 import { mockApiRoute } from '../../helpers/route';
-import { setRawSessionCookie } from '../../helpers/session';
+import { setSignedSessionCookie } from '../../helpers/session';
 
 // ─── Mock payloads ───────────────────────────────────────────────────────────
 
@@ -88,11 +88,18 @@ const MOCK_CLIENT_SESSION = {
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────
 
-// Onboarding middleware only checks for cookie existence. The server-side
-// layout guard calls getServerSession(), which tries to decode the cookie;
-// decode failure returns null and the guard does NOT redirect.
+// middleware.ts verifies the session cookie via next-auth's getToken() (see
+// PR #263) — a raw/garbage cookie no longer passes and gets redirected to
+// /auth/signin, since /auth/onboarding is not in publicRoutes. Forge a
+// properly signed cookie instead so middleware's isLoggedIn check succeeds.
 async function setFakeSessionCookie(page: Page): Promise<void> {
-  await setRawSessionCookie(page, 'e2e-fake-session-token');
+  await setSignedSessionCookie(page, {
+    id: '1',
+    name: 'Test User',
+    onBoarding: false,
+    isMentor: false,
+    token: 'mock-access-token',
+  });
 }
 
 /**
@@ -164,11 +171,9 @@ test('submit Step 1 with empty name → inline validation error shown, does NOT 
 }) => {
   await gotoOnboarding(page);
 
-  // Clear the name field so validation fires on submit. Whether the session-
-  // driven useEffect has already pre-filled it (local) or never fires because
-  // the SessionProvider sees a null server-side session and skips the
-  // refetch (remote SSR with the intentionally-invalid fake cookie),
-  // fill('') normalises both cases.
+  // Clear the name field so validation fires on submit, regardless of
+  // whether the session-driven useEffect already pre-filled it from the
+  // mocked client session.
   const nameInput = page.locator('input[name="name"]');
   await expect(nameInput).toBeVisible();
   await nameInput.fill('');
@@ -234,19 +239,25 @@ test('complete all 5 steps (happy path) → redirects to /profile/card', async (
   await page.getByRole('option', { name: '1 年以下' }).click();
   await page.getByRole('button', { name: '下一步' }).click();
 
+  // Steps 3-5's option catalogs (want_position/want_skill/want_topic) come
+  // from fetchTagCatalogServer — a server-side (RSC) fetch that page.route()
+  // cannot mock, so the mocked '測試職位' etc. text never renders here (same
+  // SSR-vs-browser-mock gap as mentor-pool.spec.ts). Select whichever real
+  // option renders first instead of matching mocked text.
+
   // Step 3 — select one interested position
   await expect(page.getByText('步驟 3 / 5')).toBeVisible();
-  await page.getByText('測試職位').click();
+  await page.getByRole('checkbox').first().click();
   await page.getByRole('button', { name: '下一步' }).click();
 
   // Step 4 — select one skill
   await expect(page.getByText('步驟 4 / 5')).toBeVisible();
-  await page.getByText('測試技能').click();
+  await page.getByRole('checkbox').first().click();
   await page.getByRole('button', { name: '下一步' }).click();
 
   // Step 5 — select one topic and submit
   await expect(page.getByText('步驟 5 / 5')).toBeVisible();
-  await page.getByText('測試主題').click();
+  await page.getByRole('checkbox').first().click();
   await page.getByRole('button', { name: '提交' }).click();
 
   await expect(page).toHaveURL('/profile/card', { timeout: 15_000 });

--- a/e2e/tests/profile/profile-edit.spec.ts
+++ b/e2e/tests/profile/profile-edit.spec.ts
@@ -49,45 +49,15 @@ function makeProfile(name: string, isMentor: boolean) {
         language: 'zh_TW',
         profession_metadata: { desc: '', icon: '' },
       },
-      interested_positions: {
-        interests: [
-          {
-            id: 1,
-            subject_group: 'TEST_POS',
-            subject: '測試職位',
-            category: 'INTERESTED_POSITION',
-            language: 'zh_TW',
-            desc: { icon: '', desc: '' },
-          },
-        ],
-        language: 'zh_TW',
-      },
-      skills: {
-        interests: [
-          {
-            id: 2,
-            subject_group: 'TEST_SKILL',
-            subject: '測試技能',
-            category: 'SKILL',
-            language: 'zh_TW',
-            desc: { icon: '', desc: '' },
-          },
-        ],
-        language: 'zh_TW',
-      },
-      topics: {
-        interests: [
-          {
-            id: 3,
-            subject_group: 'TEST_TOPIC',
-            subject: '測試主題',
-            category: 'TOPIC',
-            language: 'zh_TW',
-            desc: { icon: '', desc: '' },
-          },
-        ],
-        language: 'zh_TW',
-      },
+      // useEditProfileData.ts reads these as flat subject_group string
+      // arrays directly off MentorProfileVO (form.reset({ want_position:
+      // userDto.want_position ?? [], ... })) — not the nested
+      // { interests: [...] } shape used elsewhere for catalog responses.
+      want_position: ['TEST_POS'],
+      want_skill: ['TEST_SKILL'],
+      want_topic: ['TEST_TOPIC'],
+      have_skill: isMentor ? ['TEST_SKILL'] : [],
+      have_topic: isMentor ? ['TEST_TOPIC'] : [],
       expertises: {
         professions: isMentor
           ? [

--- a/e2e/tests/public/mentor-pool.spec.ts
+++ b/e2e/tests/public/mentor-pool.spec.ts
@@ -60,26 +60,24 @@ test.beforeEach(async ({ page }) => {
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test('page loads → mentor cards are displayed', async ({ page }) => {
-  const mentors = Array.from({ length: 3 }, (_, i) => makeMentor(i + 1));
-  await page.route(/\/v1\/mentors/, (route) =>
-    route.fulfill({
-      status: 200,
-      contentType: 'application/json',
-      body: JSON.stringify(mentorResponse(mentors)),
-    })
-  );
-
+  // The initial listing is server-rendered in MentorPoolWithData (RSC) —
+  // page.route() only intercepts browser-initiated requests, so it can't mock
+  // this fetch. Assert internal consistency (heading count matches rendered
+  // cards) against whatever the real dev backend returns, instead of a
+  // hardcoded mock-driven count.
   await page.goto('/mentor-pool');
 
-  await expect(page.locator('article')).toHaveCount(3);
-  await expect(page.getByText('找到 3 位導師')).toBeVisible();
+  const articles = page.locator('article');
+  await expect(articles.first()).toBeVisible({ timeout: 15_000 });
+  const count = await articles.count();
+  await expect(page.getByText(`找到 ${count} 位導師`)).toBeVisible();
 });
 
 test('type keyword in search bar → mentor list updates to match results', async ({
   page,
 }) => {
   await page.route(/\/v1\/mentors/, (route, request) => {
-    const keyword = new URL(request.url()).searchParams.get('searchPattern');
+    const keyword = new URL(request.url()).searchParams.get('search_pattern');
     const data = keyword
       ? [makeMentor(10), makeMentor(11)]
       : [makeMentor(1), makeMentor(2), makeMentor(3)];
@@ -90,8 +88,12 @@ test('type keyword in search bar → mentor list updates to match results', asyn
     });
   });
 
+  // Initial render comes from the unmocked SSR fetch — only wait for cards to
+  // exist, then verify the mocked client-side search actually replaces them.
   await page.goto('/mentor-pool');
-  await expect(page.locator('article')).toHaveCount(3);
+  await expect(page.locator('article').first()).toBeVisible({
+    timeout: 15_000,
+  });
 
   const responsePromise = page.waitForResponse(/\/v1\/mentors/);
   await page.fill(
@@ -108,10 +110,11 @@ test('apply a filter → mentor list updates to show only filtered results', asy
   page,
 }) => {
   await page.route(/\/v1\/mentors/, (route, request) => {
-    const position = new URL(request.url()).searchParams.get(
-      'filter_positions'
-    );
-    const data = position
+    // There is no position filter in the current UI (mentor-pool/data.ts
+    // only defines filter_skills / filter_topics / filter_industries, in
+    // that order) — filter_skills is the first combobox the test opens.
+    const skill = new URL(request.url()).searchParams.get('filter_skills');
+    const data = skill
       ? [makeMentor(20)]
       : [makeMentor(1), makeMentor(2), makeMentor(3)];
     route.fulfill({
@@ -121,15 +124,21 @@ test('apply a filter → mentor list updates to show only filtered results', asy
     });
   });
 
+  // Initial render comes from the unmocked SSR fetch — only wait for cards to
+  // exist, then verify the mocked client-side filter actually replaces them.
   await page.goto('/mentor-pool');
-  await expect(page.locator('article')).toHaveCount(3);
+  await expect(page.locator('article').first()).toBeVisible({
+    timeout: 15_000,
+  });
 
   // Open filter popover
   await page.getByRole('button', { name: /篩選/ }).click();
 
-  // Position is the first filter — click its SelectTrigger (role=combobox)
+  // filter_skills options come from the tag catalog, itself SSR-fetched (see
+  // fetchTagCatalogServer) and therefore unmockable here — select whichever
+  // real option renders first instead of a hardcoded label.
   await page.getByRole('combobox').first().click();
-  await page.getByRole('option', { name: 'Frontend Developer' }).click();
+  await page.getByRole('option').first().click();
 
   const responsePromise = page.waitForResponse(/\/v1\/mentors/);
   await page.getByRole('button', { name: '套用' }).click();
@@ -156,7 +165,11 @@ test('scroll to bottom → additional mentors are loaded and appended', async ({
     });
   });
 
-  await page.goto('/mentor-pool');
+  // Force the client-side (mockable) fetch path — via any search condition —
+  // instead of the unmocked SSR listing, so mentors.length is a deterministic
+  // multiple of PAGE_LIMIT and container.tsx's scroll-trigger guard
+  // (mentors.length % PAGE_LIMIT === 0) reliably fires fetchMoreMentors.
+  await page.goto('/mentor-pool?q=test');
   await expect(page.locator('article')).toHaveCount(PAGE_LIMIT);
 
   // Bring the last card into the viewport — IntersectionObserver fires and
@@ -172,7 +185,7 @@ test('search returns no results → empty state message is shown', async ({
   page,
 }) => {
   await page.route(/\/v1\/mentors/, (route, request) => {
-    const keyword = new URL(request.url()).searchParams.get('searchPattern');
+    const keyword = new URL(request.url()).searchParams.get('search_pattern');
     const data = keyword ? [] : [makeMentor(1)];
     route.fulfill({
       status: 200,
@@ -181,8 +194,12 @@ test('search returns no results → empty state message is shown', async ({
     });
   });
 
+  // Initial render comes from the unmocked SSR fetch — only wait for a card
+  // to exist, then verify the mocked no-results search actually clears it.
   await page.goto('/mentor-pool');
-  await expect(page.locator('article')).toHaveCount(1);
+  await expect(page.locator('article').first()).toBeVisible({
+    timeout: 15_000,
+  });
 
   const responsePromise = page.waitForResponse(/\/v1\/mentors/);
   await page.fill(

--- a/e2e/tests/reservation/reservation-mentee.spec.ts
+++ b/e2e/tests/reservation/reservation-mentee.spec.ts
@@ -180,8 +180,9 @@ test('資料載入中 → Skeleton 顯示且不閃爍錯誤內容', async ({ pag
     timeout: 10_000,
   });
 
-  // Tabs (real content) must not be visible yet
-  await expect(page.getByRole('tab', { name: /即將到來/ })).not.toBeVisible();
+  // Note: ReservationTabs.tsx always renders the TabsList chrome immediately
+  // — only TabsContent (the panel body) is skeleton-gated per tab — so the
+  // 即將到來 tab trigger itself is visible from first paint, not hidden here.
 
   // Release the delayed responses and wait for real content to appear
   resolveDelay();

--- a/e2e/tests/reservation/reservation-mentor.spec.ts
+++ b/e2e/tests/reservation/reservation-mentor.spec.ts
@@ -323,19 +323,19 @@ test('點擊拒絕並填入原因後確認 → 卡片從待您回復消失', asy
   await page.getByRole('tab', { name: /待您回復/ }).click();
   await expect(page.getByText('Mentee Lee')).toBeVisible({ timeout: 10_000 });
 
-  await page.getByRole('button', { name: /接受/ }).click();
+  // 接受/拒絕 are two independent dialogs (AcceptReservationDialog /
+  // RejectReservationDialog), not one dialog with internal steps — open the
+  // reject dialog directly via its own trigger button on the card.
+  await page.getByRole('button', { name: '拒絕' }).click();
 
-  // Dialog opens at step 'check'; click 拒絕 to go to step 'reject'
-  await expect(page.getByRole('button', { name: /拒絕/ }).first()).toBeVisible({
-    timeout: 5_000,
+  const rejectDialog = page.getByRole('dialog', {
+    name: '拒絕學員預約的原因',
   });
-  await page.getByRole('button', { name: /拒絕/ }).first().click();
+  await expect(rejectDialog).toBeVisible({ timeout: 5_000 });
 
-  // Step 'reject': textarea must be filled before confirming
-  await page.getByPlaceholder(/請在此輸入原因/).fill('時間不符');
-
-  // Confirm rejection
-  await page.getByRole('button', { name: /拒絕/ }).click();
+  // Reason textarea must be filled before the dialog's own 拒絕 button submits
+  await rejectDialog.getByPlaceholder(/請在此輸入原因/).fill('時間不符');
+  await rejectDialog.getByRole('button', { name: '拒絕' }).click();
 
   // Page reloads; wait for tabs to re-render
   await expect(page.getByRole('tab', { name: /待您回復/ })).toBeVisible({
@@ -382,8 +382,9 @@ test('資料載入中 → Skeleton 顯示且不閃爍錯誤內容', async ({ pag
     timeout: 10_000,
   });
 
-  // Real tabs must not be visible yet
-  await expect(page.getByRole('tab', { name: /即將到來/ })).not.toBeVisible();
+  // Note: ReservationTabs.tsx always renders the TabsList chrome immediately
+  // — only TabsContent (the panel body) is skeleton-gated per tab — so the
+  // 即將到來 tab trigger itself is visible from first paint, not hidden here.
 
   // Release responses and wait for real content
   resolveDelay();


### PR DESCRIPTION
## What Does This PR Do?

- Fixes 14 E2E tests that failed on develop's manual E2E run, initially
  suspected to be a next-auth 4.24.15 regression but confirmed (via CI
  log/report analysis and git archaeology) to be unrelated pre-existing
  test bugs masked until now:
  - `smoke.spec.ts`: user-menu aria-label matcher updated to the
    localized Chinese label (`開啟用戶選單`) introduced in PR #482
  - `onboarding.spec.ts`: forge a signed session cookie instead of a
    raw one, since `middleware.ts` now verifies via `getToken()` (PR
    #263); Step 3-5 option selection now picks the first rendered
    checkbox instead of matching unmockable SSR-fetched mock text
  - `profile-edit.spec.ts`: `makeProfile()` mock now matches the real
    flat `want_position`/`want_skill`/`want_topic`/`have_skill`/
    `have_topic` API contract instead of a stale nested shape
  - `mentor-pool.spec.ts`: loosened initial-listing assertions since
    the SSR fetch isn't mockable by `page.route()`; fixed
    `searchPattern` → `search_pattern` and `filter_positions` →
    `filter_skills` param mismatches; forced the client-fetch path for
    the scroll-pagination test
  - `reservation-mentor.spec.ts` / `reservation-mentee.spec.ts`: reject
    flow now opens `RejectReservationDialog` directly instead of going
    through the accept dialog; removed an incorrect assertion that the
    tab trigger itself is hidden during loading (only `TabsContent` is
    skeleton-gated)
- No `src/` changes — all fixes are test-only corrections.

## Demo

http://localhost:3000/mentor-pool

## Screenshot

N/A

## Anything to Note?

- Locally verified: chromium-anon (mentor-pool) 5/5, chromium-onboarding
  3/3, chromium-profile 4/4, chromium-reservation 8/8, all passing.
- `chromium` (smoke.spec.ts) requires real E2E_EMAIL/E2E_PASSWORD login
  credentials against a live backend and could not be verified locally;
  the single change there (aria-label matcher) was verified by reading
  source directly.
