### PR TITLE
refactor: decouple useReservationData hook from role-specific state keys (X-Tracker #349)

### DIFF
--- a/src/components/reservation/ReservationDashboard.test.tsx
+++ b/src/components/reservation/ReservationDashboard.test.tsx
@@ -101,12 +101,9 @@ describe('ReservationDashboard', () => {
       history: 'ready',
     },
     loadingMoreStates: {
-      MENTEE_UPCOMING: false,
-      MENTEE_PENDING: false,
-      MENTEE_HISTORY: false,
-      MENTOR_UPCOMING: false,
-      MENTOR_PENDING: false,
-      MENTOR_HISTORY: false,
+      upcoming: false,
+      pending: false,
+      history: false,
     },
     isLoading: false,
     isLoadingHistory: false,
@@ -219,21 +216,21 @@ describe('ReservationDashboard', () => {
     // --- Tab 1: Upcoming ---
     const upcomingLoadMore = screen.getByTestId('load-more-upcoming');
     fireEvent.click(upcomingLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTEE_UPCOMING');
+    expect(mockLoadMore).toHaveBeenCalledWith('upcoming');
 
     // --- Tab 2: Pending ---
     const pendingTrigger = screen.getByTestId('trigger-pending-mentee');
     fireEvent.click(pendingTrigger);
     const pendingLoadMore = screen.getByTestId('load-more-pending-mentee');
     fireEvent.click(pendingLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTEE_PENDING');
+    expect(mockLoadMore).toHaveBeenCalledWith('pending');
 
     // --- Tab 3: History ---
     const historyTrigger = screen.getByTestId('trigger-history');
     fireEvent.click(historyTrigger);
     const historyLoadMore = screen.getByTestId('load-more-history');
     fireEvent.click(historyLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTEE_HISTORY');
+    expect(mockLoadMore).toHaveBeenCalledWith('history');
   });
 
   it('correctly maps and triggers onLoadMore params for role "mentor"', () => {
@@ -246,20 +243,20 @@ describe('ReservationDashboard', () => {
     // --- Tab 1: Upcoming ---
     const upcomingLoadMore = screen.getByTestId('load-more-upcoming');
     fireEvent.click(upcomingLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTOR_UPCOMING');
+    expect(mockLoadMore).toHaveBeenCalledWith('upcoming');
 
     // --- Tab 2: Pending ---
     const pendingTrigger = screen.getByTestId('trigger-pending-mentor');
     fireEvent.click(pendingTrigger);
     const pendingLoadMore = screen.getByTestId('load-more-pending-mentor');
     fireEvent.click(pendingLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTOR_PENDING');
+    expect(mockLoadMore).toHaveBeenCalledWith('pending');
 
     // --- Tab 3: History ---
     const historyTrigger = screen.getByTestId('trigger-history');
     fireEvent.click(historyTrigger);
     const historyLoadMore = screen.getByTestId('load-more-history');
     fireEvent.click(historyLoadMore);
-    expect(mockLoadMore).toHaveBeenCalledWith('MENTOR_HISTORY');
+    expect(mockLoadMore).toHaveBeenCalledWith('history');
   });
 });

--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -40,18 +40,9 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   const upcomingTabValue = isMentee ? 'upcoming-mentee' : 'upcoming-mentor';
   const pendingTabValue = isMentee ? 'pending-mentee' : 'pending-mentor';
 
-  const loadMoreUpcoming = useCallback(
-    () => loadMore(isMentee ? 'MENTEE_UPCOMING' : 'MENTOR_UPCOMING'),
-    [loadMore, isMentee]
-  );
-  const loadMorePending = useCallback(
-    () => loadMore(isMentee ? 'MENTEE_PENDING' : 'MENTOR_PENDING'),
-    [loadMore, isMentee]
-  );
-  const loadMoreHistory = useCallback(
-    () => loadMore(isMentee ? 'MENTEE_HISTORY' : 'MENTOR_HISTORY'),
-    [loadMore, isMentee]
-  );
+  const loadMoreUpcoming = useCallback(() => loadMore('upcoming'), [loadMore]);
+  const loadMorePending = useCallback(() => loadMore('pending'), [loadMore]);
+  const loadMoreHistory = useCallback(() => loadMore('history'), [loadMore]);
 
   const triggerClass =
     'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
@@ -141,11 +132,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
                     myUserId={myUserId}
                     hasMore={nextTokens.upcoming !== 0}
                     onLoadMore={loadMoreUpcoming}
-                    isLoadingMore={
-                      loadingMoreStates[
-                        isMentee ? 'MENTEE_UPCOMING' : 'MENTOR_UPCOMING'
-                      ]
-                    }
+                    isLoadingMore={loadingMoreStates.upcoming}
                     onMutationSuccess={onMutationSuccess}
                   />
                 )}
@@ -162,11 +149,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
                     myUserId={myUserId}
                     hasMore={nextTokens.pending !== 0}
                     onLoadMore={loadMorePending}
-                    isLoadingMore={
-                      loadingMoreStates[
-                        isMentee ? 'MENTEE_PENDING' : 'MENTOR_PENDING'
-                      ]
-                    }
+                    isLoadingMore={loadingMoreStates.pending}
                     onMutationSuccess={onMutationSuccess}
                   />
                 )}
@@ -183,11 +166,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
                     myUserId={myUserId}
                     hasMore={nextTokens.history !== 0}
                     onLoadMore={loadMoreHistory}
-                    isLoadingMore={
-                      loadingMoreStates[
-                        isMentee ? 'MENTEE_HISTORY' : 'MENTOR_HISTORY'
-                      ]
-                    }
+                    isLoadingMore={loadingMoreStates.history}
                     onMutationSuccess={onMutationSuccess}
                   />
                 )}

--- a/src/components/reservation/ReservationList.test.tsx
+++ b/src/components/reservation/ReservationList.test.tsx
@@ -1,0 +1,200 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { updateReservationStatus } from '@/services/reservations';
+
+import { ReservationList } from './ReservationList';
+
+// Mock dialogs to render a simple button for callback execution
+vi.mock('@/components/reservation/AcceptReservationDialog', () => ({
+  __esModule: true,
+  default: ({ onAccept, reservation }: any) => (
+    <button
+      data-testid="accept-btn"
+      onClick={() =>
+        onAccept({ id: reservation.id, message: 'Accept Message' })
+      }
+    >
+      Accept Button
+    </button>
+  ),
+}));
+
+vi.mock('@/components/reservation/RejectReservationDialog', () => ({
+  __esModule: true,
+  default: ({ onReject, reservation }: any) => (
+    <button
+      data-testid="reject-btn"
+      onClick={() => onReject({ id: reservation.id, reason: 'Reject Reason' })}
+    >
+      Reject Button
+    </button>
+  ),
+}));
+
+vi.mock('@/components/reservation/CancelReservationDialog', () => ({
+  __esModule: true,
+  default: ({ onConfirmCancel, reservation }: any) => (
+    <button
+      data-testid="cancel-btn"
+      onClick={() =>
+        onConfirmCancel({ id: reservation.id, reason: 'Cancel Reason' })
+      }
+    >
+      Cancel Button
+    </button>
+  ),
+}));
+
+vi.mock('@/components/reservation/ReservationConversationDialog', () => ({
+  __esModule: true,
+  default: () => <div data-testid="conversation-dialog" />,
+}));
+
+// Mock the API client
+vi.mock('@/services/reservations', () => ({
+  updateReservationStatus: vi.fn().mockResolvedValue({}),
+}));
+
+// Mock toast and other modules
+vi.mock('@/components/ui/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn(),
+}));
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+// Mock ReservationCard for fully isolated testing
+vi.mock('./ReservationCard', () => ({
+  ReservationCard: ({ actions, item }: any) => (
+    <div data-testid={`reservation-card-${item.id}`}>
+      {item.name}
+      {actions}
+    </div>
+  ),
+}));
+
+const mockReservation = {
+  id: 'res-abc',
+  name: 'Test Partner',
+  roleLine: 'Designer',
+  date: 'Mon, Jan 01, 2024',
+  time: '10:00 am – 11:00 am',
+  messages: [],
+  scheduleId: 101,
+  dtstart: 1700000000,
+  dtend: 1700003600,
+  senderUserId: 'user-123',
+  participantUserId: 'user-456',
+};
+
+describe('ReservationList', () => {
+  const mockOnMutationSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('triggers onMutationSuccess with ["pending", "upcoming"] when accepting in pending-mentor variant', async () => {
+    render(
+      <ReservationList
+        items={[mockReservation]}
+        variant="pending-mentor"
+        sourceRole="mentor"
+        myUserId="user-123"
+        onMutationSuccess={mockOnMutationSuccess}
+      />
+    );
+
+    const acceptBtn = screen.getByTestId('accept-btn');
+    fireEvent.click(acceptBtn);
+
+    await waitFor(() => {
+      expect(updateReservationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockOnMutationSuccess).toHaveBeenCalledWith('res-abc', [
+      'pending',
+      'upcoming',
+    ]);
+  });
+
+  it('triggers onMutationSuccess with ["pending", "history"] when rejecting in pending-mentor variant', async () => {
+    render(
+      <ReservationList
+        items={[mockReservation]}
+        variant="pending-mentor"
+        sourceRole="mentor"
+        myUserId="user-123"
+        onMutationSuccess={mockOnMutationSuccess}
+      />
+    );
+
+    const rejectBtn = screen.getByTestId('reject-btn');
+    fireEvent.click(rejectBtn);
+
+    await waitFor(() => {
+      expect(updateReservationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockOnMutationSuccess).toHaveBeenCalledWith('res-abc', [
+      'pending',
+      'history',
+    ]);
+  });
+
+  it('triggers onMutationSuccess with ["pending", "history"] when cancelling in pending-mentee variant', async () => {
+    render(
+      <ReservationList
+        items={[mockReservation]}
+        variant="pending-mentee"
+        sourceRole="mentee"
+        myUserId="user-123"
+        onMutationSuccess={mockOnMutationSuccess}
+      />
+    );
+
+    const cancelBtn = screen.getByTestId('cancel-btn');
+    fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      expect(updateReservationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockOnMutationSuccess).toHaveBeenCalledWith('res-abc', [
+      'pending',
+      'history',
+    ]);
+  });
+
+  it('triggers onMutationSuccess with ["upcoming", "history"] when cancelling in upcoming variant', async () => {
+    render(
+      <ReservationList
+        items={[mockReservation]}
+        variant="upcoming"
+        sourceRole="mentor"
+        myUserId="user-123"
+        onMutationSuccess={mockOnMutationSuccess}
+      />
+    );
+
+    const cancelBtn = screen.getByTestId('cancel-btn');
+    fireEvent.click(cancelBtn);
+
+    await waitFor(() => {
+      expect(updateReservationStatus).toHaveBeenCalledTimes(1);
+    });
+
+    expect(mockOnMutationSuccess).toHaveBeenCalledWith('res-abc', [
+      'upcoming',
+      'history',
+    ]);
+  });
+});

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -8,12 +8,10 @@ import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { useToast } from '@/components/ui/use-toast';
+import { ListKey } from '@/hooks/user/reservation/useReservationData';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
-import {
-  ReservationState,
-  updateReservationStatus,
-} from '@/services/reservations';
+import { updateReservationStatus } from '@/services/reservations';
 
 import {
   ReservationCard,
@@ -51,26 +49,23 @@ export function ReservationList({
   // Called after a successful accept / reject / cancel so the parent hook can
   // optimistically remove the operated item and refetch only the affected
   // states in the background.
-  onMutationSuccess?: (id: string, affectedStates: ReservationState[]) => void;
+  onMutationSuccess?: (id: string, affectedTabs: ListKey[]) => void;
 }) {
   const { toast } = useToast();
 
   // Accept on pending-mentor: pending-mentor → upcoming-mentor.
-  const ACCEPT_AFFECTED_STATES: ReservationState[] = [
-    'MENTOR_PENDING',
-    'MENTOR_UPCOMING',
-  ];
+  const ACCEPT_AFFECTED_TABS: ListKey[] = ['pending', 'upcoming'];
 
   // Reject / cancel always lands the reservation in the role's HISTORY list.
   // The source state depends on the variant.
-  const buildRejectOrCancelAffectedStates = (): ReservationState[] => {
-    const upper = sourceRole === 'mentor' ? 'MENTOR' : 'MENTEE';
-    const history = `${upper}_HISTORY` as ReservationState;
-    if (variant === 'upcoming')
-      return [`${upper}_UPCOMING` as ReservationState, history];
-    if (variant === 'pending-mentor') return ['MENTOR_PENDING', history];
-    if (variant === 'pending-mentee') return ['MENTEE_PENDING', history];
-    return [];
+  const buildRejectOrCancelAffectedTabs = (): ListKey[] => {
+    const sourceTab: ListKey | null =
+      variant === 'upcoming'
+        ? 'upcoming'
+        : variant === 'pending-mentor' || variant === 'pending-mentee'
+          ? 'pending'
+          : null;
+    return sourceTab ? [sourceTab, 'history'] : [];
   };
 
   const findItem = (id: string): Reservation => {
@@ -121,7 +116,7 @@ export function ReservationList({
         title: '已接受預約',
         description: '會議連結將於數分鐘內寄至雙方信箱',
       });
-      onMutationSuccess?.(id, ACCEPT_AFFECTED_STATES);
+      onMutationSuccess?.(id, ACCEPT_AFFECTED_TABS);
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_accept',
@@ -168,7 +163,7 @@ export function ReservationList({
 
       trackEvent({ name: 'reservation_rejected', feature: 'reservation' });
       toast({ description: successMessage });
-      onMutationSuccess?.(id, buildRejectOrCancelAffectedStates());
+      onMutationSuccess?.(id, buildRejectOrCancelAffectedTabs());
     } catch (err) {
       captureFlowFailure({
         flow: 'reservation_reject',

--- a/src/hooks/user/reservation/useReservationData.test.ts
+++ b/src/hooks/user/reservation/useReservationData.test.ts
@@ -127,10 +127,7 @@ describe('useReservationData (mentee)', () => {
     mockFetch.mockClear();
 
     await act(async () => {
-      result.current.onMutationSuccess('any-id', [
-        'MENTEE_PENDING',
-        'MENTEE_HISTORY',
-      ]);
+      result.current.onMutationSuccess('any-id', ['pending', 'history']);
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(1);
@@ -149,10 +146,7 @@ describe('useReservationData (mentee)', () => {
     mockFetch.mockClear();
 
     await act(async () => {
-      result.current.onMutationSuccess('any-id', [
-        'MENTEE_PENDING',
-        'MENTEE_HISTORY',
-      ]);
+      result.current.onMutationSuccess('any-id', ['pending', 'history']);
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -164,21 +158,6 @@ describe('useReservationData (mentee)', () => {
       userId: mockSession.user.id,
       state: 'MENTEE_HISTORY',
     });
-  });
-
-  it('onMutationSuccess ignores affectedStates that belong to the other role', async () => {
-    const { result } = renderHook(() => useReservationData({ role: 'mentee' }));
-    await waitFor(() => expect(result.current.isLoading).toBe(false));
-    mockFetch.mockClear();
-
-    await act(async () => {
-      result.current.onMutationSuccess('any-id', [
-        'MENTOR_PENDING',
-        'MENTOR_UPCOMING',
-      ]);
-    });
-
-    expect(mockFetch).not.toHaveBeenCalled();
   });
 
   it('initial fetch failure → data stays null, isLoading becomes false', async () => {
@@ -230,16 +209,16 @@ describe('useReservationData (mentee)', () => {
     });
 
     await act(async () => {
-      void result.current.loadMore('MENTEE_UPCOMING');
+      void result.current.loadMore('upcoming');
     });
-    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(true);
-    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(false);
+    expect(result.current.loadingMoreStates.upcoming).toBe(true);
+    expect(result.current.loadingMoreStates.pending).toBe(false);
 
     await act(async () => {
-      void result.current.loadMore('MENTEE_PENDING');
+      void result.current.loadMore('pending');
     });
-    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(true);
-    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(true);
+    expect(result.current.loadingMoreStates.upcoming).toBe(true);
+    expect(result.current.loadingMoreStates.pending).toBe(true);
 
     await act(async () => {
       resolveUpcoming({
@@ -247,8 +226,8 @@ describe('useReservationData (mentee)', () => {
         next_dtend: 0,
       });
     });
-    expect(result.current.loadingMoreStates.MENTEE_UPCOMING).toBe(false);
-    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(true);
+    expect(result.current.loadingMoreStates.upcoming).toBe(false);
+    expect(result.current.loadingMoreStates.pending).toBe(true);
 
     await act(async () => {
       resolvePending({
@@ -256,7 +235,7 @@ describe('useReservationData (mentee)', () => {
         next_dtend: 0,
       });
     });
-    expect(result.current.loadingMoreStates.MENTEE_PENDING).toBe(false);
+    expect(result.current.loadingMoreStates.pending).toBe(false);
   });
 
   it('component unmounts before fetch resolves → state is NOT updated', async () => {
@@ -315,10 +294,7 @@ describe('useReservationData (mentor)', () => {
     mockFetch.mockClear();
 
     await act(async () => {
-      result.current.onMutationSuccess('any-id', [
-        'MENTOR_PENDING',
-        'MENTOR_UPCOMING',
-      ]);
+      result.current.onMutationSuccess('any-id', ['pending', 'upcoming']);
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
@@ -338,7 +314,7 @@ describe('useReservationData (mentor)', () => {
     mockFetch.mockClear();
 
     await act(async () => {
-      result.current.onMutationSuccess('any-id', ['MENTOR_PENDING']);
+      result.current.onMutationSuccess('any-id', ['pending']);
     });
 
     expect(mockFetch).toHaveBeenCalledWith({

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -21,7 +21,7 @@ export interface ReservationData {
   nextTokens: NextTokens;
 }
 
-type ListKey = 'upcoming' | 'pending' | 'history';
+export type ListKey = 'upcoming' | 'pending' | 'history';
 
 const ROLE_STATES: Record<
   ReservationRole,
@@ -52,15 +52,12 @@ export type ListLoadState = 'idle' | 'loading' | 'ready';
 
 export type InitialListState = Record<ListKey, ListLoadState>;
 
-export type LoadingMoreStates = Record<ReservationState, boolean>;
+export type LoadingMoreStates = Record<ListKey, boolean>;
 
 const EMPTY_LOADING_MORE: LoadingMoreStates = {
-  MENTEE_UPCOMING: false,
-  MENTEE_PENDING: false,
-  MENTEE_HISTORY: false,
-  MENTOR_UPCOMING: false,
-  MENTOR_PENDING: false,
-  MENTOR_HISTORY: false,
+  upcoming: false,
+  pending: false,
+  history: false,
 };
 
 const EMPTY_DATA: ReservationData = {
@@ -85,9 +82,9 @@ export interface UseReservationDataReturn {
   isLoadingHistory: boolean;
   isHistoryLoaded: boolean;
   myUserId: string;
-  loadMore: (state: ReservationState) => Promise<void>;
+  loadMore: (tab: ListKey) => Promise<void>;
   loadHistory: () => Promise<void>;
-  onMutationSuccess: (id: string, affectedStates: ReservationState[]) => void;
+  onMutationSuccess: (id: string, affectedTabs: ListKey[]) => void;
 }
 
 export function useReservationData({
@@ -261,11 +258,12 @@ export function useReservationData({
   );
 
   const onMutationSuccess = useCallback(
-    (id: string, affectedStates: ReservationState[]) => {
+    (id: string, affectedTabs: ListKey[]) => {
       removeItem(id);
+      const affectedStates = affectedTabs.map((tab) => states[tab]);
       void refetchStates(affectedStates);
     },
-    [removeItem, refetchStates]
+    [removeItem, refetchStates, states]
   );
 
   const loadHistory = useCallback(async () => {
@@ -305,15 +303,15 @@ export function useReservationData({
   }, [myUserId, states.history, isHistoryLoaded, isLoadingHistory, updateData]);
 
   const loadMore = useCallback(
-    async (state: ReservationState): Promise<void> => {
+    async (tab: ListKey): Promise<void> => {
       if (!myUserId) return;
       const currentData = dataRef.current;
       if (!currentData) return;
-      const key = STATE_TO_LIST_KEY[state];
-      const cursor = currentData.nextTokens[key];
+      const state = states[tab];
+      const cursor = currentData.nextTokens[tab];
       if (cursor === 0) return;
 
-      setLoadingMoreStates((prev) => ({ ...prev, [state]: true }));
+      setLoadingMoreStates((prev) => ({ ...prev, [tab]: true }));
       try {
         const result = await fetchReservations({
           userId: myUserId,
@@ -323,13 +321,13 @@ export function useReservationData({
 
         updateData((prev) => {
           if (!prev) return prev;
-          const merged = [...prev[key], ...result.items];
+          const merged = [...prev[tab], ...result.items];
           return {
             ...prev,
-            [key]: key === 'history' ? merged : sortByDtstartAsc(merged),
+            [tab]: tab === 'history' ? merged : sortByDtstartAsc(merged),
             nextTokens: {
               ...prev.nextTokens,
-              [key]: result.next_dtend,
+              [tab]: result.next_dtend,
             },
           };
         });
@@ -346,10 +344,10 @@ export function useReservationData({
         });
         console.error('[useReservationData] loadMore error:', err);
       } finally {
-        setLoadingMoreStates((prev) => ({ ...prev, [state]: false }));
+        setLoadingMoreStates((prev) => ({ ...prev, [tab]: false }));
       }
     },
-    [myUserId, updateData]
+    [myUserId, states, updateData]
   );
 
   const historyState: ListLoadState = isHistoryLoaded


### PR DESCRIPTION
Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/349

- Refactor useReservationData to export ListKey and use it in loadMore and onMutationSuccess

- Update ReservationList and ReservationDashboard to use role-independent tab names

- Update tests to match the new decoupled type signatures
