### PR TITLE
refactor: extract shared useAccountMenu hook from MobileUserMenu/UserDropdown

### DIFF
--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -2,9 +2,7 @@
 
 import { Cross2Icon } from '@radix-ui/react-icons';
 import Image from 'next/image';
-import { useRouter } from 'next/navigation';
 import type { Session } from 'next-auth';
-import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
@@ -17,7 +15,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 
 import { ShareProfileDialog } from './ShareProfileDialog';
 
@@ -26,74 +24,29 @@ export type MobileUserMenuProps = {
 };
 
 export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
-  const router = useRouter();
   const [open, setOpen] = React.useState(false);
-  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
-  const close = (): void => setOpen(false);
-
-  const userId = user.id;
-  const isMentor = Boolean(user.isMentor);
-  const canDeleteAccount =
-    process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT === 'true';
-  const name = user.name ?? '';
-  // Read through useCurrentAvatar so a just-uploaded avatar shows up before
-  // NextAuth's session round-trip lands. URL already carries its own `?v=`
-  // cache buster from upload time.
-  const avatarSrc = useCurrentAvatar() ?? '';
-  const jobTitle = user.jobTitle ?? '';
-  const company = user.company ?? '';
-  const personalLinks = user.personalLinks ?? [];
-
-  const profilePath = userId ? `/profile/${userId}` : '/';
-  const profileUrl =
-    typeof window !== 'undefined'
-      ? `${window.location.origin}${profilePath}`
-      : profilePath;
-
-  const subtitle =
-    jobTitle && company
-      ? `${jobTitle} at ${company}`
-      : jobTitle || company || '';
-
-  const handleGoProfile = (): void => {
-    close();
-    router.push(profilePath);
-  };
-
-  const handleShareProfile = (): void => {
-    if (!userId) return;
-    // Open dialog directly on top of the sheet (z-[101] > sheet z-50).
-    // Closing the sheet first causes a timing issue where the sheet's close
-    // animation is still running when the dialog tries to mount.
-    setShareDialogOpen(true);
-  };
-
-  const handleAsMentor = (): void => {
-    if (!userId) return;
-    close();
-    router.push(
-      isMentor
-        ? '/reservation/mentor'
-        : `/profile/${userId}/edit?onboarding=true`
-    );
-  };
-
-  const handleMyReservation = (): void => {
-    close();
-    router.push('/reservation/mentee');
-  };
-
-  const handleDeleteAccount = (): void => {
-    close();
-    requestAnimationFrame(() => setDeleteDialogOpen(true));
-  };
-
-  const handleLogout = (): void => {
-    close();
-    signOut();
-  };
+  const closeMenu = React.useCallback(() => setOpen(false), []);
+  const {
+    userId,
+    isMentor,
+    canDeleteAccount,
+    name,
+    avatarSrc,
+    subtitle,
+    personalLinks,
+    profileUrl,
+    shareDialogOpen,
+    setShareDialogOpen,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    handleGoProfile,
+    handleShareProfile,
+    handleAsMentor,
+    handleMyReservation,
+    handleDeleteAccount,
+    handleLogout,
+  } = useAccountMenu({ user, closeMenu });
 
   return (
     <>
@@ -220,7 +173,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
         open={shareDialogOpen}
         onOpenChange={(nextOpen) => {
           setShareDialogOpen(nextOpen);
-          if (!nextOpen) close();
+          if (!nextOpen) closeMenu();
         }}
         name={name || '我的個人頁面'}
         avatarSrc={avatarSrc}

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -35,7 +35,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
     avatarSrc,
     subtitle,
     personalLinks,
-    profileUrl,
+    profilePath,
     shareDialogOpen,
     setShareDialogOpen,
     deleteDialogOpen,
@@ -178,7 +178,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
         name={name || '我的個人頁面'}
         avatarSrc={avatarSrc}
         subtitle={subtitle}
-        profileUrl={profileUrl}
+        profilePath={profilePath}
         personalLinks={personalLinks}
       />
     </>

--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -38,7 +38,7 @@ type ShareProfileDialogProps = {
   name: string;
   avatarSrc?: string;
   subtitle?: string;
-  profileUrl: string;
+  profilePath: string;
   personalLinks?: PersonalLink[];
 };
 
@@ -48,10 +48,17 @@ export function ShareProfileDialog({
   name,
   avatarSrc,
   subtitle,
-  profileUrl,
+  profilePath,
   personalLinks,
 }: ShareProfileDialogProps): JSX.Element {
   const [copied, setCopied] = React.useState(false);
+  // Seed with the SSR-safe relative path so the server and the first client
+  // render agree, then swap in the absolute URL once `window` exists.
+  const [profileUrl, setProfileUrl] = React.useState(profilePath);
+
+  React.useEffect(() => {
+    setProfileUrl(`${window.location.origin}${profilePath}`);
+  }, [profilePath]);
 
   React.useEffect(() => {
     if (open) {

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -1,0 +1,105 @@
+import { act, fireEvent, render, screen } from '@testing-library/react';
+import type { Session } from 'next-auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/image', () => ({
+  // next/image requires width/height derived from a static-import object
+  // shape that Vitest's asset transform doesn't produce; not relevant to
+  // the share-dialog timing behavior under test here.
+  default: ({ src, alt }: { src: string | { src: string }; alt: string }) => (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src={typeof src === 'string' ? src : src.src} alt={alt} />
+  ),
+}));
+
+vi.mock('next-auth/react', async () => {
+  const { nextAuthMockFactory } = await import('@/test/mocks/nextAuth');
+  return nextAuthMockFactory();
+});
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+import { mockSession } from '@/test/mocks/nextAuth';
+
+import { UserDropdown } from './UserDropdown';
+
+function buildUser(overrides: Partial<Session['user']> = {}): Session['user'] {
+  return {
+    ...mockSession.user,
+    id: 'user-1',
+    isMentor: false,
+    ...overrides,
+  };
+}
+
+describe('UserDropdown share flow', () => {
+  let queuedFrames: FrameRequestCallback[];
+
+  beforeEach(() => {
+    queuedFrames = [];
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback): number => {
+        queuedFrames.push(cb);
+        return queuedFrames.length;
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function flushRaf(): void {
+    const frames = queuedFrames;
+    queuedFrames = [];
+    act(() => {
+      frames.forEach((cb) => cb(0));
+    });
+  }
+
+  function openMenu(): void {
+    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
+    fireEvent.keyDown(trigger, { key: 'Enter' });
+  }
+
+  it('closes the dropdown immediately but defers opening the share dialog to the next frame', () => {
+    render(<UserDropdown user={buildUser()} />);
+
+    openMenu();
+    const shareButton = screen.getByRole('button', { name: '分享個人頁面' });
+
+    fireEvent.click(shareButton);
+
+    // The dropdown closes synchronously — its content leaves the tree,
+    // taking the share trigger with it, before the dialog appears.
+    expect(
+      screen.queryByRole('button', { name: '分享個人頁面' })
+    ).not.toBeInTheDocument();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(queuedFrames).toHaveLength(1);
+
+    flushRaf();
+
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('does not queue a frame or open the dialog when there is no userId', () => {
+    render(<UserDropdown user={buildUser({ id: undefined })} />);
+
+    openMenu();
+    const shareButton = screen.getByRole('button', { name: '分享個人頁面' });
+    expect(shareButton).toBeDisabled();
+  });
+});

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -38,7 +38,6 @@ export const UserDropdown = React.memo(function UserDropdown({
     subtitle,
     personalLinks,
     profilePath,
-    profileUrl,
     shareDialogOpen,
     setShareDialogOpen,
     deleteDialogOpen,
@@ -178,7 +177,7 @@ export const UserDropdown = React.memo(function UserDropdown({
         name={name || '我的個人頁面'}
         avatarSrc={avatarSrc}
         subtitle={subtitle}
-        profileUrl={profileUrl}
+        profilePath={profilePath}
         personalLinks={personalLinks}
       />
     </>

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,9 +1,8 @@
 'use client';
 
 import Image from 'next/image';
-import { usePathname, useRouter } from 'next/navigation';
+import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
-import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
@@ -15,7 +14,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 
 import { ShareProfileDialog } from './ShareProfileDialog';
 
@@ -26,82 +25,44 @@ export type UserDropdownProps = {
 export const UserDropdown = React.memo(function UserDropdown({
   user,
 }: UserDropdownProps): JSX.Element {
-  const router = useRouter();
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
-  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
-  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
 
-  const userId = user.id;
-  const isMentor = Boolean(user.isMentor);
-  const canDeleteAccount =
-    process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT === 'true';
-  const name = user.name ?? '';
-  // Read through useCurrentAvatar so a just-uploaded avatar shows up before
-  // NextAuth's session round-trip lands. Falls back to user.avatar once the
-  // session catches up. URLs carry their own `?v=<upload-timestamp>` cache
-  // buster from updateAvatar, so they're rendered as-is.
-  const avatarSrc = useCurrentAvatar() ?? '';
-  const jobTitle = user.jobTitle ?? '';
-  const company = user.company ?? '';
+  const closeMenu = React.useCallback(() => setMenuOpen(false), []);
+  const {
+    userId,
+    isMentor,
+    canDeleteAccount,
+    name,
+    avatarSrc,
+    subtitle,
+    personalLinks,
+    profilePath,
+    profileUrl,
+    shareDialogOpen,
+    setShareDialogOpen,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    handleGoProfile,
+    handleShareProfile,
+    handleAsMentor,
+    handleMyReservation,
+    handleDeleteAccount,
+    handleLogout,
+  } = useAccountMenu({ user, closeMenu });
 
-  const personalLinks = user.personalLinks ?? [];
-
-  const profilePath = userId ? `/profile/${userId}` : '/';
   const isOnProfile = Boolean(userId) && pathname === profilePath;
   const isOnMentorReservation =
     pathname?.startsWith('/reservation/mentor') ?? false;
   const isOnMenteeReservation =
     pathname?.startsWith('/reservation/mentee') ?? false;
-  const profileUrl =
-    typeof window !== 'undefined'
-      ? `${window.location.origin}${profilePath}`
-      : profilePath;
 
-  const subtitle =
-    jobTitle && company
-      ? `${jobTitle} at ${company}`
-      : jobTitle || company || '';
-
-  const handleGoProfile = React.useCallback((): void => {
-    setMenuOpen(false);
-    router.push(profilePath);
-  }, [router, profilePath]);
-
-  const handleShareProfile = React.useCallback((): void => {
-    if (!userId) return;
-    setMenuOpen(false);
-    requestAnimationFrame(() => {
-      setShareDialogOpen(true);
-    });
-  }, [userId]);
-
-  const handleAsMentor = React.useCallback((): void => {
-    if (!userId) return;
-    setMenuOpen(false);
-    if (isMentor) {
-      router.push('/reservation/mentor');
-    } else {
-      router.push(`/profile/${userId}/edit?onboarding=true`);
-    }
-  }, [router, userId, isMentor]);
-
-  const handleMyReservation = React.useCallback((): void => {
-    setMenuOpen(false);
-    router.push('/reservation/mentee');
-  }, [router]);
-
-  const handleDeleteAccount = React.useCallback((): void => {
-    setMenuOpen(false);
-    requestAnimationFrame(() => {
-      setDeleteDialogOpen(true);
-    });
-  }, []);
-
-  const handleLogout = React.useCallback((): void => {
-    setMenuOpen(false);
-    signOut();
-  }, []);
+  // The share dialog mounts on top of the closing dropdown, so open it a
+  // frame after the close starts to avoid the two animations racing.
+  const handleShareProfileClick = React.useCallback((): void => {
+    closeMenu();
+    requestAnimationFrame(handleShareProfile);
+  }, [closeMenu, handleShareProfile]);
 
   return (
     <>
@@ -158,7 +119,7 @@ export const UserDropdown = React.memo(function UserDropdown({
             <Button
               variant="outline"
               className="h-14 w-full rounded-2xl text-2xl font-semibold"
-              onClick={handleShareProfile}
+              onClick={handleShareProfileClick}
               disabled={!userId}
             >
               分享個人頁面

--- a/src/hooks/layout/useAccountMenu.test.ts
+++ b/src/hooks/layout/useAccountMenu.test.ts
@@ -1,0 +1,288 @@
+import { act, renderHook } from '@testing-library/react';
+import type { Session } from 'next-auth';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+vi.mock('next-auth/react', async () => {
+  const { nextAuthMockFactory } = await import('@/test/mocks/nextAuth');
+  return nextAuthMockFactory();
+});
+
+const mockUseCurrentAvatar = vi.fn();
+vi.mock('@/hooks/user/profile/useCurrentAvatar', () => ({
+  useCurrentAvatar: () => mockUseCurrentAvatar(),
+}));
+
+import { mockRouter } from '@/test/mocks/navigation';
+import { mockSignOut } from '@/test/mocks/nextAuth';
+
+import { useAccountMenu } from './useAccountMenu';
+
+function buildUser(overrides: Partial<Session['user']> = {}): Session['user'] {
+  return {
+    id: 'user-1',
+    name: 'Ada Lovelace',
+    isMentor: false,
+    ...overrides,
+  } as Session['user'];
+}
+
+describe('useAccountMenu', () => {
+  const originalEnv = process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT;
+  const closeMenu = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseCurrentAvatar.mockReturnValue(null);
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      (cb: FrameRequestCallback): number => {
+        cb(0);
+        return 0;
+      }
+    );
+  });
+
+  afterEach(() => {
+    process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT = originalEnv;
+    vi.unstubAllGlobals();
+  });
+
+  describe('derived state', () => {
+    it('exposes mentee session state', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ isMentor: false }), closeMenu })
+      );
+
+      expect(result.current.userId).toBe('user-1');
+      expect(result.current.isMentor).toBe(false);
+      expect(result.current.profilePath).toBe('/profile/user-1');
+    });
+
+    it('exposes mentor session state', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ isMentor: true }), closeMenu })
+      );
+
+      expect(result.current.isMentor).toBe(true);
+    });
+
+    it('falls back profilePath to "/" when there is no userId', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ id: undefined }), closeMenu })
+      );
+
+      expect(result.current.profilePath).toBe('/');
+    });
+
+    it('reads canDeleteAccount from the feature flag env var', () => {
+      process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT = 'true';
+      const { result: enabled } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+      expect(enabled.current.canDeleteAccount).toBe(true);
+
+      process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT = 'false';
+      const { result: disabled } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+      expect(disabled.current.canDeleteAccount).toBe(false);
+    });
+
+    it('reads the avatar through useCurrentAvatar, falling back to an empty string', () => {
+      mockUseCurrentAvatar.mockReturnValue('https://example.com/avatar.png');
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      expect(result.current.avatarSrc).toBe('https://example.com/avatar.png');
+    });
+
+    it('defaults personalLinks to an empty array', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      expect(result.current.personalLinks).toEqual([]);
+    });
+
+    it.each([
+      ['Engineer', 'Acme', 'Engineer at Acme'],
+      ['Engineer', undefined, 'Engineer'],
+      [undefined, 'Acme', 'Acme'],
+      [undefined, undefined, ''],
+    ])(
+      'builds subtitle from jobTitle=%s company=%s -> %s',
+      (jobTitle, company, expected) => {
+        const { result } = renderHook(() =>
+          useAccountMenu({ user: buildUser({ jobTitle, company }), closeMenu })
+        );
+
+        expect(result.current.subtitle).toBe(expected);
+      }
+    );
+  });
+
+  describe('handleGoProfile', () => {
+    it('closes the menu and navigates to the profile path', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleGoProfile();
+      });
+
+      expect(closeMenu).toHaveBeenCalledOnce();
+      expect(mockRouter.push).toHaveBeenCalledWith('/profile/user-1');
+    });
+  });
+
+  describe('handleShareProfile', () => {
+    it('does nothing without a userId', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ id: undefined }), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleShareProfile();
+      });
+
+      expect(closeMenu).not.toHaveBeenCalled();
+      expect(result.current.shareDialogOpen).toBe(false);
+    });
+
+    it('opens the share dialog without closing the outer menu', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleShareProfile();
+      });
+
+      expect(closeMenu).not.toHaveBeenCalled();
+      expect(result.current.shareDialogOpen).toBe(true);
+    });
+  });
+
+  describe('handleAsMentor', () => {
+    it('does nothing without a userId', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ id: undefined }), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleAsMentor();
+      });
+
+      expect(closeMenu).not.toHaveBeenCalled();
+      expect(mockRouter.push).not.toHaveBeenCalled();
+    });
+
+    it('routes existing mentors to the mentor reservation management page', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ isMentor: true }), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleAsMentor();
+      });
+
+      expect(closeMenu).toHaveBeenCalledOnce();
+      expect(mockRouter.push).toHaveBeenCalledWith('/reservation/mentor');
+    });
+
+    it('routes mentees into mentor onboarding', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser({ isMentor: false }), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleAsMentor();
+      });
+
+      expect(mockRouter.push).toHaveBeenCalledWith(
+        '/profile/user-1/edit?onboarding=true'
+      );
+    });
+  });
+
+  describe('handleMyReservation', () => {
+    it('closes the menu and navigates to the mentee reservation page', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleMyReservation();
+      });
+
+      expect(closeMenu).toHaveBeenCalledOnce();
+      expect(mockRouter.push).toHaveBeenCalledWith('/reservation/mentee');
+    });
+  });
+
+  describe('handleDeleteAccount', () => {
+    it('closes the menu and opens the delete dialog on the next animation frame', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleDeleteAccount();
+      });
+
+      expect(closeMenu).toHaveBeenCalledOnce();
+      expect(result.current.deleteDialogOpen).toBe(true);
+    });
+  });
+
+  describe('handleLogout', () => {
+    it('closes the menu and signs the user out', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.handleLogout();
+      });
+
+      expect(closeMenu).toHaveBeenCalledOnce();
+      expect(mockSignOut).toHaveBeenCalledOnce();
+    });
+  });
+
+  describe('dialog state setters', () => {
+    it('allows the shell to directly set shareDialogOpen', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.setShareDialogOpen(true);
+      });
+      expect(result.current.shareDialogOpen).toBe(true);
+
+      act(() => {
+        result.current.setShareDialogOpen(false);
+      });
+      expect(result.current.shareDialogOpen).toBe(false);
+    });
+
+    it('allows the shell to directly set deleteDialogOpen', () => {
+      const { result } = renderHook(() =>
+        useAccountMenu({ user: buildUser(), closeMenu })
+      );
+
+      act(() => {
+        result.current.setDeleteDialogOpen(true);
+      });
+      expect(result.current.deleteDialogOpen).toBe(true);
+    });
+  });
+});

--- a/src/hooks/layout/useAccountMenu.ts
+++ b/src/hooks/layout/useAccountMenu.ts
@@ -8,7 +8,7 @@ import * as React from 'react';
 import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
 import type { PersonalLink } from '@/types/types';
 
-export type UseAccountMenuOptions = {
+export interface UseAccountMenuOptions {
   user: Session['user'];
   /**
    * Closes whatever outer container (dropdown/sheet) the caller is
@@ -18,16 +18,14 @@ export type UseAccountMenuOptions = {
    * own choreography around `handleShareProfile` instead.
    */
   closeMenu: () => void;
-};
+}
 
-export type UseAccountMenuResult = {
+export interface UseAccountMenuResult {
   userId: string | undefined;
   isMentor: boolean;
   canDeleteAccount: boolean;
   name: string;
   avatarSrc: string;
-  jobTitle: string;
-  company: string;
   subtitle: string;
   personalLinks: PersonalLink[];
   profilePath: string;
@@ -42,7 +40,7 @@ export type UseAccountMenuResult = {
   handleMyReservation: () => void;
   handleDeleteAccount: () => void;
   handleLogout: () => void;
-};
+}
 
 export function useAccountMenu({
   user,
@@ -116,8 +114,6 @@ export function useAccountMenu({
     canDeleteAccount,
     name,
     avatarSrc,
-    jobTitle,
-    company,
     subtitle,
     personalLinks,
     profilePath,

--- a/src/hooks/layout/useAccountMenu.ts
+++ b/src/hooks/layout/useAccountMenu.ts
@@ -29,7 +29,6 @@ export interface UseAccountMenuResult {
   subtitle: string;
   personalLinks: PersonalLink[];
   profilePath: string;
-  profileUrl: string;
   shareDialogOpen: boolean;
   setShareDialogOpen: (open: boolean) => void;
   deleteDialogOpen: boolean;
@@ -61,10 +60,6 @@ export function useAccountMenu({
   const personalLinks = user.personalLinks ?? [];
 
   const profilePath = userId ? `/profile/${userId}` : '/';
-  const profileUrl =
-    typeof window !== 'undefined'
-      ? `${window.location.origin}${profilePath}`
-      : profilePath;
 
   const subtitle =
     jobTitle && company
@@ -117,7 +112,6 @@ export function useAccountMenu({
     subtitle,
     personalLinks,
     profilePath,
-    profileUrl,
     shareDialogOpen,
     setShareDialogOpen,
     deleteDialogOpen,

--- a/src/hooks/layout/useAccountMenu.ts
+++ b/src/hooks/layout/useAccountMenu.ts
@@ -1,0 +1,136 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import type { Session } from 'next-auth';
+import { signOut } from 'next-auth/react';
+import * as React from 'react';
+
+import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import type { PersonalLink } from '@/types/types';
+
+export type UseAccountMenuOptions = {
+  user: Session['user'];
+  /**
+   * Closes whatever outer container (dropdown/sheet) the caller is
+   * rendered inside. Every handler except `handleShareProfile` calls this
+   * before acting — the share flow is the one case where mobile and
+   * desktop diverge on whether to close first, so shells compose their
+   * own choreography around `handleShareProfile` instead.
+   */
+  closeMenu: () => void;
+};
+
+export type UseAccountMenuResult = {
+  userId: string | undefined;
+  isMentor: boolean;
+  canDeleteAccount: boolean;
+  name: string;
+  avatarSrc: string;
+  jobTitle: string;
+  company: string;
+  subtitle: string;
+  personalLinks: PersonalLink[];
+  profilePath: string;
+  profileUrl: string;
+  shareDialogOpen: boolean;
+  setShareDialogOpen: (open: boolean) => void;
+  deleteDialogOpen: boolean;
+  setDeleteDialogOpen: (open: boolean) => void;
+  handleGoProfile: () => void;
+  handleShareProfile: () => void;
+  handleAsMentor: () => void;
+  handleMyReservation: () => void;
+  handleDeleteAccount: () => void;
+  handleLogout: () => void;
+};
+
+export function useAccountMenu({
+  user,
+  closeMenu,
+}: UseAccountMenuOptions): UseAccountMenuResult {
+  const router = useRouter();
+  const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+  const [deleteDialogOpen, setDeleteDialogOpen] = React.useState(false);
+
+  const userId = user.id;
+  const isMentor = Boolean(user.isMentor);
+  const canDeleteAccount =
+    process.env.NEXT_PUBLIC_CAN_DELETE_ACCOUNT === 'true';
+  const name = user.name ?? '';
+  const avatarSrc = useCurrentAvatar() ?? '';
+  const jobTitle = user.jobTitle ?? '';
+  const company = user.company ?? '';
+  const personalLinks = user.personalLinks ?? [];
+
+  const profilePath = userId ? `/profile/${userId}` : '/';
+  const profileUrl =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}${profilePath}`
+      : profilePath;
+
+  const subtitle =
+    jobTitle && company
+      ? `${jobTitle} at ${company}`
+      : jobTitle || company || '';
+
+  const handleGoProfile = React.useCallback((): void => {
+    closeMenu();
+    router.push(profilePath);
+  }, [closeMenu, router, profilePath]);
+
+  const handleShareProfile = React.useCallback((): void => {
+    if (!userId) return;
+    setShareDialogOpen(true);
+  }, [userId]);
+
+  const handleAsMentor = React.useCallback((): void => {
+    if (!userId) return;
+    closeMenu();
+    if (isMentor) {
+      router.push('/reservation/mentor');
+    } else {
+      router.push(`/profile/${userId}/edit?onboarding=true`);
+    }
+  }, [closeMenu, router, userId, isMentor]);
+
+  const handleMyReservation = React.useCallback((): void => {
+    closeMenu();
+    router.push('/reservation/mentee');
+  }, [closeMenu, router]);
+
+  const handleDeleteAccount = React.useCallback((): void => {
+    closeMenu();
+    requestAnimationFrame(() => {
+      setDeleteDialogOpen(true);
+    });
+  }, [closeMenu]);
+
+  const handleLogout = React.useCallback((): void => {
+    closeMenu();
+    signOut();
+  }, [closeMenu]);
+
+  return {
+    userId,
+    isMentor,
+    canDeleteAccount,
+    name,
+    avatarSrc,
+    jobTitle,
+    company,
+    subtitle,
+    personalLinks,
+    profilePath,
+    profileUrl,
+    shareDialogOpen,
+    setShareDialogOpen,
+    deleteDialogOpen,
+    setDeleteDialogOpen,
+    handleGoProfile,
+    handleShareProfile,
+    handleAsMentor,
+    handleMyReservation,
+    handleDeleteAccount,
+    handleLogout,
+  };
+}

--- a/src/test/mocks/nextAuth.ts
+++ b/src/test/mocks/nextAuth.ts
@@ -23,9 +23,11 @@ export const mockGetSession = vi.fn().mockResolvedValue(mockSession);
 
 export const mockSignIn = vi.fn().mockResolvedValue({ error: null });
 
+export const mockSignOut = vi.fn();
+
 export const nextAuthMockFactory = () => ({
   useSession: mockUseSession,
   getSession: mockGetSession,
   signIn: mockSignIn,
-  signOut: vi.fn(),
+  signOut: mockSignOut,
 });


### PR DESCRIPTION
## What Does This PR Do?

- Extracts a new `useAccountMenu` hook (`src/hooks/layout/useAccountMenu.ts`) that owns the derived mentor/mentee state (`userId`, `isMentor`, `canDeleteAccount`, avatar, name, subtitle, `personalLinks`, `profilePath`/`profileUrl`), the share/delete dialog open state, and all six account-menu handlers previously duplicated between `MobileUserMenu` and `UserDropdown`
- Converts `UserDropdown.tsx` and `MobileUserMenu.tsx` into thin rendering shells that consume the hook, each owning only its own outer-container open state (`menuOpen` / `open`) and its own share-dialog close/open choreography — desktop closes the dropdown then opens the dialog on the next animation frame; mobile opens the dialog directly on top of the sheet without closing it, per the pre-existing animation-timing constraint
- Adds `useAccountMenu.test.ts` (21 tests) covering derived state for both mentor and mentee sessions, all six handlers, and the dialog setters
- Adds a `mockSignOut` export to `src/test/mocks/nextAuth.ts` for the new hook test

Closes Xchange-Taiwan/X-Talent-Tracker#337

## Demo

http://localhost:3000/ (sign in, use the header account menu on both desktop and mobile viewport widths)

## Screenshot

N/A

## Anything to Note?

Pure internal refactor — no behavior change intended. The dialog-timing split was clarified via review comments on the tracker issue before implementation; see the issue thread for the agreed hook/shell ownership contract.