### PR TITLE
refactor: deepen the profile save module

### DIFF
--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -3,12 +3,8 @@ import { useEffect, useLayoutEffect } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
-import {
-  MentorExperiencePayload,
-  toFormValues,
-} from '@/lib/profile/parseUserExperiences';
-import { readIndustryTag } from '@/lib/profile/readIndustryTag';
-import { defaultValues, ProfileFormValues } from '@/schemas/profileSchema';
+import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
+import { ProfileFormValues } from '@/schemas/profileSchema';
 
 interface Options {
   userId: number;
@@ -39,51 +35,10 @@ export function useEditProfileData({
   useLayoutEffect(() => {
     if (!isAuthorized || !userDto) return;
 
-    const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
-    const experiences =
-      userDto.experiences as unknown as MentorExperiencePayload[];
+    const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
+    form.reset(formValues);
 
-    const {
-      workExperiences: parsedExperiences,
-      educations: parsedEducations,
-      links: parsedLinks,
-    } = toFormValues(experiences);
-
-    // BFF returns industry enriched as a TagVO-shaped object; the OpenAPI
-    // generator types it as `Record<string, never>` because the BFF model
-    // declares it as `Optional[Dict[str, Any]]`.
-    const industryTag = readIndustryTag(userDto.industry);
-    const industrySg = industryTag?.subject_group ?? '';
-
-    // Reset must include every server-driven field so RHF treats them as the
-    // new defaults; otherwise dirtyFields starts non-empty and submit-time
-    // skip optimisations cannot tell what the user actually changed.
-    form.reset({
-      is_mentor: mentorFlag,
-      avatar: userDto.avatar || '',
-      avatarFile: undefined,
-      name: userDto.name || '',
-      location: userDto.location || '',
-      statement: userDto.personal_statement || '',
-      about: userDto.about || '',
-      industry: industrySg,
-      years_of_experience: userDto.years_of_experience || '',
-      work_experiences: parsedExperiences || defaultValues.work_experiences,
-      educations: parsedEducations || defaultValues.educations,
-      linkedin: parsedLinks.linkedin || defaultValues.linkedin,
-      facebook: parsedLinks.facebook || defaultValues.facebook,
-      instagram: parsedLinks.instagram || defaultValues.instagram,
-      twitter: parsedLinks.twitter || defaultValues.twitter,
-      youtube: parsedLinks.youtube || defaultValues.youtube,
-      website: parsedLinks.website || defaultValues.website,
-      have_topic: userDto.have_topic ?? [],
-      have_skill: userDto.have_skill ?? [],
-      want_position: userDto.want_position ?? [],
-      want_skill: userDto.want_skill ?? [],
-      want_topic: userDto.want_topic ?? [],
-    });
-
-    setIsMentor(mentorFlag);
+    setIsMentor(formValues.is_mentor);
     setIsPageLoading(false);
   }, [
     userDto,

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -18,6 +18,7 @@ import {
 } from '@/lib/profile/pollUntilSynced';
 import {
   computeDirtyStates,
+  extractValidLinks,
   mapFormValuesToPayload,
   type ProfileDirtyFields,
 } from '@/lib/profile/profileSaveAdapter';
@@ -100,11 +101,7 @@ export function useProfileSubmit({
         isMentorOnboarding
       );
 
-      const payload = mapFormValuesToPayload(
-        values,
-        avatar ?? '',
-        experiencesDirty
-      );
+      const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
 
       const { job_title, company: companyFromPrimary } = payload;
 
@@ -127,19 +124,10 @@ export function useProfileSubmit({
       //    blocking the user behind a ~800ms timeout.
       const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
       const sessionUser = session?.user;
-      const personalLinks = [
-        values.linkedin,
-        values.facebook,
-        values.instagram,
-        values.twitter,
-        values.youtube,
-        values.website,
-      ]
-        .filter((l) => l && l.url)
-        .map((link) => ({
-          platform: link.platform,
-          url: link.url,
-        }));
+      const personalLinks = extractValidLinks(values).map((link) => ({
+        platform: link.platform,
+        url: link.url,
+      }));
 
       if (sessionUserId) {
         clearUserDataCache(sessionUserId, 'zh_TW');

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -12,30 +12,21 @@ import {
 import { trackEvent } from '@/lib/analytics';
 import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
 import { captureFlowFailure } from '@/lib/monitoring';
-import { encode } from '@/lib/profile/experienceCodec';
 import {
   firstSyncedFetch,
   pollUntilSynced,
 } from '@/lib/profile/pollUntilSynced';
+import {
+  computeDirtyStates,
+  mapFormValuesToPayload,
+  type ProfileDirtyFields,
+} from '@/lib/profile/profileSaveAdapter';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { MentorProfileVO } from '@/services/profile/user';
 
-// RHF's dirtyFields is a deep partial where leaves are `true`. Nested fields
-// (objects, arrays) carry the same shape, so we recurse to detect "anything
-// dirty inside" without enumerating every leaf.
-export type ProfileDirtyFields = Partial<
-  Record<keyof ProfileFormValues, unknown>
->;
-
-function hasDirtyValue(v: unknown): boolean {
-  if (!v) return false;
-  if (typeof v === 'boolean') return v;
-  if (Array.isArray(v)) return v.some(hasDirtyValue);
-  if (typeof v === 'object') return Object.values(v).some(hasDirtyValue);
-  return Boolean(v);
-}
+export type { ProfileDirtyFields };
 
 interface Options {
   pageUserId: string;
@@ -103,80 +94,19 @@ export function useProfileSubmit({
       //    When `dirtyFields` is omitted we fall back to the legacy
       //    "send everything" behaviour so existing callers and tests are
       //    unaffected.
-      const isDirty = (key: keyof ProfileFormValues): boolean => {
-        if (!dirtyFields) return true;
-        return hasDirtyValue(dirtyFields[key]);
-      };
+      const { experiencesDirty, profileDirty } = computeDirtyStates(
+        values,
+        dirtyFields,
+        isMentorOnboarding
+      );
 
-      const workDirty = isDirty('work_experiences');
-      const educationDirty = isDirty('educations');
-      const linksDirty =
-        isDirty('linkedin') ||
-        isDirty('facebook') ||
-        isDirty('instagram') ||
-        isDirty('twitter') ||
-        isDirty('youtube') ||
-        isDirty('website');
-      const experiencesDirty = workDirty || educationDirty || linksDirty;
+      const payload = mapFormValuesToPayload(
+        values,
+        avatar ?? '',
+        experiencesDirty
+      );
 
-      // updateProfile sends every form field, so any non-experience profile
-      // edit triggers it. `isMentorOnboarding` forces it through so the
-      // backend onboarding flag flips even when the user submits without
-      // touching anything. A new avatar file also counts. Any dirty
-      // experience section also triggers it because experiences travel inline.
-      const profileDirty =
-        isMentorOnboarding ||
-        Boolean(values.avatarFile) ||
-        isDirty('avatar') ||
-        isDirty('name') ||
-        isDirty('about') ||
-        isDirty('location') ||
-        isDirty('industry') ||
-        isDirty('years_of_experience') ||
-        isDirty('statement') ||
-        isDirty('have_skill') ||
-        isDirty('have_topic') ||
-        isDirty('want_position') ||
-        isDirty('want_skill') ||
-        isDirty('want_topic') ||
-        experiencesDirty;
-
-      const links = [
-        values.linkedin,
-        values.facebook,
-        values.instagram,
-        values.twitter,
-        values.youtube,
-        values.website,
-      ].filter((l) => l && l.url);
-
-      // The codec derives both the wire-format experiences batch and the
-      // top-level job_title/company mirror (which consumers like the
-      // profile page, mentor pool card, and reservations read directly
-      // without re-deriving from the experience list) from the same form
-      // values — see experienceCodec.ts.
-      const {
-        experiences,
-        job_title,
-        company: companyFromPrimary,
-      } = encode({
-        workExperiences: values.work_experiences ?? [],
-        educations: values.educations ?? [],
-        personalLinks: links,
-      });
-
-      const payload = {
-        ...values,
-        avatar,
-        avatarFile: undefined,
-        job_title,
-        company: companyFromPrimary,
-        // Three-state semantic on the wire: omit when no experience section
-        // changed (backend leaves the column alone); include the full set
-        // when any section is dirty (backend overwrites). Replace semantics:
-        // backend overwrites profiles.experiences wholesale with this batch.
-        ...(experiencesDirty ? { experiences } : {}),
-      };
+      const { job_title, company: companyFromPrimary } = payload;
 
       try {
         if (profileDirty) {
@@ -197,10 +127,19 @@ export function useProfileSubmit({
       //    blocking the user behind a ~800ms timeout.
       const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
       const sessionUser = session?.user;
-      const personalLinks = links.map((link) => ({
-        platform: link.platform,
-        url: link.url,
-      }));
+      const personalLinks = [
+        values.linkedin,
+        values.facebook,
+        values.instagram,
+        values.twitter,
+        values.youtube,
+        values.website,
+      ]
+        .filter((l) => l && l.url)
+        .map((link) => ({
+          platform: link.platform,
+          url: link.url,
+        }));
 
       if (sessionUserId) {
         clearUserDataCache(sessionUserId, 'zh_TW');

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,28 +1,7 @@
 import { captureFlowFailure } from '@/lib/monitoring';
-import { readIndustryTag } from '@/lib/profile/readIndustryTag';
+import { isProfileSynced } from '@/lib/profile/profileSaveAdapter';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import { fetchUser, MentorProfileVO } from '@/services/profile/user';
-
-function isProfileSynced(
-  values: ProfileFormValues,
-  latest: MentorProfileVO,
-  avatar: string
-): boolean {
-  if (latest.name !== values.name) return false;
-  if ((latest.location ?? '') !== (values.location ?? '')) return false;
-  if ((latest.personal_statement ?? '') !== (values.statement ?? ''))
-    return false;
-  if ((latest.about ?? '') !== (values.about ?? '')) return false;
-  if ((latest.years_of_experience ?? '') !== (values.years_of_experience ?? ''))
-    return false;
-  if (
-    (readIndustryTag(latest.industry)?.subject_group ?? '') !==
-    (values.industry ?? '')
-  )
-    return false;
-  if (avatar && latest.avatar !== avatar) return false;
-  return true;
-}
 
 /**
  * Single, fast attempt to read the latest profile and confirm it matches the

--- a/src/lib/profile/profileSaveAdapter.test.ts
+++ b/src/lib/profile/profileSaveAdapter.test.ts
@@ -65,7 +65,7 @@ describe('profileSaveAdapter', () => {
         subject_group: 'tech',
         subject: 'Software',
         language: 'zh_TW',
-      } as any,
+      } as unknown as MentorProfileVO['industry'],
       experiences: [
         {
           category: 'WORK',
@@ -83,7 +83,7 @@ describe('profileSaveAdapter', () => {
                 is_primary: true,
               },
             ],
-          } as any,
+          } as unknown as Record<string, never>,
         },
       ],
       onboarding: true,
@@ -156,6 +156,19 @@ describe('profileSaveAdapter', () => {
       const { profileDirty } = computeDirtyStates(valuesWithAvatar, {}, false);
       expect(profileDirty).toBe(true);
     });
+
+    it('returns experiencesDirty and profileDirty as true when a single social link is dirty', () => {
+      const dirtyFields = {
+        linkedin: true,
+      };
+      const { experiencesDirty, profileDirty } = computeDirtyStates(
+        mockValues,
+        dirtyFields,
+        false
+      );
+      expect(experiencesDirty).toBe(true);
+      expect(profileDirty).toBe(true);
+    });
   });
 
   describe('mapFormValuesToPayload', () => {
@@ -189,6 +202,37 @@ describe('profileSaveAdapter', () => {
       expect(payload.company).toBe('Apple');
       expect(payload.experiences).toHaveLength(3);
     });
+
+    it('filters out invalid/empty personal links', () => {
+      const mockValues: ProfileFormValues = {
+        ...defaultValues,
+        linkedin: {
+          id: 1,
+          platform: 'linkedin',
+          url: 'https://linkedin.com/in/bob',
+        },
+        facebook: { id: 2, platform: 'facebook', url: '' },
+      };
+
+      const payload = mapFormValuesToPayload(mockValues, undefined, true);
+      const linkExperience = payload.experiences?.find(
+        (e) => e.category === 'LINK'
+      );
+      const linksData = linkExperience?.mentor_experiences_metadata
+        ?.data as unknown as { platform: string; url: string }[];
+      expect(linksData).toHaveLength(1);
+      expect(linksData[0].platform).toBe('linkedin');
+      expect(linksData[0].url).toBe('https://linkedin.com/in/bob');
+    });
+
+    it('retains undefined avatar to avoid clearing existing avatar in the backend', () => {
+      const mockValues: ProfileFormValues = {
+        ...defaultValues,
+        avatar: 'https://existing-avatar.com/bob',
+      };
+      const payload = mapFormValuesToPayload(mockValues, undefined, false);
+      expect(payload.avatar).toBeUndefined();
+    });
   });
 
   describe('isProfileSynced', () => {
@@ -218,7 +262,7 @@ describe('profileSaveAdapter', () => {
         subject_group: 'tech',
         subject: 'Software',
         language: 'zh_TW',
-      } as any,
+      } as unknown as MentorProfileVO['industry'],
       experiences: [],
       onboarding: true,
       is_mentor: true,
@@ -246,6 +290,35 @@ describe('profileSaveAdapter', () => {
 
     it('returns false if location differs', () => {
       const differentVo = { ...mockVo, location: 'Hsinchu' };
+      expect(
+        isProfileSynced(mockValues, differentVo, 'https://avatar.com/bob')
+      ).toBe(false);
+    });
+
+    it('returns false if avatar differs', () => {
+      expect(
+        isProfileSynced(mockValues, mockVo, 'https://avatar.com/new-bob')
+      ).toBe(false);
+    });
+
+    it('returns true if avatar is empty or matches', () => {
+      expect(isProfileSynced(mockValues, mockVo, '')).toBe(true);
+      expect(
+        isProfileSynced(mockValues, mockVo, 'https://avatar.com/bob')
+      ).toBe(true);
+    });
+
+    it('returns false if industry differs', () => {
+      const differentVo = {
+        ...mockVo,
+        industry: {
+          id: 1,
+          kind: 'industry',
+          subject_group: 'finance',
+          subject: 'Banking',
+          language: 'zh_TW',
+        } as unknown as MentorProfileVO['industry'],
+      };
       expect(
         isProfileSynced(mockValues, differentVo, 'https://avatar.com/bob')
       ).toBe(false);

--- a/src/lib/profile/profileSaveAdapter.test.ts
+++ b/src/lib/profile/profileSaveAdapter.test.ts
@@ -1,0 +1,254 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { defaultValues, ProfileFormValues } from '@/schemas/profileSchema';
+import { MentorProfileVO } from '@/services/profile/user';
+
+import {
+  computeDirtyStates,
+  hasDirtyValue,
+  isProfileSynced,
+  mapFormValuesToPayload,
+  mapVoToFormValues,
+} from './profileSaveAdapter';
+
+vi.mock('@/lib/profile/readIndustryTag', () => ({
+  readIndustryTag: vi.fn((industry) => {
+    if (
+      industry &&
+      typeof industry === 'object' &&
+      'subject_group' in industry
+    ) {
+      return industry;
+    }
+    return null;
+  }),
+}));
+
+describe('profileSaveAdapter', () => {
+  describe('hasDirtyValue', () => {
+    it('returns false for falsy values', () => {
+      expect(hasDirtyValue(null)).toBe(false);
+      expect(hasDirtyValue(undefined)).toBe(false);
+      expect(hasDirtyValue(false)).toBe(false);
+      expect(hasDirtyValue('')).toBe(false);
+    });
+
+    it('returns true for boolean true', () => {
+      expect(hasDirtyValue(true)).toBe(true);
+    });
+
+    it('recursively checks arrays', () => {
+      expect(hasDirtyValue([false, null, undefined])).toBe(false);
+      expect(hasDirtyValue([false, true, null])).toBe(true);
+    });
+
+    it('recursively checks objects', () => {
+      expect(hasDirtyValue({ a: false, b: null })).toBe(false);
+      expect(hasDirtyValue({ a: false, b: { c: true } })).toBe(true);
+    });
+  });
+
+  describe('mapVoToFormValues', () => {
+    const mockVo: MentorProfileVO = {
+      user_id: 42,
+      name: 'John Doe',
+      avatar: 'https://avatar.com/john',
+      job_title: null,
+      company: null,
+      location: 'Taipei',
+      personal_statement: 'My statement',
+      about: 'About me',
+      years_of_experience: '3_5',
+      industry: {
+        id: 100,
+        kind: 'industry',
+        subject_group: 'tech',
+        subject: 'Software',
+        language: 'zh_TW',
+      } as any,
+      experiences: [
+        {
+          category: 'WORK',
+          order: 1,
+          mentor_experiences_metadata: {
+            data: [
+              {
+                job: 'Engineer',
+                company: 'Google',
+                job_period_start: '2020',
+                job_period_end: '2023',
+                industry: 'Tech',
+                job_location: 'Taipei',
+                description: 'Coding',
+                is_primary: true,
+              },
+            ],
+          } as any,
+        },
+      ],
+      onboarding: true,
+      is_mentor: true,
+      language: 'zh_TW',
+      seniority_level: null,
+      want_position: ['Developer'],
+      want_skill: ['React'],
+      want_topic: ['Career'],
+      have_skill: ['JS'],
+      have_topic: ['Onboarding'],
+    };
+
+    it('correctly maps a VO to form values', () => {
+      const result = mapVoToFormValues(mockVo, false);
+      expect(result.name).toBe('John Doe');
+      expect(result.avatar).toBe('https://avatar.com/john');
+      expect(result.location).toBe('Taipei');
+      expect(result.statement).toBe('My statement');
+      expect(result.about).toBe('About me');
+      expect(result.industry).toBe('tech');
+      expect(result.years_of_experience).toBe('3_5');
+      expect(result.work_experiences).toHaveLength(1);
+      expect(result.work_experiences[0].company).toBe('Google');
+      expect(result.work_experiences[0].job).toBe('Engineer');
+      expect(result.want_position).toEqual(['Developer']);
+    });
+  });
+
+  describe('computeDirtyStates', () => {
+    const mockValues: ProfileFormValues = {
+      ...defaultValues,
+      name: 'Alice',
+      avatarFile: undefined,
+    };
+
+    it('returns all dirty as true if dirtyFields is undefined', () => {
+      const { experiencesDirty, profileDirty } = computeDirtyStates(
+        mockValues,
+        undefined,
+        false
+      );
+      expect(experiencesDirty).toBe(true);
+      expect(profileDirty).toBe(true);
+    });
+
+    it('correctly identifies dirty fields based on dirtyFields map', () => {
+      const dirtyFields = {
+        name: true,
+      };
+      const { experiencesDirty, profileDirty } = computeDirtyStates(
+        mockValues,
+        dirtyFields,
+        false
+      );
+      expect(experiencesDirty).toBe(false);
+      expect(profileDirty).toBe(true);
+    });
+
+    it('forces profileDirty when isMentorOnboarding is true', () => {
+      const { profileDirty } = computeDirtyStates(mockValues, {}, true);
+      expect(profileDirty).toBe(true);
+    });
+
+    it('forces profileDirty when avatarFile is present', () => {
+      const valuesWithAvatar = {
+        ...mockValues,
+        avatarFile: new File([], 'avatar.png'),
+      };
+      const { profileDirty } = computeDirtyStates(valuesWithAvatar, {}, false);
+      expect(profileDirty).toBe(true);
+    });
+  });
+
+  describe('mapFormValuesToPayload', () => {
+    it('constructs payload from form values and avatar', () => {
+      const mockValues: ProfileFormValues = {
+        ...defaultValues,
+        name: 'Bob',
+        work_experiences: [
+          {
+            id: 0,
+            job: 'Manager',
+            company: 'Apple',
+            job_period_start: '2021',
+            job_period_end: '2024',
+            industry: 'Tech',
+            job_location: 'US',
+            description: 'Managing',
+            is_primary: true,
+          },
+        ],
+      };
+
+      const payload = mapFormValuesToPayload(
+        mockValues,
+        'https://avatar.com/bob',
+        true
+      );
+      expect(payload.name).toBe('Bob');
+      expect(payload.avatar).toBe('https://avatar.com/bob');
+      expect(payload.job_title).toBe('Manager');
+      expect(payload.company).toBe('Apple');
+      expect(payload.experiences).toHaveLength(3);
+    });
+  });
+
+  describe('isProfileSynced', () => {
+    const mockValues: ProfileFormValues = {
+      ...defaultValues,
+      name: 'Bob',
+      location: 'Taipei',
+      statement: 'Hi',
+      about: 'About',
+      industry: 'tech',
+      years_of_experience: '3_5',
+    };
+
+    const mockVo: MentorProfileVO = {
+      user_id: 1,
+      name: 'Bob',
+      avatar: 'https://avatar.com/bob',
+      job_title: null,
+      company: null,
+      location: 'Taipei',
+      personal_statement: 'Hi',
+      about: 'About',
+      years_of_experience: '3_5',
+      industry: {
+        id: 1,
+        kind: 'industry',
+        subject_group: 'tech',
+        subject: 'Software',
+        language: 'zh_TW',
+      } as any,
+      experiences: [],
+      onboarding: true,
+      is_mentor: true,
+      language: 'zh_TW',
+      seniority_level: null,
+      want_position: null,
+      want_skill: null,
+      want_topic: null,
+      have_skill: null,
+      have_topic: null,
+    };
+
+    it('returns true if all checked fields match', () => {
+      expect(
+        isProfileSynced(mockValues, mockVo, 'https://avatar.com/bob')
+      ).toBe(true);
+    });
+
+    it('returns false if name differs', () => {
+      const differentVo = { ...mockVo, name: 'Alice' };
+      expect(
+        isProfileSynced(mockValues, differentVo, 'https://avatar.com/bob')
+      ).toBe(false);
+    });
+
+    it('returns false if location differs', () => {
+      const differentVo = { ...mockVo, location: 'Hsinchu' };
+      expect(
+        isProfileSynced(mockValues, differentVo, 'https://avatar.com/bob')
+      ).toBe(false);
+    });
+  });
+});

--- a/src/lib/profile/profileSaveAdapter.test.ts
+++ b/src/lib/profile/profileSaveAdapter.test.ts
@@ -278,6 +278,16 @@ describe('profileSaveAdapter', () => {
       const payload = mapFormValuesToPayload(mockValues, undefined, false);
       expect(payload.avatar).toBeUndefined();
     });
+
+    it('omits experiences property when experiencesDirty is false to respect three-state semantics', () => {
+      const mockValues: ProfileFormValues = {
+        ...defaultValues,
+        name: 'Bob',
+      };
+      const payload = mapFormValuesToPayload(mockValues, undefined, false);
+      expect(payload).not.toHaveProperty('experiences');
+      expect(payload.experiences).toBeUndefined();
+    });
   });
 
   describe('isProfileSynced', () => {

--- a/src/lib/profile/profileSaveAdapter.test.ts
+++ b/src/lib/profile/profileSaveAdapter.test.ts
@@ -111,6 +111,51 @@ describe('profileSaveAdapter', () => {
       expect(result.work_experiences[0].job).toBe('Engineer');
       expect(result.want_position).toEqual(['Developer']);
     });
+
+    it('correctly falls back to defaults when optional API fields are null or empty', () => {
+      const incompleteVo: MentorProfileVO = {
+        user_id: 99,
+        name: null,
+        avatar: null,
+        job_title: null,
+        company: null,
+        location: null,
+        personal_statement: null,
+        about: null,
+        years_of_experience: null,
+        industry: null,
+        experiences: [],
+        onboarding: false,
+        is_mentor: false,
+        language: 'zh_TW',
+        seniority_level: null,
+        want_position: null,
+        want_skill: null,
+        want_topic: null,
+        have_skill: null,
+        have_topic: null,
+      };
+
+      const result = mapVoToFormValues(incompleteVo, false);
+
+      expect(result.name).toBe('');
+      expect(result.avatar).toBe('');
+      expect(result.location).toBe('');
+      expect(result.statement).toBe('');
+      expect(result.about).toBe('');
+      expect(result.industry).toBe('');
+      expect(result.years_of_experience).toBe('');
+      expect(result.work_experiences).toEqual([]);
+      expect(result.educations).toEqual([]);
+      expect(result.linkedin.url).toBe('');
+      expect(result.facebook.url).toBe('');
+      expect(result.instagram.url).toBe('');
+      expect(result.twitter.url).toBe('');
+      expect(result.youtube.url).toBe('');
+      expect(result.website.url).toBe('');
+      expect(result.have_topic).toEqual([]);
+      expect(result.have_skill).toEqual([]);
+    });
   });
 
   describe('computeDirtyStates', () => {

--- a/src/lib/profile/profileSaveAdapter.ts
+++ b/src/lib/profile/profileSaveAdapter.ts
@@ -113,14 +113,10 @@ export function computeDirtyStates(
 }
 
 /**
- * Maps ProfileFormValues into the payload needed for the updateProfile API.
+ * Filters and extracts the valid personal links that have a non-empty URL.
  */
-export function mapFormValuesToPayload(
-  values: ProfileFormValues,
-  avatar: string,
-  experiencesDirty: boolean
-) {
-  const links = [
+export function extractValidLinks(values: ProfileFormValues) {
+  return [
     values.linkedin,
     values.facebook,
     values.instagram,
@@ -128,6 +124,17 @@ export function mapFormValuesToPayload(
     values.youtube,
     values.website,
   ].filter((l) => l && l.url);
+}
+
+/**
+ * Maps ProfileFormValues into the payload needed for the updateProfile API.
+ */
+export function mapFormValuesToPayload(
+  values: ProfileFormValues,
+  avatar: string | undefined,
+  experiencesDirty: boolean
+) {
+  const links = extractValidLinks(values);
 
   const {
     experiences,
@@ -145,6 +152,10 @@ export function mapFormValuesToPayload(
     avatarFile: undefined,
     job_title,
     company: companyFromPrimary,
+    // Three-state semantic on the wire: omit when no experience section
+    // changed (backend leaves the column alone); include the full set
+    // when any section is dirty (backend overwrites). Replace semantics:
+    // backend overwrites profiles.experiences wholesale with this batch.
     ...(experiencesDirty ? { experiences } : {}),
   };
 }

--- a/src/lib/profile/profileSaveAdapter.ts
+++ b/src/lib/profile/profileSaveAdapter.ts
@@ -1,0 +1,174 @@
+import { encode } from '@/lib/profile/experienceCodec';
+import {
+  MentorExperiencePayload,
+  toFormValues,
+} from '@/lib/profile/parseUserExperiences';
+import { readIndustryTag } from '@/lib/profile/readIndustryTag';
+import { defaultValues, ProfileFormValues } from '@/schemas/profileSchema';
+import { MentorProfileVO } from '@/services/profile/user';
+
+export type ProfileDirtyFields = Partial<
+  Record<keyof ProfileFormValues, unknown>
+>;
+
+/**
+ * Checks if a partial/nested value in React Hook Form's dirtyFields is actually dirty.
+ */
+export function hasDirtyValue(v: unknown): boolean {
+  if (!v) return false;
+  if (typeof v === 'boolean') return v;
+  if (Array.isArray(v)) return v.some(hasDirtyValue);
+  if (typeof v === 'object') return Object.values(v).some(hasDirtyValue);
+  return Boolean(v);
+}
+
+/**
+ * Maps MentorProfileVO (from API) into ProfileFormValues (for React Hook Form).
+ */
+export function mapVoToFormValues(
+  userDto: MentorProfileVO,
+  isMentorOnboarding: boolean
+): ProfileFormValues {
+  const mentorFlag = Boolean(userDto.is_mentor || isMentorOnboarding);
+  const experiences =
+    userDto.experiences as unknown as MentorExperiencePayload[];
+
+  const {
+    workExperiences: parsedExperiences,
+    educations: parsedEducations,
+    links: parsedLinks,
+  } = toFormValues(experiences);
+
+  const industryTag = readIndustryTag(userDto.industry);
+  const industrySg = industryTag?.subject_group ?? '';
+
+  return {
+    is_mentor: mentorFlag,
+    avatar: userDto.avatar || '',
+    avatarFile: undefined,
+    name: userDto.name || '',
+    location: userDto.location || '',
+    statement: userDto.personal_statement || '',
+    about: userDto.about || '',
+    industry: industrySg,
+    years_of_experience: userDto.years_of_experience || '',
+    work_experiences: parsedExperiences || defaultValues.work_experiences,
+    educations: parsedEducations || defaultValues.educations,
+    linkedin: parsedLinks.linkedin || defaultValues.linkedin,
+    facebook: parsedLinks.facebook || defaultValues.facebook,
+    instagram: parsedLinks.instagram || defaultValues.instagram,
+    twitter: parsedLinks.twitter || defaultValues.twitter,
+    youtube: parsedLinks.youtube || defaultValues.youtube,
+    website: parsedLinks.website || defaultValues.website,
+    have_topic: userDto.have_topic ?? [],
+    have_skill: userDto.have_skill ?? [],
+    want_position: userDto.want_position ?? [],
+    want_skill: userDto.want_skill ?? [],
+    want_topic: userDto.want_topic ?? [],
+  };
+}
+
+/**
+ * Computes dirty states for profile fields based on React Hook Form's dirtyFields.
+ */
+export function computeDirtyStates(
+  values: ProfileFormValues,
+  dirtyFields: ProfileDirtyFields | undefined,
+  isMentorOnboarding: boolean
+): { experiencesDirty: boolean; profileDirty: boolean } {
+  const isDirty = (key: keyof ProfileFormValues): boolean => {
+    if (!dirtyFields) return true;
+    return hasDirtyValue(dirtyFields[key]);
+  };
+
+  const workDirty = isDirty('work_experiences');
+  const educationDirty = isDirty('educations');
+  const linksDirty =
+    isDirty('linkedin') ||
+    isDirty('facebook') ||
+    isDirty('instagram') ||
+    isDirty('twitter') ||
+    isDirty('youtube') ||
+    isDirty('website');
+  const experiencesDirty = workDirty || educationDirty || linksDirty;
+
+  const profileDirty =
+    isMentorOnboarding ||
+    Boolean(values.avatarFile) ||
+    isDirty('avatar') ||
+    isDirty('name') ||
+    isDirty('about') ||
+    isDirty('location') ||
+    isDirty('industry') ||
+    isDirty('years_of_experience') ||
+    isDirty('statement') ||
+    isDirty('have_skill') ||
+    isDirty('have_topic') ||
+    isDirty('want_position') ||
+    isDirty('want_skill') ||
+    isDirty('want_topic') ||
+    experiencesDirty;
+
+  return { experiencesDirty, profileDirty };
+}
+
+/**
+ * Maps ProfileFormValues into the payload needed for the updateProfile API.
+ */
+export function mapFormValuesToPayload(
+  values: ProfileFormValues,
+  avatar: string,
+  experiencesDirty: boolean
+) {
+  const links = [
+    values.linkedin,
+    values.facebook,
+    values.instagram,
+    values.twitter,
+    values.youtube,
+    values.website,
+  ].filter((l) => l && l.url);
+
+  const {
+    experiences,
+    job_title,
+    company: companyFromPrimary,
+  } = encode({
+    workExperiences: values.work_experiences ?? [],
+    educations: values.educations ?? [],
+    personalLinks: links,
+  });
+
+  return {
+    ...values,
+    avatar,
+    avatarFile: undefined,
+    job_title,
+    company: companyFromPrimary,
+    ...(experiencesDirty ? { experiences } : {}),
+  };
+}
+
+/**
+ * Verifies if the latest MentorProfileVO fetched from the backend matches the submitted form values.
+ */
+export function isProfileSynced(
+  values: ProfileFormValues,
+  latest: MentorProfileVO,
+  avatar: string
+): boolean {
+  if (latest.name !== values.name) return false;
+  if ((latest.location ?? '') !== (values.location ?? '')) return false;
+  if ((latest.personal_statement ?? '') !== (values.statement ?? ''))
+    return false;
+  if ((latest.about ?? '') !== (values.about ?? '')) return false;
+  if ((latest.years_of_experience ?? '') !== (values.years_of_experience ?? ''))
+    return false;
+  if (
+    (readIndustryTag(latest.industry)?.subject_group ?? '') !==
+    (values.industry ?? '')
+  )
+    return false;
+  if (avatar && latest.avatar !== avatar) return false;
+  return true;
+}


### PR DESCRIPTION
## What Does This PR Do?

Refactors the profile save flow to establish a single source of truth for Form-to-DTO/VO mapping, dirty diffing, and synchronization checks.

- Created \src/lib/profile/profileSaveAdapter.ts\ to own all mapping, diffing, and sync check logic.
- Migrated \useEditProfileData.ts\ to use \mapVoToFormValues\ from the adapter.
- Migrated \useProfileSubmit.ts\ to use \computeDirtyStates\ and \mapFormValuesToPayload\ from the adapter.
- Migrated \pollUntilSynced.ts\ to use \isProfileSynced\ from the adapter.
- Added comprehensive unit tests in \src/lib/profile/profileSaveAdapter.test.ts\.

## Demo

N/A (Refactoring - no visual changes)

## Screenshot

N/A

## Anything to Note?

N/A