### PR TITLE
refactor: consolidate experience wire-format encode/decode

### DIFF
--- a/src/components/profile/experience-section/ExperienceSection.tsx
+++ b/src/components/profile/experience-section/ExperienceSection.tsx
@@ -5,7 +5,7 @@ import Divider from '@/components/auth/Divider';
 import {
   EducationExperienceMetadata,
   WorkExperienceMetadata,
-} from '@/hooks/user/user-data/useUserData';
+} from '@/lib/profile/experienceCodec';
 
 export type ExperienceItem = {
   title: string;

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -9,9 +9,7 @@ import {
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 import {
   MentorExperiencePayload,
-  parseEducations,
-  parseLinks,
-  parseWorkExperiences,
+  toFormValues,
 } from '@/lib/profile/parseUserExperiences';
 import type { TagVO } from '@/types/tag';
 
@@ -48,9 +46,11 @@ export function useEditProfileData({
     const experiences =
       userDto.experiences as unknown as MentorExperiencePayload[];
 
-    const parsedExperiences = parseWorkExperiences(experiences);
-    const parsedEducations = parseEducations(experiences);
-    const parsedLinks = parseLinks(experiences);
+    const {
+      workExperiences: parsedExperiences,
+      educations: parsedEducations,
+      links: parsedLinks,
+    } = toFormValues(experiences);
 
     // BFF returns industry enriched as a TagVO-shaped object; the OpenAPI
     // generator types it as `Record<string, never>` because the BFF model

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -13,12 +13,11 @@ import {
 import { trackEvent } from '@/lib/analytics';
 import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
 import { captureFlowFailure } from '@/lib/monitoring';
-import { MentorExperiencePayload } from '@/lib/profile/parseUserExperiences';
+import { encode } from '@/lib/profile/experienceCodec';
 import {
   firstSyncedFetch,
   pollUntilSynced,
 } from '@/lib/profile/pollUntilSynced';
-import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { MentorProfileVO } from '@/services/profile/user';
@@ -142,17 +141,6 @@ export function useProfileSubmit({
         isDirty('want_topic') ||
         experiencesDirty;
 
-      // Mentor's top-level job_title / company mirror the primary work
-      // experience so consumers (profile page, mentor pool card, reservations)
-      // can read them directly from the mentor record without re-deriving
-      // from the experience list. Falls back to the first entry when no
-      // primary is flagged, matching the JobExperienceSection UI invariant.
-      const primaryWork =
-        values.work_experiences?.find((w) => w.is_primary) ??
-        values.work_experiences?.[0];
-      const job_title = primaryWork?.job ?? '';
-      const companyFromPrimary = primaryWork?.company ?? '';
-
       const links = [
         values.linkedin,
         values.facebook,
@@ -162,50 +150,20 @@ export function useProfileSubmit({
         values.website,
       ].filter((l) => l && l.url);
 
-      // Replace semantics: send the full experiences set every time any
-      // section is dirty. Backend overwrites profiles.experiences wholesale.
-      // Sections without dirty form items still ride along with their
-      // current values to avoid clobbering them.
-      const buildExperiences = (): MentorExperiencePayload[] => [
-        {
-          category: ExperienceType.WORK,
-          order: 1,
-          mentor_experiences_metadata: {
-            data: (values.work_experiences ?? []).map((item) => ({
-              job: item.job,
-              company: item.company,
-              job_period_start: item.job_period_start,
-              job_period_end: item.job_period_end,
-              industry: item.industry,
-              job_location: item.job_location,
-              description: item.description,
-              is_primary: item.is_primary ?? false,
-            })),
-          },
-        },
-        {
-          category: ExperienceType.EDUCATION,
-          order: 2,
-          mentor_experiences_metadata: {
-            data: (values.educations ?? []).map((item) => ({
-              school: item.school,
-              subject: item.subject,
-              education_period_start: item.education_period_start,
-              education_period_end: item.education_period_end,
-            })),
-          },
-        },
-        {
-          category: ExperienceType.LINK,
-          order: 3,
-          mentor_experiences_metadata: {
-            data: links.map((link) => ({
-              platform: link.platform,
-              url: link.url,
-            })),
-          },
-        },
-      ];
+      // The codec derives both the wire-format experiences batch and the
+      // top-level job_title/company mirror (which consumers like the
+      // profile page, mentor pool card, and reservations read directly
+      // without re-deriving from the experience list) from the same form
+      // values — see experienceCodec.ts.
+      const {
+        experiences,
+        job_title,
+        company: companyFromPrimary,
+      } = encode({
+        workExperiences: values.work_experiences ?? [],
+        educations: values.educations ?? [],
+        personalLinks: links,
+      });
 
       const payload = {
         ...values,
@@ -215,8 +173,9 @@ export function useProfileSubmit({
         company: companyFromPrimary,
         // Three-state semantic on the wire: omit when no experience section
         // changed (backend leaves the column alone); include the full set
-        // when any section is dirty (backend overwrites).
-        ...(experiencesDirty ? { experiences: buildExperiences() } : {}),
+        // when any section is dirty (backend overwrites). Replace semantics:
+        // backend overwrites profiles.experiences wholesale with this batch.
+        ...(experiencesDirty ? { experiences } : {}),
       };
 
       try {

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -1,7 +1,12 @@
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
-import { isSafeUrl } from '@/lib/url/isSafeUrl';
-import { ExperienceType } from '@/services/profile/experienceType';
+import {
+  decode,
+  type EducationExperienceMetadata,
+  type MentorExperiencePayload,
+  type PersonalLinkMetadata,
+  type WorkExperienceMetadata,
+} from '@/lib/profile/experienceCodec';
 import {
   buildTagLabelMap,
   type TagCatalogsByBucket,
@@ -27,29 +32,6 @@ export interface TagDisplay {
   subject: string;
 }
 
-export interface WorkExperienceMetadata {
-  job?: string;
-  company?: string;
-  job_period_start?: string;
-  job_period_end?: string;
-  job_location?: string;
-  description?: string;
-  industry?: string;
-  is_primary?: boolean;
-}
-
-export interface EducationExperienceMetadata {
-  subject?: string;
-  school?: string;
-  education_period_start?: string;
-  education_period_end?: string;
-}
-
-export interface PersonalLinkMetadata {
-  platform: string;
-  url: string;
-}
-
 export interface UserType {
   user_id: number;
   name: string;
@@ -70,11 +52,6 @@ export interface UserType {
   personalLinks?: PersonalLinkMetadata[];
 }
 
-type ExperienceBlock = {
-  category: ExperienceType;
-  mentor_experiences_metadata?: { data?: unknown[] };
-};
-
 // Subject_group codes shipped by the BFF round-trip directly back to writes,
 // so resolve them to display labels via the localized catalog. Catalog miss
 // (legacy or unpublished tag) falls back to the raw code rather than dropping
@@ -92,52 +69,15 @@ function toTagDisplay(
     }));
 }
 
-function getBlocksByCategory(
-  experiences: MentorProfileVO['experiences'],
-  category: ExperienceType
-): ExperienceBlock[] {
-  if (!experiences) return [];
-  return (experiences as unknown as ExperienceBlock[]).filter(
-    (exp) => exp.category === category
-  );
-}
-
-function getMetadataArray<T>(block: ExperienceBlock): T[] {
-  return (block.mentor_experiences_metadata?.data ?? []) as T[];
-}
-
 function parseUserDtoToUserType(
   userDto: MentorProfileVO,
   catalogs: TagCatalogsByBucket
 ): UserType {
   const labelMap = buildTagLabelMap(catalogs);
 
-  const workBlocks = getBlocksByCategory(
-    userDto.experiences,
-    ExperienceType.WORK
+  const { workExperiences, educations, personalLinks } = decode(
+    userDto.experiences as unknown as MentorExperiencePayload[]
   );
-  const educationBlocks = getBlocksByCategory(
-    userDto.experiences,
-    ExperienceType.EDUCATION
-  );
-  const linkBlocks = getBlocksByCategory(
-    userDto.experiences,
-    ExperienceType.LINK
-  );
-
-  const workExperiences = workBlocks.flatMap((b) =>
-    getMetadataArray<WorkExperienceMetadata>(b)
-  );
-  const educations = educationBlocks.flatMap((b) =>
-    getMetadataArray<EducationExperienceMetadata>(b)
-  );
-  // Drop links whose URL doesn't pass the scheme allow-list. The form schema
-  // already blocks javascript:, but profiles can be written via direct BFF
-  // calls — render-time filtering closes that bypass before <a href> ever
-  // sees the value.
-  const personalLinks = linkBlocks
-    .flatMap((b) => getMetadataArray<PersonalLinkMetadata>(b))
-    .filter((l) => isSafeUrl(l.url));
 
   // BFF emits industry enriched (TagVO-shaped); OpenAPI types it as
   // `Record<string, never>`. Pull subject through the local TagVO type.

--- a/src/lib/profile/experienceCodec.test.ts
+++ b/src/lib/profile/experienceCodec.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it } from 'vitest';
+
+import { ExperienceType } from '@/services/profile/experienceType';
+
+import {
+  decode,
+  encode,
+  type EncodeInput,
+  type MentorExperiencePayload,
+} from './experienceCodec';
+
+function payloadFor(
+  category: ExperienceType,
+  data: unknown[]
+): MentorExperiencePayload {
+  return {
+    category,
+    order: 1,
+    mentor_experiences_metadata: { data },
+  };
+}
+
+describe('experienceCodec', () => {
+  it('round-trips a representative fixture through encode then decode', () => {
+    const input: EncodeInput = {
+      workExperiences: [
+        {
+          job: 'Engineer',
+          company: 'Acme',
+          job_period_start: '2020',
+          job_period_end: 'now',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'building things',
+          is_primary: true,
+        },
+        {
+          job: 'Junior Engineer',
+          company: 'OldCo',
+          job_period_start: '2015',
+          job_period_end: '2019',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'learning things',
+          is_primary: false,
+        },
+      ],
+      educations: [
+        {
+          subject: 'CS',
+          school: 'NTU',
+          education_period_start: '2011',
+          education_period_end: '2015',
+        },
+      ],
+      personalLinks: [
+        { platform: 'linkedin', url: 'https://linkedin.com/in/me' },
+      ],
+    };
+
+    const { experiences, job_title, company } = encode(input);
+    const decoded = decode(experiences);
+
+    expect(decoded).toEqual(input);
+    expect(job_title).toBe('Engineer');
+    expect(company).toBe('Acme');
+  });
+
+  it('decode: single work experience with no is_primary falls back to marking it primary', () => {
+    const experiences = [
+      payloadFor(ExperienceType.WORK, [{ job: 'Engineer', company: 'Acme' }]),
+    ];
+
+    const { workExperiences } = decode(experiences);
+
+    expect(workExperiences).toHaveLength(1);
+    expect(workExperiences[0].is_primary).toBe(true);
+  });
+
+  it('decode: filters out unsafe URLs (e.g. javascript:) from personal links', () => {
+    const experiences = [
+      payloadFor(ExperienceType.LINK, [
+        { platform: 'website', url: 'javascript:alert(1)' },
+        { platform: 'linkedin', url: 'https://linkedin.com/in/me' },
+      ]),
+    ];
+
+    const { personalLinks } = decode(experiences);
+
+    expect(personalLinks).toEqual([
+      { platform: 'linkedin', url: 'https://linkedin.com/in/me' },
+    ]);
+  });
+
+  it('decode: missing fields across categories fall back to safe defaults without throwing', () => {
+    const experiences = [
+      payloadFor(ExperienceType.WORK, [{}]),
+      payloadFor(ExperienceType.EDUCATION, [{}]),
+      payloadFor(ExperienceType.LINK, [{ platform: 'website' }]),
+    ];
+
+    const decoded = decode(experiences);
+
+    expect(decoded.workExperiences[0]).toEqual({
+      job: '',
+      company: '',
+      job_period_start: '',
+      job_period_end: '',
+      industry: '',
+      job_location: '',
+      description: '',
+      is_primary: true,
+    });
+    expect(decoded.educations[0]).toEqual({
+      subject: '',
+      school: '',
+      education_period_start: '',
+      education_period_end: '',
+    });
+    // Missing url fails isSafeUrl and is dropped.
+    expect(decoded.personalLinks).toEqual([]);
+  });
+
+  it('decode: unknown category is silently ignored', () => {
+    const experiences = [
+      payloadFor('SOMETHING_NEW' as ExperienceType, [{ foo: 'bar' }]),
+    ];
+
+    expect(decode(experiences)).toEqual({
+      workExperiences: [],
+      educations: [],
+      personalLinks: [],
+    });
+  });
+
+  it('decode: undefined experiences returns empty arrays', () => {
+    expect(decode(undefined)).toEqual({
+      workExperiences: [],
+      educations: [],
+      personalLinks: [],
+    });
+  });
+
+  it('encode: multiple work experiences flagged is_primary mirrors the first match (Array.find semantics)', () => {
+    const input: EncodeInput = {
+      workExperiences: [
+        { job: 'First Primary', company: 'A', is_primary: true },
+        { job: 'Second Primary', company: 'B', is_primary: true },
+      ],
+      educations: [],
+      personalLinks: [],
+    };
+
+    const { job_title, company } = encode(input);
+
+    expect(job_title).toBe('First Primary');
+    expect(company).toBe('A');
+  });
+
+  it('encode: no work experiences mirrors job_title/company as empty strings, not undefined', () => {
+    const input: EncodeInput = {
+      workExperiences: [],
+      educations: [],
+      personalLinks: [],
+    };
+
+    const { job_title, company, experiences } = encode(input);
+
+    expect(job_title).toBe('');
+    expect(company).toBe('');
+    expect(
+      experiences.find((e) => e.category === ExperienceType.WORK)
+        ?.mentor_experiences_metadata.data
+    ).toEqual([]);
+  });
+});

--- a/src/lib/profile/experienceCodec.ts
+++ b/src/lib/profile/experienceCodec.ts
@@ -1,0 +1,177 @@
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
+import { ExperienceType } from '@/services/profile/experienceType';
+
+// Wire shape for experiences. Mirrors the inline batch on
+// MentorProfileVO/DTO: backend stores them as JSONB[] on profiles.experiences.
+// No row id — each category packs its items in metadata.data.
+export interface MentorExperiencePayload {
+  category: ExperienceType | string;
+  mentor_experiences_metadata: Record<string, unknown>;
+  order: number;
+}
+
+export interface WorkExperienceMetadata {
+  job?: string;
+  company?: string;
+  job_period_start?: string;
+  job_period_end?: string;
+  job_location?: string;
+  description?: string;
+  industry?: string;
+  is_primary?: boolean;
+}
+
+export interface EducationExperienceMetadata {
+  subject?: string;
+  school?: string;
+  education_period_start?: string;
+  education_period_end?: string;
+}
+
+export interface PersonalLinkMetadata {
+  platform: string;
+  url: string;
+}
+
+export interface DecodedExperiences {
+  workExperiences: WorkExperienceMetadata[];
+  educations: EducationExperienceMetadata[];
+  personalLinks: PersonalLinkMetadata[];
+}
+
+// encode() accepts the same flat domain shape decode() produces, so callers
+// on both sides of the wire share one set of types instead of re-declaring
+// per-category fields.
+export type EncodeInput = DecodedExperiences;
+
+export interface EncodeResult {
+  experiences: MentorExperiencePayload[];
+  job_title: string;
+  company: string;
+}
+
+type MentorExperienceMetadataBlock<T> = { data?: T[] };
+
+function getMetadataArray<T>(
+  experiences: MentorExperiencePayload[] | undefined,
+  category: ExperienceType
+): T[] {
+  return (experiences ?? [])
+    .filter((e) => e.category === category)
+    .flatMap((e) => {
+      const metadata =
+        e.mentor_experiences_metadata as MentorExperienceMetadataBlock<T>;
+      return metadata?.data ?? [];
+    });
+}
+
+export function decode(
+  experiences: MentorExperiencePayload[] | undefined
+): DecodedExperiences {
+  const workExperiences = getMetadataArray<WorkExperienceMetadata>(
+    experiences,
+    ExperienceType.WORK
+  ).map((item) => ({
+    job: item.job || '',
+    company: item.company || '',
+    job_period_start: item.job_period_start || '',
+    job_period_end: item.job_period_end || '',
+    industry: item.industry || '',
+    job_location: item.job_location || '',
+    description: item.description || '',
+    is_primary: item.is_primary ?? false,
+  }));
+
+  // Self-healing invariant: legacy data with no work experience flagged
+  // primary falls back to the first entry, matching the JobExperienceSection
+  // UI. Only kicks in when nothing is already marked primary.
+  if (
+    workExperiences.length > 0 &&
+    !workExperiences.some((w) => w.is_primary)
+  ) {
+    workExperiences[0].is_primary = true;
+  }
+
+  const educations = getMetadataArray<EducationExperienceMetadata>(
+    experiences,
+    ExperienceType.EDUCATION
+  ).map((item) => ({
+    subject: item.subject || '',
+    school: item.school || '',
+    education_period_start: item.education_period_start || '',
+    education_period_end: item.education_period_end || '',
+  }));
+
+  // isSafeUrl blocks javascript:/data:/etc. Applied here (not per-caller) so
+  // both the display path and the RHF edit form get the same protection —
+  // profiles can be written directly via BFF calls, bypassing the form's own
+  // URL validation.
+  const personalLinks = getMetadataArray<PersonalLinkMetadata>(
+    experiences,
+    ExperienceType.LINK
+  )
+    .map((item) => ({ platform: item.platform, url: item.url || '' }))
+    .filter((link) => isSafeUrl(link.url));
+
+  return { workExperiences, educations, personalLinks };
+}
+
+export function encode({
+  workExperiences,
+  educations,
+  personalLinks,
+}: EncodeInput): EncodeResult {
+  // Mentor's top-level job_title / company mirror the primary work
+  // experience so consumers (profile page, mentor pool card, reservations)
+  // can read them directly without re-deriving from the experience list.
+  // Falls back to the first entry when none is flagged primary; empty
+  // strings (not undefined) when there are no work experiences at all, so
+  // the backend clears stale values rather than leaving them untouched.
+  const primaryWork =
+    workExperiences.find((w) => w.is_primary) ?? workExperiences[0];
+  const job_title = primaryWork?.job ?? '';
+  const company = primaryWork?.company ?? '';
+
+  const experiences: MentorExperiencePayload[] = [
+    {
+      category: ExperienceType.WORK,
+      order: 1,
+      mentor_experiences_metadata: {
+        data: workExperiences.map((item) => ({
+          job: item.job,
+          company: item.company,
+          job_period_start: item.job_period_start,
+          job_period_end: item.job_period_end,
+          industry: item.industry,
+          job_location: item.job_location,
+          description: item.description,
+          is_primary: item.is_primary ?? false,
+        })),
+      },
+    },
+    {
+      category: ExperienceType.EDUCATION,
+      order: 2,
+      mentor_experiences_metadata: {
+        data: educations.map((item) => ({
+          school: item.school,
+          subject: item.subject,
+          education_period_start: item.education_period_start,
+          education_period_end: item.education_period_end,
+        })),
+      },
+    },
+    {
+      category: ExperienceType.LINK,
+      order: 3,
+      mentor_experiences_metadata: {
+        data: personalLinks.map((link) => ({
+          platform: link.platform,
+          url: link.url,
+        })),
+      },
+    },
+  ];
+
+  return { experiences, job_title, company };
+}

--- a/src/lib/profile/experienceCodec.ts
+++ b/src/lib/profile/experienceCodec.ts
@@ -10,22 +10,25 @@ export interface MentorExperiencePayload {
   order: number;
 }
 
+// Fields are guaranteed present (never undefined) on decode()'s output —
+// decode() fills every field with a safe default, so callers can consume
+// the result directly without re-declaring fallback logic of their own.
 export interface WorkExperienceMetadata {
-  job?: string;
-  company?: string;
-  job_period_start?: string;
-  job_period_end?: string;
-  job_location?: string;
-  description?: string;
-  industry?: string;
-  is_primary?: boolean;
+  job: string;
+  company: string;
+  job_period_start: string;
+  job_period_end: string;
+  job_location: string;
+  description: string;
+  industry: string;
+  is_primary: boolean;
 }
 
 export interface EducationExperienceMetadata {
-  subject?: string;
-  school?: string;
-  education_period_start?: string;
-  education_period_end?: string;
+  subject: string;
+  school: string;
+  education_period_start: string;
+  education_period_end: string;
 }
 
 export interface PersonalLinkMetadata {
@@ -39,10 +42,14 @@ export interface DecodedExperiences {
   personalLinks: PersonalLinkMetadata[];
 }
 
-// encode() accepts the same flat domain shape decode() produces, so callers
-// on both sides of the wire share one set of types instead of re-declaring
-// per-category fields.
-export type EncodeInput = DecodedExperiences;
+// encode() tolerates partial per-item data (legacy rows, in-progress edits)
+// and fills the same wire defaults decode() does on the way back — so its
+// input is intentionally looser than decode()'s guaranteed output shape.
+export interface EncodeInput {
+  workExperiences: Partial<WorkExperienceMetadata>[];
+  educations: Partial<EducationExperienceMetadata>[];
+  personalLinks: PersonalLinkMetadata[];
+}
 
 export interface EncodeResult {
   experiences: MentorExperiencePayload[];
@@ -68,7 +75,7 @@ function getMetadataArray<T>(
 export function decode(
   experiences: MentorExperiencePayload[] | undefined
 ): DecodedExperiences {
-  const workExperiences = getMetadataArray<WorkExperienceMetadata>(
+  const workExperiences = getMetadataArray<Partial<WorkExperienceMetadata>>(
     experiences,
     ExperienceType.WORK
   ).map((item) => ({
@@ -92,7 +99,7 @@ export function decode(
     workExperiences[0].is_primary = true;
   }
 
-  const educations = getMetadataArray<EducationExperienceMetadata>(
+  const educations = getMetadataArray<Partial<EducationExperienceMetadata>>(
     experiences,
     ExperienceType.EDUCATION
   ).map((item) => ({

--- a/src/lib/profile/parseUserExperiences.test.ts
+++ b/src/lib/profile/parseUserExperiences.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { ExperienceType } from '@/services/profile/experienceType';
+
+import type { MentorExperiencePayload } from './experienceCodec';
+import * as codec from './experienceCodec';
+import { toFormValues } from './parseUserExperiences';
+
+function payloadFor(
+  category: ExperienceType,
+  data: unknown[]
+): MentorExperiencePayload {
+  return {
+    category,
+    order: 1,
+    mentor_experiences_metadata: { data },
+  };
+}
+
+describe('parseUserExperiences.toFormValues', () => {
+  it('calls experienceCodec.decode exactly once per payload', () => {
+    const decodeSpy = vi.spyOn(codec, 'decode');
+    const experiences = [
+      payloadFor(ExperienceType.WORK, [{ job: 'Engineer' }]),
+    ];
+
+    toFormValues(experiences);
+
+    expect(decodeSpy).toHaveBeenCalledTimes(1);
+    decodeSpy.mockRestore();
+  });
+
+  it('injects a stable RHF id (array index) into work experiences and educations', () => {
+    const experiences = [
+      payloadFor(ExperienceType.WORK, [{ job: 'A' }, { job: 'B' }]),
+      payloadFor(ExperienceType.EDUCATION, [{ subject: 'CS' }]),
+    ];
+
+    const { workExperiences, educations } = toFormValues(experiences);
+
+    expect(workExperiences.map((w) => w.id)).toEqual([0, 1]);
+    expect(educations.map((e) => e.id)).toEqual([0]);
+  });
+
+  it('groups the flat personalLinks array into a per-platform Record', () => {
+    const experiences = [
+      payloadFor(ExperienceType.LINK, [
+        { platform: 'linkedin', url: 'https://linkedin.com/in/me' },
+        { platform: 'website', url: 'https://example.com' },
+      ]),
+    ];
+
+    const { links } = toFormValues(experiences);
+
+    expect(links.linkedin).toEqual({
+      id: 0,
+      platform: 'linkedin',
+      url: 'https://linkedin.com/in/me',
+    });
+    expect(links.website).toEqual({
+      id: 1,
+      platform: 'website',
+      url: 'https://example.com',
+    });
+  });
+
+  it('last-writer-wins when the same platform appears more than once', () => {
+    const experiences = [
+      payloadFor(ExperienceType.LINK, [
+        { platform: 'linkedin', url: 'https://linkedin.com/in/first' },
+        { platform: 'linkedin', url: 'https://linkedin.com/in/second' },
+      ]),
+    ];
+
+    const { links } = toFormValues(experiences);
+
+    expect(links.linkedin?.url).toBe('https://linkedin.com/in/second');
+  });
+
+  it('drops an unrecognized link platform', () => {
+    const experiences = [
+      payloadFor(ExperienceType.LINK, [
+        { platform: 'myspace', url: 'https://myspace.com/me' },
+      ]),
+    ];
+
+    const { links } = toFormValues(experiences);
+
+    expect(links).toEqual({});
+  });
+});

--- a/src/lib/profile/parseUserExperiences.ts
+++ b/src/lib/profile/parseUserExperiences.ts
@@ -5,116 +5,78 @@ import {
   jobSchema,
   personLinkSchema,
 } from '@/components/profile/edit/profileSchema';
-import { ExperienceType } from '@/services/profile/experienceType';
+
+import { decode, type MentorExperiencePayload } from './experienceCodec';
+
+export type { MentorExperiencePayload };
 
 type PersonalLinkFormValue = z.infer<typeof personLinkSchema>;
 type WorkExperienceFormValue = z.infer<typeof jobSchema>;
 type EducationFormValue = z.infer<typeof educationSchema>;
 
-// Wire shape for experiences. Mirrors the inline batch on
-// MentorProfileVO/DTO: backend stores them as JSONB[] on profiles.experiences.
-// No row id — each category packs its items in metadata.data, and RHF gets
-// a stable per-form-item id from the array index when we hydrate the form.
-export interface MentorExperiencePayload {
-  category: ExperienceType | string;
-  mentor_experiences_metadata: Record<string, unknown>;
-  order: number;
+const LINK_PLATFORMS = [
+  'linkedin',
+  'facebook',
+  'instagram',
+  'twitter',
+  'youtube',
+  'website',
+] as const;
+type LinkPlatform = (typeof LINK_PLATFORMS)[number];
+
+function isLinkPlatform(platform: string): platform is LinkPlatform {
+  return (LINK_PLATFORMS as readonly string[]).includes(platform);
 }
 
-type MentorExperienceMetadata<T> = { data?: T[] };
-
-export function parseLinks(
-  experiences: MentorExperiencePayload[]
-): Partial<
-  Record<
-    'linkedin' | 'facebook' | 'instagram' | 'twitter' | 'youtube' | 'website',
-    PersonalLinkFormValue
-  >
-> {
-  const result: Partial<
-    Record<
-      'linkedin' | 'facebook' | 'instagram' | 'twitter' | 'youtube' | 'website',
-      PersonalLinkFormValue
-    >
-  > = {};
-
-  experiences
-    ?.filter((e) => e.category === 'LINK')
-    .forEach((e) => {
-      const metadata =
-        e.mentor_experiences_metadata as MentorExperienceMetadata<PersonalLinkFormValue>;
-      const entries = metadata?.data || [];
-
-      entries.forEach((entry, idx) => {
-        const platform = entry.platform as keyof typeof result;
-        const url = entry.url || '';
-        // RHF only needs a stable numeric id for the form item; array index
-        // suffices now that experiences no longer carry a DB row id.
-        const id = idx;
-
-        if (
-          platform &&
-          [
-            'linkedin',
-            'facebook',
-            'instagram',
-            'twitter',
-            'youtube',
-            'website',
-          ].includes(platform)
-        ) {
-          result[platform] = { id, platform, url };
-        }
-      });
-    });
-
-  return result;
+export interface ExperienceFormValues {
+  workExperiences: WorkExperienceFormValue[];
+  educations: EducationFormValue[];
+  links: Partial<Record<LinkPlatform, PersonalLinkFormValue>>;
 }
 
-export function parseWorkExperiences(
+// Thin RHF adapter over experienceCodec.decode(). The codec owns the wire
+// <-> domain transform (including is_primary fallback and URL safety
+// filtering); this adapter only adds what RHF specifically needs: a stable
+// per-form-item `id` from array index, and packing the flat personalLinks
+// array into the per-platform Record the form schema expects. Decodes once
+// and derives all three form pieces from that single result.
+export function toFormValues(
   experiences: MentorExperiencePayload[]
-): WorkExperienceFormValue[] {
-  const flattened = (experiences ?? [])
-    .filter((e) => e.category === 'WORK')
-    .flatMap((e) => {
-      const metadata =
-        e.mentor_experiences_metadata as MentorExperienceMetadata<WorkExperienceFormValue>;
-      const entries = metadata?.data || [];
-      return entries.map((item, idx) => ({
+): ExperienceFormValues {
+  const { workExperiences, educations, personalLinks } = decode(experiences);
+
+  const links: Partial<Record<LinkPlatform, PersonalLinkFormValue>> = {};
+  personalLinks.forEach((link, idx) => {
+    if (isLinkPlatform(link.platform)) {
+      // Last-writer-wins on duplicate platforms, matching Object assignment
+      // order — same as the pre-codec implementation.
+      links[link.platform] = {
         id: idx,
-        job: item.job || '',
-        company: item.company || '',
-        job_period_start: item.job_period_start || '',
-        job_period_end: item.job_period_end || '',
-        industry: item.industry || '',
-        job_location: item.job_location || '',
-        description: item.description || '',
-        is_primary: item.is_primary ?? false,
-      }));
-    });
+        platform: link.platform,
+        url: link.url,
+      };
+    }
+  });
 
-  if (flattened.length > 0 && !flattened.some((item) => item.is_primary)) {
-    flattened[0].is_primary = true;
-  }
-
-  return flattened;
-}
-
-export function parseEducations(
-  experiences: MentorExperiencePayload[]
-): EducationFormValue[] {
-  return (experiences ?? [])
-    .filter((e) => e.category === 'EDUCATION')
-    .flatMap((e) => {
-      const metadata =
-        e.mentor_experiences_metadata as MentorExperienceMetadata<EducationFormValue>;
-      const entries = metadata?.data || [];
-      return entries.map((item, idx) => ({
-        id: idx,
-        subject: item.subject || '',
-        school: item.school || '',
-        education_period_start: item.education_period_start || '',
-        education_period_end: item.education_period_end || '',
-      }));
-    });
+  return {
+    workExperiences: workExperiences.map((item, idx) => ({
+      id: idx,
+      job: item.job || '',
+      company: item.company || '',
+      job_period_start: item.job_period_start || '',
+      job_period_end: item.job_period_end || '',
+      industry: item.industry || '',
+      job_location: item.job_location || '',
+      description: item.description || '',
+      is_primary: item.is_primary ?? false,
+    })),
+    educations: educations.map((item, idx) => ({
+      id: idx,
+      subject: item.subject || '',
+      school: item.school || '',
+      education_period_start: item.education_period_start || '',
+      education_period_end: item.education_period_end || '',
+    })),
+    links,
+  };
 }

--- a/src/lib/profile/parseUserExperiences.ts
+++ b/src/lib/profile/parseUserExperiences.ts
@@ -59,24 +59,8 @@ export function toFormValues(
   });
 
   return {
-    workExperiences: workExperiences.map((item, idx) => ({
-      id: idx,
-      job: item.job || '',
-      company: item.company || '',
-      job_period_start: item.job_period_start || '',
-      job_period_end: item.job_period_end || '',
-      industry: item.industry || '',
-      job_location: item.job_location || '',
-      description: item.description || '',
-      is_primary: item.is_primary ?? false,
-    })),
-    educations: educations.map((item, idx) => ({
-      id: idx,
-      subject: item.subject || '',
-      school: item.school || '',
-      education_period_start: item.education_period_start || '',
-      education_period_end: item.education_period_end || '',
-    })),
+    workExperiences: workExperiences.map((item, idx) => ({ id: idx, ...item })),
+    educations: educations.map((item, idx) => ({ id: idx, ...item })),
     links,
   };
 }

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -1,7 +1,7 @@
 import type { StaticImageData } from 'next/image';
 
 import avatarImage from '@/assets/default-avatar.png';
-import type { WorkExperienceMetadata } from '@/hooks/user/user-data/useUserData';
+import type { WorkExperienceMetadata } from '@/lib/profile/experienceCodec';
 import type { components } from '@/types/api';
 
 type RawMentor = components['schemas']['SearchMentorProfileVO'];


### PR DESCRIPTION
## What Does This PR Do?

- Extracts `experienceCodec.ts` as the single owner of the WORK/EDUCATION/LINK mentor-experiences wire format, replacing three independent hand-rolled implementations in `useProfileSubmit.ts`, `parseUserExperiences.ts`, and `useUserData.ts`.
- `decode()` centralizes the `is_primary` fallback and `isSafeUrl` filtering, which were previously applied inconsistently (only the display path filtered unsafe URLs; the RHF edit form did not).
- `encode()` centralizes the `job_title`/`company` mirroring from the primary work experience, returning `{ experiences, job_title, company }` instead of leaving each caller to re-derive it.
- `parseUserExperiences.ts` becomes a thin RHF adapter (`toFormValues`) that decodes the payload once and adds the form-only concerns: a stable per-item `id` and grouping personal links by platform.
- Adds round-trip tests (`decode(encode(x))`) covering the edge cases raised during ticket review: missing `is_primary`, unsafe URLs, missing fields, multiple `is_primary` flags, and empty experiences.
- Closes #336

## Demo

http://localhost:3000/profile/[pageUserId]/edit

## Screenshot

N/A

## Anything to Note?

N/A