### PR TITLE
docs(ai-review): add context-manifest.json to document cross-repo business-rules coupling

### DIFF
--- a/scripts/ai-review/prompts/_shared/business-rules.md
+++ b/scripts/ai-review/prompts/_shared/business-rules.md
@@ -1,5 +1,7 @@
 這份文件收錄「不會寫在單一 ticket 裡、但整個平台都要遵守」的業務規則（domain invariants）。目的是讓 Business Logic Reviewer 不需要靠 tribal knowledge，也能判斷一個 PR 是不是做了「技術上邏輯正確、但業務上根本不該存在」的事。
 
+> **這份檔案被 `X-Talent-Tracker` 的 `ai-ticket-review` 跨 repo 讀取（見 [`context-manifest.json`](./context-manifest.json) 的 `externalConsumers`）。搬動或改名這份檔案前，先同步更新該 repo 的 `config/context-manifest.json`，否則對方的 workflow 會直接 fail。**
+
 **維護方式**：只要 AI reviewer（或人類 reviewer）事後發現漏掉一個「因為不懂平台業務規則而犯的錯」，就把那條規則寫進來，避免同一類錯誤在下一個 PR 又發生一次。每條規則都要附上「為什麼」跟「reviewer 該怎麼做」，單純條列規則但沒有依據，之後很容易被誤用或誤判成過時。
 
 ---

--- a/scripts/ai-review/prompts/_shared/context-manifest.json
+++ b/scripts/ai-review/prompts/_shared/context-manifest.json
@@ -1,0 +1,33 @@
+{
+  "description": "Index of shared prompt fragments in this folder — what each file is for and who reads it. Update this file whenever a file here is added, removed, or renamed; see externalConsumers for the cross-repo dependency that also needs updating.",
+  "files": [
+    {
+      "path": "project-context.md",
+      "purpose": "前端技術棧與程式慣例（架構、資料流向、styling、role-based UI 等），判斷 diff 是否符合既有慣例的依據",
+      "consumers": ["ai-dev", "ai-review", "ai-qa"]
+    },
+    {
+      "path": "business-rules.md",
+      "purpose": "跨頁面、跨 PR 都成立的業務不變量（domain invariants），判斷 diff 是不是技術上邏輯正確、但業務上根本不該存在",
+      "consumers": [
+        "ai-dev",
+        "ai-review",
+        "ai-qa",
+        "X-Talent-Tracker:ai-ticket-review"
+      ]
+    },
+    {
+      "path": "review-discipline.md",
+      "purpose": "AI reviewer 輸出格式與紀律（語言、finding 格式、style 評論限制）",
+      "consumers": ["ai-dev", "ai-review", "ai-qa"]
+    }
+  ],
+  "externalConsumers": [
+    {
+      "repo": "Xchange-Taiwan/X-Talent-Tracker",
+      "reads": ["business-rules.md"],
+      "via": "scripts/ticket-review/index.mjs，透過 GitHub Contents API 抓取，repo/path 記在該 repo 的 config/context-manifest.json",
+      "note": "改動 business-rules.md 的檔名或路徑前，先同步更新 X-Talent-Tracker 的 config/context-manifest.json；沒有同步更新的話，ai-ticket-review 這個 workflow 會直接 fail（fail-fast，不會靜默 fallback 成無業務規則的 prompt）。"
+    }
+  ]
+}


### PR DESCRIPTION
## What Does This PR Do?

- Adds `scripts/ai-review/prompts/_shared/context-manifest.json` indexing what each `_shared/` prompt fragment is for and which pipelines (`ai-dev`/`ai-review`/`ai-qa`) consume it, plus an `externalConsumers` entry documenting that `X-Talent-Tracker`'s `ai-ticket-review` reads `business-rules.md` cross-repo
- Adds a note at the top of `business-rules.md` pointing back to the manifest and warning that renaming/moving the file requires updating `X-Talent-Tracker`'s `config/context-manifest.json` in the same change

## How to Test

No behavior change — `prompt.mjs`'s `loadShared()` is untouched. Verify the new JSON parses and the pipelines still build their prompts as before:
```
cd X-Talent-Frontend
node -e "JSON.parse(require('fs').readFileSync('scripts/ai-review/prompts/_shared/context-manifest.json','utf-8'))"
pnpm test scripts/ai-review
```

## Anything to Note?

Companion PR in `X-Talent-Tracker` adds the config file this manifest points to and makes that repo's `ai-ticket-review` fail-fast instead of silently falling back when it can't fetch this file.

Closes Xchange-Taiwan/X-Talent-Tracker#325

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>