### PR TITLE
test: add e2e tests for email verification and fix missing token handling

### DIFF
--- a/e2e/tests/public/email-verify.spec.ts
+++ b/e2e/tests/public/email-verify.spec.ts
@@ -1,0 +1,115 @@
+import { expect, test } from '@playwright/test';
+
+import { mockApiRoute } from '../../helpers/route';
+
+test.describe('Email Verification Flow', () => {
+  test('visit /auth/email-verified with a valid token → calls confirmRegister successfully and displays success status', async ({
+    page,
+  }) => {
+    // Mock the confirm endpoint to succeed
+    await mockApiRoute(page, /\/v1\/auth\/signup\/confirm/, {
+      body: { code: '0', msg: 'ok', data: null },
+    });
+
+    await page.goto('/auth/email-verified?token=test-valid-token');
+
+    // Page should display success heading
+    await expect(page.getByRole('heading', { name: '驗證成功' })).toBeVisible();
+    await expect(
+      page.getByText(
+        '你的帳號已完成註冊。現在可以開始建立你的個人頁面和尋找 Mentors 了！'
+      )
+    ).toBeVisible();
+
+    // Verify the button text and redirect
+    const setupProfileBtn = page.getByRole('button', { name: '設定個人資訊' });
+    await expect(setupProfileBtn).toBeVisible();
+
+    await setupProfileBtn.click();
+    await expect(page).toHaveURL('/auth/signin', { timeout: 10_000 });
+  });
+
+  test('visit /auth/email-verified without a token → displays error state (does not call API)', async ({
+    page,
+  }) => {
+    // Go directly to email-verified page without token query param
+    await page.goto('/auth/email-verified');
+
+    // Toast should show "缺少驗證 Token"
+    await expect(
+      page.getByText('缺少驗證 Token，請重新申請驗證信。', { exact: true })
+    ).toBeVisible();
+
+    // The page should transition to failure/error state and show failure heading
+    await expect(page.getByRole('heading', { name: '驗證失敗' })).toBeVisible();
+    await expect(
+      page.getByText('您的驗證連結已失效，請重新輸入Email再次驗證')
+    ).toBeVisible();
+
+    const retryBtn = page.getByRole('button', { name: '返回重試' });
+    await expect(retryBtn).toBeVisible();
+
+    await retryBtn.click();
+    await expect(page).toHaveURL('/auth/signup', { timeout: 10_000 });
+  });
+
+  test('visit /auth/email-verified with invalid or expired token → displays error state', async ({
+    page,
+  }) => {
+    // Mock the confirm endpoint to fail
+    await mockApiRoute(page, /\/v1\/auth\/signup\/confirm/, {
+      status: 400,
+      body: { code: '400', msg: '驗證連結已失效' },
+    });
+
+    await page.goto('/auth/email-verified?token=expired-token');
+
+    // Toast should show the error message from API
+    await expect(
+      page.getByText('驗證連結已失效', { exact: true })
+    ).toBeVisible();
+
+    // The page should transition to failure/error state and show failure heading
+    await expect(page.getByRole('heading', { name: '驗證失敗' })).toBeVisible();
+    await expect(
+      page.getByText('您的驗證連結已失效，請重新輸入Email再次驗證')
+    ).toBeVisible();
+
+    const retryBtn = page.getByRole('button', { name: '返回重試' });
+    await expect(retryBtn).toBeVisible();
+
+    await retryBtn.click();
+    await expect(page).toHaveURL('/auth/signup', { timeout: 10_000 });
+  });
+
+  test('visit /auth/email-verify page and click resend → calls resendVerificationEmail and shows success toast', async ({
+    page,
+  }) => {
+    // 1. Visit homepage to establish origin for sessionStorage
+    await page.goto('/');
+
+    // 2. Set the email in sessionStorage as expected by the page
+    await page.evaluate(() => {
+      sessionStorage.setItem('email', 'test@example.com');
+    });
+
+    // 3. Mock the resend API call
+    await mockApiRoute(page, /\/v1\/auth\/email\/resend/, {
+      body: { code: '0', msg: 'ok', data: null },
+    });
+
+    // 4. Navigate to email-verify page
+    await page.goto('/auth/email-verify');
+
+    // Verify the email verification heading is shown
+    await expect(page.getByRole('heading', { name: '驗證信箱' })).toBeVisible();
+
+    // 5. Click the "點此重新寄送" link
+    await page.getByText('點此重新寄送').click();
+
+    // 6. Expect the success toast
+    await expect(
+      page.getByText('驗證信已重新寄送！', { exact: true })
+    ).toBeVisible();
+  });
+});

--- a/src/app/auth/email-verified/container.tsx
+++ b/src/app/auth/email-verified/container.tsx
@@ -1,64 +1,42 @@
 'use client';
 
 import dynamic from 'next/dynamic';
-import { useRouter, useSearchParams } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import EmailVerifiedFailuredIconUrl from '@/assets/auth/email-verified-failed-icon.svg';
 import EmailVerifiedIconUrl from '@/assets/auth/email-verified-icon.svg';
 import { PageLoading } from '@/components/ui/loading-spinner';
-import { useToast } from '@/components/ui/use-toast';
-import { confirmRegister } from '@/services/auth/confirmRegister';
+import { useConfirmRegister } from '@/hooks/auth/useConfirmRegister';
 
 const EmailVerifiedPresentation = dynamic(() => import('./ui'));
 
 export default function EmailVerifiedContainer() {
   const router = useRouter();
-  const searchParams = useSearchParams();
-  const token = searchParams.get('token');
-  const { toast } = useToast();
-  const [isLoading, setIsLoading] = useState(true);
-  const [icon, setIcon] = useState(EmailVerifiedIconUrl.src);
-  const [title, setTitle] = useState('驗證成功');
-  const [content, setContent] = useState(
-    '你的帳號已完成註冊。現在可以開始建立你的個人頁面和尋找 Mentors 了！'
-  );
-  const [btnContent, setBtnContent] = useState('設定個人資訊');
-  const [redirectUrl, setRedirectUrl] = useState('/auth/signin');
+  const { status } = useConfirmRegister();
 
-  useEffect(() => {
-    if (!token) {
-      router.push('/');
-      return;
-    }
-
-    const confirmSignup = async () => {
-      try {
-        await confirmRegister(token);
-      } catch (error) {
-        toast({
-          variant: 'destructive',
-          title: '註冊失敗',
-          description:
-            error instanceof Error ? error.message : '註冊失敗，請稍後再試。',
-        });
-
-        setIcon(EmailVerifiedFailuredIconUrl.src);
-        setTitle('驗證失敗');
-        setContent('您的驗證連結已失效，請重新輸入Email再次驗證');
-        setBtnContent('返回重試');
-        setRedirectUrl('/auth/signup');
-      } finally {
-        setIsLoading(false);
-      }
-    };
-
-    confirmSignup();
-  }, [token, router, toast]);
-
-  if (isLoading) {
+  if (status === 'loading') {
     return <PageLoading />;
   }
+
+  const uiContent = {
+    success: {
+      icon: EmailVerifiedIconUrl.src,
+      title: '驗證成功',
+      content:
+        '你的帳號已完成註冊。現在可以開始建立你的個人頁面和尋找 Mentors 了！',
+      btnContent: '設定個人資訊',
+      redirectUrl: '/auth/signin',
+    },
+    failure: {
+      icon: EmailVerifiedFailuredIconUrl.src,
+      title: '驗證失敗',
+      content: '您的驗證連結已失效，請重新輸入Email再次驗證',
+      btnContent: '返回重試',
+      redirectUrl: '/auth/signup',
+    },
+  };
+
+  const { icon, title, content, btnContent, redirectUrl } = uiContent[status];
 
   return (
     <EmailVerifiedPresentation

--- a/src/hooks/auth/useConfirmRegister.test.ts
+++ b/src/hooks/auth/useConfirmRegister.test.ts
@@ -1,0 +1,202 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+vi.mock('@/services/auth/confirmRegister', () => ({
+  confirmRegister: vi.fn(),
+}));
+
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+import { confirmRegister } from '@/services/auth/confirmRegister';
+import { mockSearchParams } from '@/test/mocks/navigation';
+import { mockToast } from '@/test/mocks/useToast';
+
+import { useConfirmRegister } from './useConfirmRegister';
+
+const mockConfirmRegister = vi.mocked(confirmRegister);
+
+describe('useConfirmRegister', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearchParams.get.mockReturnValue(null);
+  });
+
+  it('no token on URL → status is failure, calls toast with "缺少驗證 Token"', () => {
+    mockSearchParams.get.mockReturnValue(null);
+
+    const { result } = renderHook(() => useConfirmRegister());
+
+    expect(result.current.status).toBe('failure');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        title: '驗證失敗',
+        description: '缺少驗證 Token，請重新申請驗證信。',
+      })
+    );
+    expect(mockConfirmRegister).not.toHaveBeenCalled();
+  });
+
+  it('token on URL + confirmRegister succeeds → status transitions from loading to success', async () => {
+    mockSearchParams.get.mockReturnValue('valid-token');
+
+    let resolvePromise!: () => void;
+    const apiPromise = new Promise<void>((resolve) => {
+      resolvePromise = resolve;
+    });
+    mockConfirmRegister.mockReturnValueOnce(apiPromise);
+
+    const { result } = renderHook(() => useConfirmRegister());
+
+    // Initial state should be loading
+    expect(result.current.status).toBe('loading');
+
+    // Resolve the promise
+    await act(async () => {
+      resolvePromise();
+      await apiPromise;
+    });
+
+    expect(result.current.status).toBe('success');
+    expect(mockConfirmRegister).toHaveBeenCalledWith('valid-token');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+
+  it('token on URL + confirmRegister fails → status transitions from loading to failure and shows toast', async () => {
+    mockSearchParams.get.mockReturnValue('invalid-token');
+    mockConfirmRegister.mockRejectedValueOnce(new Error('驗證連結已失效'));
+
+    const { result } = renderHook(() => useConfirmRegister());
+
+    // Wait for the hook to finish processing the async confirmRegister call
+    await act(async () => {
+      await Promise.resolve(); // allow microtasks to flush
+    });
+
+    expect(result.current.status).toBe('failure');
+    expect(mockConfirmRegister).toHaveBeenCalledWith('invalid-token');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '驗證連結已失效',
+      })
+    );
+  });
+
+  it('Strict Mode double-mount simulation → does not call API or toast twice', async () => {
+    mockSearchParams.get.mockReturnValue('valid-token');
+    mockConfirmRegister.mockResolvedValueOnce();
+
+    const { rerender } = renderHook(() => useConfirmRegister());
+
+    // Simulate strict mode unmount & remount by rerendering (effects are re-run)
+    rerender();
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // API should only be called once
+    expect(mockConfirmRegister).toHaveBeenCalledTimes(1);
+  });
+
+  it('token dynamically changes → resets state to loading and triggers a new API verification call', async () => {
+    mockSearchParams.get.mockReturnValue('token-1');
+    mockConfirmRegister.mockResolvedValue();
+
+    const { rerender, result } = renderHook(() => useConfirmRegister());
+
+    expect(mockConfirmRegister).toHaveBeenCalledWith('token-1');
+    expect(result.current.status).toBe('loading');
+
+    // Dynamically change token and rerender
+    mockSearchParams.get.mockReturnValue('token-2');
+    rerender();
+
+    // Verification state should reset to loading while token-2 is being verified
+    expect(result.current.status).toBe('loading');
+
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(mockConfirmRegister).toHaveBeenCalledWith('token-2');
+    expect(mockConfirmRegister).toHaveBeenCalledTimes(2);
+  });
+
+  it('token dynamically removed → resets state to failure and triggers missing token toast', async () => {
+    mockSearchParams.get.mockReturnValue('token-1');
+    mockConfirmRegister.mockResolvedValue();
+
+    const { rerender, result } = renderHook(() => useConfirmRegister());
+
+    expect(result.current.status).toBe('loading');
+
+    // Dynamically remove token and rerender
+    mockSearchParams.get.mockReturnValue(null);
+    rerender();
+
+    // State should immediately become failure and trigger the toast
+    expect(result.current.status).toBe('failure');
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        title: '驗證失敗',
+        description: '缺少驗證 Token，請重新申請驗證信。',
+      })
+    );
+  });
+
+  it('handles race conditions: ignores stale API responses', async () => {
+    // 1. Initial token: token-1
+    mockSearchParams.get.mockReturnValue('token-1');
+
+    let resolve1!: () => void;
+    const promise1 = new Promise<void>((resolve) => {
+      resolve1 = resolve;
+    });
+    mockConfirmRegister.mockReturnValueOnce(promise1);
+
+    const { rerender, result } = renderHook(() => useConfirmRegister());
+
+    expect(result.current.status).toBe('loading');
+
+    // 2. Dynamically change token to token-2
+    mockSearchParams.get.mockReturnValue('token-2');
+
+    let resolve2!: () => void;
+    const promise2 = new Promise<void>((resolve) => {
+      resolve2 = resolve;
+    });
+    mockConfirmRegister.mockReturnValueOnce(promise2);
+
+    rerender(); // Trigger effect for token-2
+
+    // 3. Resolve promise2 first (the newer request)
+    await act(async () => {
+      resolve2();
+      await promise2;
+    });
+
+    expect(result.current.status).toBe('success');
+
+    // 4. Resolve promise1 last (the older/stale request)
+    await act(async () => {
+      resolve1();
+      await promise1;
+    });
+
+    // It should still be 'success' (from token-2), NOT overwritten by the stale token-1 response!
+    expect(result.current.status).toBe('success');
+    expect(mockToast).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/auth/useConfirmRegister.ts
+++ b/src/hooks/auth/useConfirmRegister.ts
@@ -1,0 +1,61 @@
+import { useSearchParams } from 'next/navigation';
+import { useEffect, useRef, useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { confirmRegister } from '@/services/auth/confirmRegister';
+
+export function useConfirmRegister() {
+  const searchParams = useSearchParams();
+  const token = searchParams.get('token');
+  const { toast } = useToast();
+
+  const [status, setStatus] = useState<'loading' | 'success' | 'failure'>(
+    () => {
+      return token ? 'loading' : 'failure';
+    }
+  );
+
+  const processedTokenRef = useRef<string | null | undefined>(undefined);
+
+  useEffect(() => {
+    if (processedTokenRef.current === token) {
+      return;
+    }
+    processedTokenRef.current = token;
+
+    if (!token) {
+      setStatus('failure');
+      toast({
+        variant: 'destructive',
+        title: '驗證失敗',
+        description: '缺少驗證 Token，請重新申請驗證信。',
+      });
+      return;
+    }
+
+    setStatus('loading');
+
+    const confirmSignup = async () => {
+      try {
+        await confirmRegister(token);
+        if (processedTokenRef.current === token) {
+          setStatus('success');
+        }
+      } catch (error) {
+        if (processedTokenRef.current === token) {
+          toast({
+            variant: 'destructive',
+            title: '註冊失敗',
+            description:
+              error instanceof Error ? error.message : '註冊失敗，請稍後再試。',
+          });
+          setStatus('failure');
+        }
+      }
+    };
+
+    confirmSignup();
+  }, [token, toast]);
+
+  return { status };
+}


### PR DESCRIPTION
## What Does This PR Do?

- Fixed missing token scenario in email-verified container to properly transition to the error state and display a toast instead of immediately redirecting to the homepage.
- Added comprehensive E2E tests in `e2e/tests/public/email-verify.spec.ts` covering success, missing token, API error, and resend email flow.

Closes Xchange-Taiwan/X-Talent-Tracker#316

## Demo

- http://localhost:3000/auth/email-verified (test with and without token)
- http://localhost:3000/auth/email-verify

## Screenshot

N/A

## Anything to Note?

N/A
