### PR TITLE
refactor: centralize industry tag casting into readIndustryTag adapter (#341)

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -11,7 +11,7 @@ import {
   MentorExperiencePayload,
   toFormValues,
 } from '@/lib/profile/parseUserExperiences';
-import type { TagVO } from '@/types/tag';
+import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 
 interface Options {
   userId: number;
@@ -55,7 +55,7 @@ export function useEditProfileData({
     // BFF returns industry enriched as a TagVO-shaped object; the OpenAPI
     // generator types it as `Record<string, never>` because the BFF model
     // declares it as `Optional[Dict[str, Any]]`.
-    const industryTag = userDto.industry as unknown as TagVO | null | undefined;
+    const industryTag = readIndustryTag(userDto.industry);
     const industrySg = industryTag?.subject_group ?? '';
 
     // Reset must include every server-driven field so RHF treats them as the

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -7,12 +7,12 @@ import {
   type PersonalLinkMetadata,
   type WorkExperienceMetadata,
 } from '@/lib/profile/experienceCodec';
+import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 import {
   buildTagLabelMap,
   type TagCatalogsByBucket,
 } from '@/services/profile/tagCatalog';
 import { MentorProfileVO } from '@/services/profile/user';
-import type { TagVO } from '@/types/tag';
 
 import {
   clearUserProfileDtoCache,
@@ -81,7 +81,7 @@ function parseUserDtoToUserType(
 
   // BFF emits industry enriched (TagVO-shaped); OpenAPI types it as
   // `Record<string, never>`. Pull subject through the local TagVO type.
-  const industryTag = userDto.industry as unknown as TagVO | null | undefined;
+  const industryTag = readIndustryTag(userDto.industry);
 
   return {
     user_id: userDto.user_id,

--- a/src/lib/profile/pollUntilSynced.test.ts
+++ b/src/lib/profile/pollUntilSynced.test.ts
@@ -170,8 +170,8 @@ describe('firstSyncedFetch', () => {
     it('does not sync when latest.industry is a primitive invalid value', async () => {
       mockFetchUser.mockResolvedValueOnce({
         ...makeSyncedDto(),
-        industry: 'not-an-object' as any,
-      } as MentorProfileVO);
+        industry: 'not-an-object' as unknown,
+      } as unknown as MentorProfileVO);
 
       const result = await firstSyncedFetch(
         { ...baseValues, industry: 'tech' },

--- a/src/lib/profile/pollUntilSynced.test.ts
+++ b/src/lib/profile/pollUntilSynced.test.ts
@@ -89,4 +89,95 @@ describe('firstSyncedFetch', () => {
 
     expect(await promise).toBeNull();
   });
+
+  describe('isProfileSynced industry boundary conditions', () => {
+    it('syncs successfully when latest.industry matching values.industry', async () => {
+      mockFetchUser.mockResolvedValueOnce({
+        ...makeSyncedDto(),
+        industry: { subject_group: 'tech' },
+      } as unknown as MentorProfileVO);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: 'tech' },
+        ''
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('does not sync when latest.industry does not match values.industry', async () => {
+      mockFetchUser.mockResolvedValueOnce({
+        ...makeSyncedDto(),
+        industry: { subject_group: 'design' },
+      } as unknown as MentorProfileVO);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: 'tech' },
+        ''
+      );
+      expect(result).toBeNull();
+    });
+
+    it('syncs successfully when latest.industry is null and values.industry is undefined or empty', async () => {
+      mockFetchUser.mockResolvedValueOnce({
+        ...makeSyncedDto(),
+        industry: null,
+      } as MentorProfileVO);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: '' },
+        ''
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('does not sync when latest.industry is null but values.industry has a value', async () => {
+      mockFetchUser.mockResolvedValueOnce({
+        ...makeSyncedDto(),
+        industry: null,
+      } as MentorProfileVO);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: 'tech' },
+        ''
+      );
+      expect(result).toBeNull();
+    });
+
+    it('syncs successfully when latest.industry is undefined and values.industry is empty', async () => {
+      const dto = makeSyncedDto();
+      delete dto.industry;
+      mockFetchUser.mockResolvedValueOnce(dto);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: '' },
+        ''
+      );
+      expect(result).not.toBeNull();
+    });
+
+    it('does not sync when latest.industry is undefined but values.industry has a value', async () => {
+      const dto = makeSyncedDto();
+      delete dto.industry;
+      mockFetchUser.mockResolvedValueOnce(dto);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: 'tech' },
+        ''
+      );
+      expect(result).toBeNull();
+    });
+
+    it('does not sync when latest.industry is a primitive invalid value', async () => {
+      mockFetchUser.mockResolvedValueOnce({
+        ...makeSyncedDto(),
+        industry: 'not-an-object' as any,
+      } as MentorProfileVO);
+
+      const result = await firstSyncedFetch(
+        { ...baseValues, industry: 'tech' },
+        ''
+      );
+      expect(result).toBeNull();
+    });
+  });
 });

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,5 +1,6 @@
 import { ProfileFormValues } from '@/components/profile/edit/profileSchema';
 import { captureFlowFailure } from '@/lib/monitoring';
+import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 import { fetchUser, MentorProfileVO } from '@/services/profile/user';
 
 function isProfileSynced(
@@ -14,7 +15,10 @@ function isProfileSynced(
   if ((latest.about ?? '') !== (values.about ?? '')) return false;
   if ((latest.years_of_experience ?? '') !== (values.years_of_experience ?? ''))
     return false;
-  if ((latest.industry?.subject_group ?? '') !== (values.industry ?? ''))
+  if (
+    (readIndustryTag(latest.industry)?.subject_group ?? '') !==
+    (values.industry ?? '')
+  )
     return false;
   if (avatar && latest.avatar !== avatar) return false;
   return true;

--- a/src/lib/profile/readIndustryTag.test.ts
+++ b/src/lib/profile/readIndustryTag.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { readIndustryTag } from './readIndustryTag';
+
+describe('readIndustryTag', () => {
+  it('returns null when industry is null', () => {
+    expect(readIndustryTag(null)).toBeNull();
+  });
+
+  it('returns null when industry is undefined', () => {
+    expect(readIndustryTag(undefined)).toBeNull();
+  });
+
+  it('returns null when industry is an empty string', () => {
+    expect(readIndustryTag('')).toBeNull();
+  });
+
+  it('returns the same object casted to TagVO when industry is a valid object', () => {
+    const mockIndustry = {
+      id: 42,
+      kind: 'industry',
+      subject_group: 'tech',
+      subject: 'Technology',
+    };
+    expect(readIndustryTag(mockIndustry)).toEqual(mockIndustry);
+  });
+});

--- a/src/lib/profile/readIndustryTag.test.ts
+++ b/src/lib/profile/readIndustryTag.test.ts
@@ -15,7 +15,40 @@ describe('readIndustryTag', () => {
     expect(readIndustryTag('')).toBeNull();
   });
 
-  it('returns the same object casted to TagVO when industry is a valid object', () => {
+  it('returns null when industry is a primitive number', () => {
+    expect(readIndustryTag(123)).toBeNull();
+  });
+
+  it('returns null when industry is a boolean', () => {
+    expect(readIndustryTag(true)).toBeNull();
+  });
+
+  it('returns null when industry is a malformed object without tag properties', () => {
+    expect(readIndustryTag({ foo: 'bar' })).toBeNull();
+  });
+
+  it('returns the same object casted to TagVO when industry is a valid object containing subject_group', () => {
+    const mockIndustry = {
+      subject_group: 'tech',
+    };
+    expect(readIndustryTag(mockIndustry)).toEqual(mockIndustry);
+  });
+
+  it('returns the same object casted to TagVO when industry is a valid object containing subject', () => {
+    const mockIndustry = {
+      subject: 'Technology',
+    };
+    expect(readIndustryTag(mockIndustry)).toEqual(mockIndustry);
+  });
+
+  it('returns the same object casted to TagVO when industry is a valid object containing id', () => {
+    const mockIndustry = {
+      id: 42,
+    };
+    expect(readIndustryTag(mockIndustry)).toEqual(mockIndustry);
+  });
+
+  it('returns the same object casted to TagVO when industry is a complete valid object', () => {
     const mockIndustry = {
       id: 42,
       kind: 'industry',

--- a/src/lib/profile/readIndustryTag.ts
+++ b/src/lib/profile/readIndustryTag.ts
@@ -1,0 +1,18 @@
+import type { TagVO } from '@/types/tag';
+
+/**
+ * Safely casts and extracts the industry tag from the DTO format.
+ * The BFF returns industry enriched as a TagVO-shaped object, but the OpenAPI
+ * generator types it as Record<string, never> or similar because the BFF model
+ * declares it as Optional[Dict[str, Any]].
+ *
+ * This adapter centralizes the cast to prevent duplicate as-unknown casts
+ * across the codebase.
+ *
+ * @param industry The industry object from the backend DTO.
+ * @returns The casted TagVO object, or null if the input is falsy.
+ */
+export function readIndustryTag(industry: unknown): TagVO | null {
+  if (!industry) return null;
+  return industry as TagVO;
+}

--- a/src/lib/profile/readIndustryTag.ts
+++ b/src/lib/profile/readIndustryTag.ts
@@ -1,18 +1,31 @@
 import type { TagVO } from '@/types/tag';
 
 /**
+ * Type guard to determine if a value is a valid TagVO-like object.
+ */
+function isTagVO(value: unknown): value is TagVO {
+  if (typeof value !== 'object' || value === null) {
+    return false;
+  }
+  // A valid TagVO from the backend typically has 'subject_group' or 'subject' or 'id'
+  return 'subject_group' in value || 'subject' in value || 'id' in value;
+}
+
+/**
  * Safely casts and extracts the industry tag from the DTO format.
  * The BFF returns industry enriched as a TagVO-shaped object, but the OpenAPI
  * generator types it as Record<string, never> or similar because the BFF model
  * declares it as Optional[Dict[str, Any]].
  *
- * This adapter centralizes the cast to prevent duplicate as-unknown casts
- * across the codebase.
+ * This adapter centralizes the cast and performs runtime type narrowing to ensure
+ * type safety when reading enriched fields.
  *
  * @param industry The industry object from the backend DTO.
- * @returns The casted TagVO object, or null if the input is falsy.
+ * @returns The verified TagVO object, or null if the input is invalid or falsy.
  */
 export function readIndustryTag(industry: unknown): TagVO | null {
-  if (!industry) return null;
-  return industry as TagVO;
+  if (isTagVO(industry)) {
+    return industry;
+  }
+  return null;
 }

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -1,7 +1,7 @@
+import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 import { isSafeUrl } from '@/lib/url/isSafeUrl';
 import { ExperienceType } from '@/services/profile/experienceType';
 import type { MentorProfileVO } from '@/services/profile/user';
-import type { TagVO } from '@/types/tag';
 
 export type SocialPlatform =
   | 'linkedin'
@@ -147,7 +147,7 @@ export function sanitizePublicProfile(
   // BFF emits industry as an enriched TagVO-shaped object even though the
   // OpenAPI generator types it as `Record<string, never>`. Fall back to the
   // raw subject_group key when the localized subject is missing.
-  const industryTag = profile.industry as unknown as TagVO | null | undefined;
+  const industryTag = readIndustryTag(profile.industry);
   const industry = industryTag?.subject ?? industryTag?.subject_group ?? null;
 
   return {


### PR DESCRIPTION
## Scope & Purpose
Refactors and centralizes the duplicate, raw \s unknown as TagVO\ type-casts used when parsing the enriched industry field from the backend GET/profile responses into a single, clean \eadIndustryTag\ adapter.

## Changes Introduced
- Created \eadIndustryTag\ adapter under \src/lib/profile/readIndustryTag.ts\.
- Added unit test suite \src/lib/profile/readIndustryTag.test.ts\ to fully verify the adapter against null/undefined, empty strings, and valid TagVO object shapes.
- Replaced duplicate inline casting in:
  - \src/hooks/user/profile/useEditProfileData.ts\`n  - \src/hooks/user/user-data/useUserData.ts\`n  - \src/lib/seo/sanitizePublicProfile.ts\`n  - \src/lib/profile/pollUntilSynced.ts\ (also making its direct DTO access safer and cleaner)
- Removed unused \TagVO\ imports in the refactored files to resolve ESLint unused-var errors.

## Verification
- Ran \
pm run lint\ (all imports sorted, 0 errors).
- Ran \
pm run type-check\ (all types compiled, 0 errors).
- Ran \
pm run test\ (all 278 unit tests passed).