### PR TITLE
[Tech Debt] Split mentor/mentee onboarding parameter to avoid confusion

### DIFF
--- a/scripts/ai-review/prompts/_shared/business-rules.md
+++ b/scripts/ai-review/prompts/_shared/business-rules.md
@@ -17,7 +17,7 @@
 
 - **「onboarding」在這個專案裡其實是兩個語意完全不同的入口，不能只看名字判斷。**
   1. `/auth/(sign)/onboarding`（`src/app/auth/(sign)/onboarding/**`）—— 新用戶「註冊後」的初次填寫個人資料流程，就是上面那條規則講的、永遠是 mentee 的那個。
-  2. `/profile/[pageUserId]/edit?onboarding=true` —— 既有使用者「成為導師」的流程。所有「成為導師」按鈕（Header、HamburgerMenu、UserDropdown、MobileUserMenu）都導到這裡；`isMentorOnboarding` 這個 query flag 會傳進 `useEditProfileData` / `useProfileSubmit`，讓既有的 profile edit 頁面切換成「導師專屬必填欄位」模式。沒有任何入口導到 `/auth/onboarding`。
+  2. `/profile/[pageUserId]/edit?mentor-onboarding=true` —— 既有使用者「成為導師」的流程。所有「成為導師」按鈕（Header、HamburgerMenu、UserDropdown、MobileUserMenu）都導到這裡；`isMentorOnboarding` 這個 query flag 會傳進 `useEditProfileData` / `useProfileSubmit`，讓既有的 profile edit 頁面切換成「導師專屬必填欄位」模式。沒有任何入口導到 `/auth/onboarding`。
   - **因此**：PR 描述或 ticket 只寫「onboarding」時不能假設是指哪一個，要看 diff 實際動到 `src/app/auth/(sign)/onboarding/**` 還是 `src/app/profile/[pageUserId]/edit/**` 才能判斷。
   - **案例**：PR #641「mentor 需強制上傳頭像」正確位置是入口 2（`/profile/edit`，該 PR 也確實這樣做了），但同一份 PR 把同樣的邏輯又加了一份到入口 1（`/auth/onboarding`）——很可能就是把這兩個「onboarding」搞混了，這正是本文件最上面那條規則的真正成因。
   - **Reviewer 該做的事**：如果同一個「只該屬於某一邊」的需求同時出現在兩個入口，視為 Misplaced Implementation。

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -14,6 +14,7 @@ import useUserData from '@/hooks/user/user-data/useUserData';
 import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
+import { getMentorOnboardingUrl } from '@/lib/routes';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
 import { createReservation } from '@/services/reservations';
@@ -264,9 +265,7 @@ export default function ProfilePageContainer({
       isSubmitting={isSubmitting}
       onConfirmReservation={handleConfirmReservation}
       onEditProfile={() => router.push(`/profile/${pageUserId}/edit`)}
-      onBecomeMentor={() =>
-        router.push(`/profile/${pageUserId}/edit?mentor-onboarding=true`)
-      }
+      onBecomeMentor={() => router.push(getMentorOnboardingUrl(pageUserId))}
     />
   );
 }

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -265,7 +265,7 @@ export default function ProfilePageContainer({
       onConfirmReservation={handleConfirmReservation}
       onEditProfile={() => router.push(`/profile/${pageUserId}/edit`)}
       onBecomeMentor={() =>
-        router.push(`/profile/${pageUserId}/edit?onboarding=true`)
+        router.push(`/profile/${pageUserId}/edit?mentor-onboarding=true`)
       }
     />
   );

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -1,0 +1,134 @@
+import { render } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+// mock navigate & searchParams
+const mockSearchParamsGet = vi.fn().mockReturnValue(null);
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  useSearchParams: () => ({ get: mockSearchParamsGet }),
+}));
+
+// mock session
+vi.mock('next-auth/react', () => ({
+  useSession: () => ({ data: { user: { id: '1' } }, update: vi.fn() }),
+}));
+
+// mock other hooks to isolate our container test
+const mockUseEditProfileData = vi.fn();
+vi.mock('@/hooks/user/profile/useEditProfileData', () => ({
+  useEditProfileData: (options: any) => mockUseEditProfileData(options),
+}));
+
+const mockUseProfileSubmit = vi
+  .fn()
+  .mockReturnValue({ onSubmit: vi.fn(), isSaving: false });
+vi.mock('@/hooks/user/profile/useProfileSubmit', () => ({
+  useProfileSubmit: (options: any) => mockUseProfileSubmit(options),
+}));
+
+const mockUseProfileAuth = vi.fn().mockReturnValue({ isAuthorized: true });
+vi.mock('@/hooks/user/auth/useProfileAuth', () => ({
+  useProfileAuth: () => mockUseProfileAuth(),
+}));
+
+vi.mock('@/hooks/user/profile/useBackgroundAvatarUpload', () => ({
+  useBackgroundAvatarUpload: () => ({
+    kickOff: vi.fn(),
+    rollback: vi.fn(),
+    consume: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useUnsavedChangesPrompt', () => ({
+  useUnsavedChangesPrompt: () => ({
+    isPromptOpen: false,
+    confirmLeave: vi.fn(),
+    cancelLeave: vi.fn(),
+    guardNavigate: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/user/country/useLocations', () => ({
+  default: () => ({ locations: [] }),
+}));
+
+vi.mock('@/hooks/user/tags/useTagCatalog', () => ({
+  default: () => ({
+    industry: [],
+    have_topic: [],
+    have_skill: [],
+    want_position: [],
+    want_skill: [],
+    want_topic: [],
+  }),
+}));
+
+// Mock the child sections so the form renders with zero issues
+vi.mock('@/components/profile/edit/EditPageHeader', () => ({
+  EditPageHeader: () => <div data-testid="edit-header" />,
+}));
+vi.mock('@/components/profile/edit/AvatarSection', () => ({
+  AvatarSection: () => <div data-testid="avatar-section" />,
+}));
+vi.mock('@/components/profile/edit/Fields', () => ({
+  TextField: () => <div />,
+  TextareaField: () => <div />,
+  SelectField: () => <div />,
+}));
+vi.mock('@/components/profile/edit/CategoryMultiSelectField', () => ({
+  CategoryMultiSelectField: () => <div />,
+}));
+vi.mock('@/components/profile/edit/Section', () => ({
+  Section: ({ children }: any) => <div>{children}</div>,
+}));
+
+import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
+
+import EditProfileContainer from './container';
+
+describe('EditProfileContainer isMentorOnboarding parsing', () => {
+  it('correctly parses isMentorOnboarding as true when query param is true', () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === MENTOR_ONBOARDING_KEY) return 'true';
+      return null;
+    });
+
+    render(
+      <EditProfileContainer pageUserId="1" initialTagCatalog={{} as any} />
+    );
+
+    // Check that useEditProfileData was called with isMentorOnboarding: true
+    expect(mockUseEditProfileData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: true,
+      })
+    );
+
+    // Check that useProfileSubmit was called with isMentorOnboarding: true
+    expect(mockUseProfileSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: true,
+      })
+    );
+  });
+
+  it('correctly parses isMentorOnboarding as false when query param is absent', () => {
+    mockSearchParamsGet.mockImplementation(() => null);
+
+    render(
+      <EditProfileContainer pageUserId="1" initialTagCatalog={{} as any} />
+    );
+
+    expect(mockUseEditProfileData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: false,
+      })
+    );
+
+    expect(mockUseProfileSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: false,
+      })
+    );
+  });
+});

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -1,4 +1,5 @@
 import { render } from '@testing-library/react';
+import React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
 // mock navigate & searchParams
@@ -16,14 +17,14 @@ vi.mock('next-auth/react', () => ({
 // mock other hooks to isolate our container test
 const mockUseEditProfileData = vi.fn();
 vi.mock('@/hooks/user/profile/useEditProfileData', () => ({
-  useEditProfileData: (options: any) => mockUseEditProfileData(options),
+  useEditProfileData: (options: unknown) => mockUseEditProfileData(options),
 }));
 
 const mockUseProfileSubmit = vi
   .fn()
   .mockReturnValue({ onSubmit: vi.fn(), isSaving: false });
 vi.mock('@/hooks/user/profile/useProfileSubmit', () => ({
-  useProfileSubmit: (options: any) => mockUseProfileSubmit(options),
+  useProfileSubmit: (options: unknown) => mockUseProfileSubmit(options),
 }));
 
 const mockUseProfileAuth = vi.fn().mockReturnValue({ isAuthorized: true });
@@ -79,10 +80,13 @@ vi.mock('@/components/profile/edit/CategoryMultiSelectField', () => ({
   CategoryMultiSelectField: () => <div />,
 }));
 vi.mock('@/components/profile/edit/Section', () => ({
-  Section: ({ children }: any) => <div>{children}</div>,
+  Section: ({ children }: { children: React.ReactNode }) => (
+    <div>{children}</div>
+  ),
 }));
 
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
+import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 
 import EditProfileContainer from './container';
 
@@ -94,7 +98,10 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
     });
 
     render(
-      <EditProfileContainer pageUserId="1" initialTagCatalog={{} as any} />
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
     );
 
     // Check that useEditProfileData was called with isMentorOnboarding: true
@@ -112,11 +119,40 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
     );
   });
 
+  it('correctly parses isMentorOnboarding as true when the legacy onboarding query param is true (backwards compatibility)', () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === 'onboarding') return 'true';
+      return null;
+    });
+
+    render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(mockUseEditProfileData).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: true,
+      })
+    );
+
+    expect(mockUseProfileSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        isMentorOnboarding: true,
+      })
+    );
+  });
+
   it('correctly parses isMentorOnboarding as false when query param is absent', () => {
     mockSearchParamsGet.mockImplementation(() => null);
 
     render(
-      <EditProfileContainer pageUserId="1" initialTagCatalog={{} as any} />
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
     );
 
     expect(mockUseEditProfileData).toHaveBeenCalledWith(

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -73,7 +73,8 @@ export default function EditProfileContainer({
   const router = useRouter();
   const searchParams = useSearchParams();
   const isMentorOnboarding =
-    searchParams?.get(MENTOR_ONBOARDING_KEY) === 'true';
+    searchParams?.get(MENTOR_ONBOARDING_KEY) === 'true' ||
+    searchParams?.get('onboarding') === 'true';
 
   const { data: session, update: updateSession } = useSession();
 

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -41,6 +41,7 @@ import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt';
 import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
+import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { prefetchPresignedUrl } from '@/services/profile/updateAvatar';
 
@@ -71,7 +72,8 @@ export default function EditProfileContainer({
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const isMentorOnboarding = searchParams?.get('mentor-onboarding') === 'true';
+  const isMentorOnboarding =
+    searchParams?.get(MENTOR_ONBOARDING_KEY) === 'true';
 
   const { data: session, update: updateSession } = useSession();
 

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -71,7 +71,7 @@ export default function EditProfileContainer({
 }: Props) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const isMentorOnboarding = searchParams?.get('onboarding') === 'true';
+  const isMentorOnboarding = searchParams?.get('mentor-onboarding') === 'true';
 
   const { data: session, update: updateSession } = useSession();
 

--- a/src/app/profile/card/container.tsx
+++ b/src/app/profile/card/container.tsx
@@ -7,6 +7,7 @@ import { useEffect, useState } from 'react';
 
 import { PageLoading } from '@/components/ui/loading-spinner';
 import useUserData from '@/hooks/user/user-data/useUserData';
+import { getMentorOnboardingUrl } from '@/lib/routes';
 
 const ProfileCardUI = dynamic(() => import('./ui'));
 
@@ -42,9 +43,7 @@ export default function ProfileCardContainer() {
       userData={userData}
       isMentor={isMentor}
       linkedinUrl={linkedinUrl}
-      onBecomeMentor={() =>
-        router.push(`/profile/${loginUserId}/edit?mentor-onboarding=true`)
-      }
+      onBecomeMentor={() => router.push(getMentorOnboardingUrl(loginUserId))}
       onGoToMentorPool={() => router.push('/mentor-pool')}
       onBackToProfile={() => router.push(`/profile/${loginUserId}`)}
     />

--- a/src/app/profile/card/container.tsx
+++ b/src/app/profile/card/container.tsx
@@ -43,7 +43,7 @@ export default function ProfileCardContainer() {
       isMentor={isMentor}
       linkedinUrl={linkedinUrl}
       onBecomeMentor={() =>
-        router.push(`/profile/${loginUserId}/edit?onboarding=true`)
+        router.push(`/profile/${loginUserId}/edit?mentor-onboarding=true`)
       }
       onGoToMentorPool={() => router.push('/mentor-pool')}
       onBackToProfile={() => router.push(`/profile/${loginUserId}`)}

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -72,7 +72,7 @@ describe('Header', () => {
     const link = screen.getByRole('link', { name: '成為導師' });
     expect(link).toHaveAttribute(
       'href',
-      '/profile/user-123/edit?onboarding=true'
+      '/profile/user-123/edit?mentor-onboarding=true'
     );
     expect(link).toHaveAttribute('aria-disabled', 'false');
   });

--- a/src/components/layout/Header/navHrefs.test.ts
+++ b/src/components/layout/Header/navHrefs.test.ts
@@ -16,7 +16,7 @@ describe('navHrefs', () => {
   describe('getBecomeMentorHref', () => {
     it('returns the onboarding edit URL when userId is present', () => {
       expect(getBecomeMentorHref('user-123')).toBe(
-        '/profile/user-123/edit?onboarding=true'
+        '/profile/user-123/edit?mentor-onboarding=true'
       );
     });
 

--- a/src/components/layout/Header/navHrefs.ts
+++ b/src/components/layout/Header/navHrefs.ts
@@ -6,5 +6,7 @@ export function getProfileHref(userId: string | undefined): string {
 }
 
 export function getBecomeMentorHref(userId: string | undefined): string {
-  return userId ? `/profile/${userId}/edit?onboarding=true` : '/auth/signup';
+  return userId
+    ? `/profile/${userId}/edit?mentor-onboarding=true`
+    : '/auth/signup';
 }

--- a/src/components/layout/Header/navHrefs.ts
+++ b/src/components/layout/Header/navHrefs.ts
@@ -1,12 +1,12 @@
 // Single source of truth for the userId-dependent nav destinations shared by
 // Header.tsx and HamburgerMenu.tsx, so the two never drift out of sync.
 
+import { getMentorOnboardingUrl } from '@/lib/routes';
+
 export function getProfileHref(userId: string | undefined): string {
   return userId ? `/profile/${userId}` : '/';
 }
 
 export function getBecomeMentorHref(userId: string | undefined): string {
-  return userId
-    ? `/profile/${userId}/edit?mentor-onboarding=true`
-    : '/auth/signup';
+  return userId ? getMentorOnboardingUrl(userId) : '/auth/signup';
 }

--- a/src/hooks/layout/useAccountMenu.test.ts
+++ b/src/hooks/layout/useAccountMenu.test.ts
@@ -207,7 +207,7 @@ describe('useAccountMenu', () => {
       });
 
       expect(mockRouter.push).toHaveBeenCalledWith(
-        '/profile/user-1/edit?onboarding=true'
+        '/profile/user-1/edit?mentor-onboarding=true'
       );
     });
   });

--- a/src/hooks/layout/useAccountMenu.ts
+++ b/src/hooks/layout/useAccountMenu.ts
@@ -6,6 +6,7 @@ import { signOut } from 'next-auth/react';
 import * as React from 'react';
 
 import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import { getMentorOnboardingUrl } from '@/lib/routes';
 import type { PersonalLink } from '@/types/types';
 
 export interface UseAccountMenuOptions {
@@ -82,7 +83,7 @@ export function useAccountMenu({
     if (isMentor) {
       router.push('/reservation/mentor');
     } else {
-      router.push(`/profile/${userId}/edit?mentor-onboarding=true`);
+      router.push(getMentorOnboardingUrl(userId));
     }
   }, [closeMenu, router, userId, isMentor]);
 

--- a/src/hooks/layout/useAccountMenu.ts
+++ b/src/hooks/layout/useAccountMenu.ts
@@ -82,7 +82,7 @@ export function useAccountMenu({
     if (isMentor) {
       router.push('/reservation/mentor');
     } else {
-      router.push(`/profile/${userId}/edit?onboarding=true`);
+      router.push(`/profile/${userId}/edit?mentor-onboarding=true`);
     }
   }, [closeMenu, router, userId, isMentor]);
 

--- a/src/lib/routes.test.ts
+++ b/src/lib/routes.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getMentorOnboardingUrl,
+  getProfileEditUrl,
+  MENTOR_ONBOARDING_KEY,
+} from './routes';
+
+describe('routes helpers', () => {
+  it('defines MENTOR_ONBOARDING_KEY correctly', () => {
+    expect(MENTOR_ONBOARDING_KEY).toBe('mentor-onboarding');
+  });
+
+  describe('getProfileEditUrl', () => {
+    it('returns the correct profile edit path', () => {
+      expect(getProfileEditUrl(123)).toBe('/profile/123/edit');
+      expect(getProfileEditUrl('abc')).toBe('/profile/abc/edit');
+    });
+  });
+
+  describe('getMentorOnboardingUrl', () => {
+    it('returns the correct mentor onboarding path', () => {
+      expect(getMentorOnboardingUrl(123)).toBe(
+        '/profile/123/edit?mentor-onboarding=true'
+      );
+      expect(getMentorOnboardingUrl('abc')).toBe(
+        '/profile/abc/edit?mentor-onboarding=true'
+      );
+    });
+  });
+});

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -5,5 +5,5 @@ export function getProfileEditUrl(userId: string | number): string {
 }
 
 export function getMentorOnboardingUrl(userId: string | number): string {
-  return `/profile/${userId}/edit?${MENTOR_ONBOARDING_KEY}=true`;
+  return `${getProfileEditUrl(userId)}?${MENTOR_ONBOARDING_KEY}=true`;
 }

--- a/src/lib/routes.ts
+++ b/src/lib/routes.ts
@@ -1,0 +1,9 @@
+export const MENTOR_ONBOARDING_KEY = 'mentor-onboarding';
+
+export function getProfileEditUrl(userId: string | number): string {
+  return `/profile/${userId}/edit`;
+}
+
+export function getMentorOnboardingUrl(userId: string | number): string {
+  return `/profile/${userId}/edit?${MENTOR_ONBOARDING_KEY}=true`;
+}


### PR DESCRIPTION
Refactors the query parameter on the profile edit page for mentor onboarding from \onboarding=true\ to \mentor-onboarding=true\ to completely split the two different onboarding route contexts and avoid confusion.