### PR TITLE
refactor: deepen the profile-edit container's composition (X-Tracker #345)

### DIFF
--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -1,5 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
+import { UseFormReturn } from 'react-hook-form';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // mock navigate & searchParams
@@ -92,7 +93,9 @@ vi.mock('@/components/profile/edit/Section', () => ({
   ),
 }));
 
+import * as useEditProfileFormModule from '@/hooks/user/profile/useEditProfileForm';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
+import { ProfileFormValues } from '@/schemas/profileSchema';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 
 import EditProfileContainer from './container';
@@ -335,5 +338,49 @@ describe('EditProfileContainer error handling and scrolling', () => {
       getBoundingClientRectSpy.mockRestore();
       document.getElementById = originalGetElementById;
     }
+  });
+
+  it('resets the form with mapped values when userDto is successfully fetched', () => {
+    const mockUserDto = {
+      id: 1,
+      name: 'Loaded Test Name',
+      is_mentor: false,
+    };
+
+    mockUseEditProfileData.mockReturnValue({
+      userDto: mockUserDto,
+      isMentor: false,
+      isPageLoading: false,
+      isError: false,
+    });
+
+    const mockReset = vi.fn();
+    const mockForm = {
+      reset: mockReset,
+      control: {},
+      formState: { dirtyFields: {} },
+      handleSubmit: vi.fn().mockReturnValue(vi.fn()),
+    } as unknown as UseFormReturn<ProfileFormValues>;
+
+    const useEditProfileFormSpy = vi
+      .spyOn(useEditProfileFormModule, 'useEditProfileForm')
+      .mockReturnValue({ form: mockForm });
+
+    render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    // Verify form.reset was called with values mapped from mockUserDto
+    expect(mockReset).toHaveBeenCalled();
+    expect(mockReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Loaded Test Name',
+      })
+    );
+
+    useEditProfileFormSpy.mockRestore();
   });
 });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -217,7 +217,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
     const getBoundingClientRectSpy = vi
       .spyOn(Element.prototype, 'getBoundingClientRect')
       .mockImplementation(function (this: Element) {
-        if (this.id === 'about') {
+        if (this.id === 'want_position') {
           return {
             top: 150,
             left: 0,
@@ -265,10 +265,10 @@ describe('EditProfileContainer error handling and scrolling', () => {
       );
 
       const nameEl = container.querySelector('#name');
-      const aboutEl = container.querySelector('#about');
+      const wantPositionEl = container.querySelector('#want_position');
 
       expect(nameEl).not.toBeNull();
-      expect(aboutEl).not.toBeNull();
+      expect(wantPositionEl).not.toBeNull();
 
       const formEl = container.querySelector('form');
       if (formEl) {
@@ -281,8 +281,8 @@ describe('EditProfileContainer error handling and scrolling', () => {
         expect(scrolledIds.length).toBeGreaterThan(0);
       });
 
-      // It should have scrolled to 'about' first because 150 < 300 (it's higher up in the layout)
-      expect(scrolledIds[0]).toBe('about');
+      // It should have scrolled to 'want_position' first because 150 < 300 (it's higher up in the layout)
+      expect(scrolledIds[0]).toBe('want_position');
     } finally {
       delete (Element.prototype as unknown as Record<string, unknown>)
         .scrollIntoView;

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -16,6 +16,7 @@ vi.mock('next-auth/react', () => ({
 
 // mock other hooks to isolate our container test
 const mockUseEditProfileData = vi.fn().mockReturnValue({
+  userDto: null,
   isMentor: false,
   isPageLoading: false,
   isError: false,
@@ -110,13 +111,6 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
       />
     );
 
-    // Check that useEditProfileData was called with isMentorOnboarding: true
-    expect(mockUseEditProfileData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isMentorOnboarding: true,
-      })
-    );
-
     // Check that useProfileSubmit was called with isMentorOnboarding: true
     expect(mockUseProfileSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,12 +132,6 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
       />
     );
 
-    expect(mockUseEditProfileData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isMentorOnboarding: true,
-      })
-    );
-
     expect(mockUseProfileSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         isMentorOnboarding: true,
@@ -161,12 +149,6 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
       />
     );
 
-    expect(mockUseEditProfileData).toHaveBeenCalledWith(
-      expect.objectContaining({
-        isMentorOnboarding: false,
-      })
-    );
-
     expect(mockUseProfileSubmit).toHaveBeenCalledWith(
       expect.objectContaining({
         isMentorOnboarding: false,
@@ -179,6 +161,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockUseEditProfileData.mockReturnValue({
+      userDto: null,
       isMentor: false,
       isPageLoading: false,
       isError: false,
@@ -187,6 +170,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('shows error screen when useEditProfileData returns isError: true', () => {
     mockUseEditProfileData.mockReturnValue({
+      userDto: null,
       isMentor: false,
       isPageLoading: false,
       isError: true,
@@ -204,6 +188,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('triggers scroll to the correct topmost error element when validation fails', async () => {
     mockUseEditProfileData.mockReturnValue({
+      userDto: null,
       isMentor: true,
       isPageLoading: false,
       isError: false,
@@ -292,6 +277,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('does not crash or scroll if validation fails but corresponding DOM element does not exist', async () => {
     mockUseEditProfileData.mockReturnValue({
+      userDto: null,
       isMentor: true,
       isPageLoading: false,
       isError: false,

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -210,17 +210,41 @@ describe('EditProfileContainer error handling and scrolling', () => {
     });
 
     const scrolledIds: string[] = [];
-    const originalScrollIntoView = Element.prototype.scrollIntoView;
     Element.prototype.scrollIntoView = function (this: HTMLElement) {
       if (this.id) scrolledIds.push(this.id);
     };
 
-    const originalGetBoundingClientRect =
-      Element.prototype.getBoundingClientRect;
-    Element.prototype.getBoundingClientRect = function (this: Element) {
-      if (this.id === 'about') {
+    const getBoundingClientRectSpy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        if (this.id === 'about') {
+          return {
+            top: 150,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            width: 0,
+            height: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+          } as DOMRect;
+        }
+        if (this.id === 'name') {
+          return {
+            top: 300,
+            left: 0,
+            bottom: 0,
+            right: 0,
+            width: 0,
+            height: 0,
+            x: 0,
+            y: 0,
+            toJSON: () => {},
+          } as DOMRect;
+        }
         return {
-          top: 150,
+          top: 9999,
           left: 0,
           bottom: 0,
           right: 0,
@@ -230,61 +254,38 @@ describe('EditProfileContainer error handling and scrolling', () => {
           y: 0,
           toJSON: () => {},
         } as DOMRect;
+      });
+
+    try {
+      const { container } = render(
+        <EditProfileContainer
+          pageUserId="1"
+          initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+        />
+      );
+
+      const nameEl = container.querySelector('#name');
+      const aboutEl = container.querySelector('#about');
+
+      expect(nameEl).not.toBeNull();
+      expect(aboutEl).not.toBeNull();
+
+      const formEl = container.querySelector('form');
+      if (formEl) {
+        const { fireEvent } = await import('@testing-library/react');
+        fireEvent.submit(formEl);
       }
-      if (this.id === 'name') {
-        return {
-          top: 300,
-          left: 0,
-          bottom: 0,
-          right: 0,
-          width: 0,
-          height: 0,
-          x: 0,
-          y: 0,
-          toJSON: () => {},
-        } as DOMRect;
-      }
-      return {
-        top: 9999,
-        left: 0,
-        bottom: 0,
-        right: 0,
-        width: 0,
-        height: 0,
-        x: 0,
-        y: 0,
-        toJSON: () => {},
-      } as DOMRect;
-    };
 
-    const { container } = render(
-      <EditProfileContainer
-        pageUserId="1"
-        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
-      />
-    );
+      const { waitFor } = await import('@testing-library/react');
+      await waitFor(() => {
+        expect(scrolledIds.length).toBeGreaterThan(0);
+      });
 
-    const nameEl = container.querySelector('#name');
-    const aboutEl = container.querySelector('#about');
-
-    expect(nameEl).not.toBeNull();
-    expect(aboutEl).not.toBeNull();
-
-    const formEl = container.querySelector('form');
-    if (formEl) {
-      const { fireEvent } = await import('@testing-library/react');
-      fireEvent.submit(formEl);
+      // It should have scrolled to 'about' first because 150 < 300 (it's higher up in the layout)
+      expect(scrolledIds[0]).toBe('about');
+    } finally {
+      delete (Element.prototype as any).scrollIntoView;
+      getBoundingClientRectSpy.mockRestore();
     }
-
-    const { waitFor } = await import('@testing-library/react');
-    await waitFor(() => {
-      expect(scrolledIds.length).toBeGreaterThan(0);
-    });
-
-    // It should have scrolled to 'about' first because 150 < 300 (it's higher up in the layout)
-    expect(scrolledIds[0]).toBe('about');
-
-    Element.prototype.scrollIntoView = originalScrollIntoView;
-    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 import React from 'react';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // mock navigate & searchParams
 const mockSearchParamsGet = vi.fn().mockReturnValue(null);
@@ -15,7 +15,11 @@ vi.mock('next-auth/react', () => ({
 }));
 
 // mock other hooks to isolate our container test
-const mockUseEditProfileData = vi.fn();
+const mockUseEditProfileData = vi.fn().mockReturnValue({
+  isMentor: false,
+  isPageLoading: false,
+  isError: false,
+});
 vi.mock('@/hooks/user/profile/useEditProfileData', () => ({
   useEditProfileData: (options: unknown) => mockUseEditProfileData(options),
 }));
@@ -69,7 +73,9 @@ vi.mock('@/components/profile/edit/EditPageHeader', () => ({
   EditPageHeader: () => <div data-testid="edit-header" />,
 }));
 vi.mock('@/components/profile/edit/AvatarSection', () => ({
-  AvatarSection: () => <div data-testid="avatar-section" />,
+  AvatarSection: ({ id }: { id?: string }) => (
+    <div id={id} data-testid="avatar-section" />
+  ),
 }));
 vi.mock('@/components/profile/edit/Fields', () => ({
   TextField: () => <div />,
@@ -80,8 +86,8 @@ vi.mock('@/components/profile/edit/CategoryMultiSelectField', () => ({
   CategoryMultiSelectField: () => <div />,
 }));
 vi.mock('@/components/profile/edit/Section', () => ({
-  Section: ({ children }: { children: React.ReactNode }) => (
-    <div>{children}</div>
+  Section: ({ id, children }: { id?: string; children: React.ReactNode }) => (
+    <div id={id}>{children}</div>
   ),
 }));
 
@@ -166,5 +172,119 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
         isMentorOnboarding: false,
       })
     );
+  });
+});
+
+describe('EditProfileContainer error handling and scrolling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseEditProfileData.mockReturnValue({
+      isMentor: false,
+      isPageLoading: false,
+      isError: false,
+    });
+  });
+
+  it('shows error screen when useEditProfileData returns isError: true', () => {
+    mockUseEditProfileData.mockReturnValue({
+      isMentor: false,
+      isPageLoading: false,
+      isError: true,
+    });
+
+    const { getByText } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(getByText('載入失敗，請稍後再試。')).toBeInTheDocument();
+  });
+
+  it('triggers scroll to the correct topmost error element when validation fails', async () => {
+    mockUseEditProfileData.mockReturnValue({
+      isMentor: true,
+      isPageLoading: false,
+      isError: false,
+    });
+
+    const scrolledIds: string[] = [];
+    const originalScrollIntoView = Element.prototype.scrollIntoView;
+    Element.prototype.scrollIntoView = function (this: HTMLElement) {
+      if (this.id) scrolledIds.push(this.id);
+    };
+
+    const originalGetBoundingClientRect =
+      Element.prototype.getBoundingClientRect;
+    Element.prototype.getBoundingClientRect = function (this: Element) {
+      if (this.id === 'about') {
+        return {
+          top: 150,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        } as DOMRect;
+      }
+      if (this.id === 'name') {
+        return {
+          top: 300,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        } as DOMRect;
+      }
+      return {
+        top: 9999,
+        left: 0,
+        bottom: 0,
+        right: 0,
+        width: 0,
+        height: 0,
+        x: 0,
+        y: 0,
+        toJSON: () => {},
+      } as DOMRect;
+    };
+
+    const { container } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    const nameEl = container.querySelector('#name');
+    const aboutEl = container.querySelector('#about');
+
+    expect(nameEl).not.toBeNull();
+    expect(aboutEl).not.toBeNull();
+
+    const formEl = container.querySelector('form');
+    if (formEl) {
+      const { fireEvent } = await import('@testing-library/react');
+      fireEvent.submit(formEl);
+    }
+
+    const { waitFor } = await import('@testing-library/react');
+    await waitFor(() => {
+      expect(scrolledIds.length).toBeGreaterThan(0);
+    });
+
+    // It should have scrolled to 'about' first because 150 < 300 (it's higher up in the layout)
+    expect(scrolledIds[0]).toBe('about');
+
+    Element.prototype.scrollIntoView = originalScrollIntoView;
+    HTMLElement.prototype.getBoundingClientRect = originalGetBoundingClientRect;
   });
 });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -381,13 +381,13 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('does not trigger form reset a second time when userDto updates after initial loading', () => {
     const mockUserDtoFirst = {
-      id: 1,
+      user_id: 1,
       name: 'Initial Loaded Name',
       is_mentor: false,
     };
 
     const mockUserDtoSecond = {
-      id: 1,
+      user_id: 1,
       name: 'Background Revalidated Name',
       is_mentor: false,
     };
@@ -440,6 +440,77 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
     // It should not reset the form a second time
     expect(mockReset).toHaveBeenCalledTimes(1);
+
+    useEditProfileFormSpy.mockRestore();
+  });
+
+  it('resets the form again when pageUserId route parameter switches to a different user', () => {
+    const mockUserDtoFirst = {
+      user_id: 1,
+      name: 'User One Name',
+      is_mentor: false,
+    };
+
+    const mockUserDtoSecond = {
+      user_id: 2,
+      name: 'User Two Name',
+      is_mentor: false,
+    };
+
+    // 1) Render for first user
+    mockUseEditProfileData.mockReturnValue({
+      userDto: mockUserDtoFirst,
+      isMentor: false,
+      isError: false,
+    });
+
+    const mockReset = vi.fn();
+    const mockForm = {
+      reset: mockReset,
+      control: {},
+      formState: { dirtyFields: {} },
+      handleSubmit: vi.fn().mockReturnValue(vi.fn()),
+    } as unknown as UseFormReturn<ProfileFormValues>;
+
+    const useEditProfileFormSpy = vi
+      .spyOn(useEditProfileFormModule, 'useEditProfileForm')
+      .mockReturnValue({ form: mockForm });
+
+    const { rerender } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'User One Name',
+      })
+    );
+
+    // 2) Re-render/routing switches to second user
+    mockUseEditProfileData.mockReturnValue({
+      userDto: mockUserDtoSecond,
+      isMentor: false,
+      isError: false,
+    });
+
+    rerender(
+      <EditProfileContainer
+        pageUserId="2"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    // It should trigger reset a second time since user ID has changed (from 1 to 2)!
+    expect(mockReset).toHaveBeenCalledTimes(2);
+    expect(mockReset).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        name: 'User Two Name',
+      })
+    );
 
     useEditProfileFormSpy.mockRestore();
   });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -19,7 +19,6 @@ vi.mock('next-auth/react', () => ({
 const mockUseEditProfileData = vi.fn().mockReturnValue({
   userDto: null,
   isMentor: false,
-  isPageLoading: false,
   isError: false,
 });
 vi.mock('@/hooks/user/profile/useEditProfileData', () => ({
@@ -167,7 +166,6 @@ describe('EditProfileContainer error handling and scrolling', () => {
     mockUseEditProfileData.mockReturnValue({
       userDto: null,
       isMentor: false,
-      isPageLoading: false,
       isError: false,
     });
   });
@@ -176,7 +174,6 @@ describe('EditProfileContainer error handling and scrolling', () => {
     mockUseEditProfileData.mockReturnValue({
       userDto: null,
       isMentor: false,
-      isPageLoading: false,
       isError: true,
     });
 
@@ -194,7 +191,6 @@ describe('EditProfileContainer error handling and scrolling', () => {
     mockUseEditProfileData.mockReturnValue({
       userDto: {} as unknown as MentorProfileVO,
       isMentor: true,
-      isPageLoading: false,
       isError: false,
     });
 
@@ -283,7 +279,6 @@ describe('EditProfileContainer error handling and scrolling', () => {
     mockUseEditProfileData.mockReturnValue({
       userDto: {} as unknown as MentorProfileVO,
       isMentor: true,
-      isPageLoading: false,
       isError: false,
     });
 
@@ -351,7 +346,6 @@ describe('EditProfileContainer error handling and scrolling', () => {
     mockUseEditProfileData.mockReturnValue({
       userDto: mockUserDto,
       isMentor: false,
-      isPageLoading: false,
       isError: false,
     });
 
@@ -381,6 +375,71 @@ describe('EditProfileContainer error handling and scrolling', () => {
         name: 'Loaded Test Name',
       })
     );
+
+    useEditProfileFormSpy.mockRestore();
+  });
+
+  it('does not trigger form reset a second time when userDto updates after initial loading', () => {
+    const mockUserDtoFirst = {
+      id: 1,
+      name: 'Initial Loaded Name',
+      is_mentor: false,
+    };
+
+    const mockUserDtoSecond = {
+      id: 1,
+      name: 'Background Revalidated Name',
+      is_mentor: false,
+    };
+
+    mockUseEditProfileData.mockReturnValue({
+      userDto: mockUserDtoFirst,
+      isMentor: false,
+      isError: false,
+    });
+
+    const mockReset = vi.fn();
+    const mockForm = {
+      reset: mockReset,
+      control: {},
+      formState: { dirtyFields: {} },
+      handleSubmit: vi.fn().mockReturnValue(vi.fn()),
+    } as unknown as UseFormReturn<ProfileFormValues>;
+
+    const useEditProfileFormSpy = vi
+      .spyOn(useEditProfileFormModule, 'useEditProfileForm')
+      .mockReturnValue({ form: mockForm });
+
+    const { rerender } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(mockReset).toHaveBeenCalledTimes(1);
+    expect(mockReset).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'Initial Loaded Name',
+      })
+    );
+
+    // Mock background revalidation success
+    mockUseEditProfileData.mockReturnValue({
+      userDto: mockUserDtoSecond,
+      isMentor: false,
+      isError: false,
+    });
+
+    rerender(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    // It should not reset the form a second time
+    expect(mockReset).toHaveBeenCalledTimes(1);
 
     useEditProfileFormSpy.mockRestore();
   });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -97,6 +97,7 @@ import * as useEditProfileFormModule from '@/hooks/user/profile/useEditProfileFo
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
+import { MentorProfileVO } from '@/services/profile/user';
 
 import EditProfileContainer from './container';
 
@@ -191,7 +192,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('triggers scroll to the correct topmost error element when validation fails', async () => {
     mockUseEditProfileData.mockReturnValue({
-      userDto: null,
+      userDto: {} as unknown as MentorProfileVO,
       isMentor: true,
       isPageLoading: false,
       isError: false,
@@ -280,7 +281,7 @@ describe('EditProfileContainer error handling and scrolling', () => {
 
   it('does not crash or scroll if validation fails but corresponding DOM element does not exist', async () => {
     mockUseEditProfileData.mockReturnValue({
-      userDto: null,
+      userDto: {} as unknown as MentorProfileVO,
       isMentor: true,
       isPageLoading: false,
       isError: false,

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -284,8 +284,70 @@ describe('EditProfileContainer error handling and scrolling', () => {
       // It should have scrolled to 'about' first because 150 < 300 (it's higher up in the layout)
       expect(scrolledIds[0]).toBe('about');
     } finally {
-      delete (Element.prototype as any).scrollIntoView;
+      delete (Element.prototype as unknown as Record<string, unknown>)
+        .scrollIntoView;
       getBoundingClientRectSpy.mockRestore();
+    }
+  });
+
+  it('does not crash or scroll if validation fails but corresponding DOM element does not exist', async () => {
+    mockUseEditProfileData.mockReturnValue({
+      isMentor: true,
+      isPageLoading: false,
+      isError: false,
+    });
+
+    const scrolledIds: string[] = [];
+    Element.prototype.scrollIntoView = function (this: HTMLElement) {
+      if (this.id) scrolledIds.push(this.id);
+    };
+
+    const getBoundingClientRectSpy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        return {
+          top: 9999,
+          left: 0,
+          bottom: 0,
+          right: 0,
+          width: 0,
+          height: 0,
+          x: 0,
+          y: 0,
+          toJSON: () => {},
+        } as DOMRect;
+      });
+
+    const originalGetElementById = document.getElementById;
+    document.getElementById = (id: string) => {
+      if (id === 'about' || id === 'name') return null;
+      return originalGetElementById.call(document, id);
+    };
+
+    try {
+      const { container } = render(
+        <EditProfileContainer
+          pageUserId="1"
+          initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+        />
+      );
+
+      const formEl = container.querySelector('form');
+      if (formEl) {
+        const { fireEvent } = await import('@testing-library/react');
+        fireEvent.submit(formEl);
+      }
+
+      const { waitFor } = await import('@testing-library/react');
+      await waitFor(() => {
+        expect(scrolledIds).not.toContain('about');
+        expect(scrolledIds).not.toContain('name');
+      });
+    } finally {
+      delete (Element.prototype as unknown as Record<string, unknown>)
+        .scrollIntoView;
+      getBoundingClientRectSpy.mockRestore();
+      document.getElementById = originalGetElementById;
     }
   });
 });

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
@@ -84,6 +84,14 @@ export default function EditProfileContainer({
   const industries = tagCatalog.industry;
 
   const [isContainerLoading, setIsContainerLoading] = useState(true);
+  const [prevPageUserId, setPrevPageUserId] = useState(pageUserId);
+
+  // Synchronously reset container loading state back to true when route switches to a different pageUserId.
+  // This satisfies React's standard prop-sync guidelines and prevents old user data leaks during swaps.
+  if (pageUserId !== prevPageUserId) {
+    setPrevPageUserId(pageUserId);
+    setIsContainerLoading(true);
+  }
 
   const { userDto, isMentor, isError } = useEditProfileData({
     userId: Number(pageUserId),
@@ -95,13 +103,17 @@ export default function EditProfileContainer({
   const { formRef, onError, scrollToField } =
     useFormErrorScroll<ProfileFormValues>();
 
+  const lastResetUserIdRef = useRef<number | null>(null);
+
   // Reset form when user profile data successfully loads or updates
   useLayoutEffect(() => {
     if (!isAuthorized || !userDto) return;
-    if (!isContainerLoading) return; // Only allow form reset during initial loading!
+    if (lastResetUserIdRef.current === userDto.user_id && !isContainerLoading)
+      return; // Tolerates SWR focus revalidation successes silently without resetting active inputs.
 
     const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
     form.reset(formValues);
+    lastResetUserIdRef.current = userDto.user_id;
     setIsContainerLoading(false);
   }, [userDto, isAuthorized, isMentorOnboarding, form, isContainerLoading]);
 

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -80,8 +80,6 @@ export default function EditProfileContainer({
 
   const { isAuthorized } = useProfileAuth(pageUserId);
 
-  const [isMentor, setIsMentor] = useState(false);
-  const [isPageLoading, setIsPageLoading] = useState(true);
   const [jobSectionError, setJobSectionError] = useState(false);
   const [educationSectionError, setEducationSectionError] = useState(false);
 
@@ -89,8 +87,7 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const isMentorRef = useRef(isMentor);
-  isMentorRef.current = isMentor;
+  const isMentorRef = useRef(false);
 
   const form = useForm<ProfileFormValues>({
     resolver: (...args) =>
@@ -98,14 +95,14 @@ export default function EditProfileContainer({
     defaultValues,
   });
 
-  useEditProfileData({
+  const { isMentor, isPageLoading, isError } = useEditProfileData({
     userId: Number(pageUserId),
     form,
     isAuthorized,
     isMentorOnboarding,
-    setIsMentor,
-    setIsPageLoading,
   });
+
+  isMentorRef.current = isMentor;
 
   // Warm up the avatar presigned URL once authorized. Saves a serial round
   // trip from the submit waterfall when the user uploads a new avatar.
@@ -134,25 +131,24 @@ export default function EditProfileContainer({
       ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };
 
-  const FIELD_SCROLL_ORDER: (keyof ProfileFormValues)[] = [
-    'avatarFile',
-    'name',
-    'about',
-    'have_topic',
-    'have_skill',
-    'location',
-    'years_of_experience',
-    'industry',
-    'want_position',
-    'want_skill',
-    'want_topic',
-    'work_experiences',
-    'educations',
-  ];
-
   const onError = (errors: FieldErrors<ProfileFormValues>) => {
-    const firstKey = FIELD_SCROLL_ORDER.find((key) => key in errors);
-    if (firstKey) scrollToField(firstKey);
+    const errorKeys = Object.keys(errors) as (keyof ProfileFormValues)[];
+
+    const elementsWithErrors = errorKeys
+      .map((key) => {
+        const element = document.getElementById(key);
+        if (!element) return null;
+        return { key, rect: element.getBoundingClientRect() };
+      })
+      .filter(
+        (item): item is { key: keyof ProfileFormValues; rect: DOMRect } =>
+          item !== null
+      );
+
+    if (elementsWithErrors.length > 0) {
+      elementsWithErrors.sort((a, b) => a.rect.top - b.rect.top);
+      scrollToField(elementsWithErrors[0].key);
+    }
   };
 
   const { onSubmit, isSaving } = useProfileSubmit({
@@ -173,6 +169,19 @@ export default function EditProfileContainer({
 
   if (!isAuthorized) return null;
   if (isPageLoading) return <PageLoading />;
+
+  if (isError) {
+    return (
+      <div className="flex min-h-[400px] flex-col items-center justify-center space-y-4">
+        <p className="text-lg font-medium text-destructive">
+          載入失敗，請稍後再試。
+        </p>
+        <Button onClick={() => window.location.reload()} variant="outline">
+          重新整理
+        </Button>
+      </div>
+    );
+  }
 
   const handleGoToPrev = () => {
     unsaved.guardNavigate(() => router.push(`/profile/${pageUserId}`));

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -83,7 +83,7 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const { form, isMentorRef } = useEditProfileForm();
+  const { form, syncMentorStatus } = useEditProfileForm();
 
   const { isMentor, isPageLoading, isError } = useEditProfileData({
     userId: Number(pageUserId),
@@ -92,7 +92,10 @@ export default function EditProfileContainer({
     isMentorOnboarding,
   });
 
-  isMentorRef.current = isMentor;
+  // Synchronize mentor status to form ref inside useEffect during commit phase to comply with React rendering rules.
+  useEffect(() => {
+    syncMentorStatus(isMentor);
+  }, [isMentor, syncMentorStatus]);
 
   // Warm up the avatar presigned URL once authorized. Saves a serial round
   // trip from the submit waterfall when the user uploads a new avatar.
@@ -115,6 +118,9 @@ export default function EditProfileContainer({
   const wantSkillCategories = tagGroupsToCategories(tagCatalog.want_skill);
   const wantTopicCategories = tagGroupsToCategories(tagCatalog.want_topic);
 
+  // NOTE: document.getElementById is used to query dynamic error-bearing section container boundaries.
+  // This approach bypasses standard React refs to avoid inflating complexity with dozens of sub-component
+  // ref callback dictionaries, while cleanly retaining declarative styling structures.
   const scrollToField = (fieldId: string) => {
     document
       .getElementById(fieldId)

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -3,8 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useLayoutEffect, useRef, useState } from 'react';
-import { FieldErrors } from 'react-hook-form';
+import { useEffect, useLayoutEffect, useState } from 'react';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
@@ -32,6 +31,7 @@ import useLocations from '@/hooks/user/country/useLocations';
 import { useBackgroundAvatarUpload } from '@/hooks/user/profile/useBackgroundAvatarUpload';
 import { useEditProfileData } from '@/hooks/user/profile/useEditProfileData';
 import { useEditProfileForm } from '@/hooks/user/profile/useEditProfileForm';
+import { useFormErrorScroll } from '@/hooks/user/profile/useFormErrorScroll';
 import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt';
@@ -84,14 +84,17 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const { userDto, isMentor, isPageLoading, isError } = useEditProfileData({
+  const [isContainerLoading, setIsContainerLoading] = useState(true);
+
+  const { userDto, isMentor, isError } = useEditProfileData({
     userId: Number(pageUserId),
     isAuthorized,
   });
 
   const { form } = useEditProfileForm(isMentorOnboarding || isMentor);
 
-  const formRef = useRef<HTMLFormElement>(null);
+  const { formRef, onError, scrollToField } =
+    useFormErrorScroll<ProfileFormValues>();
 
   // Reset form when user profile data successfully loads or updates
   useLayoutEffect(() => {
@@ -99,6 +102,7 @@ export default function EditProfileContainer({
 
     const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
     form.reset(formValues);
+    setIsContainerLoading(false);
   }, [userDto, isAuthorized, isMentorOnboarding, form]);
 
   // Warm up the avatar presigned URL once authorized. Saves a serial round
@@ -125,36 +129,6 @@ export default function EditProfileContainer({
   // NOTE: document.getElementById/formRef querySelector is used to query dynamic error-bearing section container boundaries.
   // This approach bypasses standard React refs to avoid inflating complexity with dozens of sub-component
   // ref callback dictionaries, while cleanly retaining declarative styling structures.
-  const scrollToField = (fieldId: string) => {
-    const element = formRef.current
-      ? formRef.current.querySelector('#' + fieldId)
-      : null;
-    element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  };
-
-  const onError = (errors: FieldErrors<ProfileFormValues>) => {
-    const errorKeys = Object.keys(errors) as (keyof ProfileFormValues)[];
-    const formEl = formRef.current;
-
-    const elementsWithErrors = errorKeys
-      .map((key) => {
-        const element = formEl
-          ? (formEl.querySelector('#' + key) as HTMLElement)
-          : null;
-        if (!element) return null;
-        return { key, rect: element.getBoundingClientRect() };
-      })
-      .filter(
-        (item): item is { key: keyof ProfileFormValues; rect: DOMRect } =>
-          item !== null
-      );
-
-    if (elementsWithErrors.length > 0) {
-      elementsWithErrors.sort((a, b) => a.rect.top - b.rect.top);
-      scrollToField(elementsWithErrors[0].key);
-    }
-  };
-
   const { onSubmit, isSaving } = useProfileSubmit({
     pageUserId,
     isMentorOnboarding,
@@ -172,7 +146,6 @@ export default function EditProfileContainer({
   const unsaved = useUnsavedChangesPrompt(form.formState.isDirty && !isSaving);
 
   if (!isAuthorized) return null;
-  if (isPageLoading) return <PageLoading />;
 
   if (isError) {
     return (
@@ -186,6 +159,8 @@ export default function EditProfileContainer({
       </div>
     );
   }
+
+  if (isContainerLoading) return <PageLoading />;
 
   const handleGoToPrev = () => {
     unsaved.guardNavigate(() => router.push(`/profile/${pageUserId}`));

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -83,7 +83,7 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const { form, syncMentorStatus } = useEditProfileForm();
+  const { form } = useEditProfileForm();
 
   const { isMentor, isPageLoading, isError } = useEditProfileData({
     userId: Number(pageUserId),
@@ -91,11 +91,6 @@ export default function EditProfileContainer({
     isAuthorized,
     isMentorOnboarding,
   });
-
-  // Synchronize mentor status to form ref inside useEffect during commit phase to comply with React rendering rules.
-  useEffect(() => {
-    syncMentorStatus(isMentor);
-  }, [isMentor, syncMentorStatus]);
 
   // Warm up the avatar presigned URL once authorized. Saves a serial round
   // trip from the submit waterfall when the user uploads a new avatar.

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { FieldErrors } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
@@ -89,7 +89,9 @@ export default function EditProfileContainer({
     isAuthorized,
   });
 
-  const { form } = useEditProfileForm(isMentor);
+  const { form } = useEditProfileForm(isMentorOnboarding || isMentor);
+
+  const formRef = useRef<HTMLFormElement>(null);
 
   // Reset form when user profile data successfully loads or updates
   useLayoutEffect(() => {
@@ -120,21 +122,25 @@ export default function EditProfileContainer({
   const wantSkillCategories = tagGroupsToCategories(tagCatalog.want_skill);
   const wantTopicCategories = tagGroupsToCategories(tagCatalog.want_topic);
 
-  // NOTE: document.getElementById is used to query dynamic error-bearing section container boundaries.
+  // NOTE: document.getElementById/formRef querySelector is used to query dynamic error-bearing section container boundaries.
   // This approach bypasses standard React refs to avoid inflating complexity with dozens of sub-component
   // ref callback dictionaries, while cleanly retaining declarative styling structures.
   const scrollToField = (fieldId: string) => {
-    document
-      .getElementById(fieldId)
-      ?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    const element = formRef.current
+      ? formRef.current.querySelector('#' + fieldId)
+      : null;
+    element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
   };
 
   const onError = (errors: FieldErrors<ProfileFormValues>) => {
     const errorKeys = Object.keys(errors) as (keyof ProfileFormValues)[];
+    const formEl = formRef.current;
 
     const elementsWithErrors = errorKeys
       .map((key) => {
-        const element = document.getElementById(key);
+        const element = formEl
+          ? (formEl.querySelector('#' + key) as HTMLElement)
+          : null;
         if (!element) return null;
         return { key, rect: element.getBoundingClientRect() };
       })
@@ -195,6 +201,7 @@ export default function EditProfileContainer({
 
       <Form {...form}>
         <form
+          ref={formRef}
           id="edit-profile-form"
           onSubmit={form.handleSubmit(
             (values) => onSubmit(values, form.formState.dirtyFields),

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -88,7 +88,6 @@ export default function EditProfileContainer({
 
   const { userDto, isMentor, isError } = useEditProfileData({
     userId: Number(pageUserId),
-    isAuthorized,
   });
 
   const { form } = useEditProfileForm(isMentorOnboarding || isMentor);

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useState } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { FieldErrors } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
@@ -36,6 +36,7 @@ import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt';
 import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
+import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
@@ -83,14 +84,20 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const { form } = useEditProfileForm();
-
-  const { isMentor, isPageLoading, isError } = useEditProfileData({
+  const { userDto, isMentor, isPageLoading, isError } = useEditProfileData({
     userId: Number(pageUserId),
-    form,
     isAuthorized,
-    isMentorOnboarding,
   });
+
+  const { form } = useEditProfileForm(isMentor);
+
+  // Reset form when user profile data successfully loads or updates
+  useLayoutEffect(() => {
+    if (!isAuthorized || !userDto) return;
+
+    const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
+    form.reset(formValues);
+  }, [userDto, isAuthorized, isMentorOnboarding, form]);
 
   // Warm up the avatar presigned URL once authorized. Saves a serial round
   // trip from the submit waterfall when the user uploads a new avatar.

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -1,11 +1,10 @@
 'use client';
 
-import { zodResolver } from '@hookform/resolvers/zod';
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useRef, useState } from 'react';
-import { FieldErrors, useForm } from 'react-hook-form';
+import { useEffect, useState } from 'react';
+import { FieldErrors } from 'react-hook-form';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
@@ -32,16 +31,13 @@ import { useProfileAuth } from '@/hooks/user/auth/useProfileAuth';
 import useLocations from '@/hooks/user/country/useLocations';
 import { useBackgroundAvatarUpload } from '@/hooks/user/profile/useBackgroundAvatarUpload';
 import { useEditProfileData } from '@/hooks/user/profile/useEditProfileData';
+import { useEditProfileForm } from '@/hooks/user/profile/useEditProfileForm';
 import { useProfileSubmit } from '@/hooks/user/profile/useProfileSubmit';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { useUnsavedChangesPrompt } from '@/hooks/useUnsavedChangesPrompt';
 import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
-import {
-  createProfileFormSchema,
-  defaultValues,
-  ProfileFormValues,
-} from '@/schemas/profileSchema';
+import { ProfileFormValues } from '@/schemas/profileSchema';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { prefetchPresignedUrl } from '@/services/profile/updateAvatar';
 
@@ -87,13 +83,7 @@ export default function EditProfileContainer({
   const tagCatalog = useTagCatalog('zh_TW', initialTagCatalog);
   const industries = tagCatalog.industry;
 
-  const isMentorRef = useRef(false);
-
-  const form = useForm<ProfileFormValues>({
-    resolver: (...args) =>
-      zodResolver(createProfileFormSchema(isMentorRef.current))(...args),
-    defaultValues,
-  });
+  const { form, isMentorRef } = useEditProfileForm();
 
   const { isMentor, isPageLoading, isError } = useEditProfileData({
     userId: Number(pageUserId),
@@ -176,7 +166,7 @@ export default function EditProfileContainer({
         <p className="text-lg font-medium text-destructive">
           載入失敗，請稍後再試。
         </p>
-        <Button onClick={() => router.refresh()} variant="outline">
+        <Button onClick={() => window.location.reload()} variant="outline">
           重新整理
         </Button>
       </div>

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -176,7 +176,7 @@ export default function EditProfileContainer({
         <p className="text-lg font-medium text-destructive">
           載入失敗，請稍後再試。
         </p>
-        <Button onClick={() => window.location.reload()} variant="outline">
+        <Button onClick={() => router.refresh()} variant="outline">
           重新整理
         </Button>
       </div>

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -3,7 +3,7 @@
 import dynamic from 'next/dynamic';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { useSession } from 'next-auth/react';
-import { useEffect, useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useState } from 'react';
 
 import { totalWorkSpanOptions } from '@/components/onboarding/steps/constant';
 import { AvatarSection } from '@/components/profile/edit/AvatarSection';
@@ -40,7 +40,6 @@ import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
-import { prefetchPresignedUrl } from '@/services/profile/updateAvatar';
 
 const JobExperienceSection = dynamic(async () => {
   const m = await import('@/components/profile/edit/JobExperienceSection');
@@ -88,6 +87,7 @@ export default function EditProfileContainer({
 
   const { userDto, isMentor, isError } = useEditProfileData({
     userId: Number(pageUserId),
+    isAuthorized,
   });
 
   const { form } = useEditProfileForm(isMentorOnboarding || isMentor);
@@ -98,20 +98,12 @@ export default function EditProfileContainer({
   // Reset form when user profile data successfully loads or updates
   useLayoutEffect(() => {
     if (!isAuthorized || !userDto) return;
+    if (!isContainerLoading) return; // Only allow form reset during initial loading!
 
     const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
     form.reset(formValues);
     setIsContainerLoading(false);
-  }, [userDto, isAuthorized, isMentorOnboarding, form]);
-
-  // Warm up the avatar presigned URL once authorized. Saves a serial round
-  // trip from the submit waterfall when the user uploads a new avatar.
-  useEffect(() => {
-    if (!isAuthorized) return;
-    const userId = Number(pageUserId);
-    if (!Number.isFinite(userId)) return;
-    prefetchPresignedUrl(userId);
-  }, [isAuthorized, pageUserId]);
+  }, [userDto, isAuthorized, isMentorOnboarding, form, isContainerLoading]);
 
   // Kicks off the S3 upload the moment the user crops a new avatar so
   // submit doesn't pay the round trip — see useBackgroundAvatarUpload.

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -18,7 +18,7 @@ describe('useEditProfileData', () => {
     vi.clearAllMocks();
   });
 
-  it('initially returns default loading states and false for isMentor/isError', () => {
+  it('initially returns false for isMentor/isError and null for userDto', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: null,
       isLoading: true,
@@ -28,17 +28,15 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        isAuthorized: true,
       })
     );
 
     expect(result.current.isMentor).toBe(false);
-    expect(result.current.isPageLoading).toBe(true);
     expect(result.current.isError).toBe(false);
     expect(result.current.userDto).toBeNull();
   });
 
-  it('sets loaded states and derives correct isMentor when isAuthorized is true and userDto is successfully fetched', () => {
+  it('sets loaded states and derives correct isMentor when userDto is successfully fetched', () => {
     const mockUserDto = {
       id: 1,
       username: 'test_user',
@@ -54,17 +52,15 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        isAuthorized: true,
       })
     );
 
     expect(result.current.isMentor).toBe(true);
-    expect(result.current.isPageLoading).toBe(false);
     expect(result.current.isError).toBe(false);
     expect(result.current.userDto).toEqual(mockUserDto);
   });
 
-  it('keeps isPageLoading=true when unauthorized even if userDto is fetched', () => {
+  it('derives correct states even if userDto is fetched with different role', () => {
     const mockUserDto = {
       id: 1,
       username: 'test_user',
@@ -80,16 +76,14 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        isAuthorized: false,
       })
     );
 
-    expect(result.current.isMentor).toBe(true); // Derived directly, but page remains in loading
-    expect(result.current.isPageLoading).toBe(true);
+    expect(result.current.isMentor).toBe(true);
     expect(result.current.isError).toBe(false);
   });
 
-  it('sets isError to true and finishes loading when fetching fails with an error', () => {
+  it('sets isError to true when fetching fails with an error', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: null,
       isLoading: false,
@@ -99,12 +93,10 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        isAuthorized: true,
       })
     );
 
     expect(result.current.isMentor).toBe(false);
-    expect(result.current.isPageLoading).toBe(false);
     expect(result.current.isError).toBe(true);
   });
 
@@ -127,13 +119,11 @@ describe('useEditProfileData', () => {
       {
         initialProps: {
           userId: 1,
-          isAuthorized: true,
         },
       }
     );
 
     expect(result.current.isError).toBe(true);
-    expect(result.current.isPageLoading).toBe(false);
 
     // 2) Mock resolution
     mockUseUserProfileDto.mockReturnValue({
@@ -144,15 +134,13 @@ describe('useEditProfileData', () => {
 
     rerender({
       userId: 1,
-      isAuthorized: true,
     });
 
     expect(result.current.isError).toBe(false);
-    expect(result.current.isPageLoading).toBe(false);
     expect(result.current.userDto).toEqual(mockUserDto);
   });
 
-  it('safely serializes object errors to prevent Sentry PII capturing', () => {
+  it('safely serializes object errors to prevent Sentry PII capturing while preserving message debugging value', () => {
     const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
 
     const mockErrorObject = {
@@ -169,13 +157,12 @@ describe('useEditProfileData', () => {
     renderHook(() =>
       useEditProfileData({
         userId: 1,
-        isAuthorized: true,
       })
     );
 
     expect(consoleSpy).toHaveBeenCalledWith(
       'Failed to fetch user data:',
-      '[object Object]'
+      'Failed to fetch'
     );
 
     consoleSpy.mockRestore();

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -5,6 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
 import { ProfileFormValues } from '@/schemas/profileSchema';
+import { MentorProfileVO } from '@/services/profile/user';
 
 import { useEditProfileData } from './useEditProfileData';
 
@@ -54,8 +55,11 @@ describe('useEditProfileData', () => {
   });
 
   it('populates form and sets loaded states when isAuthorized is true and userDto is successfully fetched', () => {
-    const mockUserDto = { id: 1, username: 'test_user' } as any;
-    const mockFormValues = { is_mentor: true } as any;
+    const mockUserDto = {
+      id: 1,
+      username: 'test_user',
+    } as unknown as MentorProfileVO;
+    const mockFormValues = { is_mentor: true } as unknown as ProfileFormValues;
 
     mockUseUserProfileDto.mockReturnValue({
       userDto: mockUserDto,
@@ -81,7 +85,10 @@ describe('useEditProfileData', () => {
   });
 
   it('keeps isPageLoading=true and does not reset form when unauthorized even if userDto is fetched', () => {
-    const mockUserDto = { id: 1, username: 'test_user' } as any;
+    const mockUserDto = {
+      id: 1,
+      username: 'test_user',
+    } as unknown as MentorProfileVO;
 
     mockUseUserProfileDto.mockReturnValue({
       userDto: mockUserDto,
@@ -126,8 +133,11 @@ describe('useEditProfileData', () => {
   });
 
   it('clears isError status and sets values on successful background retry/resolution', () => {
-    const mockUserDto = { id: 1, username: 'test_user' } as any;
-    const mockFormValues = { is_mentor: false } as any;
+    const mockUserDto = {
+      id: 1,
+      username: 'test_user',
+    } as unknown as MentorProfileVO;
+    const mockFormValues = { is_mentor: false } as unknown as ProfileFormValues;
 
     // 1) First render starts with error
     mockUseUserProfileDto.mockReturnValue({

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -1,5 +1,14 @@
 import { renderHook } from '@testing-library/react';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  MockInstance,
+  vi,
+} from 'vitest';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 import { MentorProfileVO } from '@/services/profile/user';
@@ -14,6 +23,28 @@ vi.mock('@/hooks/user/user-data/useUserProfileDto', () => ({
 const mockUseUserProfileDto = vi.mocked(useUserProfileDto);
 
 describe('useEditProfileData', () => {
+  let originalFetch: typeof global.fetch;
+  let consoleSpy: MockInstance;
+
+  beforeAll(() => {
+    // Suppress console.error during hook tests and prevent next-auth log rejections
+    consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    originalFetch = global.fetch;
+    global.fetch = vi.fn().mockImplementation((url) => {
+      if (String(url).includes('/api/auth/_log')) {
+        return Promise.resolve(
+          new Response(JSON.stringify({}), { status: 200 })
+        );
+      }
+      return originalFetch(url);
+    });
+  });
+
+  afterAll(() => {
+    consoleSpy.mockRestore();
+    global.fetch = originalFetch;
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
   });
@@ -28,6 +59,7 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
+        isAuthorized: true,
       })
     );
 
@@ -52,6 +84,7 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
+        isAuthorized: true,
       })
     );
 
@@ -76,6 +109,7 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
+        isAuthorized: false,
       })
     );
 
@@ -93,6 +127,7 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
+        isAuthorized: true,
       })
     );
 
@@ -119,6 +154,7 @@ describe('useEditProfileData', () => {
       {
         initialProps: {
           userId: 1,
+          isAuthorized: true,
         },
       }
     );
@@ -134,6 +170,7 @@ describe('useEditProfileData', () => {
 
     rerender({
       userId: 1,
+      isAuthorized: true,
     });
 
     expect(result.current.isError).toBe(false);
@@ -141,8 +178,6 @@ describe('useEditProfileData', () => {
   });
 
   it('safely serializes object errors to prevent Sentry PII capturing while preserving message debugging value', () => {
-    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-
     const mockErrorObject = {
       message: 'Failed to fetch',
       config: { headers: { Authorization: 'Bearer token123' } },
@@ -157,6 +192,7 @@ describe('useEditProfileData', () => {
     renderHook(() =>
       useEditProfileData({
         userId: 1,
+        isAuthorized: true,
       })
     );
 
@@ -164,8 +200,6 @@ describe('useEditProfileData', () => {
       'Failed to fetch user data:',
       'Failed to fetch'
     );
-
-    consoleSpy.mockRestore();
   });
 
   it('keeps isError as false when background focus revalidation fails but we already have userDto loaded', () => {
@@ -187,6 +221,7 @@ describe('useEditProfileData', () => {
       {
         initialProps: {
           userId: 1,
+          isAuthorized: true,
         },
       }
     );
@@ -203,6 +238,7 @@ describe('useEditProfileData', () => {
 
     rerender({
       userId: 1,
+      isAuthorized: true,
     });
 
     // It should tolerate background error, keeping isError=false so the form does not unmount!

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -167,4 +167,46 @@ describe('useEditProfileData', () => {
 
     consoleSpy.mockRestore();
   });
+
+  it('keeps isError as false when background focus revalidation fails but we already have userDto loaded', () => {
+    const mockUserDto = {
+      id: 1,
+      username: 'test_user',
+      is_mentor: false,
+    } as unknown as MentorProfileVO;
+
+    // 1) First render succeeds with data
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: mockUserDto,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result, rerender } = renderHook(
+      (props) => useEditProfileData(props),
+      {
+        initialProps: {
+          userId: 1,
+        },
+      }
+    );
+
+    expect(result.current.isError).toBe(false);
+    expect(result.current.userDto).toEqual(mockUserDto);
+
+    // 2) SWR triggers background revalidation on window focus and fails with network error, but keeps cached userDto
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: mockUserDto,
+      isLoading: false,
+      error: 'Background Focus Sync Timeout',
+    });
+
+    rerender({
+      userId: 1,
+    });
+
+    // It should tolerate background error, keeping isError=false so the form does not unmount!
+    expect(result.current.isError).toBe(false);
+    expect(result.current.userDto).toEqual(mockUserDto);
+  });
 });

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -151,4 +151,33 @@ describe('useEditProfileData', () => {
     expect(result.current.isPageLoading).toBe(false);
     expect(result.current.userDto).toEqual(mockUserDto);
   });
+
+  it('safely serializes object errors to prevent Sentry PII capturing', () => {
+    const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    const mockErrorObject = {
+      message: 'Failed to fetch',
+      config: { headers: { Authorization: 'Bearer token123' } },
+    };
+
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: null,
+      isLoading: false,
+      error: mockErrorObject as unknown as string,
+    });
+
+    renderHook(() =>
+      useEditProfileData({
+        userId: 1,
+        isAuthorized: true,
+      })
+    );
+
+    expect(consoleSpy).toHaveBeenCalledWith(
+      'Failed to fetch user data:',
+      '[object Object]'
+    );
+
+    consoleSpy.mockRestore();
+  });
 });

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -1,0 +1,174 @@
+import { renderHook } from '@testing-library/react';
+import { UseFormReturn } from 'react-hook-form';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
+import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
+import { ProfileFormValues } from '@/schemas/profileSchema';
+
+import { useEditProfileData } from './useEditProfileData';
+
+// Mock mapVoToFormValues
+vi.mock('@/lib/profile/profileSaveAdapter', () => ({
+  mapVoToFormValues: vi.fn(),
+}));
+
+// Mock useUserProfileDto
+vi.mock('@/hooks/user/user-data/useUserProfileDto', () => ({
+  useUserProfileDto: vi.fn(),
+}));
+
+const mockMapVoToFormValues = vi.mocked(mapVoToFormValues);
+const mockUseUserProfileDto = vi.mocked(useUserProfileDto);
+
+describe('useEditProfileData', () => {
+  let mockForm: UseFormReturn<ProfileFormValues>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockForm = {
+      reset: vi.fn(),
+    } as unknown as UseFormReturn<ProfileFormValues>;
+  });
+
+  it('initially returns default loading states and false for isMentor/isError', () => {
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: null,
+      isLoading: true,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useEditProfileData({
+        userId: 1,
+        form: mockForm,
+        isAuthorized: true,
+        isMentorOnboarding: false,
+      })
+    );
+
+    expect(result.current.isMentor).toBe(false);
+    expect(result.current.isPageLoading).toBe(true);
+    expect(result.current.isError).toBe(false);
+    expect(mockForm.reset).not.toHaveBeenCalled();
+  });
+
+  it('populates form and sets loaded states when isAuthorized is true and userDto is successfully fetched', () => {
+    const mockUserDto = { id: 1, username: 'test_user' } as any;
+    const mockFormValues = { is_mentor: true } as any;
+
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: mockUserDto,
+      isLoading: false,
+      error: null,
+    });
+    mockMapVoToFormValues.mockReturnValue(mockFormValues);
+
+    const { result } = renderHook(() =>
+      useEditProfileData({
+        userId: 1,
+        form: mockForm,
+        isAuthorized: true,
+        isMentorOnboarding: false,
+      })
+    );
+
+    expect(mockMapVoToFormValues).toHaveBeenCalledWith(mockUserDto, false);
+    expect(mockForm.reset).toHaveBeenCalledWith(mockFormValues);
+    expect(result.current.isMentor).toBe(true);
+    expect(result.current.isPageLoading).toBe(false);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('keeps isPageLoading=true and does not reset form when unauthorized even if userDto is fetched', () => {
+    const mockUserDto = { id: 1, username: 'test_user' } as any;
+
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: mockUserDto,
+      isLoading: false,
+      error: null,
+    });
+
+    const { result } = renderHook(() =>
+      useEditProfileData({
+        userId: 1,
+        form: mockForm,
+        isAuthorized: false,
+        isMentorOnboarding: false,
+      })
+    );
+
+    expect(mockForm.reset).not.toHaveBeenCalled();
+    expect(result.current.isMentor).toBe(false);
+    expect(result.current.isPageLoading).toBe(true);
+    expect(result.current.isError).toBe(false);
+  });
+
+  it('sets isError to true and finishes loading when fetching fails with an error', () => {
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: null,
+      isLoading: false,
+      error: 'Fetch failed',
+    });
+
+    const { result } = renderHook(() =>
+      useEditProfileData({
+        userId: 1,
+        form: mockForm,
+        isAuthorized: true,
+        isMentorOnboarding: false,
+      })
+    );
+
+    expect(result.current.isMentor).toBe(false);
+    expect(result.current.isPageLoading).toBe(false);
+    expect(result.current.isError).toBe(true);
+  });
+
+  it('clears isError status and sets values on successful background retry/resolution', () => {
+    const mockUserDto = { id: 1, username: 'test_user' } as any;
+    const mockFormValues = { is_mentor: false } as any;
+
+    // 1) First render starts with error
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: null,
+      isLoading: false,
+      error: 'Network Timeout',
+    });
+
+    const { result, rerender } = renderHook(
+      (props) => useEditProfileData(props),
+      {
+        initialProps: {
+          userId: 1,
+          form: mockForm,
+          isAuthorized: true,
+          isMentorOnboarding: false,
+        },
+      }
+    );
+
+    expect(result.current.isError).toBe(true);
+    expect(result.current.isPageLoading).toBe(false);
+
+    // 2) Mock background retry success
+    mockUseUserProfileDto.mockReturnValue({
+      userDto: mockUserDto,
+      isLoading: false,
+      error: null,
+    });
+    mockMapVoToFormValues.mockReturnValue(mockFormValues);
+
+    rerender({
+      userId: 1,
+      form: mockForm,
+      isAuthorized: true,
+      isMentorOnboarding: false,
+    });
+
+    // It should successfully recover, reset isError, and populate form values
+    expect(result.current.isError).toBe(false);
+    expect(result.current.isPageLoading).toBe(false);
+    expect(mockForm.reset).toHaveBeenCalledWith(mockFormValues);
+  });
+});

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -1,35 +1,21 @@
 import { renderHook } from '@testing-library/react';
-import { UseFormReturn } from 'react-hook-form';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
-import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
-import { ProfileFormValues } from '@/schemas/profileSchema';
 import { MentorProfileVO } from '@/services/profile/user';
 
 import { useEditProfileData } from './useEditProfileData';
-
-// Mock mapVoToFormValues
-vi.mock('@/lib/profile/profileSaveAdapter', () => ({
-  mapVoToFormValues: vi.fn(),
-}));
 
 // Mock useUserProfileDto
 vi.mock('@/hooks/user/user-data/useUserProfileDto', () => ({
   useUserProfileDto: vi.fn(),
 }));
 
-const mockMapVoToFormValues = vi.mocked(mapVoToFormValues);
 const mockUseUserProfileDto = vi.mocked(useUserProfileDto);
 
 describe('useEditProfileData', () => {
-  let mockForm: UseFormReturn<ProfileFormValues>;
-
   beforeEach(() => {
     vi.clearAllMocks();
-    mockForm = {
-      reset: vi.fn(),
-    } as unknown as UseFormReturn<ProfileFormValues>;
   });
 
   it('initially returns default loading states and false for isMentor/isError', () => {
@@ -42,52 +28,47 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        form: mockForm,
         isAuthorized: true,
-        isMentorOnboarding: false,
       })
     );
 
     expect(result.current.isMentor).toBe(false);
     expect(result.current.isPageLoading).toBe(true);
     expect(result.current.isError).toBe(false);
-    expect(mockForm.reset).not.toHaveBeenCalled();
+    expect(result.current.userDto).toBeNull();
   });
 
-  it('populates form and sets loaded states when isAuthorized is true and userDto is successfully fetched', () => {
+  it('sets loaded states and derives correct isMentor when isAuthorized is true and userDto is successfully fetched', () => {
     const mockUserDto = {
       id: 1,
       username: 'test_user',
+      is_mentor: true,
     } as unknown as MentorProfileVO;
-    const mockFormValues = { is_mentor: true } as unknown as ProfileFormValues;
 
     mockUseUserProfileDto.mockReturnValue({
       userDto: mockUserDto,
       isLoading: false,
       error: null,
     });
-    mockMapVoToFormValues.mockReturnValue(mockFormValues);
 
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        form: mockForm,
         isAuthorized: true,
-        isMentorOnboarding: false,
       })
     );
 
-    expect(mockMapVoToFormValues).toHaveBeenCalledWith(mockUserDto, false);
-    expect(mockForm.reset).toHaveBeenCalledWith(mockFormValues);
     expect(result.current.isMentor).toBe(true);
     expect(result.current.isPageLoading).toBe(false);
     expect(result.current.isError).toBe(false);
+    expect(result.current.userDto).toEqual(mockUserDto);
   });
 
-  it('keeps isPageLoading=true and does not reset form when unauthorized even if userDto is fetched', () => {
+  it('keeps isPageLoading=true when unauthorized even if userDto is fetched', () => {
     const mockUserDto = {
       id: 1,
       username: 'test_user',
+      is_mentor: true,
     } as unknown as MentorProfileVO;
 
     mockUseUserProfileDto.mockReturnValue({
@@ -99,14 +80,11 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        form: mockForm,
         isAuthorized: false,
-        isMentorOnboarding: false,
       })
     );
 
-    expect(mockForm.reset).not.toHaveBeenCalled();
-    expect(result.current.isMentor).toBe(false);
+    expect(result.current.isMentor).toBe(true); // Derived directly, but page remains in loading
     expect(result.current.isPageLoading).toBe(true);
     expect(result.current.isError).toBe(false);
   });
@@ -121,9 +99,7 @@ describe('useEditProfileData', () => {
     const { result } = renderHook(() =>
       useEditProfileData({
         userId: 1,
-        form: mockForm,
         isAuthorized: true,
-        isMentorOnboarding: false,
       })
     );
 
@@ -132,12 +108,12 @@ describe('useEditProfileData', () => {
     expect(result.current.isError).toBe(true);
   });
 
-  it('clears isError status and sets values on successful background retry/resolution', () => {
+  it('clears isError status on successful resolution', () => {
     const mockUserDto = {
       id: 1,
       username: 'test_user',
+      is_mentor: false,
     } as unknown as MentorProfileVO;
-    const mockFormValues = { is_mentor: false } as unknown as ProfileFormValues;
 
     // 1) First render starts with error
     mockUseUserProfileDto.mockReturnValue({
@@ -151,9 +127,7 @@ describe('useEditProfileData', () => {
       {
         initialProps: {
           userId: 1,
-          form: mockForm,
           isAuthorized: true,
-          isMentorOnboarding: false,
         },
       }
     );
@@ -161,24 +135,20 @@ describe('useEditProfileData', () => {
     expect(result.current.isError).toBe(true);
     expect(result.current.isPageLoading).toBe(false);
 
-    // 2) Mock background retry success
+    // 2) Mock resolution
     mockUseUserProfileDto.mockReturnValue({
       userDto: mockUserDto,
       isLoading: false,
       error: null,
     });
-    mockMapVoToFormValues.mockReturnValue(mockFormValues);
 
     rerender({
       userId: 1,
-      form: mockForm,
       isAuthorized: true,
-      isMentorOnboarding: false,
     });
 
-    // It should successfully recover, reset isError, and populate form values
     expect(result.current.isError).toBe(false);
     expect(result.current.isPageLoading).toBe(false);
-    expect(mockForm.reset).toHaveBeenCalledWith(mockFormValues);
+    expect(result.current.userDto).toEqual(mockUserDto);
   });
 });

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -5,27 +5,31 @@ import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 
 interface Options {
   userId: number;
-  isAuthorized: boolean;
 }
 
-export function useEditProfileData({ userId, isAuthorized }: Options) {
+export function useEditProfileData({ userId }: Options) {
   // Fire the user fetch in parallel with auth resolution.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
   useEffect(() => {
     if (!error) return;
-    // Sanitized with String() to prevent raw object/header leaks to Sentry console capturing
+
+    // Safely serialize and extract error message without exposing full Axios config / PII headers to Sentry
+    const errObj = error as unknown;
     console.error(
       'Failed to fetch user data:',
-      typeof error === 'string' ? error : String(error)
+      typeof error === 'string'
+        ? error
+        : errObj instanceof Error
+          ? errObj.message
+          : typeof errObj === 'object' && errObj && 'message' in errObj
+            ? String((errObj as Record<string, unknown>).message)
+            : 'Unknown error'
     );
   }, [error]);
 
   const isMentor = userDto ? Boolean(userDto.is_mentor) : false;
   const isError = Boolean(error);
-  // Derived page loading state: isPageLoading is false synchronously on the very first render if data is already cached,
-  // completely eliminating first-frame loading flashes and layout effects.
-  const isPageLoading = !isAuthorized || (!userDto && !error);
 
-  return { userDto, isMentor, isPageLoading, isError };
+  return { userDto, isMentor, isError };
 }

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -2,30 +2,31 @@
 import { useEffect } from 'react';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
+import { getSafeErrorMessage } from '@/lib/errorUtils';
+import { prefetchPresignedUrl } from '@/services/profile/updateAvatar';
 
 interface Options {
   userId: number;
+  isAuthorized: boolean;
 }
 
-export function useEditProfileData({ userId }: Options) {
+export function useEditProfileData({ userId, isAuthorized }: Options) {
   // Fire the user fetch in parallel with auth resolution.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
+  // Warm up the avatar presigned URL once authorized. Saves a serial round
+  // trip from the submit waterfall when the user uploads a new avatar.
+  useEffect(() => {
+    if (!isAuthorized) return;
+    const uId = Number(userId);
+    if (!Number.isFinite(uId)) return;
+    prefetchPresignedUrl(uId);
+  }, [isAuthorized, userId]);
+
   useEffect(() => {
     if (!error) return;
-
-    // Safely serialize and extract error message without exposing full Axios config / PII headers to Sentry
-    const errObj = error as unknown;
-    console.error(
-      'Failed to fetch user data:',
-      typeof error === 'string'
-        ? error
-        : errObj instanceof Error
-          ? errObj.message
-          : typeof errObj === 'object' && errObj && 'message' in errObj
-            ? String((errObj as Record<string, unknown>).message)
-            : 'Unknown error'
-    );
+    // Sanitized to prevent PII / secret leak to Sentry console capture
+    console.error('Failed to fetch user data:', getSafeErrorMessage(error));
   }, [error]);
 
   const isMentor = userDto ? Boolean(userDto.is_mentor) : false;

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -26,7 +26,7 @@ export function useEditProfileData({
   // Fire the user fetch in parallel with auth resolution. The form.reset
   // effect below still gates on `isAuthorized`, so unauthorized callers
   // (redirected by useProfileAuth) never see the data populated.
-  const { userDto, isLoading, error } = useUserProfileDto(userId, 'zh_TW');
+  const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
@@ -41,7 +41,7 @@ export function useEditProfileData({
     setIsMentor(formValues.is_mentor);
     setIsPageLoading(false);
     setIsError(false);
-  }, [userDto, isAuthorized, isMentorOnboarding, form, isLoading]);
+  }, [userDto, isAuthorized, isMentorOnboarding, form]);
 
   useEffect(() => {
     if (!error) return;

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -26,7 +26,7 @@ export function useEditProfileData({
   // Fire the user fetch in parallel with auth resolution. The form.reset
   // effect below still gates on `isAuthorized`, so unauthorized callers
   // (redirected by useProfileAuth) never see the data populated.
-  const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
+  const { userDto, isLoading, error } = useUserProfileDto(userId, 'zh_TW');
 
   // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
   // commit before the browser paints. When the dto is already cached at mount
@@ -41,10 +41,11 @@ export function useEditProfileData({
     setIsMentor(formValues.is_mentor);
     setIsPageLoading(false);
     setIsError(false);
-  }, [userDto, isAuthorized, isMentorOnboarding, form]);
+  }, [userDto, isAuthorized, isMentorOnboarding, form, isLoading]);
 
   useEffect(() => {
     if (!error) return;
+    // Sanitized to prevent PII / secret leak to Sentry console capture
     console.error('Failed to fetch user data:', error);
     setIsPageLoading(false);
     setIsError(true);

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -29,7 +29,10 @@ export function useEditProfileData({ userId }: Options) {
   }, [error]);
 
   const isMentor = userDto ? Boolean(userDto.is_mentor) : false;
-  const isError = Boolean(error);
+  // Fatal isError is only true if we have an error AND no existing userDto has been resolved.
+  // This allows background revalidations (e.g. SWR revalidateOnFocus) to fail silently
+  // without triggering a fatal error unmount that would wipe out the user's unsaved form inputs.
+  const isError = Boolean(error) && !userDto;
 
   return { userDto, isMentor, isError };
 }

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
 
@@ -9,33 +9,23 @@ interface Options {
 }
 
 export function useEditProfileData({ userId, isAuthorized }: Options) {
-  const [isPageLoading, setIsPageLoading] = useState(true);
-  const [isError, setIsError] = useState(false);
-
   // Fire the user fetch in parallel with auth resolution.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
   useEffect(() => {
-    if (!isAuthorized) return;
-
-    if (userDto) {
-      setIsPageLoading(false);
-      setIsError(false);
-    }
-  }, [userDto, isAuthorized]);
-
-  useEffect(() => {
     if (!error) return;
-    // Sanitized to prevent PII / secret leak to Sentry console capture
+    // Sanitized with String() to prevent raw object/header leaks to Sentry console capturing
     console.error(
       'Failed to fetch user data:',
       typeof error === 'string' ? error : String(error)
     );
-    setIsPageLoading(false);
-    setIsError(true);
   }, [error]);
 
   const isMentor = userDto ? Boolean(userDto.is_mentor) : false;
+  const isError = Boolean(error);
+  // Derived page loading state: isPageLoading is false synchronously on the very first render if data is already cached,
+  // completely eliminating first-frame loading flashes and layout effects.
+  const isPageLoading = !isAuthorized || (!userDto && !error);
 
   return { userDto, isMentor, isPageLoading, isError };
 }

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -1,55 +1,41 @@
 'use client';
-import { useEffect, useLayoutEffect, useState } from 'react';
-import { UseFormReturn } from 'react-hook-form';
+import { useEffect, useState } from 'react';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
-import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
-import { ProfileFormValues } from '@/schemas/profileSchema';
 
 interface Options {
   userId: number;
-  form: UseFormReturn<ProfileFormValues>;
   isAuthorized: boolean;
-  isMentorOnboarding: boolean;
 }
 
-export function useEditProfileData({
-  userId,
-  form,
-  isAuthorized,
-  isMentorOnboarding,
-}: Options) {
-  const [isMentor, setIsMentor] = useState(false);
+export function useEditProfileData({ userId, isAuthorized }: Options) {
   const [isPageLoading, setIsPageLoading] = useState(true);
   const [isError, setIsError] = useState(false);
 
-  // Fire the user fetch in parallel with auth resolution. The form.reset
-  // effect below still gates on `isAuthorized`, so unauthorized callers
-  // (redirected by useProfileAuth) never see the data populated.
+  // Fire the user fetch in parallel with auth resolution.
   const { userDto, error } = useUserProfileDto(userId, 'zh_TW');
 
-  // useLayoutEffect (not useEffect) so form.reset + setIsPageLoading(false)
-  // commit before the browser paints. When the dto is already cached at mount
-  // (the common profile → edit nav), this skips the one-frame `<PageLoading />`
-  // spinner that otherwise paints between the initial render and the effect.
-  useLayoutEffect(() => {
-    if (!isAuthorized || !userDto) return;
+  useEffect(() => {
+    if (!isAuthorized) return;
 
-    const formValues = mapVoToFormValues(userDto, isMentorOnboarding);
-    form.reset(formValues);
-
-    setIsMentor(formValues.is_mentor);
-    setIsPageLoading(false);
-    setIsError(false);
-  }, [userDto, isAuthorized, isMentorOnboarding, form]);
+    if (userDto) {
+      setIsPageLoading(false);
+      setIsError(false);
+    }
+  }, [userDto, isAuthorized]);
 
   useEffect(() => {
     if (!error) return;
     // Sanitized to prevent PII / secret leak to Sentry console capture
-    console.error('Failed to fetch user data:', error);
+    console.error(
+      'Failed to fetch user data:',
+      typeof error === 'string' ? error : String(error)
+    );
     setIsPageLoading(false);
     setIsError(true);
   }, [error]);
 
-  return { isMentor, isPageLoading, isError };
+  const isMentor = userDto ? Boolean(userDto.is_mentor) : false;
+
+  return { userDto, isMentor, isPageLoading, isError };
 }

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -1,5 +1,5 @@
 'use client';
-import { useEffect, useLayoutEffect } from 'react';
+import { useEffect, useLayoutEffect, useState } from 'react';
 import { UseFormReturn } from 'react-hook-form';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
@@ -11,8 +11,6 @@ interface Options {
   form: UseFormReturn<ProfileFormValues>;
   isAuthorized: boolean;
   isMentorOnboarding: boolean;
-  setIsMentor: (v: boolean) => void;
-  setIsPageLoading: (v: boolean) => void;
 }
 
 export function useEditProfileData({
@@ -20,9 +18,11 @@ export function useEditProfileData({
   form,
   isAuthorized,
   isMentorOnboarding,
-  setIsMentor,
-  setIsPageLoading,
 }: Options) {
+  const [isMentor, setIsMentor] = useState(false);
+  const [isPageLoading, setIsPageLoading] = useState(true);
+  const [isError, setIsError] = useState(false);
+
   // Fire the user fetch in parallel with auth resolution. The form.reset
   // effect below still gates on `isAuthorized`, so unauthorized callers
   // (redirected by useProfileAuth) never see the data populated.
@@ -40,18 +40,14 @@ export function useEditProfileData({
 
     setIsMentor(formValues.is_mentor);
     setIsPageLoading(false);
-  }, [
-    userDto,
-    isAuthorized,
-    isMentorOnboarding,
-    form,
-    setIsMentor,
-    setIsPageLoading,
-  ]);
+  }, [userDto, isAuthorized, isMentorOnboarding, form]);
 
   useEffect(() => {
     if (!error) return;
     console.error('Failed to fetch user data:', error);
     setIsPageLoading(false);
-  }, [error, setIsPageLoading]);
+    setIsError(true);
+  }, [error]);
+
+  return { isMentor, isPageLoading, isError };
 }

--- a/src/hooks/user/profile/useEditProfileData.ts
+++ b/src/hooks/user/profile/useEditProfileData.ts
@@ -40,6 +40,7 @@ export function useEditProfileData({
 
     setIsMentor(formValues.is_mentor);
     setIsPageLoading(false);
+    setIsError(false);
   }, [userDto, isAuthorized, isMentorOnboarding, form]);
 
   useEffect(() => {

--- a/src/hooks/user/profile/useEditProfileForm.test.ts
+++ b/src/hooks/user/profile/useEditProfileForm.test.ts
@@ -4,34 +4,16 @@ import { describe, expect, it } from 'vitest';
 import { useEditProfileForm } from './useEditProfileForm';
 
 describe('useEditProfileForm', () => {
-  it('initializes form with default values and is_mentor as false', () => {
+  it('initializes form with default values and uses the correct resolver schema based on isMentor parameter', async () => {
     const { result } = renderHook(() => {
-      const hookRes = useEditProfileForm();
+      const hookRes = useEditProfileForm(false);
       void hookRes.form.formState.errors; // subscribe to errors proxy
       return hookRes;
     });
 
     expect(result.current.form).toBeDefined();
-    expect(result.current.form.getValues('is_mentor')).toBe(false);
-  });
-
-  it('validates correctly under mentee mode (about and have_topic are optional)', async () => {
-    const { result } = renderHook(() => {
-      const hookRes = useEditProfileForm();
-      void hookRes.form.formState.errors; // subscribe to errors proxy
-      return hookRes;
-    });
-
-    // Set is_mentor to false
-    await act(async () => {
-      result.current.form.setValue('is_mentor', false);
-    });
 
     await act(async () => {
-      // name is required, so validating empty name should fail
-      const isNameValid = await result.current.form.trigger('name');
-      expect(isNameValid).toBe(false);
-
       // about is optional for mentees, so validating empty about should succeed
       const isAboutValid = await result.current.form.trigger('about');
       expect(isAboutValid).toBe(true);
@@ -40,14 +22,9 @@ describe('useEditProfileForm', () => {
 
   it('validates correctly under mentor mode (about is required)', async () => {
     const { result } = renderHook(() => {
-      const hookRes = useEditProfileForm();
+      const hookRes = useEditProfileForm(true);
       void hookRes.form.formState.errors; // subscribe to errors proxy
       return hookRes;
-    });
-
-    // Set is_mentor to true
-    await act(async () => {
-      result.current.form.setValue('is_mentor', true);
     });
 
     await act(async () => {

--- a/src/hooks/user/profile/useEditProfileForm.test.ts
+++ b/src/hooks/user/profile/useEditProfileForm.test.ts
@@ -1,0 +1,61 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useEditProfileForm } from './useEditProfileForm';
+
+describe('useEditProfileForm', () => {
+  it('initializes form with default values and isMentorRef as false', () => {
+    const { result } = renderHook(() => {
+      const hookRes = useEditProfileForm();
+      void hookRes.form.formState.errors; // subscribe to errors proxy
+      return hookRes;
+    });
+
+    expect(result.current.form).toBeDefined();
+    expect(result.current.form.getValues('is_mentor')).toBe(false);
+  });
+
+  it('validates correctly under mentee mode (about and have_topic are optional)', async () => {
+    const { result } = renderHook(() => {
+      const hookRes = useEditProfileForm();
+      void hookRes.form.formState.errors; // subscribe to errors proxy
+      return hookRes;
+    });
+
+    // By default, mode is non-mentor (mentee)
+    result.current.syncMentorStatus(false);
+
+    await act(async () => {
+      // name is required, so validating empty name should fail
+      const isNameValid = await result.current.form.trigger('name');
+      expect(isNameValid).toBe(false);
+
+      // about is optional for mentees, so validating empty about should succeed
+      const isAboutValid = await result.current.form.trigger('about');
+      expect(isAboutValid).toBe(true);
+    });
+  });
+
+  it('validates correctly under mentor mode (about is required)', async () => {
+    const { result } = renderHook(() => {
+      const hookRes = useEditProfileForm();
+      void hookRes.form.formState.errors; // subscribe to errors proxy
+      return hookRes;
+    });
+
+    // Sync mentor mode
+    result.current.syncMentorStatus(true);
+
+    await act(async () => {
+      // about is required for mentors, so validating empty about should fail
+      const isAboutValid = await result.current.form.trigger('about');
+      expect(isAboutValid).toBe(false);
+    });
+
+    await waitFor(() => {
+      expect(result.current.form.formState.errors.about?.message).toBe(
+        '請填寫關於我'
+      );
+    });
+  });
+});

--- a/src/hooks/user/profile/useEditProfileForm.test.ts
+++ b/src/hooks/user/profile/useEditProfileForm.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it } from 'vitest';
 import { useEditProfileForm } from './useEditProfileForm';
 
 describe('useEditProfileForm', () => {
-  it('initializes form with default values and isMentorRef as false', () => {
+  it('initializes form with default values and is_mentor as false', () => {
     const { result } = renderHook(() => {
       const hookRes = useEditProfileForm();
       void hookRes.form.formState.errors; // subscribe to errors proxy
@@ -22,8 +22,10 @@ describe('useEditProfileForm', () => {
       return hookRes;
     });
 
-    // By default, mode is non-mentor (mentee)
-    result.current.syncMentorStatus(false);
+    // Set is_mentor to false
+    await act(async () => {
+      result.current.form.setValue('is_mentor', false);
+    });
 
     await act(async () => {
       // name is required, so validating empty name should fail
@@ -43,8 +45,10 @@ describe('useEditProfileForm', () => {
       return hookRes;
     });
 
-    // Sync mentor mode
-    result.current.syncMentorStatus(true);
+    // Set is_mentor to true
+    await act(async () => {
+      result.current.form.setValue('is_mentor', true);
+    });
 
     await act(async () => {
       // about is required for mentors, so validating empty about should fail

--- a/src/hooks/user/profile/useEditProfileForm.ts
+++ b/src/hooks/user/profile/useEditProfileForm.ts
@@ -1,7 +1,6 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useRef } from 'react';
 import { useForm } from 'react-hook-form';
 
 import {
@@ -11,19 +10,14 @@ import {
 } from '@/schemas/profileSchema';
 
 export function useEditProfileForm() {
-  const isMentorRef = useRef(false);
-
-  const syncMentorStatus = (isMentor: boolean) => {
-    isMentorRef.current = isMentor;
-  };
-
   const form = useForm<ProfileFormValues>({
     resolver: (values, context, options) => {
-      const activeSchema = createProfileFormSchema(isMentorRef.current);
+      // Dynamically resolve schema based on form values (values.is_mentor) passed by react-hook-form during validation.
+      const activeSchema = createProfileFormSchema(values.is_mentor);
       return zodResolver(activeSchema)(values, context, options);
     },
     defaultValues,
   });
 
-  return { form, syncMentorStatus };
+  return { form };
 }

--- a/src/hooks/user/profile/useEditProfileForm.ts
+++ b/src/hooks/user/profile/useEditProfileForm.ts
@@ -13,11 +13,17 @@ import {
 export function useEditProfileForm() {
   const isMentorRef = useRef(false);
 
+  const syncMentorStatus = (isMentor: boolean) => {
+    isMentorRef.current = isMentor;
+  };
+
   const form = useForm<ProfileFormValues>({
-    resolver: (...args) =>
-      zodResolver(createProfileFormSchema(isMentorRef.current))(...args),
+    resolver: (values, context, options) => {
+      const activeSchema = createProfileFormSchema(isMentorRef.current);
+      return zodResolver(activeSchema)(values, context, options);
+    },
     defaultValues,
   });
 
-  return { form, isMentorRef };
+  return { form, syncMentorStatus };
 }

--- a/src/hooks/user/profile/useEditProfileForm.ts
+++ b/src/hooks/user/profile/useEditProfileForm.ts
@@ -1,6 +1,7 @@
 'use client';
 
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
 import {
@@ -9,13 +10,13 @@ import {
   ProfileFormValues,
 } from '@/schemas/profileSchema';
 
-export function useEditProfileForm() {
+export function useEditProfileForm(isMentor: boolean) {
+  const resolver = useMemo(() => {
+    return zodResolver(createProfileFormSchema(isMentor));
+  }, [isMentor]);
+
   const form = useForm<ProfileFormValues>({
-    resolver: (values, context, options) => {
-      // Dynamically resolve schema based on form values (values.is_mentor) passed by react-hook-form during validation.
-      const activeSchema = createProfileFormSchema(values.is_mentor);
-      return zodResolver(activeSchema)(values, context, options);
-    },
+    resolver,
     defaultValues,
   });
 

--- a/src/hooks/user/profile/useEditProfileForm.ts
+++ b/src/hooks/user/profile/useEditProfileForm.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRef } from 'react';
+import { useForm } from 'react-hook-form';
+
+import {
+  createProfileFormSchema,
+  defaultValues,
+  ProfileFormValues,
+} from '@/schemas/profileSchema';
+
+export function useEditProfileForm() {
+  const isMentorRef = useRef(false);
+
+  const form = useForm<ProfileFormValues>({
+    resolver: (...args) =>
+      zodResolver(createProfileFormSchema(isMentorRef.current))(...args),
+    defaultValues,
+  });
+
+  return { form, isMentorRef };
+}

--- a/src/hooks/user/profile/useFormErrorScroll.ts
+++ b/src/hooks/user/profile/useFormErrorScroll.ts
@@ -1,0 +1,37 @@
+'use client';
+
+import { useRef } from 'react';
+import { FieldErrors, FieldValues } from 'react-hook-form';
+
+export function useFormErrorScroll<T extends FieldValues>() {
+  const formRef = useRef<HTMLFormElement>(null);
+
+  const scrollToField = (fieldId: string) => {
+    const element = formRef.current
+      ? (formRef.current.querySelector('#' + fieldId) as HTMLElement)
+      : null;
+    element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+  };
+
+  const onError = (errors: FieldErrors<T>) => {
+    const errorKeys = Object.keys(errors) as (keyof T)[];
+    const formEl = formRef.current;
+
+    const elementsWithErrors = errorKeys
+      .map((key) => {
+        const element = formEl
+          ? (formEl.querySelector('#' + String(key)) as HTMLElement)
+          : null;
+        if (!element) return null;
+        return { key, rect: element.getBoundingClientRect() };
+      })
+      .filter((item): item is { key: keyof T; rect: DOMRect } => item !== null);
+
+    if (elementsWithErrors.length > 0) {
+      elementsWithErrors.sort((a, b) => a.rect.top - b.rect.top);
+      scrollToField(String(elementsWithErrors[0].key));
+    }
+  };
+
+  return { formRef, onError, scrollToField };
+}

--- a/src/hooks/user/profile/useFormErrorScroll.ts
+++ b/src/hooks/user/profile/useFormErrorScroll.ts
@@ -1,37 +1,42 @@
 'use client';
 
-import { useRef } from 'react';
+import { useCallback, useRef } from 'react';
 import { FieldErrors, FieldValues } from 'react-hook-form';
 
 export function useFormErrorScroll<T extends FieldValues>() {
   const formRef = useRef<HTMLFormElement>(null);
 
-  const scrollToField = (fieldId: string) => {
-    const element = formRef.current
-      ? (formRef.current.querySelector('#' + fieldId) as HTMLElement)
-      : null;
-    element?.scrollIntoView({ behavior: 'smooth', block: 'center' });
-  };
-
-  const onError = (errors: FieldErrors<T>) => {
-    const errorKeys = Object.keys(errors) as (keyof T)[];
-    const formEl = formRef.current;
-
-    const elementsWithErrors = errorKeys
-      .map((key) => {
-        const element = formEl
-          ? (formEl.querySelector('#' + String(key)) as HTMLElement)
-          : null;
-        if (!element) return null;
-        return { key, rect: element.getBoundingClientRect() };
-      })
-      .filter((item): item is { key: keyof T; rect: DOMRect } => item !== null);
-
-    if (elementsWithErrors.length > 0) {
-      elementsWithErrors.sort((a, b) => a.rect.top - b.rect.top);
-      scrollToField(String(elementsWithErrors[0].key));
+  const scrollToField = useCallback((fieldId: string) => {
+    const element = document.getElementById(fieldId);
+    if (element && formRef.current?.contains(element)) {
+      element.scrollIntoView({ behavior: 'smooth', block: 'center' });
     }
-  };
+  }, []);
+
+  const onError = useCallback(
+    (errors: FieldErrors<T>) => {
+      const errorKeys = Object.keys(errors) as (keyof T)[];
+      const formEl = formRef.current;
+
+      const elementsWithErrors = errorKeys
+        .map((key) => {
+          const element = document.getElementById(String(key));
+          if (element && formEl?.contains(element)) {
+            return { key, rect: element.getBoundingClientRect() };
+          }
+          return null;
+        })
+        .filter(
+          (item): item is { key: keyof T; rect: DOMRect } => item !== null
+        );
+
+      if (elementsWithErrors.length > 0) {
+        elementsWithErrors.sort((a, b) => a.rect.top - b.rect.top);
+        scrollToField(String(elementsWithErrors[0].key));
+      }
+    },
+    [scrollToField]
+  );
 
   return { formRef, onError, scrollToField };
 }

--- a/src/lib/errorUtils.test.ts
+++ b/src/lib/errorUtils.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { getSafeErrorMessage } from './errorUtils';
+
+describe('getSafeErrorMessage', () => {
+  it('returns the error directly if it is a string', () => {
+    const error = 'Failed to load profile';
+    expect(getSafeErrorMessage(error)).toBe('Failed to load profile');
+  });
+
+  it('extracts message if error is an instance of Error', () => {
+    const error = new Error('Database connection failed');
+    expect(getSafeErrorMessage(error)).toBe('Database connection failed');
+  });
+
+  it('extracts message if error is a custom object with a message property', () => {
+    const error = {
+      message: 'Network Timeout',
+      config: { headers: { Authorization: 'Bearer token123' } },
+    };
+    expect(getSafeErrorMessage(error)).toBe('Network Timeout');
+  });
+
+  it('returns Unknown error for null or undefined errors', () => {
+    expect(getSafeErrorMessage(null)).toBe('Unknown error');
+    expect(getSafeErrorMessage(undefined)).toBe('Unknown error');
+  });
+
+  it('returns Unknown error for non-error types without a message property', () => {
+    expect(getSafeErrorMessage(404)).toBe('Unknown error');
+    expect(getSafeErrorMessage({})).toBe('Unknown error');
+  });
+});

--- a/src/lib/errorUtils.ts
+++ b/src/lib/errorUtils.ts
@@ -1,0 +1,17 @@
+/**
+ * Safely extracts and serializes an error message from an unknown error object,
+ * preventing full Axios response objects, headers, or private user configs
+ * containing Authorization tokens/PII from leaking into logging/monitoring streams.
+ */
+export function getSafeErrorMessage(error: unknown): string {
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as Record<string, unknown>).message);
+  }
+  return 'Unknown error';
+}


### PR DESCRIPTION
This PR deepens the composition of the profile-edit container and decouples UI visual order from schema validation logic, addressing all criteria for issue #345.

### Key Changes
1. **useEditProfileData Hook:** Encapsulated states locally. Now returns `{ isMentor, isPageLoading, isError }` directly rather than accepting setters.
2. **container.tsx:** 
   - Cleaned up container by removing manual state declarations for `isMentor` and `isPageLoading`.
   - Rendered a styled error fallback screen when `isError` is true.
   - Removed the manual `FIELD_SCROLL_ORDER` array.
   - Implemented dynamic DOM-based coordinate sorting using `getBoundingClientRect().top` to identify the visually topmost error when validation fails.
3. **container.test.tsx:** Added comprehensive unit tests for the error fallback screen and dynamic DOM sorting scrolling behavior.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/345
