### PR TITLE
feat: allow auto-PR on medium risk, drop findings-count gate

### DIFF
--- a/scripts/ai-dev/README.md
+++ b/scripts/ai-dev/README.md
@@ -2,10 +2,10 @@
 
 `pnpm ai:dev <ticket-number>` runs a local dev → review → fix loop against a
 `X-Talent-Tracker` issue using Gemini, entirely on your machine. If the review
-pipeline judges the result **low risk with zero findings**, it automatically
-commits, pushes, and opens a real PR for you — see "Auto-PR" below for the
-exact gating condition. Otherwise it stops once it hits its iteration cap (or
-gets stuck) and hands control back to you with the diff staged, uncommitted.
+pipeline judges the overall risk **low or medium**, it automatically commits,
+pushes, and opens a real PR for you — see "Auto-PR" below for the exact
+gating condition. Otherwise it stops once it hits its iteration cap (or gets
+stuck) and hands control back to you with the diff staged, uncommitted.
 
 This tool is intentionally independent of Claude Code / `.claude/commands` —
 anyone with Node, `gh`, and a Gemini API key can run it, regardless of which
@@ -89,11 +89,18 @@ final findings are left exactly as-is for you to take over manually.
 After the loop ends, one extra step runs automatically — there is no flag to
 opt in or out:
 
-**Gating condition** — all three must hold:
+**Gating condition** (`isAutoPrGatePassed` in `orchestrator.mjs`) — both must hold:
 
 - `finalState.status === 'passed'` (the loop ended cleanly, not stuck/capped)
-- `review.overallRisk.level === 'low'`
-- `review.findings.length === 0`
+- `review.overallRisk.level` is `low` or `medium` — `high` never actually
+  reaches this check, since it already forces another retry iteration
+  upstream (`hasBlockingFindings`), so in practice this excludes runs that
+  never got past `high` risk
+
+Individual findings no longer gate auto-PR — a `medium`-risk merge can still
+carry findings (shown in the final report and, once opened, on the PR
+itself); triaging those is on whoever reviews the resulting PR, not a reason
+to withhold it.
 
 If the gate passes: the staged diff is committed for real (no `wip:` prefix,
 Conventional-Commits style, hooks run normally — this is what actually gets
@@ -102,8 +109,8 @@ via `gh pr create` (auto-linked to the tracker issue through the existing
 linked-branch relationship). Further changes belong as additional commits on
 the now-open PR, not another local WIP/reset loop.
 
-If the gate fails — `medium`/`high` risk, any findings, or a non-`passed`
-final status — auto-PR is a no-op: same staged-diff hand-off described above.
+If the gate fails — `high` risk or a non-`passed` final status — auto-PR is a
+no-op: same staged-diff hand-off described above.
 
 **Failure handling** — any failure during the auto-PR sequence itself falls
 back to the staged-diff hand-off instead of leaving a broken state:
@@ -119,10 +126,10 @@ back to the staged-diff hand-off instead of leaving a broken state:
 
 **Risk trade-off** — the risk level gating this is itself an LLM judgment
 call over untrusted ticket content. A crafted/misleading ticket could in
-theory get its own change misjudged as `low` risk with zero findings, which
-would then get pushed and opened as a real PR unattended. Only run this tool
-on tickets from trusted sources, same as the general prompt-injection caveat
-printed at startup.
+theory get its own change misjudged as `low`/`medium` risk, which would then
+get pushed and opened as a real PR unattended. Only run this tool on tickets
+from trusted sources, same as the general prompt-injection caveat printed at
+startup.
 
 ## v1 limitations (by design, not oversights)
 

--- a/scripts/ai-dev/lib/pr.mjs
+++ b/scripts/ai-dev/lib/pr.mjs
@@ -31,7 +31,7 @@ export function buildCommitSubject(ticket) {
 
 export function buildPrBody(ticket) {
   return [
-    'Auto-created by `pnpm ai:dev --auto-pr` — the review pipeline judged this change low risk with zero findings.',
+    'Auto-created by `pnpm ai:dev --auto-pr` — the review pipeline judged this change low or medium risk.',
     '',
     `Closes ${TRACKER_OWNER}/${TRACKER_REPO}#${ticket.number}`,
   ].join('\n');

--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -321,6 +321,25 @@ export function isQaBlocking(qa) {
   return process.env.AI_QA_BLOCKING === 'true' && qa.status === 'failed';
 }
 
+const RISK_RANK = { low: 0, medium: 1, high: 2 };
+
+/**
+ * Auto-PR gate. `high` risk never actually reaches this check — it's
+ * already `hasBlockingFindings` in review-bridge.mjs, which forces another
+ * retry iteration, so `finalState.status` only becomes `'passed'` once risk
+ * is `low` or `medium`. Individual findings no longer block auto-PR on
+ * their own (only the aggregate risk level does) — the human reviewing the
+ * resulting PR is expected to triage any findings a `medium`-risk merge
+ * still carries.
+ */
+export function isAutoPrGatePassed(finalState) {
+  const level = finalState?.review?.overallRisk?.level;
+  return (
+    finalState?.status === 'passed' &&
+    (RISK_RANK[level] ?? Infinity) <= RISK_RANK.medium
+  );
+}
+
 function printFinalReport(finalState, prResult) {
   console.log('\n[ai:dev] ' + '='.repeat(40));
   console.log(
@@ -368,10 +387,11 @@ function printFinalReport(finalState, prResult) {
 }
 
 /**
- * Only called once the gating condition (passed, low risk, zero findings)
- * already holds. Every failure here falls back to the "leave it staged"
- * behavior instead of leaving a broken half-done state — see README for the
- * exact gating condition and risk trade-off.
+ * Only called once the gating condition (passed, risk low or medium —
+ * findings don't factor in, see isAutoPrGatePassed) already holds. Every
+ * failure here falls back to the "leave it staged" behavior instead of
+ * leaving a broken half-done state — see README for the exact gating
+ * condition and risk trade-off.
  *
  * `resolvedBaseRef` is passed explicitly (rather than read off the
  * module-scope variable of the same name) so this function stays testable
@@ -468,8 +488,8 @@ async function main() {
       'dependency/config changes) but this is not a full sandbox. Once the static reviewer passes, ' +
       'the QA stage boots a real `pnpm dev` server and drives it with a real browser under a ' +
       'dedicated QA test account (see scripts/ai-qa/README.md) — set SKIP_QA=1 to skip this. If the ' +
-      'review pipeline judges the result low risk with zero findings, it will automatically commit, ' +
-      'push, and open a real PR — no manual step required.'
+      'review pipeline judges the overall risk low or medium, it will automatically commit, push, ' +
+      'and open a real PR — no manual step required.'
   );
 
   log('running preflight checks...');
@@ -668,10 +688,7 @@ async function main() {
     resetSoft(resolvedBaseRef);
   }
 
-  const gatePassed =
-    finalState.status === 'passed' &&
-    finalState.review?.overallRisk?.level === 'low' &&
-    (finalState.review?.findings?.length ?? 0) === 0;
+  const gatePassed = isAutoPrGatePassed(finalState);
 
   const prResult = gatePassed
     ? await attemptAutoPr({ ticket, resolvedBaseRef, qa: finalState.qa })

--- a/scripts/ai-dev/orchestrator.test.mjs
+++ b/scripts/ai-dev/orchestrator.test.mjs
@@ -6,7 +6,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 const { execFileSync } = await import('node:child_process');
-const { attemptAutoPr, buildRetryTask, isQaBlocking } =
+const { attemptAutoPr, buildRetryTask, isAutoPrGatePassed, isQaBlocking } =
   await import('./orchestrator.mjs');
 
 function failure(message = 'command failed') {
@@ -33,7 +33,7 @@ const ticket = {
 };
 const RESOLVED_BASE_REF = 'abc123';
 const PR_CREATE_KEY =
-  'pr create --base develop --head feat/312-test-branch --title feat: ai:dev: auto create PR --body Auto-created by `pnpm ai:dev --auto-pr` — the review pipeline judged this change low risk with zero findings.\n\nCloses Xchange-Taiwan/X-Talent-Tracker#312';
+  'pr create --base develop --head feat/312-test-branch --title feat: ai:dev: auto create PR --body Auto-created by `pnpm ai:dev --auto-pr` — the review pipeline judged this change low or medium risk.\n\nCloses Xchange-Taiwan/X-Talent-Tracker#312';
 
 beforeEach(() => {
   execFileSync.mockReset();
@@ -312,5 +312,46 @@ describe('isQaBlocking', () => {
   it('treats any value other than the literal string "true" as unset', () => {
     process.env.AI_QA_BLOCKING = '1';
     expect(isQaBlocking({ status: 'failed' })).toBe(false);
+  });
+});
+
+describe('isAutoPrGatePassed', () => {
+  function state(status, level, findingsCount = 0) {
+    return {
+      status,
+      review: {
+        overallRisk: level ? { level } : null,
+        findings: Array.from({ length: findingsCount }, (_, i) => ({
+          file: `f${i}.ts`,
+          issue: `issue ${i}`,
+        })),
+      },
+    };
+  }
+
+  it('passes on low risk with no findings', () => {
+    expect(isAutoPrGatePassed(state('passed', 'low', 0))).toBe(true);
+  });
+
+  it('passes on medium risk, regardless of findings count', () => {
+    expect(isAutoPrGatePassed(state('passed', 'medium', 4))).toBe(true);
+  });
+
+  it('passes on low risk even with findings present', () => {
+    expect(isAutoPrGatePassed(state('passed', 'low', 2))).toBe(true);
+  });
+
+  it('fails on high risk', () => {
+    expect(isAutoPrGatePassed(state('passed', 'high', 0))).toBe(false);
+  });
+
+  it('fails when status is not passed, even with low risk', () => {
+    expect(isAutoPrGatePassed(state('stuck-no-progress', 'low', 0))).toBe(
+      false
+    );
+  });
+
+  it('fails when overallRisk is missing entirely', () => {
+    expect(isAutoPrGatePassed(state('passed', null, 0))).toBe(false);
   });
 });


### PR DESCRIPTION
## What Does This PR Do?

- Extracts the auto-PR gate into a testable `isAutoPrGatePassed(finalState)`
  in `orchestrator.mjs`. Previously auto-PR required `status === 'passed'`
  AND `overallRisk.level === 'low'` AND `findings.length === 0`; now it's
  `status === 'passed'` AND `overallRisk.level` is `low` or `medium`.
  Individual findings no longer gate auto-PR at all — a medium-risk merge
  can still carry findings, and triaging those becomes the job of whoever
  reviews the resulting PR rather than a reason to withhold it entirely.
  (`high` risk never actually reached this check anyway — it already forces
  another retry round upstream via `hasBlockingFindings`.)
- Updates the startup warning banner and the auto-generated PR body
  (`lib/pr.mjs`) to stop claiming "zero findings", since that's no longer
  part of the gate.
- Updates `scripts/ai-dev/README.md`'s Auto-PR section and adds unit tests
  for `isAutoPrGatePassed` covering low/medium/high risk, missing risk data,
  and non-`passed` final status.

## Demo

N/A — local dev-tooling change to the ai:dev pipeline itself, not app UI.

## Screenshot

N/A

## Anything to Note?

Independent of PR #670 (QA blocking default + schema mock fallback) —
this branches off `develop` directly and doesn't depend on it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
