### PR TITLE
fix: stop ai:dev leaking dev-only env vars into git hooks

### DIFF
--- a/scripts/ai-dev/lib/git.mjs
+++ b/scripts/ai-dev/lib/git.mjs
@@ -2,11 +2,27 @@ import { execFileSync } from 'node:child_process';
 
 export class GitError extends Error {}
 
+// orchestrator.mjs loads .env.development.local into its own process.env
+// with override:true so ai-qa/lib/server.mjs can spread it into the QA dev
+// server's child env — but `git push`/`commit` here can trigger the
+// developer's real .husky hooks (pre-commit's lint-staged, pre-push's
+// `pnpm test`), which have no business inheriting dev-only config or
+// GEMINI_API_KEY. captureCleanEnv() lets orchestrator.mjs snapshot
+// process.env before those config() calls so git subprocesses (and
+// anything the hooks they trigger spawn) see the same environment a
+// developer's own shell would have.
+let cleanEnv = null;
+
+export function captureCleanEnv() {
+  cleanEnv = { ...process.env };
+}
+
 function run(args, { allowFailure = false } = {}) {
   try {
     return execFileSync('git', args, {
       encoding: 'utf-8',
       maxBuffer: 1024 * 1024 * 20,
+      env: cleanEnv ?? process.env,
     }).trim();
   } catch (err) {
     if (allowFailure) return null;

--- a/scripts/ai-dev/lib/git.test.mjs
+++ b/scripts/ai-dev/lib/git.test.mjs
@@ -7,6 +7,7 @@ vi.mock('node:child_process', () => ({
 
 const { execFileSync } = await import('node:child_process');
 const {
+  captureCleanEnv,
   GitError,
   isWorkingTreeClean,
   currentBranch,
@@ -57,6 +58,34 @@ describe('isWorkingTreeClean', () => {
   it('is false when there is uncommitted output', () => {
     mockGit({ 'status --porcelain': ' M some/file.ts\n' });
     expect(isWorkingTreeClean()).toBe(false);
+  });
+});
+
+describe('captureCleanEnv', () => {
+  it('before capture, git subprocesses inherit live process.env', () => {
+    mockGit({ 'rev-parse --abbrev-ref HEAD': 'develop' });
+    currentBranch();
+    const [, , opts] = execFileSync.mock.calls[0];
+    expect(opts.env).toBe(process.env);
+  });
+
+  it('after capture, git subprocesses get the pre-capture snapshot, not live process.env — so dev-only vars .env.development.local injects afterwards (NEXT_PUBLIC_API_URL, GEMINI_API_KEY, etc.) never reach a `git push`/`commit` and the .husky hooks they can trigger', () => {
+    const before = process.env.NEXT_PUBLIC_API_URL;
+    delete process.env.NEXT_PUBLIC_API_URL;
+    try {
+      captureCleanEnv();
+      process.env.NEXT_PUBLIC_API_URL = 'https://leaked.example.com/api';
+
+      mockGit({ 'rev-parse --abbrev-ref HEAD': 'develop' });
+      currentBranch();
+
+      const [, , opts] = execFileSync.mock.calls[0];
+      expect(opts.env).not.toBe(process.env);
+      expect(opts.env.NEXT_PUBLIC_API_URL).toBeUndefined();
+    } finally {
+      delete process.env.NEXT_PUBLIC_API_URL;
+      if (before !== undefined) process.env.NEXT_PUBLIC_API_URL = before;
+    }
   });
 });
 

--- a/scripts/ai-dev/orchestrator.mjs
+++ b/scripts/ai-dev/orchestrator.mjs
@@ -22,6 +22,7 @@ import {
   userTurn,
 } from './lib/gemini-agent.mjs';
 import {
+  captureCleanEnv,
   commit,
   commitWip,
   currentBranch,
@@ -54,6 +55,9 @@ import {
   TOOL_DECLARATIONS,
 } from './lib/tools.mjs';
 
+// Snapshot before loading dev-only config below, so git subprocesses (and
+// any .husky hooks they trigger) don't inherit it — see git.mjs.
+captureCleanEnv();
 config();
 config({ path: '.env.development.local', override: true });
 

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -14,6 +14,11 @@ export default defineConfig({
     globals: true,
     env: {
       TZ: 'UTC',
+      // Pinned so URL-building tests get a deterministic relative-path
+      // BASE_URL regardless of what's leaked into process.env by whatever
+      // invoked vitest (e.g. ai:dev's orchestrator loading
+      // .env.development.local for the QA dev server).
+      NEXT_PUBLIC_API_URL: '',
     },
     setupFiles: ['./src/test/setup.ts'],
     include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs'],


### PR DESCRIPTION
## Summary
- `orchestrator.mjs` loads `.env.development.local` into its own `process.env` with `override: true` so the QA stage's dev server can see dev-only config — but `git.mjs`'s git subprocesses (`push`/`commit`) inherited that same polluted environment. That leaked `NEXT_PUBLIC_API_URL` (and `GEMINI_API_KEY`) into `.husky/pre-push`'s `pnpm test`, which broke `apiClient.test.ts`'s relative-URL assertions and caused every auto-PR push attempt to fail.
- `git.mjs` now exposes `captureCleanEnv()`, snapshotting `process.env` before the dotenv loads; git subprocesses use that snapshot instead of live `process.env`.
- `orchestrator.mjs` calls `captureCleanEnv()` before `config()`.
- `vitest.config.mts` pins `NEXT_PUBLIC_API_URL: ''` in `test.env` so the suite stays hermetic regardless of what launched it.

## Test plan
- [x] `pnpm test` — 511/511 passing (including the previously-failing `apiClient.test.ts` URL-building tests)
- [x] `pnpm type-check` — clean
- [x] New `git.test.mjs` cases assert `execFileSync` receives the pre-capture env snapshot, not live `process.env`, after `captureCleanEnv()` runs
- [x] Reproduced the real fix end-to-end: this branch's own `git push` went through `.husky/pre-push` (`pnpm type-check && pnpm test`) and passed cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)