### PR TITLE
fix: default QA gate to blocking; add OpenAPI schema mock fallback

### DIFF
--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -310,15 +310,21 @@ async function runQaStage({ ticket, baseRef }) {
  * the sharp end of issue #318's "無限重試與回饋迴圈" risk area, so it's
  * pulled out on its own to be directly unit-testable rather than only
  * reachable by driving the whole main() loop. Only a confirmed `failed`
- * (a genuine scenario assertion mismatch) can block, and only when
- * explicitly opted into via AI_QA_BLOCKING — `infra-error` / `not-applicable`
- * / `skipped` must never trigger a retry no matter what the flag says,
+ * (a genuine scenario assertion mismatch) can block — `infra-error` /
+ * `not-applicable` / `skipped` must never trigger a retry no matter what,
  * since retrying can't fix an environment problem and would just burn
  * iterations (or worse, feed the dev agent a "fix" for something that was
  * never actually broken).
+ *
+ * Blocking by default, matching issue #318's original gating rule (any
+ * failed scenario blocks auto-PR and feeds back to the dev agent, same as
+ * reviewer findings) — the existing `checkCircuitBreaker` already covers
+ * "when to stop retrying" so this doesn't need its own runaway-loop logic.
+ * Set `AI_QA_BLOCKING=false` to opt back out to report-only mode, e.g. while
+ * chasing a suspected false positive from an incomplete mock fixture.
  */
 export function isQaBlocking(qa) {
-  return process.env.AI_QA_BLOCKING === 'true' && qa.status === 'failed';
+  return process.env.AI_QA_BLOCKING !== 'false' && qa.status === 'failed';
 }
 
 function printFinalReport(finalState, prResult) {
@@ -632,10 +638,10 @@ async function main() {
         continue;
       }
 
-      // Non-blocking by default (see issue #318: v1 QA runs and reports but
-      // doesn't gate) — `infra-error`/`not-applicable`/`skipped` never block
-      // regardless of AI_QA_BLOCKING; only a confirmed `failed` does, and
-      // only when explicitly opted in.
+      // Reaching here means isQaBlocking(qa) was false: either qa.status
+      // isn't a confirmed `failed` (`infra-error`/`not-applicable`/`skipped`
+      // never block, regardless of AI_QA_BLOCKING), or the run opted out via
+      // AI_QA_BLOCKING=false.
       finalState = { status: 'passed', iteration, review, qa };
       break;
     }

--- a/scripts/ai-dev/orchestrator.test.mjs
+++ b/scripts/ai-dev/orchestrator.test.mjs
@@ -279,38 +279,38 @@ describe('isQaBlocking', () => {
     else process.env.AI_QA_BLOCKING = originalFlag;
   });
 
-  it('blocks on a failed QA result when AI_QA_BLOCKING=true', () => {
+  it('blocks on a failed QA result when AI_QA_BLOCKING is unset (default)', () => {
+    delete process.env.AI_QA_BLOCKING;
+    expect(isQaBlocking({ status: 'failed' })).toBe(true);
+  });
+
+  it('blocks on a failed QA result when AI_QA_BLOCKING is any value other than "false"', () => {
     process.env.AI_QA_BLOCKING = 'true';
     expect(isQaBlocking({ status: 'failed' })).toBe(true);
   });
 
-  it('does not block on a failed QA result when AI_QA_BLOCKING is unset (default)', () => {
-    delete process.env.AI_QA_BLOCKING;
+  it('does not block on a failed QA result when explicitly opted out via AI_QA_BLOCKING=false', () => {
+    process.env.AI_QA_BLOCKING = 'false';
     expect(isQaBlocking({ status: 'failed' })).toBe(false);
   });
 
-  it('never blocks on infra-error, even with AI_QA_BLOCKING=true', () => {
-    process.env.AI_QA_BLOCKING = 'true';
+  it('never blocks on infra-error, even by default', () => {
+    delete process.env.AI_QA_BLOCKING;
     expect(isQaBlocking({ status: 'infra-error' })).toBe(false);
   });
 
-  it('never blocks on not-applicable, even with AI_QA_BLOCKING=true', () => {
-    process.env.AI_QA_BLOCKING = 'true';
+  it('never blocks on not-applicable, even by default', () => {
+    delete process.env.AI_QA_BLOCKING;
     expect(isQaBlocking({ status: 'not-applicable' })).toBe(false);
   });
 
-  it('never blocks on skipped, even with AI_QA_BLOCKING=true', () => {
-    process.env.AI_QA_BLOCKING = 'true';
+  it('never blocks on skipped, even by default', () => {
+    delete process.env.AI_QA_BLOCKING;
     expect(isQaBlocking({ status: 'skipped' })).toBe(false);
   });
 
   it('never blocks on passed', () => {
-    process.env.AI_QA_BLOCKING = 'true';
+    delete process.env.AI_QA_BLOCKING;
     expect(isQaBlocking({ status: 'passed' })).toBe(false);
-  });
-
-  it('treats any value other than the literal string "true" as unset', () => {
-    process.env.AI_QA_BLOCKING = '1';
-    expect(isQaBlocking({ status: 'failed' })).toBe(false);
   });
 });

--- a/scripts/ai-qa/README.md
+++ b/scripts/ai-qa/README.md
@@ -29,11 +29,15 @@ below), so no real backend account setup is required.
    the scenarios are likely to call.
 3. A standalone **mock API server** (`lib/mock-api-server.mjs`) starts on an
    ephemeral port, seeded with a baseline `/v1/auth/login` handler plus the
-   fixture planner's output. This is a real local HTTP server, not MSW —
-   MSW patches the process making the requests, which doesn't fit here since
-   the QA dev server runs as a separate child process; pointing
-   `NEXT_PUBLIC_API_URL` at a real local server covers both client- and
-   server-side calls with zero changes to `src/`.
+   fixture planner's output. Any endpoint the fixture planner didn't plan a
+   fixture for, but that genuinely exists in the OpenAPI contract, still gets
+   a generic response sampled from that contract's schema (`lib/schema-mock.mjs`,
+   backed by the `scripts/ai-qa/openapi-spec.json` snapshot — see "Mock API
+   server vs. a real backend" below) instead of 404ing. This is a real local
+   HTTP server, not MSW — MSW patches the process making the requests, which
+   doesn't fit here since the QA dev server runs as a separate child process;
+   pointing `NEXT_PUBLIC_API_URL` at a real local server covers both client-
+   and server-side calls with zero changes to `src/`.
 4. A real `next dev` server is booted on an ephemeral port, with
    `NEXT_PUBLIC_API_URL` pointed at the mock server, for the current working
    tree.
@@ -67,9 +71,27 @@ below), so no real backend account setup is required.
 **Default: mock.** A fresh mock server starts per QA run. Role sessions log
 in with fixed sentinel emails (`qa-mentor@mock.local` / `qa-mentee@mock.local`
 — see `lib/mock-api-server.mjs`) that the mock server's `/v1/auth/login`
-handler recognizes; any endpoint the fixture planner didn't anticipate 404s
-loudly instead of silently returning a plausible-but-wrong response — a
-missing fixture should be obvious, not a "ghost mock" masking a real bug.
+handler recognizes. Requests are resolved in order:
+
+1. An exact-match fixture — login, or one the fixture planner (or a
+   scenario) registered. Realistic, scenario-aware data.
+2. A generic baseline sampled from the OpenAPI contract
+   (`lib/schema-mock.mjs`) for any endpoint the contract defines but nobody
+   registered a fixture for — e.g. a pre-existing endpoint a page calls that
+   this ticket's diff didn't touch, so the fixture planner (which only reads
+   the diff) had no way to know about it. Field values come from each
+   schema field's declared `default`, or a type-based zero value (`''`, `0`,
+   `false`, `{}`) — plausible shape, not scenario-realistic content.
+3. 404, loudly, instead of silently returning a plausible-but-wrong
+   response — only for a path that isn't in the OpenAPI contract at all, so
+   a genuinely wrong/unexpected endpoint call still surfaces as a "ghost
+   mock masking a real bug" signal rather than being papered over.
+
+The schema baseline is sampled from `scripts/ai-qa/openapi-spec.json`, a
+snapshot of the same `BFF_OPENAPI_URL` spec that generates `src/types/api.ts`
+— regenerated together by `pnpm generate:types`, so it can't drift out of
+sync with the real contract. If that snapshot is missing, step 2 is simply
+skipped (falls straight through to 404) rather than erroring.
 
 **Opt-in: real backend.** Set `QA_USE_REAL_BACKEND=1` to skip the mock
 server entirely and hit whatever `NEXT_PUBLIC_API_URL` already points to.
@@ -91,12 +113,14 @@ can't silently get sent to the mock server and resolve to the wrong role.
 
 - `SKIP_QA=1` — skip the whole stage (useful for a fast local iteration loop).
 - `QA_USE_REAL_BACKEND=1` — see above.
-- `AI_QA_BLOCKING=true` — opt into having a `failed` QA result (a genuine
+- `AI_QA_BLOCKING=false` — opt out of having a `failed` QA result (a genuine
   scenario assertion mismatch) block auto-PR and feed back into the dev
-  agent's next retry round, the same way reviewer findings do. **Default is
-  unset (non-blocking)** — v1 runs and reports, but doesn't gate, per the
-  issue #318 rollout plan. `infra-error` / `not-applicable` never block,
-  regardless of this flag.
+  agent's next retry round. **Default is blocking**, matching issue #318's
+  original gating rule — any value other than the literal string `false`
+  blocks. `infra-error` / `not-applicable` never block, regardless of this
+  flag. Reach for `AI_QA_BLOCKING=false` when chasing a suspected false
+  positive (e.g. the fixture planner missed an endpoint the scenario
+  actually needed — see "v1 scope" below) rather than a real bug.
 
 ## Status values
 
@@ -110,9 +134,18 @@ can't silently get sent to the mock server and resolve to the wrong role.
 
 ## v1 scope (by design)
 
-- **Fixture planner covers common cases, not every endpoint.** It's an LLM
-  guessing which endpoints matter from the diff and drafting plausible
-  responses — not a schema-driven generator against the OpenAPI spec
-  (`src/types/api.ts`). An endpoint it misses 404s; that scenario reports
-  `infra-error`, not `failed`.
+- **Fixture planner covers common cases, not every endpoint** — it's an LLM
+  guessing which endpoints matter from the diff and drafting scenario-realistic
+  responses, so it can miss an endpoint the diff doesn't mention. The schema
+  baseline (`lib/schema-mock.mjs`, see above) is the safety net for that gap:
+  it guarantees any endpoint the OpenAPI contract defines gets _some_ valid
+  response, just not a scenario-realistic one — a scenario that depends on
+  specific data in that endpoint's response (not just "the page renders
+  without erroring") may still need the fixture planner to have gotten it
+  right, or a manually-registered fixture.
+- **Only an endpoint outside the contract entirely still 404s** — and even
+  then, whether that becomes a reported `infra-error` (harness issue) versus
+  `failed` (genuine bug) depends on the QA agent's own LLM correctly
+  recognizing the 404 as an environment problem (`classification:
+'environment-error'` — see `lib/qa-agent.mjs`); it isn't automatic.
 - **No CI integration.** Local `ai:dev` only.

--- a/scripts/ai-qa/lib/fixture-planner.mjs
+++ b/scripts/ai-qa/lib/fixture-planner.mjs
@@ -44,9 +44,10 @@ export function isValidFixture(f) {
 /**
  * Returns a validated `{ method, path, status, body }[]`, capped at
  * MAX_FIXTURES. Never throws on a malformed planner response — an empty
- * array just means scenarios only get the baseline login mock, and any
- * endpoint they actually need 404s loudly (see mock-api-server.mjs) rather
- * than silently serving something wrong-shaped.
+ * array just means scenarios fall back to the OpenAPI-schema-sampled
+ * baseline for any endpoint the contract defines (see schema-mock.mjs), or
+ * 404 loudly (see mock-api-server.mjs) for one the contract doesn't define,
+ * rather than silently serving something wrong-shaped.
  */
 export async function planFixtures({ ticket, baseRef }) {
   const { diff, truncated } = getDiff(baseRef);

--- a/scripts/ai-qa/lib/mock-api-server.mjs
+++ b/scripts/ai-qa/lib/mock-api-server.mjs
@@ -12,6 +12,8 @@
 // calls with zero changes to app source. See qa-bridge.mjs for the wiring.
 import { createServer } from 'node:http';
 
+import { getSchemaMockFixture } from './schema-mock.mjs';
+
 // Shared with auth-fixtures.mjs, which logs in with these fixed emails when
 // no real QA_TEST_ACCOUNT_* credentials are configured — the mock server
 // doesn't check passwords, only which sentinel email decides the role.
@@ -71,10 +73,15 @@ function loginResponseFor(email) {
 /**
  * `routes` is a Map keyed by `METHOD path` (exact match — scenario/fixture
  * paths are concrete, not patterns) to a handler `(parsedBody, req) => { status, body }`.
- * Unmatched routes 404 loudly instead of returning a generic empty-but-valid
- * body — a silently "successful" wrong-shaped response is exactly the
- * "ghost mock masking a real bug" risk flagged in issue #318's Risks
- * section; a clear 404 makes a missing fixture obvious instead of plausible.
+ * Lookup order per request: (1) an exact-match registered route (login, or
+ * one the fixture planner/a scenario registered — realistic, scenario-aware
+ * data); (2) a generic baseline sampled from the OpenAPI contract (see
+ * schema-mock.mjs) for any endpoint the contract defines but nobody
+ * registered a fixture for; (3) 404. Only a path the contract doesn't define
+ * at all reaches the 404 — a silently "successful" wrong-shaped response for
+ * an endpoint that isn't even real is the "ghost mock masking a real bug"
+ * risk flagged in issue #318's Risks section, so that case still 404s loudly
+ * instead of returning a generic empty-but-valid body.
  */
 export function createMockApiServer() {
   const routes = new Map();
@@ -99,14 +106,25 @@ export function createMockApiServer() {
   const server = createServer(async (req, res) => {
     const url = new URL(req.url, 'http://localhost');
     const key = `${req.method} ${url.pathname}`;
-    const handler = routes.get(key);
+    let handler = routes.get(key);
+
+    if (!handler) {
+      const schemaFixture = getSchemaMockFixture(req.method, url.pathname);
+      if (schemaFixture) {
+        console.log(
+          `[ai-qa] mock-api-server: no fixture registered for ${key}, serving a generic ` +
+            'schema-sampled baseline from the OpenAPI contract (see schema-mock.mjs)'
+        );
+        handler = async () => schemaFixture;
+      }
+    }
 
     if (!handler) {
       console.warn(`[ai-qa] mock-api-server: no fixture registered for ${key}`);
       sendJson(res, 404, {
         msg:
-          `No mock fixture registered for ${key}. Add one via the fixture planner, or this ` +
-          'endpoint is unexpected for this ticket.',
+          `No mock fixture registered for ${key}, and it isn't in the OpenAPI contract either. ` +
+          'Add one via the fixture planner, or this endpoint is unexpected for this ticket.',
       });
       return;
     }

--- a/scripts/ai-qa/lib/mock-api-server.test.mjs
+++ b/scripts/ai-qa/lib/mock-api-server.test.mjs
@@ -88,3 +88,33 @@ describe('mock API server — dynamic fixtures', () => {
     expect(loginRes.status).toBe(200);
   });
 });
+
+describe('mock API server — OpenAPI schema-sampled baseline fallback', () => {
+  it('serves a generic baseline for a real contract endpoint with no registered fixture', async () => {
+    mock = await startMockApiServer();
+    const res = await fetch(`${mock.url}/v1/users/zh_TW/tags/catalog`);
+    const json = await res.json();
+    expect(res.status).toBe(200);
+    expect(json).toEqual(expect.objectContaining({ data: expect.anything() }));
+  });
+
+  it('an exact-match registered fixture still wins over the schema baseline', async () => {
+    mock = await startMockApiServer();
+    mock.registerHandler('GET', '/v1/users/zh_TW/tags/catalog', async () => ({
+      status: 200,
+      body: {
+        data: { language: 'zh_TW', catalogs: { skill: { kind: 'skill' } } },
+      },
+    }));
+
+    const res = await fetch(`${mock.url}/v1/users/zh_TW/tags/catalog`);
+    const json = await res.json();
+    expect(json.data.catalogs.skill.kind).toBe('skill');
+  });
+
+  it('still 404s for a path that is not in the OpenAPI contract at all', async () => {
+    mock = await startMockApiServer();
+    const res = await fetch(`${mock.url}/v1/nonexistent`);
+    expect(res.status).toBe(404);
+  });
+});

--- a/scripts/ai-qa/lib/schema-mock.mjs
+++ b/scripts/ai-qa/lib/schema-mock.mjs
@@ -1,0 +1,139 @@
+// Safety-net baseline for the QA mock server: any endpoint the OpenAPI
+// contract defines gets a plausible response even if nobody registered a
+// fixture for it (see fixture-planner.mjs, which only plans fixtures for
+// endpoints it spotted in the diff — it has no way to know about endpoints a
+// page calls that this ticket's diff didn't touch). This layer only ever
+// answers for endpoints that genuinely exist in the contract; a call to a
+// path the contract doesn't define still 404s in mock-api-server.mjs, so a
+// real "wrong endpoint" bug still surfaces instead of being masked.
+//
+// Deliberately generic, not scenario-realistic: values come from each
+// field's `default` (if the schema declares one) or a type-based zero value
+// (empty string, 0, false, {}). An exact-match fixture from fixture-planner
+// or a scenario always takes priority over this — see mock-api-server.mjs's
+// lookup order.
+import { readFileSync } from 'node:fs';
+
+const SPEC_PATH = new URL('../openapi-spec.json', import.meta.url);
+const MAX_DEPTH = 6;
+
+let cachedSpec;
+
+function loadSpec() {
+  if (cachedSpec !== undefined) return cachedSpec;
+  try {
+    cachedSpec = JSON.parse(readFileSync(SPEC_PATH, 'utf-8'));
+  } catch {
+    // Missing/unreadable snapshot must degrade to "no schema baseline
+    // available", not crash the mock server — same never-throws contract as
+    // fixture-planner.mjs.
+    cachedSpec = null;
+  }
+  return cachedSpec;
+}
+
+function resolveRef(spec, schema) {
+  if (schema && typeof schema.$ref === 'string') {
+    const name = schema.$ref.split('/').pop();
+    return spec.components?.schemas?.[name] ?? {};
+  }
+  return schema ?? {};
+}
+
+/** Samples a plausible JSON value for an OpenAPI schema fragment. Exported for unit testing. */
+export function sampleSchema(spec, schemaIn, depth = 0) {
+  const schema = resolveRef(spec, schemaIn);
+
+  if (schema.anyOf || schema.oneOf) {
+    const branches = schema.anyOf ?? schema.oneOf;
+    const nonNull = branches.find((b) => resolveRef(spec, b).type !== 'null');
+    return nonNull ? sampleSchema(spec, nonNull, depth) : null;
+  }
+
+  if ('default' in schema) return schema.default;
+  if (Array.isArray(schema.enum) && schema.enum.length > 0)
+    return schema.enum[0];
+
+  if (schema.type === 'array') {
+    if (depth >= MAX_DEPTH || !schema.items) return [];
+    return [sampleSchema(spec, schema.items, depth + 1)];
+  }
+
+  if (schema.properties) {
+    if (depth >= MAX_DEPTH) return {};
+    const obj = {};
+    for (const [key, propSchema] of Object.entries(schema.properties)) {
+      obj[key] = sampleSchema(spec, propSchema, depth + 1);
+    }
+    return obj;
+  }
+
+  switch (schema.type) {
+    case 'string':
+      return '';
+    case 'integer':
+    case 'number':
+      return 0;
+    case 'boolean':
+      return false;
+    case 'object':
+      return {};
+    case 'null':
+      return null;
+    default:
+      return null;
+  }
+}
+
+function pathToRegex(templatePath) {
+  const parts = templatePath
+    .split('/')
+    .map((segment) =>
+      segment.startsWith('{') && segment.endsWith('}')
+        ? '[^/]+'
+        : segment.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    );
+  return new RegExp(`^${parts.join('/')}$`);
+}
+
+function findSuccessSchema(operation) {
+  const responses = operation.responses ?? {};
+  const code = Object.keys(responses).find((c) => c.startsWith('2'));
+  if (!code) return null;
+  return responses[code]?.content?.['application/json']?.schema ?? null;
+}
+
+/**
+ * Matches `method`+`pathname` against the spec's path templates (the spec's
+ * paths are prefixed `/api/v1/...`; the app's own apiClient calls
+ * `/v1/...` — NEXT_PUBLIC_API_URL already carries the `/api` in production,
+ * but during QA it points straight at the mock server) and returns
+ * `{ status, body }` sampled from that operation's 2xx response schema, or
+ * `null` if the contract has no matching path+method+response. Exported for
+ * unit testing against a hand-built spec.
+ */
+export function findSchemaFixture(spec, method, pathname) {
+  if (!spec?.paths) return null;
+  const verb = method.toLowerCase();
+
+  for (const [specPath, pathItem] of Object.entries(spec.paths)) {
+    const normalizedPath = specPath.replace(/^\/api(?=\/)/, '');
+    if (!pathToRegex(normalizedPath).test(pathname)) continue;
+
+    const operation = pathItem[verb];
+    if (!operation) continue;
+
+    const responseSchema = findSuccessSchema(operation);
+    if (!responseSchema) continue;
+
+    return { status: 200, body: sampleSchema(spec, responseSchema) };
+  }
+  return null;
+}
+
+/** Loads the checked-in OpenAPI snapshot (scripts/ai-qa/openapi-spec.json) and looks up a fixture. */
+export function getSchemaMockFixture(method, pathname) {
+  const spec = loadSpec();
+  if (!spec) return null;
+  return findSchemaFixture(spec, method, pathname);
+}

--- a/scripts/ai-qa/lib/schema-mock.test.mjs
+++ b/scripts/ai-qa/lib/schema-mock.test.mjs
@@ -1,0 +1,161 @@
+// @vitest-environment node
+import { describe, expect, it } from 'vitest';
+
+import {
+  findSchemaFixture,
+  getSchemaMockFixture,
+  sampleSchema,
+} from './schema-mock.mjs';
+
+describe('sampleSchema', () => {
+  const spec = {
+    components: {
+      schemas: {
+        Widget: {
+          type: 'object',
+          properties: {
+            id: { type: 'integer' },
+            name: { type: 'string' },
+            active: { type: 'boolean' },
+            tag: { type: 'string', enum: ['A', 'B'] },
+            note: { type: 'string', default: 'preset' },
+          },
+        },
+      },
+    },
+  };
+
+  it('resolves a $ref against components.schemas', () => {
+    expect(sampleSchema(spec, { $ref: '#/components/schemas/Widget' })).toEqual(
+      {
+        id: 0,
+        name: '',
+        active: false,
+        tag: 'A',
+        note: 'preset',
+      }
+    );
+  });
+
+  it('prefers the non-null branch of anyOf', () => {
+    const schema = { anyOf: [{ type: 'string' }, { type: 'null' }] };
+    expect(sampleSchema(spec, schema)).toBe('');
+  });
+
+  it('returns null when every anyOf branch is null', () => {
+    const schema = { anyOf: [{ type: 'null' }] };
+    expect(sampleSchema(spec, schema)).toBeNull();
+  });
+
+  it('uses an explicit default over type-based sampling', () => {
+    expect(sampleSchema(spec, { type: 'array', default: [] })).toEqual([]);
+  });
+
+  it('uses the first enum value when there is no default', () => {
+    expect(sampleSchema(spec, { type: 'string', enum: ['X', 'Y'] })).toBe('X');
+  });
+
+  it('samples one element for an array without a default', () => {
+    const schema = { type: 'array', items: { type: 'integer' } };
+    expect(sampleSchema(spec, schema)).toEqual([0]);
+  });
+
+  it('returns {} for an object schema with no declared properties', () => {
+    expect(sampleSchema(spec, { type: 'object' })).toEqual({});
+  });
+
+  it('caps recursion depth on self-referential schemas instead of overflowing', () => {
+    const cyclic = { components: { schemas: {} } };
+    cyclic.components.schemas.Node = {
+      type: 'object',
+      properties: {
+        child: { $ref: '#/components/schemas/Node' },
+      },
+    };
+    expect(() =>
+      sampleSchema(cyclic, { $ref: '#/components/schemas/Node' })
+    ).not.toThrow();
+  });
+});
+
+describe('findSchemaFixture', () => {
+  const spec = {
+    paths: {
+      '/api/v1/mentors/{user_id}/{language}/profile': {
+        get: {
+          responses: {
+            200: {
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: { user_id: { type: 'integer' } },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+  };
+
+  it('matches a templated path with the /api prefix stripped', () => {
+    const fixture = findSchemaFixture(
+      spec,
+      'GET',
+      '/v1/mentors/9001/zh_TW/profile'
+    );
+    expect(fixture).toEqual({ status: 200, body: { user_id: 0 } });
+  });
+
+  it('is case-insensitive on the HTTP method', () => {
+    expect(
+      findSchemaFixture(spec, 'get', '/v1/mentors/9001/zh_TW/profile')
+    ).not.toBeNull();
+  });
+
+  it('returns null when no path template matches', () => {
+    expect(
+      findSchemaFixture(spec, 'GET', '/v1/totally/unknown/path')
+    ).toBeNull();
+  });
+
+  it('returns null when the path matches but the method does not', () => {
+    expect(
+      findSchemaFixture(spec, 'POST', '/v1/mentors/9001/zh_TW/profile')
+    ).toBeNull();
+  });
+
+  it('returns null when the operation has no 2xx response schema', () => {
+    const noSchemaSpec = {
+      paths: { '/api/v1/ping': { get: { responses: { 204: {} } } } },
+    };
+    expect(findSchemaFixture(noSchemaSpec, 'GET', '/v1/ping')).toBeNull();
+  });
+});
+
+describe('getSchemaMockFixture (real committed OpenAPI snapshot)', () => {
+  it('finds a baseline fixture for the mentor profile endpoint', () => {
+    const fixture = getSchemaMockFixture(
+      'GET',
+      '/v1/mentors/9001/zh_TW/profile'
+    );
+    expect(fixture?.status).toBe(200);
+    expect(fixture?.body).toEqual(
+      expect.objectContaining({ data: expect.anything() })
+    );
+  });
+
+  it('finds a baseline fixture for the tags catalog endpoint', () => {
+    const fixture = getSchemaMockFixture('GET', '/v1/users/zh_TW/tags/catalog');
+    expect(fixture?.status).toBe(200);
+    expect(fixture?.body).toEqual(
+      expect.objectContaining({ data: expect.anything() })
+    );
+  });
+
+  it('returns null for a path the contract does not define', () => {
+    expect(getSchemaMockFixture('GET', '/v1/nonexistent')).toBeNull();
+  });
+});

--- a/scripts/ai-qa/openapi-spec.json
+++ b/scripts/ai-qa/openapi-spec.json
@@ -1,0 +1,5477 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "X-Career: BFF",
+    "version": "0.1.0"
+  },
+  "servers": [
+    {
+      "url": "/dev"
+    }
+  ],
+  "paths": {
+    "/api/v1/auth/signup": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Signup",
+        "operationId": "signup_api_v1_auth_signup_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/SignupDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_EmailSentVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/email/resend": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Signup Email Resend",
+        "operationId": "signup_email_resend_api_v1_auth_email_resend_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_signup_email_resend_api_v1_auth_email_resend_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_EmailSentVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/signup/confirm": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Confirm Signup",
+        "operationId": "confirm_signup_api_v1_auth_signup_confirm_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_confirm_signup_api_v1_auth_signup_confirm_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_SignupResponseVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Login",
+        "operationId": "login_api_v1_auth_login_post",
+        "parameters": [
+          {
+            "name": "language",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "$ref": "#/components/schemas/Language",
+              "default": "zh_TW"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/LoginDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_LoginResponseVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/token": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Refresh Token",
+        "description": "OAuth 2.0 風格換發 access JWT：`grant_type=refresh_token` + `refresh_token`（form-urlencoded）。",
+        "operationId": "refresh_token_api_v1_auth_token_post",
+        "requestBody": {
+          "content": {
+            "application/x-www-form-urlencoded": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_refresh_token_api_v1_auth_token_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_TokenRefreshVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "tags": ["Auth"],
+        "summary": "Logout",
+        "operationId": "logout_api_v1_auth_logout_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_logout_api_v1_auth_logout_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_NoneType_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/password/{user_id}/update": {
+      "put": {
+        "tags": ["Auth"],
+        "summary": "Update Password",
+        "operationId": "update_password_api_v1_auth_password__user_id__update_put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdatePasswordDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_NoneType_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/password/reset/email": {
+      "get": {
+        "tags": ["Auth"],
+        "summary": "Send Reset Password Comfirm Email",
+        "operationId": "send_reset_password_comfirm_email_api_v1_auth_password_reset_email_get",
+        "parameters": [
+          {
+            "name": "email",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "format": "email",
+              "title": "Email"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_EmailSentVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/password/reset": {
+      "put": {
+        "tags": ["Auth"],
+        "summary": "Reset Password",
+        "description": "重設密碼：email 由信內連結的 verify_token 從 cache 取得，request body 不需傳入 email。",
+        "operationId": "reset_password_api_v1_auth_password_reset_put",
+        "parameters": [
+          {
+            "name": "verify_token",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Verify Token"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ResetPasswordBodyDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_NoneType_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/auth/account": {
+      "delete": {
+        "tags": ["Auth"],
+        "summary": "Delete Account",
+        "operationId": "delete_account_api_v1_auth_account_delete",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DeleteAccountDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ]
+      }
+    },
+    "/api/v1/users/{user_id}/profile": {
+      "put": {
+        "tags": ["User"],
+        "summary": "Upsert Profile",
+        "operationId": "upsert_profile_api_v1_users__user_id__profile_put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ProfileDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ProfileVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{user_id}/{language}/profile": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get Profile",
+        "operationId": "get_profile_api_v1_users__user_id___language__profile_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "language",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ProfileVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{language}/countries": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get Countries",
+        "operationId": "get_countries_api_v1_users__language__countries_get",
+        "parameters": [
+          {
+            "name": "language",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_CountryListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{language}/tags/catalog": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Get Tag Catalog",
+        "operationId": "get_tag_catalog_api_v1_users__language__tags_catalog_get",
+        "parameters": [
+          {
+            "name": "language",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Language"
+            },
+            "example": "zh_TW"
+          },
+          {
+            "name": "kind",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/TagKind"
+                  }
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "title": "Kind"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_TagCatalogsVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{user_id}/reservations": {
+      "get": {
+        "tags": ["User"],
+        "summary": "Reservation List",
+        "operationId": "reservation_list_api_v1_users__user_id__reservations_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "pattern": "^(MENTOR_UPCOMING|MENTEE_UPCOMING|MENTOR_PENDING|MENTEE_PENDING|MENTOR_HISTORY|MENTEE_HISTORY)$",
+              "example": "MENTOR_UPCOMING",
+              "title": "State"
+            }
+          },
+          {
+            "name": "batch",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "example": 10,
+              "title": "Batch"
+            }
+          },
+          {
+            "name": "next_dtend",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ],
+              "example": 1735398000,
+              "title": "Next Dtend"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ReservationInfoListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "tags": ["User"],
+        "summary": "New Booking",
+        "operationId": "new_booking_api_v1_users__user_id__reservations_post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/ReservationDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ReservationVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/users/{user_id}/reservations/{reservation_id}": {
+      "put": {
+        "tags": ["User"],
+        "summary": "Update Reservation Status",
+        "operationId": "update_reservation_status_api_v1_users__user_id__reservations__reservation_id__put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "reservation_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Reservation Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UpdateReservationDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_ReservationVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}/profile": {
+      "put": {
+        "tags": ["Mentor"],
+        "summary": "Upsert Mentor Profile",
+        "operationId": "upsert_mentor_profile_api_v1_mentors__user_id__profile_put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MentorProfileDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_MentorProfileVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}/{language}/profile": {
+      "get": {
+        "tags": ["Mentor"],
+        "summary": "Get Mentor Profile",
+        "operationId": "get_mentor_profile_api_v1_mentors__user_id___language__profile_get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "language",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Language"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_MentorProfileVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{language}/universities": {
+      "get": {
+        "tags": ["Mentor"],
+        "summary": "Get Universities",
+        "operationId": "get_universities_api_v1_mentors__language__universities_get",
+        "parameters": [
+          {
+            "name": "language",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "$ref": "#/components/schemas/Language"
+            }
+          },
+          {
+            "name": "country_name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Country Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_UniversityListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}/schedule": {
+      "put": {
+        "tags": ["Mentor"],
+        "summary": "Upsert Mentor Schedule",
+        "operationId": "upsert_mentor_schedule_api_v1_mentors__user_id__schedule_put",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/MentorScheduleDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_MentorScheduleVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}/schedule/{schedule_id}": {
+      "delete": {
+        "tags": ["Mentor"],
+        "summary": "Delete Mentor Schedule",
+        "operationId": "delete_mentor_schedule_api_v1_mentors__user_id__schedule__schedule_id__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "schedule_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Schedule Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_int_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors": {
+      "get": {
+        "tags": ["Search Mentors"],
+        "summary": "Mentor List",
+        "operationId": "mentor_list_api_v1_mentors_get",
+        "parameters": [
+          {
+            "name": "search_pattern",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "title": "Search Pattern"
+            }
+          },
+          {
+            "name": "filter_positions",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Filter Positions"
+            }
+          },
+          {
+            "name": "filter_skills",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Filter Skills"
+            }
+          },
+          {
+            "name": "filter_topics",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Filter Topics"
+            }
+          },
+          {
+            "name": "filter_expertises",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Filter Expertises"
+            }
+          },
+          {
+            "name": "filter_industries",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "title": "Filter Industries"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "default": 9,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "cursor",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "format": "date-time",
+              "title": "Cursor"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_SearchMentorProfileListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}": {
+      "get": {
+        "tags": ["Search Mentors"],
+        "summary": "Get Mentor",
+        "operationId": "get_mentor_api_v1_mentors__user_id__get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_SearchMentorProfileVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/mentors/{user_id}/schedule/y/{dt_year}/m/{dt_month}": {
+      "get": {
+        "tags": ["Search Mentors"],
+        "summary": "Get Schedules",
+        "operationId": "get_schedules_api_v1_mentors__user_id__schedule_y__dt_year__m__dt_month__get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "dt_year",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Dt Year"
+            }
+          },
+          {
+            "name": "dt_month",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "Dt Month"
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "title": "Limit"
+            }
+          },
+          {
+            "name": "next_dtstart",
+            "in": "query",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "title": "Next Dtstart"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_MentorScheduleQueryVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/file/{user_id}/{file_name}": {
+      "get": {
+        "tags": ["file"],
+        "summary": "Get File Info By Id",
+        "operationId": "get_file_info_by_id_api_v1_file__user_id___file_name__get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["file"],
+        "summary": "Delete File Info",
+        "operationId": "delete_file_info_api_v1_file__user_id___file_name__delete",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "file_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "File Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_bool_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/file/{user_id}": {
+      "get": {
+        "tags": ["file"],
+        "summary": "Get File Info By User Id",
+        "operationId": "get_file_info_by_user_id_api_v1_file__user_id__get",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "put": {
+        "tags": ["file"],
+        "summary": "Update File Info",
+        "operationId": "update_file_info_api_v1_file__user_id__put",
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileInfoDTO"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/file/": {
+      "post": {
+        "tags": ["file"],
+        "summary": "Create File Info",
+        "operationId": "create_file_info_api_v1_file__post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FileInfoDTO"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoVO_"
+                }
+              }
+            }
+          },
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/storage/": {
+      "post": {
+        "tags": ["storage"],
+        "summary": "Upload Avatar",
+        "operationId": "upload_avatar_api_v1_storage__post",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "requestBody": {
+          "required": true,
+          "content": {
+            "multipart/form-data": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_upload_avatar_api_v1_storage__post"
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoListVO_"
+                }
+              }
+            },
+            "description": "OK"
+          },
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "tags": ["storage"],
+        "summary": "Delete File",
+        "operationId": "delete_file_api_v1_storage__delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          },
+          {
+            "name": "file_name",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "File Name"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_bool_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/storage/avatar": {
+      "delete": {
+        "tags": ["storage"],
+        "summary": "Delete Avatar",
+        "operationId": "delete_avatar_api_v1_storage_avatar_delete",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_bool_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/storage/size": {
+      "get": {
+        "tags": ["storage"],
+        "summary": "Get Bucket Size",
+        "operationId": "get_bucket_size_api_v1_storage_size_get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_FileInfoListVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v1/storage/presigned-url/{user_id}": {
+      "get": {
+        "tags": ["storage"],
+        "summary": "Get Presigned Url For Avatar",
+        "operationId": "get_presigned_url_for_avatar_api_v1_storage_presigned_url__user_id__get",
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "parameters": [
+          {
+            "name": "user_id",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "integer",
+              "title": "User Id"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_dict_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/oauth/google/authorize/signup": {
+      "post": {
+        "tags": ["Google OAuth"],
+        "summary": "Oauth Authorize Signup",
+        "operationId": "oauth_authorize_signup_api_v2_oauth_google_authorize_signup_post",
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_GoogleAuthorizeVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v2/oauth/google/authorize/login": {
+      "post": {
+        "tags": ["Google OAuth"],
+        "summary": "Oauth Authorize Login",
+        "operationId": "oauth_authorize_login_api_v2_oauth_google_authorize_login_post",
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_GoogleAuthorizeVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/v2/oauth/google/callback": {
+      "post": {
+        "tags": ["Google OAuth"],
+        "summary": "Oauth Callback",
+        "operationId": "oauth_callback_api_v2_oauth_google_callback_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/Body_oauth_callback_api_v2_oauth_google_callback_post"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_GoogleCallbackVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/v2/oauth/google/callback-test": {
+      "get": {
+        "tags": ["Google OAuth"],
+        "summary": "Oauth Callback Get",
+        "description": "Google 授權完成後以 GET 導回（query 帶 code、state）。與 POST /callback 行為相同，方便本機或未接前端的 redirect_uri 直接指到 BFF。",
+        "operationId": "oauth_callback_get_api_v2_oauth_google_callback_test_get",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Code"
+            }
+          },
+          {
+            "name": "state",
+            "in": "query",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "State"
+            }
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ApiResponse_GoogleCallbackVO_"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/gateway/{term}": {
+      "get": {
+        "summary": "Info",
+        "operationId": "info_gateway__term__get",
+        "parameters": [
+          {
+            "name": "term",
+            "in": "path",
+            "required": true,
+            "schema": {
+              "type": "string",
+              "title": "Term"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Successful Response",
+            "content": {
+              "application/json": {
+                "schema": {}
+              }
+            }
+          },
+          "422": {
+            "description": "Validation Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ApiResponse_CountryListVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/CountryListVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[CountryListVO]"
+      },
+      "ApiResponse_EmailSentVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/EmailSentVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[EmailSentVO]"
+      },
+      "ApiResponse_FileInfoListVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FileInfoListVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[FileInfoListVO]"
+      },
+      "ApiResponse_FileInfoVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/FileInfoVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[FileInfoVO]"
+      },
+      "ApiResponse_GoogleAuthorizeVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GoogleAuthorizeVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[GoogleAuthorizeVO]"
+      },
+      "ApiResponse_GoogleCallbackVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/GoogleCallbackVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[GoogleCallbackVO]"
+      },
+      "ApiResponse_LoginResponseVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/LoginResponseVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[LoginResponseVO]"
+      },
+      "ApiResponse_MentorProfileVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentorProfileVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[MentorProfileVO]"
+      },
+      "ApiResponse_MentorScheduleQueryVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentorScheduleQueryVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[MentorScheduleQueryVO]"
+      },
+      "ApiResponse_MentorScheduleVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/MentorScheduleVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[MentorScheduleVO]"
+      },
+      "ApiResponse_NoneType_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "type": "null",
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[NoneType]"
+      },
+      "ApiResponse_ProfileVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProfileVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[ProfileVO]"
+      },
+      "ApiResponse_ReservationInfoListVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReservationInfoListVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[ReservationInfoListVO]"
+      },
+      "ApiResponse_ReservationVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ReservationVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[ReservationVO]"
+      },
+      "ApiResponse_SearchMentorProfileListVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SearchMentorProfileListVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[SearchMentorProfileListVO]"
+      },
+      "ApiResponse_SearchMentorProfileVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SearchMentorProfileVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[SearchMentorProfileVO]"
+      },
+      "ApiResponse_SignupResponseVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SignupResponseVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[SignupResponseVO]"
+      },
+      "ApiResponse_TagCatalogsVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TagCatalogsVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[TagCatalogsVO]"
+      },
+      "ApiResponse_TokenRefreshVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/TokenRefreshVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[TokenRefreshVO]"
+      },
+      "ApiResponse_UniversityListVO_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/UniversityListVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[UniversityListVO]"
+      },
+      "ApiResponse_bool_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[bool]"
+      },
+      "ApiResponse_dict_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[dict]"
+      },
+      "ApiResponse_int_": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code",
+            "default": "0"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Msg",
+            "default": "ok"
+          },
+          "data": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Data"
+          }
+        },
+        "type": "object",
+        "title": "ApiResponse[int]"
+      },
+      "AuthVO": {
+        "properties": {
+          "region": {
+            "type": "string",
+            "title": "Region"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token"
+          },
+          "online": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Online",
+            "default": false
+          },
+          "created_at": {
+            "type": "integer",
+            "title": "Created At"
+          }
+        },
+        "type": "object",
+        "required": ["region", "user_id", "email", "token", "created_at"],
+        "title": "AuthVO"
+      },
+      "Body_confirm_signup_api_v1_auth_signup_confirm_post": {
+        "properties": {
+          "token": {
+            "type": "string",
+            "title": "Token"
+          }
+        },
+        "type": "object",
+        "required": ["token"],
+        "title": "Body_confirm_signup_api_v1_auth_signup_confirm_post"
+      },
+      "Body_logout_api_v1_auth_logout_post": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "Body_logout_api_v1_auth_logout_post"
+      },
+      "Body_oauth_callback_api_v2_oauth_google_callback_post": {
+        "properties": {
+          "code": {
+            "type": "string",
+            "title": "Code"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": ["code", "state"],
+        "title": "Body_oauth_callback_api_v2_oauth_google_callback_post"
+      },
+      "Body_refresh_token_api_v1_auth_token_post": {
+        "properties": {
+          "grant_type": {
+            "type": "string",
+            "title": "Grant Type",
+            "description": "OAuth 2.0：必須為 refresh_token"
+          },
+          "refresh_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Refresh Token",
+            "description": "先前核發的 refresh token；若為 HttpOnly cookie 則可省略，改由瀏覽器自動帶上同名 cookie"
+          }
+        },
+        "type": "object",
+        "required": ["grant_type"],
+        "title": "Body_refresh_token_api_v1_auth_token_post"
+      },
+      "Body_signup_email_resend_api_v1_auth_email_resend_post": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          }
+        },
+        "type": "object",
+        "required": ["email"],
+        "title": "Body_signup_email_resend_api_v1_auth_email_resend_post"
+      },
+      "Body_upload_avatar_api_v1_storage__post": {
+        "properties": {
+          "file": {
+            "type": "string",
+            "format": "binary",
+            "title": "File"
+          }
+        },
+        "type": "object",
+        "required": ["file"],
+        "title": "Body_upload_avatar_api_v1_storage__post"
+      },
+      "BookingStatus": {
+        "type": "string",
+        "enum": ["PENDING", "ACCEPT", "REJECT"],
+        "title": "BookingStatus"
+      },
+      "CountryListVO": {
+        "properties": {
+          "countries": {
+            "items": {
+              "$ref": "#/components/schemas/CountryVO"
+            },
+            "type": "array",
+            "title": "Countries",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "CountryListVO"
+      },
+      "CountryVO": {
+        "properties": {
+          "country_code": {
+            "type": "string",
+            "title": "Country Code"
+          },
+          "country_name": {
+            "type": "string",
+            "title": "Country Name"
+          }
+        },
+        "type": "object",
+        "required": ["country_code", "country_name"],
+        "title": "CountryVO"
+      },
+      "DeleteAccountDTO": {
+        "properties": {
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Password"
+          },
+          "id_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id Token"
+          }
+        },
+        "type": "object",
+        "required": ["email"],
+        "title": "DeleteAccountDTO"
+      },
+      "EmailSentVO": {
+        "properties": {
+          "ttl_secs": {
+            "type": "integer",
+            "title": "Ttl Secs"
+          }
+        },
+        "type": "object",
+        "required": ["ttl_secs"],
+        "title": "EmailSentVO",
+        "description": "Returned by signup, email resend, and password reset email endpoints."
+      },
+      "ExperienceCategory": {
+        "type": "string",
+        "enum": ["WORK", "EDUCATION", "LINK", "WHAT_I_OFFER"],
+        "title": "ExperienceCategory"
+      },
+      "ExperienceVO": {
+        "properties": {
+          "category": {
+            "$ref": "#/components/schemas/ExperienceCategory"
+          },
+          "mentor_experiences_metadata": {
+            "type": "object",
+            "title": "Mentor Experiences Metadata",
+            "default": {}
+          },
+          "order": {
+            "type": "integer",
+            "title": "Order",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "ExperienceVO"
+      },
+      "FileInfoDTO": {
+        "properties": {
+          "file_id": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Id"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
+          },
+          "file_size": {
+            "type": "integer",
+            "title": "File Size"
+          },
+          "create_user_id": {
+            "type": "integer",
+            "title": "Create User Id"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "string",
+                "maxLength": 2083,
+                "minLength": 1,
+                "format": "uri"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "default": "http://example.com"
+          },
+          "is_deleted": {
+            "type": "boolean",
+            "title": "Is Deleted",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["file_name", "file_size", "create_user_id"],
+        "title": "FileInfoDTO"
+      },
+      "FileInfoListVO": {
+        "properties": {
+          "file_info_vo_list": {
+            "items": {
+              "$ref": "#/components/schemas/FileInfoVO"
+            },
+            "type": "array",
+            "title": "File Info Vo List"
+          }
+        },
+        "type": "object",
+        "required": ["file_info_vo_list"],
+        "title": "FileInfoListVO"
+      },
+      "FileInfoVO": {
+        "properties": {
+          "file_id": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "uuid4"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "File Id"
+          },
+          "file_name": {
+            "type": "string",
+            "title": "File Name"
+          },
+          "file_size": {
+            "type": "integer",
+            "title": "File Size"
+          },
+          "content_type": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Content Type"
+          },
+          "url": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Url",
+            "default": "http://example.com"
+          },
+          "create_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Create Time",
+            "default": "2026-07-25T18:51:48.150404Z"
+          },
+          "update_time": {
+            "anyOf": [
+              {
+                "type": "string",
+                "format": "date-time"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Update Time",
+            "default": "2026-07-25T18:51:48.150419Z"
+          },
+          "create_user_id": {
+            "type": "integer",
+            "title": "Create User Id"
+          },
+          "is_deleted": {
+            "type": "boolean",
+            "title": "Is Deleted",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["file_id", "file_name", "file_size", "create_user_id"],
+        "title": "FileInfoVO"
+      },
+      "GoogleAuthorizeVO": {
+        "properties": {
+          "authorization_url": {
+            "type": "string",
+            "title": "Authorization Url"
+          },
+          "state": {
+            "type": "string",
+            "title": "State"
+          }
+        },
+        "type": "object",
+        "required": ["authorization_url", "state"],
+        "title": "GoogleAuthorizeVO",
+        "description": "Returned by /authorize/signup and /authorize/login."
+      },
+      "GoogleCallbackAuthVO": {
+        "properties": {
+          "email": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Email"
+          },
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Token"
+          },
+          "region": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Region"
+          },
+          "created_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Created At"
+          },
+          "online": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Online"
+          }
+        },
+        "type": "object",
+        "title": "GoogleCallbackAuthVO"
+      },
+      "GoogleCallbackVO": {
+        "properties": {
+          "auth_type": {
+            "type": "string",
+            "title": "Auth Type"
+          },
+          "auth": {
+            "$ref": "#/components/schemas/GoogleCallbackAuthVO"
+          },
+          "user": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/ProfileVO"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "ttl_secs": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Ttl Secs"
+          },
+          "id_token": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id Token"
+          }
+        },
+        "type": "object",
+        "required": ["auth_type", "auth"],
+        "title": "GoogleCallbackVO",
+        "description": "Returned by /callback. auth_type is SIGNUP or LOGIN.\nFor LOGIN, user is populated. For SIGNUP, ttl_secs is populated."
+      },
+      "HTTPValidationError": {
+        "properties": {
+          "detail": {
+            "items": {
+              "$ref": "#/components/schemas/ValidationError"
+            },
+            "type": "array",
+            "title": "Detail"
+          }
+        },
+        "type": "object",
+        "title": "HTTPValidationError"
+      },
+      "Language": {
+        "type": "string",
+        "enum": ["en_US", "zh_TW"],
+        "title": "Language"
+      },
+      "LoginDTO": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          }
+        },
+        "type": "object",
+        "required": ["email", "password"],
+        "title": "LoginDTO",
+        "example": {
+          "email": "user@example.com",
+          "password": "secret"
+        }
+      },
+      "LoginResponseVO": {
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/AuthVO"
+          },
+          "user": {
+            "$ref": "#/components/schemas/ProfileVO"
+          }
+        },
+        "type": "object",
+        "required": ["auth", "user"],
+        "title": "LoginResponseVO"
+      },
+      "MentorProfileDTO": {
+        "properties": {
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "default": ""
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry",
+            "default": ""
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "default": "zh_TW"
+          },
+          "is_mentor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Mentor",
+            "default": false
+          },
+          "personal_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Personal Statement"
+          },
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About"
+          },
+          "seniority_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SeniorityLevel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "NO REVEAL"
+          },
+          "want_position": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Position"
+          },
+          "want_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Skill"
+          },
+          "want_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Topic"
+          },
+          "have_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Skill"
+          },
+          "have_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Topic"
+          },
+          "experiences": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ExperienceVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Experiences"
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "MentorProfileDTO",
+        "description": "與 X-Career-User `MentorProfileDTO` 欄位一致。"
+      },
+      "MentorProfileVO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "default": ""
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "onboarding": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding",
+            "default": false
+          },
+          "is_mentor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Mentor",
+            "default": false
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "default": "zh_TW"
+          },
+          "personal_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Personal Statement",
+            "default": ""
+          },
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About",
+            "default": ""
+          },
+          "seniority_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SeniorityLevel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "NO REVEAL"
+          },
+          "experiences": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ExperienceVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Experiences"
+          },
+          "want_position": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Position"
+          },
+          "want_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Skill"
+          },
+          "want_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Topic"
+          },
+          "have_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Skill"
+          },
+          "have_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Topic"
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "MentorProfileVO"
+      },
+      "MentorScheduleDTO": {
+        "properties": {
+          "until": {
+            "type": "integer",
+            "title": "Until",
+            "example": 1735689600
+          },
+          "timeslots": {
+            "items": {
+              "$ref": "#/components/schemas/TimeSlotDTO"
+            },
+            "type": "array",
+            "title": "Timeslots",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "MentorScheduleDTO"
+      },
+      "MentorScheduleQueryVO": {
+        "properties": {
+          "segments": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/MentorScheduleSegmentVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Segments",
+            "default": []
+          },
+          "next_dtstart": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Dtstart",
+            "example": 0
+          }
+        },
+        "type": "object",
+        "title": "MentorScheduleQueryVO"
+      },
+      "MentorScheduleSegmentVO": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "example": 0
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "example": 1
+          },
+          "dt_type": {
+            "$ref": "#/components/schemas/ScheduleType",
+            "example": "ALLOW"
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "example": 1717203600
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "example": 1717207200
+          },
+          "rrule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rrule",
+            "example": "FREQ=WEEKLY;COUNT=4"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "UTC",
+            "example": "UTC"
+          },
+          "exdate": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Exdate",
+            "default": [],
+            "example": [1718413200, 1719622800]
+          },
+          "source": {
+            "type": "string",
+            "title": "Source",
+            "example": "schedule"
+          },
+          "source_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Source Id",
+            "example": 100
+          }
+        },
+        "type": "object",
+        "required": ["user_id", "dt_type", "dtstart", "dtend", "source"],
+        "title": "MentorScheduleSegmentVO"
+      },
+      "MentorScheduleVO": {
+        "properties": {
+          "timeslots": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/TimeSlotVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Timeslots",
+            "default": []
+          },
+          "next_dtstart": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Dtstart",
+            "example": 0
+          }
+        },
+        "type": "object",
+        "title": "MentorScheduleVO"
+      },
+      "PreviousReserveRef": {
+        "properties": {
+          "reserve_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Reserve Id",
+            "example": 0
+          }
+        },
+        "type": "object",
+        "title": "PreviousReserveRef"
+      },
+      "ProfileDTO": {
+        "properties": {
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "default": ""
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry",
+            "default": ""
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "default": "zh_TW"
+          },
+          "is_mentor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Mentor",
+            "default": false
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "ProfileDTO"
+      },
+      "ProfileVO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "default": ""
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "onboarding": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding",
+            "default": false
+          },
+          "is_mentor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Mentor",
+            "default": false
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "default": "zh_TW"
+          }
+        },
+        "type": "object",
+        "required": ["user_id"],
+        "title": "ProfileVO"
+      },
+      "RUserInfoVO": {
+        "properties": {
+          "user_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "User Id",
+            "example": 0
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(MENTOR|MENTEE)$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role",
+            "example": "MENTEE"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(ACCEPT|REJECT|PENDING)$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Status",
+            "example": "PENDING"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          }
+        },
+        "type": "object",
+        "title": "RUserInfoVO"
+      },
+      "ReservationDTO": {
+        "properties": {
+          "my_user_id": {
+            "type": "integer",
+            "title": "My User Id",
+            "default": 0
+          },
+          "my_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BookingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "PENDING"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "default": 0
+          },
+          "schedule_id": {
+            "type": "integer",
+            "title": "Schedule Id",
+            "default": 0
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "default": 0
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "default": 0
+          },
+          "messages": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReservationMessageDTO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages",
+            "default": []
+          },
+          "previous_reserve": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviousReserveRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "ReservationDTO"
+      },
+      "ReservationInfoListVO": {
+        "properties": {
+          "reservations": {
+            "items": {
+              "$ref": "#/components/schemas/ReservationInfoVO"
+            },
+            "type": "array",
+            "title": "Reservations",
+            "default": []
+          },
+          "next_dtend": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Dtend",
+            "default": 0
+          }
+        },
+        "type": "object",
+        "title": "ReservationInfoListVO"
+      },
+      "ReservationInfoVO": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "sender": {
+            "$ref": "#/components/schemas/RUserInfoVO"
+          },
+          "participant": {
+            "$ref": "#/components/schemas/RUserInfoVO"
+          },
+          "schedule_id": {
+            "type": "integer",
+            "title": "Schedule Id",
+            "default": 0
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "default": 0
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "default": 0
+          },
+          "previous_reserve": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviousReserveRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "messages": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReservationMessageVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["sender", "participant"],
+        "title": "ReservationInfoVO"
+      },
+      "ReservationMessageDTO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "example": 0
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "example": ""
+          }
+        },
+        "type": "object",
+        "required": ["user_id", "content"],
+        "title": "ReservationMessageDTO"
+      },
+      "ReservationMessageVO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "example": 0
+          },
+          "role": {
+            "anyOf": [
+              {
+                "type": "string",
+                "pattern": "^(MENTOR|MENTEE)$"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Role",
+            "example": "MENTEE"
+          },
+          "content": {
+            "type": "string",
+            "title": "Content",
+            "example": ""
+          }
+        },
+        "type": "object",
+        "title": "ReservationMessageVO"
+      },
+      "ReservationVO": {
+        "properties": {
+          "my_user_id": {
+            "type": "integer",
+            "title": "My User Id",
+            "default": 0
+          },
+          "my_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BookingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "PENDING"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "default": 0
+          },
+          "schedule_id": {
+            "type": "integer",
+            "title": "Schedule Id",
+            "default": 0
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "default": 0
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "default": 0
+          },
+          "messages": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReservationMessageDTO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages",
+            "default": []
+          },
+          "previous_reserve": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviousReserveRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id"
+          },
+          "status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BookingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "PENDING"
+          }
+        },
+        "type": "object",
+        "title": "ReservationVO"
+      },
+      "ResetPasswordBodyDTO": {
+        "properties": {
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "confirm_password": {
+            "type": "string",
+            "title": "Confirm Password"
+          }
+        },
+        "type": "object",
+        "required": ["password", "confirm_password"],
+        "title": "ResetPasswordBodyDTO",
+        "description": "Request body for PUT /auth/password/reset. Email 由 verify_token 從 cache 取得，不經由 client 傳送。",
+        "example": {
+          "confirm_password": "secret",
+          "password": "secret"
+        }
+      },
+      "ScheduleType": {
+        "type": "string",
+        "enum": ["ALLOW", "FORBIDDEN", "BOOKED", "PENDING"],
+        "title": "ScheduleType"
+      },
+      "SearchMentorProfileListVO": {
+        "properties": {
+          "mentors": {
+            "items": {
+              "$ref": "#/components/schemas/SearchMentorProfileVO"
+            },
+            "type": "array",
+            "title": "Mentors"
+          },
+          "next_id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Next Id"
+          }
+        },
+        "type": "object",
+        "required": ["mentors", "next_id"],
+        "title": "SearchMentorProfileListVO"
+      },
+      "SearchMentorProfileVO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "name": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Name",
+            "default": ""
+          },
+          "avatar": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Avatar",
+            "default": ""
+          },
+          "job_title": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Job Title",
+            "default": ""
+          },
+          "company": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Company",
+            "default": ""
+          },
+          "years_of_experience": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Years Of Experience",
+            "default": "0"
+          },
+          "location": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Location",
+            "default": ""
+          },
+          "industry": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Industry"
+          },
+          "onboarding": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Onboarding",
+            "default": false
+          },
+          "is_mentor": {
+            "anyOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Is Mentor",
+            "default": false
+          },
+          "language": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Language",
+            "default": "zh_TW"
+          },
+          "personal_statement": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Personal Statement",
+            "default": ""
+          },
+          "about": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "About",
+            "default": ""
+          },
+          "seniority_level": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SeniorityLevel"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "default": "NO REVEAL"
+          },
+          "experiences": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ExperienceVO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Experiences"
+          },
+          "want_position": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Position"
+          },
+          "want_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Skill"
+          },
+          "want_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Want Topic"
+          },
+          "have_skill": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Skill"
+          },
+          "have_topic": {
+            "anyOf": [
+              {
+                "items": {
+                  "type": "string"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Have Topic"
+          },
+          "updated_at": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Updated At"
+          },
+          "views": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Views"
+          }
+        },
+        "type": "object",
+        "required": ["user_id", "updated_at", "views"],
+        "title": "SearchMentorProfileVO"
+      },
+      "SeniorityLevel": {
+        "type": "string",
+        "enum": [
+          "NO REVEAL",
+          "JUNIOR",
+          "INTERMEDIATE",
+          "SENIOR",
+          "STAFF",
+          "MANAGER"
+        ],
+        "title": "SeniorityLevel"
+      },
+      "SignupDTO": {
+        "properties": {
+          "email": {
+            "type": "string",
+            "format": "email",
+            "title": "Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "confirm_password": {
+            "type": "string",
+            "title": "Confirm Password"
+          }
+        },
+        "type": "object",
+        "required": ["email", "password", "confirm_password"],
+        "title": "SignupDTO",
+        "example": {
+          "confirm_password": "secret",
+          "email": "user@example.com",
+          "password": "secret"
+        }
+      },
+      "SignupResponseVO": {
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/AuthVO"
+          }
+        },
+        "type": "object",
+        "required": ["auth"],
+        "title": "SignupResponseVO"
+      },
+      "TagCatalogGroupVO": {
+        "properties": {
+          "subject_group": {
+            "type": "string",
+            "title": "Subject Group"
+          },
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "desc": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Desc"
+          },
+          "leaves": {
+            "items": {
+              "$ref": "#/components/schemas/TagCatalogLeafVO"
+            },
+            "type": "array",
+            "title": "Leaves",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["subject_group", "subject", "language"],
+        "title": "TagCatalogGroupVO"
+      },
+      "TagCatalogLeafVO": {
+        "properties": {
+          "tag_id": {
+            "type": "integer",
+            "title": "Tag Id"
+          },
+          "subject_group": {
+            "type": "string",
+            "title": "Subject Group"
+          },
+          "subject": {
+            "type": "string",
+            "title": "Subject"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "desc": {
+            "anyOf": [
+              {
+                "type": "object"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Desc"
+          }
+        },
+        "type": "object",
+        "required": ["tag_id", "subject_group", "subject", "language"],
+        "title": "TagCatalogLeafVO"
+      },
+      "TagCatalogVO": {
+        "properties": {
+          "kind": {
+            "type": "string",
+            "title": "Kind"
+          },
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "groups": {
+            "items": {
+              "$ref": "#/components/schemas/TagCatalogGroupVO"
+            },
+            "type": "array",
+            "title": "Groups",
+            "default": []
+          }
+        },
+        "type": "object",
+        "required": ["kind", "language"],
+        "title": "TagCatalogVO"
+      },
+      "TagCatalogsVO": {
+        "properties": {
+          "language": {
+            "type": "string",
+            "title": "Language"
+          },
+          "catalogs": {
+            "additionalProperties": {
+              "$ref": "#/components/schemas/TagCatalogVO"
+            },
+            "type": "object",
+            "title": "Catalogs",
+            "default": {}
+          }
+        },
+        "type": "object",
+        "required": ["language"],
+        "title": "TagCatalogsVO"
+      },
+      "TagKind": {
+        "type": "string",
+        "enum": ["skill", "position", "topic", "industry"],
+        "title": "TagKind"
+      },
+      "TimeSlotDTO": {
+        "properties": {
+          "id": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Id",
+            "example": 0
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "example": 1
+          },
+          "dt_type": {
+            "$ref": "#/components/schemas/TimeSlotType",
+            "example": "ALLOW"
+          },
+          "dt_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dt Year",
+            "example": 2024
+          },
+          "dt_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dt Month",
+            "example": 6
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "example": 1717203600
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "example": 1717207200
+          },
+          "rrule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rrule",
+            "example": "FREQ=WEEKLY;COUNT=4"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "UTC",
+            "example": "UTC"
+          },
+          "exdate": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Exdate",
+            "default": [],
+            "example": [1718413200, 1719622800]
+          }
+        },
+        "type": "object",
+        "required": ["user_id", "dt_type", "dtstart", "dtend"],
+        "title": "TimeSlotDTO"
+      },
+      "TimeSlotType": {
+        "type": "string",
+        "enum": ["ALLOW", "FORBIDDEN"],
+        "title": "TimeSlotType"
+      },
+      "TimeSlotVO": {
+        "properties": {
+          "id": {
+            "type": "integer",
+            "title": "Id",
+            "example": 0
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "example": 1
+          },
+          "dt_type": {
+            "$ref": "#/components/schemas/TimeSlotType",
+            "example": "ALLOW"
+          },
+          "dt_year": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dt Year",
+            "example": 2024
+          },
+          "dt_month": {
+            "anyOf": [
+              {
+                "type": "integer"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Dt Month",
+            "example": 6
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "example": 1717203600
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "example": 1717207200
+          },
+          "rrule": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Rrule",
+            "example": "FREQ=WEEKLY;COUNT=4"
+          },
+          "timezone": {
+            "type": "string",
+            "title": "Timezone",
+            "default": "UTC",
+            "example": "UTC"
+          },
+          "exdate": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "integer"
+                },
+                {
+                  "type": "null"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Exdate",
+            "default": [],
+            "example": [1718413200, 1719622800]
+          }
+        },
+        "type": "object",
+        "required": ["id", "user_id", "dt_type", "dtstart", "dtend"],
+        "title": "TimeSlotVO"
+      },
+      "TokenRefreshAuthVO": {
+        "properties": {
+          "user_id": {
+            "type": "integer",
+            "title": "User Id"
+          },
+          "token": {
+            "type": "string",
+            "title": "Token"
+          }
+        },
+        "type": "object",
+        "required": ["user_id", "token"],
+        "title": "TokenRefreshAuthVO"
+      },
+      "TokenRefreshVO": {
+        "properties": {
+          "auth": {
+            "$ref": "#/components/schemas/TokenRefreshAuthVO"
+          }
+        },
+        "type": "object",
+        "required": ["auth"],
+        "title": "TokenRefreshVO",
+        "description": "Returned by POST /token (refresh token pair)."
+      },
+      "UniversityListVO": {
+        "properties": {
+          "universities": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array",
+            "title": "Universities",
+            "default": []
+          }
+        },
+        "type": "object",
+        "title": "UniversityListVO"
+      },
+      "UpdatePasswordDTO": {
+        "properties": {
+          "register_email": {
+            "type": "string",
+            "format": "email",
+            "title": "Register Email"
+          },
+          "password": {
+            "type": "string",
+            "title": "Password"
+          },
+          "confirm_password": {
+            "type": "string",
+            "title": "Confirm Password"
+          },
+          "origin_password": {
+            "type": "string",
+            "title": "Origin Password"
+          }
+        },
+        "type": "object",
+        "required": [
+          "register_email",
+          "password",
+          "confirm_password",
+          "origin_password"
+        ],
+        "title": "UpdatePasswordDTO",
+        "example": {
+          "confirm_password": "secret2",
+          "origin_password": "secret",
+          "password": "secret2",
+          "register_email": "user@example.com"
+        }
+      },
+      "UpdateReservationDTO": {
+        "properties": {
+          "my_user_id": {
+            "type": "integer",
+            "title": "My User Id",
+            "default": 0
+          },
+          "my_status": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/BookingStatus"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "example": "PENDING"
+          },
+          "user_id": {
+            "type": "integer",
+            "title": "User Id",
+            "default": 0
+          },
+          "schedule_id": {
+            "type": "integer",
+            "title": "Schedule Id",
+            "default": 0
+          },
+          "dtstart": {
+            "type": "integer",
+            "title": "Dtstart",
+            "default": 0
+          },
+          "dtend": {
+            "type": "integer",
+            "title": "Dtend",
+            "default": 0
+          },
+          "messages": {
+            "anyOf": [
+              {
+                "items": {
+                  "$ref": "#/components/schemas/ReservationMessageDTO"
+                },
+                "type": "array"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "title": "Messages",
+            "default": []
+          },
+          "previous_reserve": {
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/PreviousReserveRef"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          }
+        },
+        "type": "object",
+        "title": "UpdateReservationDTO"
+      },
+      "ValidationError": {
+        "properties": {
+          "loc": {
+            "items": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "type": "integer"
+                }
+              ]
+            },
+            "type": "array",
+            "title": "Location"
+          },
+          "msg": {
+            "type": "string",
+            "title": "Message"
+          },
+          "type": {
+            "type": "string",
+            "title": "Error Type"
+          }
+        },
+        "type": "object",
+        "required": ["loc", "msg", "type"],
+        "title": "ValidationError"
+      }
+    },
+    "securitySchemes": {
+      "HTTPBearer": {
+        "type": "http",
+        "scheme": "bearer"
+      }
+    }
+  }
+}

--- a/scripts/generate-types.mjs
+++ b/scripts/generate-types.mjs
@@ -1,5 +1,6 @@
 import { config } from 'dotenv';
 import { execSync } from 'child_process';
+import { writeFileSync } from 'fs';
 
 config();
 config({ path: '.env.development.local', override: true });
@@ -10,6 +11,21 @@ if (!url) {
   process.exit(1);
 }
 
-execSync(`openapi-typescript "${url}" -o src/types/api.ts`, {
+// Fetched once and snapshotted to scripts/ai-qa/openapi-spec.json so the QA
+// mock server's schema-driven baseline fixtures (see schema-mock.mjs) have a
+// contract to sample from without a live network call during test runs, and
+// stay in sync with src/types/api.ts automatically whenever this regenerates.
+const res = await fetch(url);
+if (!res.ok) {
+  console.error(
+    `Error: failed to fetch OpenAPI spec from ${url}: ${res.status}`
+  );
+  process.exit(1);
+}
+const specText = await res.text();
+const specPath = 'scripts/ai-qa/openapi-spec.json';
+writeFileSync(specPath, JSON.stringify(JSON.parse(specText), null, 2) + '\n');
+
+execSync(`openapi-typescript "${specPath}" -o src/types/api.ts`, {
   stdio: 'inherit',
 });


### PR DESCRIPTION
## What Does This PR Do?

- Flips `isQaBlocking()` back to blocking by default, matching issue
  #318's original gating rule: a `failed` QA result now blocks
  auto-PR and feeds back into the dev agent's next retry round unless
  explicitly opted out via `AI_QA_BLOCKING=false`. Previously it only
  blocked when explicitly opted in (`AI_QA_BLOCKING=true`), so the
  ai:dev pipeline silently reported QA failures without ever retrying.
- Adds an OpenAPI-schema-sampled baseline fallback to the QA mock
  server (`schema-mock.mjs`): an endpoint the fixture planner didn't
  anticipate (it only reads the diff, not the full set of pre-existing
  API calls a page makes) now gets a generically valid response
  instead of a hard 404, removing a source of QA false positives that
  matters more now that QA blocks by default.
- Snapshots the OpenAPI contract (`scripts/ai-qa/openapi-spec.json`)
  alongside `src/types/api.ts` generation (`pnpm generate:types`) so
  the schema baseline can't drift from the real contract.
- Updates tests and `scripts/ai-qa/README.md` to match.

## Demo

N/A — local dev-tooling change to the ai:dev/ai-qa pipeline itself, not app UI.

## Screenshot

N/A

## Anything to Note?

- `scripts/ai-qa/openapi-spec.json` was generated from the current
  `BFF_OPENAPI_URL` spec; regenerate via `pnpm generate:types`
  whenever the backend contract changes.
- `AI_QA_BLOCKING=false` remains available to opt back out to
  report-only mode.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
