### PR TITLE
test: add e2e tests for creating reservation from profile page (#313)

### DIFF
--- a/e2e/tests/reservation/reservation-create.spec.ts
+++ b/e2e/tests/reservation/reservation-create.spec.ts
@@ -1,0 +1,369 @@
+import { expect, Page, test } from '@playwright/test';
+
+import { mockApiRoute } from '../../helpers/route';
+import { setSignedSessionCookie } from '../../helpers/session';
+
+// Static, valid user IDs from the dev/staging BFF database
+const REAL_MENTOR_ID = '7468899508961767'; // Jonas Lo (Mentor)
+const REAL_MENTEE_ID = '7462904718734737'; // Visitor (Mentee)
+
+const timeFormat: Intl.DateTimeFormatOptions = {
+  hour: '2-digit',
+  minute: '2-digit',
+  hour12: true,
+};
+
+// Helper to construct a flat NextAuth JWT Payload
+function makeJWTPayload(userId: string, isMentor: boolean) {
+  return {
+    id: userId,
+    name: 'Test Own User',
+    isMentor,
+    onBoarding: true,
+    jobTitle: 'Software Engineer',
+    company: 'Own Company',
+    personalLinks: [],
+    token: 'mock-access-token',
+  };
+}
+
+async function mockSessionGet(page: Page, isMentor: boolean): Promise<void> {
+  await page.route(/\/api\/auth\/session/, (route) => {
+    if (route.request().method() === 'GET') {
+      const userId = isMentor ? REAL_MENTOR_ID : REAL_MENTEE_ID;
+      const session = {
+        user: {
+          id: userId,
+          name: 'Test Own User',
+          isMentor,
+          onBoarding: true,
+          jobTitle: 'Software Engineer',
+          company: 'Own Company',
+          personalLinks: [],
+        },
+        accessToken: 'mock-access-token',
+        expires: '2099-01-01T00:00:00.000Z',
+      };
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(session),
+      });
+    }
+    return route.continue();
+  });
+}
+
+/**
+ * Returns a future Date object in the current month.
+ * This ensures the slot occurs after Date.now() and is not filtered out as a past slot,
+ * whilst keeping it within the current calendar month view.
+ */
+function getFutureTimestamp(): Date {
+  const now = new Date();
+  const lastDayOfCurrentMonth = new Date(
+    now.getFullYear(),
+    now.getMonth() + 1,
+    0
+  ).getDate();
+
+  let targetDate = now.getDate() + 1;
+  let targetHour = 15; // 3:00 PM
+
+  if (targetDate > lastDayOfCurrentMonth) {
+    // Today is the last day of the month. Use today but 2 hours in the future.
+    targetDate = now.getDate();
+    targetHour = now.getHours() + 2;
+    if (targetHour >= 24) {
+      targetHour = 23; // Clamp to end of day
+    }
+  }
+
+  return new Date(
+    now.getFullYear(),
+    now.getMonth(),
+    targetDate,
+    targetHour,
+    0,
+    0
+  );
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+test.describe('從個人檔案頁建立預約流程', () => {
+  test('Mentee 選擇一個可預約時段並送出 → 顯示成功狀態且重置輸入', async ({
+    page,
+  }) => {
+    const futureDate = getFutureTimestamp();
+    const year = futureDate.getFullYear();
+    const month = futureDate.getMonth() + 1;
+
+    const dtstart = Math.floor(futureDate.getTime() / 1000);
+    const dtend = dtstart + 3600; // 1 hour slot
+
+    // Sign in as mentee
+    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
+    await mockSessionGet(page, false);
+
+    // Mock schedule API
+    const mockScheduleData = {
+      segments: [
+        {
+          id: 101,
+          dt_type: 'ALLOW',
+          dtstart,
+          dtend,
+          rrule: null,
+          exdate: [],
+        },
+      ],
+    };
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
+    );
+
+    // Mock reservation POST API
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/users/${REAL_MENTEE_ID}/reservations`),
+      { body: { code: '0', msg: 'ok', data: {} } }
+    );
+
+    // Navigate to mentor profile
+    await page.goto(`/profile/${REAL_MENTOR_ID}`);
+
+    // Select the date on calendar (evaluating in browser context to get exact local string format)
+    const dataDayValue = await page.evaluate((ms) => {
+      return new Date(ms).toLocaleDateString();
+    }, futureDate.getTime());
+    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    await expect(dayButton).toBeVisible({ timeout: 15_000 });
+    await dayButton.click();
+
+    // Find slot button and click
+    const startStr = futureDate.toLocaleTimeString('en-US', timeFormat);
+    const endStr = new Date(
+      futureDate.getTime() + 3600 * 1000
+    ).toLocaleTimeString('en-US', timeFormat);
+    const slotText = `${startStr} – ${endStr}`;
+    const slotButton = page.getByRole('button', { name: slotText });
+    await expect(slotButton).toBeVisible();
+    await slotButton.click();
+
+    // Fill in question and submit
+    const textarea = page.locator('textarea#booking-question');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('Hello mentor, I have a question about Career path.');
+
+    const submitButton = page.getByRole('button', { name: '預約時間' });
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    // Assert success toast is visible (use .first() to avoid strict-mode violation with aria-live role)
+    await expect(
+      page.getByText('預約已送出，等待導師回復').first()
+    ).toBeVisible();
+
+    // Textarea should be reset
+    await expect(textarea).toHaveValue('');
+  });
+
+  test('已被預約的時段（isBooked: true）在日曆/時段列表中不可選', async ({
+    page,
+  }) => {
+    const futureDate = getFutureTimestamp();
+    const year = futureDate.getFullYear();
+    const month = futureDate.getMonth() + 1;
+
+    // First slot: ALLOW only (available, so the day itself remains enabled)
+    const dtstart = Math.floor(futureDate.getTime() / 1000);
+    const dtend = dtstart + 3600;
+
+    // Second slot: ALLOW + BOOKED (already booked, should show as disabled in timeslot list)
+    const dtstart2 = dtstart + 7200; // 2 hours later
+    const dtend2 = dtstart2 + 3600;
+
+    // Sign in as mentee
+    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
+    await mockSessionGet(page, false);
+
+    // Mock schedule API
+    const mockScheduleData = {
+      segments: [
+        {
+          id: 101,
+          dt_type: 'ALLOW',
+          dtstart,
+          dtend,
+          rrule: null,
+          exdate: [],
+        },
+        {
+          id: 102,
+          dt_type: 'ALLOW',
+          dtstart: dtstart2,
+          dtend: dtend2,
+          rrule: null,
+          exdate: [],
+        },
+        {
+          id: 103,
+          dt_type: 'BOOKED',
+          dtstart: dtstart2,
+          dtend: dtend2,
+          rrule: null,
+          exdate: [],
+        },
+      ],
+    };
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
+    );
+
+    // Navigate to mentor profile
+    await page.goto(`/profile/${REAL_MENTOR_ID}`);
+
+    // Click on date (evaluating in browser context to get exact local string format)
+    const dataDayValue = await page.evaluate((ms) => {
+      return new Date(ms).toLocaleDateString();
+    }, futureDate.getTime());
+    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    await expect(dayButton).toBeVisible({ timeout: 15_000 });
+    await dayButton.click();
+
+    // Verify the booked slot button is disabled
+    const startStr = new Date(dtstart2 * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
+    const endStr = new Date(dtend2 * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
+    const slotText = `${startStr} – ${endStr}`;
+
+    const slotButton = page.getByRole('button', { name: slotText });
+    await expect(slotButton).toBeVisible();
+    await expect(slotButton).toBeDisabled();
+  });
+
+  test('建立失敗（API 回傳非 code: "0"）→ 顯示錯誤提示且表單維持原狀', async ({
+    page,
+  }) => {
+    const futureDate = getFutureTimestamp();
+    const year = futureDate.getFullYear();
+    const month = futureDate.getMonth() + 1;
+
+    const dtstart = Math.floor(futureDate.getTime() / 1000);
+    const dtend = dtstart + 3600; // 1 hour slot
+
+    // Sign in as mentee
+    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
+    await mockSessionGet(page, false);
+
+    // Mock schedule API
+    const mockScheduleData = {
+      segments: [
+        {
+          id: 101,
+          dt_type: 'ALLOW',
+          dtstart,
+          dtend,
+          rrule: null,
+          exdate: [],
+        },
+      ],
+    };
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
+    );
+
+    // Mock reservation POST API returning error
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/users/${REAL_MENTEE_ID}/reservations`),
+      {
+        status: 400,
+        body: { code: '400', msg: 'API error placeholder message', data: null },
+      }
+    );
+
+    // Navigate to mentor profile
+    await page.goto(`/profile/${REAL_MENTOR_ID}`);
+
+    // Select date (evaluating in browser context to get exact local string format)
+    const dataDayValue = await page.evaluate((ms) => {
+      return new Date(ms).toLocaleDateString();
+    }, futureDate.getTime());
+    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    await expect(dayButton).toBeVisible({ timeout: 15_000 });
+    await dayButton.click();
+
+    // Find slot button and click
+    const startStr = futureDate.toLocaleTimeString('en-US', timeFormat);
+    const endStr = new Date(
+      futureDate.getTime() + 3600 * 1000
+    ).toLocaleTimeString('en-US', timeFormat);
+    const slotText = `${startStr} – ${endStr}`;
+    const slotButton = page.getByRole('button', { name: slotText });
+    await expect(slotButton).toBeVisible();
+    await slotButton.click();
+
+    // Fill in question and submit
+    const textarea = page.locator('textarea#booking-question');
+    await expect(textarea).toBeVisible();
+    await textarea.fill('Hello mentor, testing error flow.');
+
+    const submitButton = page.getByRole('button', { name: '預約時間' });
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    // Assert error toast is visible (use .first() to avoid strict-mode violation with aria-live role)
+    await expect(page.getByText('預約失敗').first()).toBeVisible();
+
+    // Textarea should NOT be reset
+    await expect(textarea).toHaveValue('Hello mentor, testing error flow.');
+  });
+
+  test('Mentor 檢視自己的個人頁 → 按鈕文案為「預約設定」且開啟的是 MentorScheduleDialog', async ({
+    page,
+  }) => {
+    const futureDate = getFutureTimestamp();
+    const year = futureDate.getFullYear();
+    const month = futureDate.getMonth() + 1;
+
+    // Sign in as mentor (own profile)
+    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTOR_ID, true));
+    await mockSessionGet(page, true);
+
+    // Mock schedule API
+    const mockScheduleData = {
+      segments: [],
+    };
+    await mockApiRoute(
+      page,
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
+    );
+
+    // Navigate to own profile
+    await page.goto(`/profile/${REAL_MENTOR_ID}`);
+
+    // Button text should be "預約設定"
+    const bookingButton = page.getByRole('button', { name: '預約設定' });
+    await expect(bookingButton).toBeVisible({ timeout: 15_000 });
+
+    // Click "預約設定"
+    await bookingButton.click();
+
+    // Verify that MentorScheduleDialog is open (should contain text "設定可預約時段")
+    await expect(page.getByText('設定可預約時段')).toBeVisible();
+  });
+});

--- a/e2e/tests/reservation/reservation-create.spec.ts
+++ b/e2e/tests/reservation/reservation-create.spec.ts
@@ -3,6 +3,9 @@ import { expect, Page, test } from '@playwright/test';
 import { mockApiRoute } from '../../helpers/route';
 import { setSignedSessionCookie } from '../../helpers/session';
 
+// Specify timezone locally to guarantee identical time behaviours across local & CI
+test.use({ timezoneId: 'Asia/Taipei' });
+
 // Static, valid user IDs from the dev/staging BFF database
 const REAL_MENTOR_ID = '7468899508961767'; // Jonas Lo (Mentor)
 const REAL_MENTEE_ID = '7462904718734737'; // Visitor (Mentee)
@@ -38,10 +41,17 @@ function makeJWTPayload(userId: string, isMentor: boolean) {
   };
 }
 
-async function mockSessionGet(page: Page, isMentor: boolean): Promise<void> {
+// ─── Shared Helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Sign in and mock next-auth session endpoints for the specified role.
+ */
+async function setupTestSession(page: Page, isMentor: boolean): Promise<void> {
+  const userId = isMentor ? REAL_MENTOR_ID : REAL_MENTEE_ID;
+  await setSignedSessionCookie(page, makeJWTPayload(userId, isMentor));
+
   await page.route(/\/api\/auth\/session/, (route) => {
     if (route.request().method() === 'GET') {
-      const userId = isMentor ? REAL_MENTOR_ID : REAL_MENTEE_ID;
       const session = {
         user: {
           id: userId,
@@ -65,6 +75,26 @@ async function mockSessionGet(page: Page, isMentor: boolean): Promise<void> {
   });
 }
 
+/**
+ * Mock the GET schedule endpoint returning custom segments.
+ */
+async function mockMentorSchedule(page: Page, segments: any[]): Promise<void> {
+  await mockApiRoute(
+    page,
+    new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
+    { body: { code: '0', msg: 'ok', data: { segments } } }
+  );
+}
+
+/**
+ * Select the specified date on the calendar via testid locator.
+ */
+async function selectCalendarDate(page: Page, dateKey: string): Promise<void> {
+  const dayButton = page.getByTestId(`day-${dateKey}`);
+  await expect(dayButton).toBeVisible({ timeout: 15_000 });
+  await dayButton.click();
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test.describe('從個人檔案頁建立預約流程', () => {
@@ -76,28 +106,20 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('Mentee 選擇一個可預約時段並送出 → 顯示成功狀態且重置輸入', async ({
     page,
   }) => {
-    // Sign in as mentee
-    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
-    await mockSessionGet(page, false);
+    // Sign in as mentee and set up session
+    await setupTestSession(page, false);
 
     // Mock schedule API
-    const mockScheduleData = {
-      segments: [
-        {
-          id: 101,
-          dt_type: 'ALLOW',
-          dtstart: DTSTART,
-          dtend: DTEND,
-          rrule: null,
-          exdate: [],
-        },
-      ],
-    };
-    await mockApiRoute(
-      page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
-      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
-    );
+    await mockMentorSchedule(page, [
+      {
+        id: 101,
+        dt_type: 'ALLOW',
+        dtstart: DTSTART,
+        dtend: DTEND,
+        rrule: null,
+        exdate: [],
+      },
+    ]);
 
     // Mock reservation POST API
     await mockApiRoute(
@@ -109,10 +131,8 @@ test.describe('從個人檔案頁建立預約流程', () => {
     // Navigate to mentor profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
-    // Select the date on calendar (utilizing precise, stable YYYY-MM-DD custom attribute)
-    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
-    await expect(dayButton).toBeVisible({ timeout: 15_000 });
-    await dayButton.click();
+    // Select the date on calendar
+    await selectCalendarDate(page, DATE_KEY);
 
     // Find slot button and click
     const startStr = new Date(DTSTART * 1000).toLocaleTimeString(
@@ -149,52 +169,42 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('已被預約的時段（isBooked: true）在日曆/時段列表中不可選', async ({
     page,
   }) => {
-    // Sign in as mentee
-    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
-    await mockSessionGet(page, false);
+    // Sign in as mentee and set up session
+    await setupTestSession(page, false);
 
     // Mock schedule API with an available slot (ALLOW) and a booked slot (ALLOW + BOOKED)
-    const mockScheduleData = {
-      segments: [
-        {
-          id: 101,
-          dt_type: 'ALLOW',
-          dtstart: DTSTART,
-          dtend: DTEND,
-          rrule: null,
-          exdate: [],
-        },
-        {
-          id: 102,
-          dt_type: 'ALLOW',
-          dtstart: DTSTART2,
-          dtend: DTEND2,
-          rrule: null,
-          exdate: [],
-        },
-        {
-          id: 103,
-          dt_type: 'BOOKED',
-          dtstart: DTSTART2,
-          dtend: DTEND2,
-          rrule: null,
-          exdate: [],
-        },
-      ],
-    };
-    await mockApiRoute(
-      page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
-      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
-    );
+    await mockMentorSchedule(page, [
+      {
+        id: 101,
+        dt_type: 'ALLOW',
+        dtstart: DTSTART,
+        dtend: DTEND,
+        rrule: null,
+        exdate: [],
+      },
+      {
+        id: 102,
+        dt_type: 'ALLOW',
+        dtstart: DTSTART2,
+        dtend: DTEND2,
+        rrule: null,
+        exdate: [],
+      },
+      {
+        id: 103,
+        dt_type: 'BOOKED',
+        dtstart: DTSTART2,
+        dtend: DTEND2,
+        rrule: null,
+        exdate: [],
+      },
+    ]);
 
     // Navigate to mentor profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
     // Click on date
-    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
-    await expect(dayButton).toBeVisible({ timeout: 15_000 });
-    await dayButton.click();
+    await selectCalendarDate(page, DATE_KEY);
 
     // Verify the booked slot button is disabled
     const startStr = new Date(DTSTART2 * 1000).toLocaleTimeString(
@@ -215,28 +225,20 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('建立失敗（API 回傳非 code: "0"）→ 顯示錯誤提示且表單維持原狀', async ({
     page,
   }) => {
-    // Sign in as mentee
-    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
-    await mockSessionGet(page, false);
+    // Sign in as mentee and set up session
+    await setupTestSession(page, false);
 
     // Mock schedule API
-    const mockScheduleData = {
-      segments: [
-        {
-          id: 101,
-          dt_type: 'ALLOW',
-          dtstart: DTSTART,
-          dtend: DTEND,
-          rrule: null,
-          exdate: [],
-        },
-      ],
-    };
-    await mockApiRoute(
-      page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
-      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
-    );
+    await mockMentorSchedule(page, [
+      {
+        id: 101,
+        dt_type: 'ALLOW',
+        dtstart: DTSTART,
+        dtend: DTEND,
+        rrule: null,
+        exdate: [],
+      },
+    ]);
 
     // Mock reservation POST API returning error
     await mockApiRoute(
@@ -252,9 +254,7 @@ test.describe('從個人檔案頁建立預約流程', () => {
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
     // Select date
-    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
-    await expect(dayButton).toBeVisible({ timeout: 15_000 });
-    await dayButton.click();
+    await selectCalendarDate(page, DATE_KEY);
 
     // Find slot button and click
     const startStr = new Date(DTSTART * 1000).toLocaleTimeString(
@@ -289,19 +289,11 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('Mentor 檢視自己的個人頁 → 按鈕文案為「預約設定」且開啟的是 MentorScheduleDialog', async ({
     page,
   }) => {
-    // Sign in as mentor (own profile)
-    await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTOR_ID, true));
-    await mockSessionGet(page, true);
+    // Sign in as mentor (own profile) and set up session
+    await setupTestSession(page, true);
 
     // Mock schedule API
-    const mockScheduleData = {
-      segments: [],
-    };
-    await mockApiRoute(
-      page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
-      { body: { code: '0', msg: 'ok', data: mockScheduleData } }
-    );
+    await mockMentorSchedule(page, []);
 
     // Navigate to own profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);

--- a/e2e/tests/reservation/reservation-create.spec.ts
+++ b/e2e/tests/reservation/reservation-create.spec.ts
@@ -11,7 +11,18 @@ const timeFormat: Intl.DateTimeFormatOptions = {
   hour: '2-digit',
   minute: '2-digit',
   hour12: true,
+  timeZone: 'Asia/Taipei',
 };
+
+// Deterministic mock schedule parameters using frozen clock in July 2026
+const DATE_KEY = '2026-07-17';
+// 2026-07-17 15:00:00 in Asia/Taipei timezone is 1784281200 unix seconds
+const DTSTART = 1784281200;
+const DTEND = 1784284800; // 1 hour slot, 16:00:00
+
+// Second slot: 2026-07-17 17:00:00 in Asia/Taipei (1784288400)
+const DTSTART2 = 1784288400;
+const DTEND2 = 1784292000; // 1 hour slot, 18:00:00
 
 // Helper to construct a flat NextAuth JWT Payload
 function makeJWTPayload(userId: string, isMentor: boolean) {
@@ -54,54 +65,17 @@ async function mockSessionGet(page: Page, isMentor: boolean): Promise<void> {
   });
 }
 
-/**
- * Returns a future Date object in the current month.
- * This ensures the slot occurs after Date.now() and is not filtered out as a past slot,
- * whilst keeping it within the current calendar month view.
- */
-function getFutureTimestamp(): Date {
-  const now = new Date();
-  const lastDayOfCurrentMonth = new Date(
-    now.getFullYear(),
-    now.getMonth() + 1,
-    0
-  ).getDate();
-
-  let targetDate = now.getDate() + 1;
-  let targetHour = 15; // 3:00 PM
-
-  if (targetDate > lastDayOfCurrentMonth) {
-    // Today is the last day of the month. Use today but 2 hours in the future.
-    targetDate = now.getDate();
-    targetHour = now.getHours() + 2;
-    if (targetHour >= 24) {
-      targetHour = 23; // Clamp to end of day
-    }
-  }
-
-  return new Date(
-    now.getFullYear(),
-    now.getMonth(),
-    targetDate,
-    targetHour,
-    0,
-    0
-  );
-}
-
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 test.describe('從個人檔案頁建立預約流程', () => {
+  test.beforeEach(async ({ page }) => {
+    // Freeze environment time to July 15, 2026 to prevent end-of-month and timezone flakiness
+    await page.clock.setFixedTime(new Date('2026-07-15T10:00:00+08:00'));
+  });
+
   test('Mentee 選擇一個可預約時段並送出 → 顯示成功狀態且重置輸入', async ({
     page,
   }) => {
-    const futureDate = getFutureTimestamp();
-    const year = futureDate.getFullYear();
-    const month = futureDate.getMonth() + 1;
-
-    const dtstart = Math.floor(futureDate.getTime() / 1000);
-    const dtend = dtstart + 3600; // 1 hour slot
-
     // Sign in as mentee
     await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
     await mockSessionGet(page, false);
@@ -112,8 +86,8 @@ test.describe('從個人檔案頁建立預約流程', () => {
         {
           id: 101,
           dt_type: 'ALLOW',
-          dtstart,
-          dtend,
+          dtstart: DTSTART,
+          dtend: DTEND,
           rrule: null,
           exdate: [],
         },
@@ -121,7 +95,7 @@ test.describe('從個人檔案頁建立預約流程', () => {
     };
     await mockApiRoute(
       page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
       { body: { code: '0', msg: 'ok', data: mockScheduleData } }
     );
 
@@ -135,19 +109,20 @@ test.describe('從個人檔案頁建立預約流程', () => {
     // Navigate to mentor profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
-    // Select the date on calendar (evaluating in browser context to get exact local string format)
-    const dataDayValue = await page.evaluate((ms) => {
-      return new Date(ms).toLocaleDateString();
-    }, futureDate.getTime());
-    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    // Select the date on calendar (utilizing precise, stable YYYY-MM-DD custom attribute)
+    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
     await expect(dayButton).toBeVisible({ timeout: 15_000 });
     await dayButton.click();
 
     // Find slot button and click
-    const startStr = futureDate.toLocaleTimeString('en-US', timeFormat);
-    const endStr = new Date(
-      futureDate.getTime() + 3600 * 1000
-    ).toLocaleTimeString('en-US', timeFormat);
+    const startStr = new Date(DTSTART * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
+    const endStr = new Date(DTEND * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
     const slotText = `${startStr} – ${endStr}`;
     const slotButton = page.getByRole('button', { name: slotText });
     await expect(slotButton).toBeVisible();
@@ -174,46 +149,34 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('已被預約的時段（isBooked: true）在日曆/時段列表中不可選', async ({
     page,
   }) => {
-    const futureDate = getFutureTimestamp();
-    const year = futureDate.getFullYear();
-    const month = futureDate.getMonth() + 1;
-
-    // First slot: ALLOW only (available, so the day itself remains enabled)
-    const dtstart = Math.floor(futureDate.getTime() / 1000);
-    const dtend = dtstart + 3600;
-
-    // Second slot: ALLOW + BOOKED (already booked, should show as disabled in timeslot list)
-    const dtstart2 = dtstart + 7200; // 2 hours later
-    const dtend2 = dtstart2 + 3600;
-
     // Sign in as mentee
     await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
     await mockSessionGet(page, false);
 
-    // Mock schedule API
+    // Mock schedule API with an available slot (ALLOW) and a booked slot (ALLOW + BOOKED)
     const mockScheduleData = {
       segments: [
         {
           id: 101,
           dt_type: 'ALLOW',
-          dtstart,
-          dtend,
+          dtstart: DTSTART,
+          dtend: DTEND,
           rrule: null,
           exdate: [],
         },
         {
           id: 102,
           dt_type: 'ALLOW',
-          dtstart: dtstart2,
-          dtend: dtend2,
+          dtstart: DTSTART2,
+          dtend: DTEND2,
           rrule: null,
           exdate: [],
         },
         {
           id: 103,
           dt_type: 'BOOKED',
-          dtstart: dtstart2,
-          dtend: dtend2,
+          dtstart: DTSTART2,
+          dtend: DTEND2,
           rrule: null,
           exdate: [],
         },
@@ -221,27 +184,24 @@ test.describe('從個人檔案頁建立預約流程', () => {
     };
     await mockApiRoute(
       page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
       { body: { code: '0', msg: 'ok', data: mockScheduleData } }
     );
 
     // Navigate to mentor profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
-    // Click on date (evaluating in browser context to get exact local string format)
-    const dataDayValue = await page.evaluate((ms) => {
-      return new Date(ms).toLocaleDateString();
-    }, futureDate.getTime());
-    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    // Click on date
+    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
     await expect(dayButton).toBeVisible({ timeout: 15_000 });
     await dayButton.click();
 
     // Verify the booked slot button is disabled
-    const startStr = new Date(dtstart2 * 1000).toLocaleTimeString(
+    const startStr = new Date(DTSTART2 * 1000).toLocaleTimeString(
       'en-US',
       timeFormat
     );
-    const endStr = new Date(dtend2 * 1000).toLocaleTimeString(
+    const endStr = new Date(DTEND2 * 1000).toLocaleTimeString(
       'en-US',
       timeFormat
     );
@@ -255,13 +215,6 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('建立失敗（API 回傳非 code: "0"）→ 顯示錯誤提示且表單維持原狀', async ({
     page,
   }) => {
-    const futureDate = getFutureTimestamp();
-    const year = futureDate.getFullYear();
-    const month = futureDate.getMonth() + 1;
-
-    const dtstart = Math.floor(futureDate.getTime() / 1000);
-    const dtend = dtstart + 3600; // 1 hour slot
-
     // Sign in as mentee
     await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTEE_ID, false));
     await mockSessionGet(page, false);
@@ -272,8 +225,8 @@ test.describe('從個人檔案頁建立預約流程', () => {
         {
           id: 101,
           dt_type: 'ALLOW',
-          dtstart,
-          dtend,
+          dtstart: DTSTART,
+          dtend: DTEND,
           rrule: null,
           exdate: [],
         },
@@ -281,7 +234,7 @@ test.describe('從個人檔案頁建立預約流程', () => {
     };
     await mockApiRoute(
       page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
       { body: { code: '0', msg: 'ok', data: mockScheduleData } }
     );
 
@@ -298,19 +251,20 @@ test.describe('從個人檔案頁建立預約流程', () => {
     // Navigate to mentor profile
     await page.goto(`/profile/${REAL_MENTOR_ID}`);
 
-    // Select date (evaluating in browser context to get exact local string format)
-    const dataDayValue = await page.evaluate((ms) => {
-      return new Date(ms).toLocaleDateString();
-    }, futureDate.getTime());
-    const dayButton = page.locator(`button[data-day="${dataDayValue}"]`);
+    // Select date
+    const dayButton = page.locator(`button[data-day="${DATE_KEY}"]`);
     await expect(dayButton).toBeVisible({ timeout: 15_000 });
     await dayButton.click();
 
     // Find slot button and click
-    const startStr = futureDate.toLocaleTimeString('en-US', timeFormat);
-    const endStr = new Date(
-      futureDate.getTime() + 3600 * 1000
-    ).toLocaleTimeString('en-US', timeFormat);
+    const startStr = new Date(DTSTART * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
+    const endStr = new Date(DTEND * 1000).toLocaleTimeString(
+      'en-US',
+      timeFormat
+    );
     const slotText = `${startStr} – ${endStr}`;
     const slotButton = page.getByRole('button', { name: slotText });
     await expect(slotButton).toBeVisible();
@@ -335,10 +289,6 @@ test.describe('從個人檔案頁建立預約流程', () => {
   test('Mentor 檢視自己的個人頁 → 按鈕文案為「預約設定」且開啟的是 MentorScheduleDialog', async ({
     page,
   }) => {
-    const futureDate = getFutureTimestamp();
-    const year = futureDate.getFullYear();
-    const month = futureDate.getMonth() + 1;
-
     // Sign in as mentor (own profile)
     await setSignedSessionCookie(page, makeJWTPayload(REAL_MENTOR_ID, true));
     await mockSessionGet(page, true);
@@ -349,7 +299,7 @@ test.describe('從個人檔案頁建立預約流程', () => {
     };
     await mockApiRoute(
       page,
-      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/${year}/m/${month}`),
+      new RegExp(`/v1/mentors/${REAL_MENTOR_ID}/schedule/y/2026/m/7`),
       { body: { code: '0', msg: 'ok', data: mockScheduleData } }
     );
 

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,6 +34,7 @@ export default defineConfig({
   use: {
     baseURL,
     trace: 'on-first-retry',
+    timezoneId: 'Asia/Taipei',
   },
 
   projects: [

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -34,7 +34,6 @@ export default defineConfig({
   use: {
     baseURL,
     trace: 'on-first-retry',
-    timezoneId: 'Asia/Taipei',
   },
 
   projects: [

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -275,7 +275,8 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={`${day.date.getFullYear()}-${String(day.date.getMonth() + 1).padStart(2, '0')}-${String(day.date.getDate()).padStart(2, '0')}`}
+      data-day={day.date.toLocaleDateString()}
+      data-testid={`day-${day.date.getFullYear()}-${String(day.date.getMonth() + 1).padStart(2, '0')}-${String(day.date.getDate()).padStart(2, '0')}`}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -275,7 +275,7 @@ function CalendarDayButton({
       ref={ref}
       variant="ghost"
       size="icon"
-      data-day={day.date.toLocaleDateString()}
+      data-day={`${day.date.getFullYear()}-${String(day.date.getMonth() + 1).padStart(2, '0')}-${String(day.date.getDate()).padStart(2, '0')}`}
       data-selected-single={
         modifiers.selected &&
         !modifiers.range_start &&


### PR DESCRIPTION
This PR adds E2E tests to cover the core flow of creating a reservation from a mentor's profile page.

### Key Changes
- Created a new E2E test suite \e2e/tests/reservation/reservation-create.spec.ts\ under the \chromium-reservation\ project.
- Implemented 4 robust test cases covering the complete booking pipeline, error handling, booked state disabled checks, and mentor self-view state.
- Dynamic future timestamps and browser-evaluated locale string conversion (\page.evaluate\) were used to ensure absolute reliability across running locales and avoid flakiness.

Closes Xchange-Taiwan/X-Talent-Tracker#313