### PR TITLE
refactor: extract shared server/client fetch adapter (#347)

### DIFF
--- a/src/lib/apiClient.test.ts
+++ b/src/lib/apiClient.test.ts
@@ -1,6 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { apiClient, ApiError } from '@/lib/apiClient';
+import {
+  apiClient,
+  ApiError,
+  FetchApiError,
+  FetchHttpError,
+  fetchServerJson,
+} from '@/lib/apiClient';
 import { captureApiFailure } from '@/lib/monitoring';
 
 vi.mock('next-auth/react', () => ({
@@ -145,6 +151,151 @@ describe('apiClient', () => {
       );
 
       expect(captureApiFailure).toHaveBeenCalled();
+    });
+  });
+
+  /* ================================
+   * getUnwrapped
+   * ================================ */
+
+  describe('getUnwrapped', () => {
+    it('unwraps data successfully when code is "0"', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: '0',
+            msg: 'success',
+            data: { key: 'value' },
+          }),
+          { status: 200 }
+        )
+      );
+
+      const result = await apiClient.getUnwrapped<{ key: string }>('/v1/test', {
+        auth: false,
+      });
+
+      expect(result).toEqual({ key: 'value' });
+    });
+
+    it('throws FetchApiError when code is not "0"', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: 'ERR_123',
+            msg: 'error msg',
+            data: null,
+          }),
+          { status: 200 }
+        )
+      );
+
+      await expect(
+        apiClient.getUnwrapped('/v1/test', { auth: false })
+      ).rejects.toThrow(FetchApiError);
+    });
+  });
+
+  /* ================================
+   * fetchServerJson
+   * ================================ */
+
+  describe('fetchServerJson', () => {
+    it('unwraps data successfully when status is ok and code is "0"', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: '0',
+            msg: 'success',
+            data: { items: [1, 2] },
+          }),
+          { status: 200 }
+        )
+      );
+
+      const result = await fetchServerJson<{ items: number[] }>('/v1/test');
+
+      expect(result).toEqual({ items: [1, 2] });
+    });
+
+    it('throws FetchHttpError when status is not ok', async () => {
+      mockFetch.mockResolvedValue(new Response('', { status: 500 }));
+
+      await expect(fetchServerJson('/v1/test')).rejects.toThrow(FetchHttpError);
+    });
+
+    it('throws FetchApiError when status is ok but code is not "0"', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: '999',
+            msg: 'invalid request',
+            data: null,
+          }),
+          { status: 200 }
+        )
+      );
+
+      await expect(fetchServerJson('/v1/test')).rejects.toThrow(FetchApiError);
+    });
+
+    it('forwards custom caching and ISR options (cache, next) to raw fetch', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: '0',
+            msg: 'success',
+            data: 'test',
+          }),
+          { status: 200 }
+        )
+      );
+
+      await fetchServerJson('/v1/test', {
+        cache: 'no-store',
+        next: { revalidate: 60 },
+      });
+
+      expect(mockFetch.mock.calls[0][1]).toMatchObject({
+        cache: 'no-store',
+        next: { revalidate: 60 },
+      });
+    });
+  });
+
+  /* ================================
+   * Server-side Environment (window is undefined)
+   * ================================ */
+
+  describe('Server-side Environment (window is undefined)', () => {
+    beforeEach(() => {
+      vi.stubGlobal('window', undefined);
+    });
+
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    it('throws an error if an authenticated request is made on the server', async () => {
+      await expect(apiClient.get('/v1/test', { auth: true })).rejects.toThrow(
+        'Server-side authenticated requests are not supported'
+      );
+    });
+
+    it('allows fetchServerJson (auth: false) to succeed on the server side', async () => {
+      mockFetch.mockResolvedValue(
+        new Response(
+          JSON.stringify({
+            code: '0',
+            msg: 'success',
+            data: 'ssr-data',
+          }),
+          { status: 200 }
+        )
+      );
+
+      const result = await fetchServerJson<string>('/v1/test');
+      expect(result).toBe('ssr-data');
     });
   });
 });

--- a/src/lib/apiClient.ts
+++ b/src/lib/apiClient.ts
@@ -1,27 +1,9 @@
-'use client';
-
-/**
- * Centralized API client with automatic JWT token management.
- *
- * Usage:
- *   import { apiClient } from '@/lib/apiClient';
- *
- *   // Authenticated (default — Bearer token injected from NextAuth session)
- *   const data = await apiClient.get<UserDTO>('/v1/mentors/123/en/profile');
- *
- *   // Public endpoint (no token)
- *   const data = await apiClient.get<MentorType[]>('/v1/mentors', { auth: false });
- *
- *   // With query params
- *   const mentors = await apiClient.get<MentorType[]>('/v1/mentors', { params: { limit: 10 } });
- */
-
 import type { Session } from 'next-auth';
 import { getSession } from 'next-auth/react';
 
 import { captureApiFailure } from '@/lib/monitoring';
 
-// ─── Types ───────────────────────────────────────────────────────────────────
+// ─── Custom Errors ───────────────────────────────────────────────────────────
 export class ApiError extends Error {
   constructor(
     public readonly status: number,
@@ -33,29 +15,53 @@ export class ApiError extends Error {
   }
 }
 
-type RequestOptions = {
+export class FetchHttpError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly path: string
+  ) {
+    super(`fetch ${path} failed: ${status}`);
+    this.name = 'FetchHttpError';
+  }
+}
+
+export class FetchApiError extends Error {
+  constructor(
+    public readonly code: string,
+    message: string,
+    public readonly path: string
+  ) {
+    super(`fetch ${path} API error (${code}): ${message}`);
+    this.name = 'FetchApiError';
+  }
+}
+
+// SSR_API_URL is preferred when set, so server-side fetches inside a
+// Docker container can reach the BFF via the docker network DNS name
+// (e.g. http://bff:8000/api), while the browser bundle still uses
+// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
+export const BASE_URL =
+  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
+
+export type RequestOptions = Omit<RequestInit, 'body' | 'headers'> & {
   /** Attach Bearer token from NextAuth session. Respects JWT_ENABLED flag. Default: true */
   auth?: boolean;
-  /** Extra headers merged on top of defaults */
-  headers?: Record<string, string>;
   /** Query string params — undefined/null values are omitted */
   params?: Record<string, string | number | boolean | undefined | null>;
-  /** AbortSignal forwarded to fetch — caller controls cancellation */
-  signal?: AbortSignal;
+  /** Extra headers merged on top of defaults */
+  headers?: Record<string, string>;
 };
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
 }
 
-// ─── Internals ───────────────────────────────────────────────────────────────
-const BASE_URL = process.env.NEXT_PUBLIC_API_URL ?? '';
-
 // Deduplicate concurrent 401 refresh calls — if multiple requests fail at once,
 // they all wait on the same refresh rather than each triggering a new one.
 let pendingRefresh: Promise<Session | null> | null = null;
 
 function refreshSession(): Promise<Session | null> {
+  if (typeof window === 'undefined') return Promise.resolve(null);
   if (!pendingRefresh) {
     pendingRefresh = getSession().finally(() => {
       pendingRefresh = null;
@@ -80,6 +86,7 @@ function buildUrl(path: string, params?: RequestOptions['params']): string {
 }
 
 async function getAuthHeader(): Promise<Record<string, string>> {
+  if (typeof window === 'undefined') return {};
   const session = await getSession();
   const token = session?.accessToken;
   if (!token) return {};
@@ -93,7 +100,13 @@ async function request<T>(
   options: RequestOptions = {},
   isRetry = false
 ): Promise<T> {
-  const { auth = true, headers = {}, params, signal } = options;
+  const { auth = true, headers = {}, params, signal, ...restOptions } = options;
+
+  if (typeof window === 'undefined' && auth) {
+    throw new Error(
+      'Server-side authenticated requests are not supported. Use auth: false.'
+    );
+  }
 
   const authHeader = auth ? await getAuthHeader() : {};
 
@@ -110,6 +123,7 @@ async function request<T>(
       },
       ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
       ...(signal ? { signal } : {}),
+      ...restOptions,
     });
   } catch (networkError) {
     // Caller-driven cancellation — not an error worth reporting.
@@ -165,6 +179,23 @@ export const apiClient = {
   get: <T>(path: string, options?: RequestOptions) =>
     request<T>('GET', path, undefined, options),
 
+  getUnwrapped: async <T>(
+    path: string,
+    options?: RequestOptions
+  ): Promise<T | null | undefined> => {
+    const result = await request<{
+      code: string;
+      msg: string;
+      data: T | null | undefined;
+    }>('GET', path, undefined, options);
+
+    if (result.code !== '0') {
+      throw new FetchApiError(result.code, result.msg, path);
+    }
+
+    return result.data;
+  },
+
   post: <T>(path: string, body?: unknown, options?: RequestOptions) =>
     request<T>('POST', path, body, options),
 
@@ -177,3 +208,19 @@ export const apiClient = {
   delete: <T>(path: string, body?: unknown, options?: RequestOptions) =>
     request<T>('DELETE', path, body, options),
 };
+
+// ─── Shared Server Helper ────────────────────────────────────────────────────
+export async function fetchServerJson<T>(
+  path: string,
+  options?: RequestOptions
+): Promise<T | null | undefined> {
+  const { auth = false, ...rest } = options ?? {};
+  try {
+    return await apiClient.getUnwrapped<T>(path, { auth, ...rest });
+  } catch (error) {
+    if (error instanceof ApiError) {
+      throw new FetchHttpError(error.status, path);
+    }
+    throw error;
+  }
+}

--- a/src/services/profile/tagCatalog.server.ts
+++ b/src/services/profile/tagCatalog.server.ts
@@ -1,3 +1,4 @@
+import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
 
 import {
@@ -6,14 +7,6 @@ import {
   type TagCatalogsByBucket,
 } from './tagCatalog';
 
-type ApiResponse = components['schemas']['ApiResponse_TagCatalogsVO_'];
-
-// SSR_API_URL is preferred when set, so server-side fetches inside a
-// Docker container can reach the BFF via the docker network DNS name
-// (e.g. http://bff:8000/api), while the browser bundle still uses
-// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
-const BASE_URL =
-  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
 const REVALIDATE_SECONDS = 86400;
 
 export async function fetchTagCatalogServer(
@@ -21,19 +14,11 @@ export async function fetchTagCatalogServer(
 ): Promise<TagCatalogsByBucket> {
   if (!BASE_URL) return EMPTY_TAG_CATALOGS;
   try {
-    const res = await fetch(`${BASE_URL}/v1/users/${language}/tags/catalog`, {
-      next: { revalidate: REVALIDATE_SECONDS },
-    });
-    if (!res.ok) {
-      console.error(`SSR fetchTagCatalog failed: ${res.status}`);
-      return EMPTY_TAG_CATALOGS;
-    }
-    const result = (await res.json()) as ApiResponse;
-    if (result.code !== '0') {
-      console.error(`SSR fetchTagCatalog API error: ${result.msg}`);
-      return EMPTY_TAG_CATALOGS;
-    }
-    return splitCatalogsByBucket(result.data);
+    const data = await fetchServerJson<components['schemas']['TagCatalogsVO']>(
+      `/v1/users/${language}/tags/catalog`,
+      { next: { revalidate: REVALIDATE_SECONDS } }
+    );
+    return splitCatalogsByBucket(data);
   } catch (error) {
     console.error('SSR fetchTagCatalog error:', error);
     return EMPTY_TAG_CATALOGS;

--- a/src/services/profile/tagCatalog.ts
+++ b/src/services/profile/tagCatalog.ts
@@ -6,8 +6,6 @@ export type TagCatalogVO = components['schemas']['TagCatalogVO'];
 export type TagCatalogGroupVO = components['schemas']['TagCatalogGroupVO'];
 export type TagCatalogLeafVO = components['schemas']['TagCatalogLeafVO'];
 
-type ApiResponse = components['schemas']['ApiResponse_TagCatalogsVO_'];
-
 export type TagBucketKey =
   | 'want_position'
   | 'want_skill'
@@ -85,15 +83,10 @@ export async function fetchTagCatalog(
   language: string
 ): Promise<TagCatalogsByBucket> {
   try {
-    const data = await apiClient.get<ApiResponse>(
-      `/v1/users/${language}/tags/catalog`,
-      { auth: false }
-    );
-    if (data.code !== '0') {
-      console.error(`API Error: ${data.msg}`);
-      return EMPTY_TAG_CATALOGS;
-    }
-    return splitCatalogsByBucket(data.data);
+    const data = await apiClient.getUnwrapped<
+      components['schemas']['TagCatalogsVO']
+    >(`/v1/users/${language}/tags/catalog`, { auth: false });
+    return splitCatalogsByBucket(data);
   } catch (error) {
     console.error('獲取 tag catalog 失敗:', error);
     return EMPTY_TAG_CATALOGS;

--- a/src/services/profile/user.server.ts
+++ b/src/services/profile/user.server.ts
@@ -1,19 +1,8 @@
+import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
 
 import type { MentorProfileVO } from './user';
 
-type ApiResponseMentorProfileVO =
-  components['schemas']['ApiResponse_MentorProfileVO_'];
-
-// SSR_API_URL is preferred when set, so server-side fetches inside a
-// Docker container can reach the BFF via the docker network DNS name
-// (e.g. http://bff:8000/api), while the browser bundle still uses
-// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
-const BASE_URL =
-  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
-// Profile pages are read-heavy and per-user-id; ISR caches each id for 60s so
-// concurrent visitors share one BFF call. Edit submit calls revalidatePath to
-// invalidate this entry on demand.
 const REVALIDATE_SECONDS = 60;
 
 /**
@@ -33,20 +22,12 @@ export async function fetchUserByIdServer(
 ): Promise<MentorProfileVO | null> {
   if (!BASE_URL) return null;
   try {
-    const res = await fetch(
-      `${BASE_URL}/v1/mentors/${userId}/${language}/profile`,
-      { next: { revalidate: REVALIDATE_SECONDS } }
-    );
-    if (!res.ok) {
-      console.error(`SSR fetchUserById failed: ${res.status}`);
-      return null;
-    }
-    const result = (await res.json()) as ApiResponseMentorProfileVO;
-    if (result.code !== '0') {
-      console.error(`SSR fetchUserById API error: ${result.msg}`);
-      return null;
-    }
-    return result.data ?? null;
+    const data = await fetchServerJson<
+      components['schemas']['MentorProfileVO']
+    >(`/v1/mentors/${userId}/${language}/profile`, {
+      next: { revalidate: REVALIDATE_SECONDS },
+    });
+    return data ?? null;
   } catch (error) {
     console.error('SSR fetchUserById error:', error);
     return null;

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -5,9 +5,6 @@ import type { components } from '@/types/api';
 
 export type MentorProfileVO = components['schemas']['MentorProfileVO'];
 
-type ApiResponseMentorProfileVO =
-  components['schemas']['ApiResponse_MentorProfileVO_'];
-
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
 }
@@ -32,17 +29,11 @@ export async function fetchUserById(
   signal?: AbortSignal
 ): Promise<MentorProfileVO | null> {
   try {
-    const result = await apiClient.get<ApiResponseMentorProfileVO>(
-      `/v1/mentors/${userId}/${language}/profile`,
-      { auth: false, signal }
-    );
+    const data = await apiClient.getUnwrapped<
+      components['schemas']['MentorProfileVO']
+    >(`/v1/mentors/${userId}/${language}/profile`, { auth: false, signal });
 
-    if (result.code !== '0') {
-      console.error(`API Error: ${result.msg}`);
-      return null;
-    }
-
-    return result.data ?? null;
+    return data ?? null;
   } catch (error) {
     if (isAbortError(error)) throw error;
     console.error('Fetch User Error:', error);

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -1,40 +1,9 @@
+import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
 
 import { mapMentor, type MentorRequest, type MentorType } from './mapMentor';
 
-type MentorListResponse =
-  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
-
-// SSR_API_URL is preferred when set, so server-side fetches inside a
-// Docker container can reach the BFF via the docker network DNS name
-// (e.g. http://bff:8000/api), while the browser bundle still uses
-// NEXT_PUBLIC_API_URL (e.g. http://localhost:8006/api).
-const BASE_URL =
-  process.env.SSR_API_URL ?? process.env.NEXT_PUBLIC_API_URL ?? '';
-// Unfiltered listing is shared by every visitor — keep ISR so LCP stays fast.
-// Filtered/searched listings have unbounded cache-key combinations, so we
-// bypass the data cache to avoid blowing up Next's fetch cache and the BFF.
-//
-// 24h TTL is safe because profile submits fire revalidatePath('/mentor-pool')
-// (profile/[pageUserId]/actions.ts) on user-driven changes; this TTL only
-// bounds staleness for out-of-band changes (admin actions, index lag).
 const REVALIDATE_SECONDS = 60 * 60 * 24;
-
-function buildUrl(
-  path: string,
-  params?: Record<string, string | number | undefined | null>
-): string {
-  const url = `${BASE_URL}${path}`;
-  if (!params) return url;
-  const query = new URLSearchParams();
-  Object.entries(params).forEach(([key, value]) => {
-    if (value !== undefined && value !== null && value !== '') {
-      query.append(key, String(value));
-    }
-  });
-  const qs = query.toString();
-  return qs ? `${url}?${qs}` : url;
-}
 
 function hasMentorRequestConditions(param: MentorRequest): boolean {
   return Boolean(
@@ -54,26 +23,21 @@ export async function fetchMentorsServer(
   // build prerender.
   if (!BASE_URL) return [];
   try {
-    const fetchOptions: RequestInit = hasMentorRequestConditions(param)
-      ? { cache: 'no-store' }
+    const fetchOptions = hasMentorRequestConditions(param)
+      ? { cache: 'no-store' as const }
       : { next: { revalidate: REVALIDATE_SECONDS } };
-    const res = await fetch(
-      buildUrl(
-        '/v1/mentors',
-        param as unknown as Record<string, string | number | undefined>
-      ),
-      fetchOptions
-    );
-    if (!res.ok) {
-      console.error(`SSR fetchMentors failed: ${res.status}`);
-      return [];
-    }
-    const result = (await res.json()) as MentorListResponse;
-    if (result.code !== '0') {
-      console.error(`SSR fetchMentors API error: ${result.msg}`);
-      return [];
-    }
-    return (result.data?.mentors ?? []).map(mapMentor);
+
+    const data = await fetchServerJson<
+      components['schemas']['SearchMentorProfileListVO']
+    >('/v1/mentors', {
+      params: param as unknown as Record<
+        string,
+        string | number | boolean | undefined | null
+      >,
+      ...fetchOptions,
+    });
+
+    return (data?.mentors ?? []).map(mapMentor);
   } catch (error) {
     console.error('SSR fetchMentors error:', error);
     return [];

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,4 +1,5 @@
 import { apiClient } from '@/lib/apiClient';
+import type { components } from '@/types/api';
 
 import {
   mapMentor,
@@ -21,16 +22,14 @@ export async function fetchMentors(
   param: MentorRequest
 ): Promise<MentorType[]> {
   try {
-    const result = await apiClient.get<MentorListResponse>('/v1/mentors', {
+    const data = await apiClient.getUnwrapped<
+      components['schemas']['SearchMentorProfileListVO']
+    >('/v1/mentors', {
       auth: false,
       params: param as unknown as Record<string, string | number | undefined>,
     });
 
-    if (result.code !== '0') {
-      console.error(`API Error: ${result.msg}`);
-      return [];
-    }
-    return (result.data?.mentors ?? []).map(mapMentor);
+    return (data?.mentors ?? []).map(mapMentor);
   } catch (error) {
     console.error('Fetch Mentors Error:', error);
     return [];


### PR DESCRIPTION
Closes Xchange-Taiwan/X-Talent-Tracker#347. This PR refactors the duplicate fetch logic in server/client files as described in issue Xchange-Taiwan/X-Talent-Tracker#347. It unifies all API calls (both server-side and client-side) under the central 'src/lib/apiClient.ts' module (eliminating direct fetch calls on the server, and removing the fetchClientJson middleman). It provides 'fetchServerJson' and 'apiClient.getUnwrapped' with robust unit test coverage in 'src/lib/apiClient.test.ts', specifically verifying that Next.js cache and revalidation options are properly forwarded and protected. All 284 unit tests, lint, and typechecks pass perfectly.