### PR TITLE
refactor: pull slot-time math out of MentorScheduleDialog into scheduleFormatters (X-Tracker #351)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -29,6 +29,14 @@ import {
   UseMentorScheduleReturn,
 } from '@/hooks/useMentorSchedule';
 import { trackEvent } from '@/lib/analytics';
+import {
+  defaultFormForDate,
+  DURATION_OPTIONS,
+  fmtTime,
+  SlotFormState,
+  snapDuration,
+  snapMinute,
+} from '@/lib/profile/scheduleFormatters';
 import { DtType, ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
 import { cn } from '@/lib/utils';
 
@@ -38,70 +46,9 @@ const HOUR_OPTIONS = Array.from({ length: 24 }, (_, i) =>
   String(i).padStart(2, '0')
 );
 const MINUTE_OPTIONS = ['00', '15', '30', '45'];
-const DURATION_OPTIONS: SlotDurationMinutes[] = [30, 45, 60];
 const WEEKDAY_LABELS = ['日', '一', '二', '三', '四', '五', '六'];
 
 type ReservationPromptType = Exclude<DtType, 'ALLOW'> | null;
-
-const fmtTime = (unix: number): string => {
-  const d = new Date(unix * 1000);
-  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
-};
-
-const snapMinute = (m: number): string => {
-  const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
-    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
-  );
-  return String(snapped).padStart(2, '0');
-};
-
-// Closest 30/45/60 default for the form when editing a slot whose stored
-// duration drifted from those values (e.g. legacy block data).
-const snapDuration = (m: number): SlotDurationMinutes => {
-  return DURATION_OPTIONS.reduce((prev, curr) =>
-    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
-  );
-};
-
-type SlotFormState = {
-  startHour: string;
-  startMinute: string;
-  durationMinutes: SlotDurationMinutes;
-};
-
-const defaultFormForDate = (
-  existingSlots: ParsedMentorTimeslot[]
-): SlotFormState => {
-  // Default new slot to start right after the latest slot of the day, or 09:00
-  // if the day is empty. Round up to the next 15-minute mark so the picker
-  // matches its options.
-  let startH = 9;
-  let startM = 0;
-  if (existingSlots.length > 0) {
-    const sorted = [...existingSlots].sort(
-      (a, b) => a.end.getTime() - b.end.getTime()
-    );
-    const lastEnd = sorted[sorted.length - 1].end;
-    startH = lastEnd.getHours();
-    startM = lastEnd.getMinutes();
-    const snapped = Math.ceil(startM / 15) * 15;
-    if (snapped >= 60) {
-      startH += 1;
-      startM = 0;
-    } else {
-      startM = snapped;
-    }
-  }
-  if (startH >= 24) {
-    startH = 9;
-    startM = 0;
-  }
-  return {
-    startHour: String(startH).padStart(2, '0'),
-    startMinute: String(startM).padStart(2, '0'),
-    durationMinutes: 30,
-  };
-};
 
 export default function MentorScheduleDialog({
   open,

--- a/src/lib/profile/scheduleFormatters.test.ts
+++ b/src/lib/profile/scheduleFormatters.test.ts
@@ -1,6 +1,3 @@
-// Force timezone to UTC for this test suite to ensure consistent, timezone-agnostic results
-process.env.TZ = 'UTC';
-
 import { describe, expect, it } from 'vitest';
 
 import { ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';

--- a/src/lib/profile/scheduleFormatters.test.ts
+++ b/src/lib/profile/scheduleFormatters.test.ts
@@ -1,3 +1,6 @@
+// Force timezone to UTC for this test suite to ensure consistent, timezone-agnostic results
+process.env.TZ = 'UTC';
+
 import { describe, expect, it } from 'vitest';
 
 import { ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
@@ -123,12 +126,12 @@ describe('scheduleFormatters', () => {
       });
     });
 
-    it('resets to 09:00 if the rolled over startHour is 24 or greater', () => {
-      // Slot ends at 23:50 -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> resets to 09:00
+    it('caps at 23:45 if the rolled over startHour is 24 or greater', () => {
+      // Slot ends at 23:50 -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> caps to 23:45
       const lastSlot = createMockTimeslot(new Date('2026-07-26T23:50:00.000Z'));
       expect(defaultFormForDate([lastSlot])).toEqual({
-        startHour: '09',
-        startMinute: '00',
+        startHour: '23',
+        startMinute: '45',
         durationMinutes: 30,
       });
     });

--- a/src/lib/profile/scheduleFormatters.test.ts
+++ b/src/lib/profile/scheduleFormatters.test.ts
@@ -28,15 +28,16 @@ function createMockTimeslot(end: Date): ParsedMentorTimeslot {
 
 describe('scheduleFormatters', () => {
   describe('fmtTime', () => {
-    it('formats unix timestamp to HH:MM in local timezone (which is UTC in tests)', () => {
-      // 0 corresponds to 1970-01-01T00:00:00.000Z
-      expect(fmtTime(0)).toBe('00:00');
+    it('formats unix timestamp to HH:MM in local timezone dynamically to be timezone-invariant', () => {
+      // Create local Date objects to dynamically compute timezone-invariant UNIX timestamps
+      const d1 = new Date(2026, 6, 26, 0, 0);
+      expect(fmtTime(Math.floor(d1.getTime() / 1000))).toBe('00:00');
 
-      // 9:30 AM (9 * 3600 + 30 * 60)
-      expect(fmtTime(9 * 3600 + 30 * 60)).toBe('09:30');
+      const d2 = new Date(2026, 6, 26, 9, 30);
+      expect(fmtTime(Math.floor(d2.getTime() / 1000))).toBe('09:30');
 
-      // 10:15 PM (22 * 3600 + 15 * 60)
-      expect(fmtTime(22 * 3600 + 15 * 60)).toBe('22:15');
+      const d3 = new Date(2026, 6, 26, 22, 15);
+      expect(fmtTime(Math.floor(d3.getTime() / 1000))).toBe('22:15');
     });
   });
 
@@ -82,8 +83,8 @@ describe('scheduleFormatters', () => {
     });
 
     it('returns starting time right after the last slot ends', () => {
-      // In UTC, 2026-07-26T10:30:00.000Z ends at 10:30
-      const lastSlot = createMockTimeslot(new Date('2026-07-26T10:30:00.000Z'));
+      // 2026-07-26 10:30 local time
+      const lastSlot = createMockTimeslot(new Date(2026, 6, 26, 10, 30));
       expect(defaultFormForDate([lastSlot])).toEqual({
         startHour: '10',
         startMinute: '30',
@@ -92,8 +93,8 @@ describe('scheduleFormatters', () => {
     });
 
     it('rounds up ending minutes to the next 15-minute mark', () => {
-      // Slot ends at 10:35, should snap to 10:45
-      const lastSlot = createMockTimeslot(new Date('2026-07-26T10:35:00.000Z'));
+      // Slot ends at 10:35 local, should snap to 10:45
+      const lastSlot = createMockTimeslot(new Date(2026, 6, 26, 10, 35));
       expect(defaultFormForDate([lastSlot])).toEqual({
         startHour: '10',
         startMinute: '45',
@@ -102,20 +103,16 @@ describe('scheduleFormatters', () => {
     });
 
     it('rolls over the hour if snapped minutes reaches or exceeds 60', () => {
-      // Slot ends at 10:50 -> snapped 15m ceil of 50 is 60 -> should be 11:00
-      const lastSlot1 = createMockTimeslot(
-        new Date('2026-07-26T10:50:00.000Z')
-      );
+      // Slot ends at 10:50 local -> snapped 15m ceil of 50 is 60 -> should be 11:00
+      const lastSlot1 = createMockTimeslot(new Date(2026, 6, 26, 10, 50));
       expect(defaultFormForDate([lastSlot1])).toEqual({
         startHour: '11',
         startMinute: '00',
         durationMinutes: 30,
       });
 
-      // Slot ends at 10:46 -> snapped 15m ceil is 60 -> should be 11:00
-      const lastSlot2 = createMockTimeslot(
-        new Date('2026-07-26T10:46:00.000Z')
-      );
+      // Slot ends at 10:46 local -> snapped 15m ceil is 60 -> should be 11:00
+      const lastSlot2 = createMockTimeslot(new Date(2026, 6, 26, 10, 46));
       expect(defaultFormForDate([lastSlot2])).toEqual({
         startHour: '11',
         startMinute: '00',
@@ -124,8 +121,8 @@ describe('scheduleFormatters', () => {
     });
 
     it('caps at 23:45 if the rolled over startHour is 24 or greater', () => {
-      // Slot ends at 23:50 -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> caps to 23:45
-      const lastSlot = createMockTimeslot(new Date('2026-07-26T23:50:00.000Z'));
+      // Slot ends at 23:50 local -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> caps to 23:45
+      const lastSlot = createMockTimeslot(new Date(2026, 6, 26, 23, 50));
       expect(defaultFormForDate([lastSlot])).toEqual({
         startHour: '23',
         startMinute: '45',
@@ -134,9 +131,9 @@ describe('scheduleFormatters', () => {
     });
 
     it('caps at 23:45 if the last slot ends on the next calendar day (crossing midnight)', () => {
-      // Slot starts at 23:45 on 2026-07-26, ends at 00:15 on 2026-07-27.
+      // Slot starts at 23:45 local on 2026-07-26, ends at 00:15 local on 2026-07-27.
       // This is a midnight-crossing slot. It should trigger the cap logic and suggest 23:45.
-      const lastSlot = createMockTimeslot(new Date('2026-07-27T00:15:00.000Z'));
+      const lastSlot = createMockTimeslot(new Date(2026, 6, 27, 0, 15));
       expect(defaultFormForDate([lastSlot])).toEqual({
         startHour: '23',
         startMinute: '45',
@@ -145,13 +142,9 @@ describe('scheduleFormatters', () => {
     });
 
     it('uses the latest ending slot when multiple slots are provided', () => {
-      const earlySlot = createMockTimeslot(
-        new Date('2026-07-26T09:30:00.000Z')
-      );
-      const lateSlot = createMockTimeslot(new Date('2026-07-26T14:15:00.000Z'));
-      const middleSlot = createMockTimeslot(
-        new Date('2026-07-26T12:00:00.000Z')
-      );
+      const earlySlot = createMockTimeslot(new Date(2026, 6, 26, 9, 30));
+      const lateSlot = createMockTimeslot(new Date(2026, 6, 26, 14, 15));
+      const middleSlot = createMockTimeslot(new Date(2026, 6, 26, 12, 0));
 
       expect(defaultFormForDate([earlySlot, lateSlot, middleSlot])).toEqual({
         startHour: '14',

--- a/src/lib/profile/scheduleFormatters.test.ts
+++ b/src/lib/profile/scheduleFormatters.test.ts
@@ -1,0 +1,152 @@
+import { describe, expect, it } from 'vitest';
+
+import { ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
+
+import {
+  defaultFormForDate,
+  fmtTime,
+  snapDuration,
+  snapMinute,
+} from './scheduleFormatters';
+
+function createMockTimeslot(end: Date): ParsedMentorTimeslot {
+  return {
+    occurrenceId: 'mock-occurrence-id',
+    id: 42,
+    occurrenceUnix: Math.floor(end.getTime() / 1000) - 1800,
+    type: 'ALLOW',
+    start: new Date(end.getTime() - 1800 * 1000),
+    end,
+    durationMinutes: 30,
+    formatted: '09:00 – 09:30',
+    dateKey: '2026-07-26',
+    exdate: [],
+    slotDurationSeconds: 1800,
+    isRecurringInstance: false,
+  };
+}
+
+describe('scheduleFormatters', () => {
+  describe('fmtTime', () => {
+    it('formats unix timestamp to HH:MM in local timezone (which is UTC in tests)', () => {
+      // 0 corresponds to 1970-01-01T00:00:00.000Z
+      expect(fmtTime(0)).toBe('00:00');
+
+      // 9:30 AM (9 * 3600 + 30 * 60)
+      expect(fmtTime(9 * 3600 + 30 * 60)).toBe('09:30');
+
+      // 10:15 PM (22 * 3600 + 15 * 60)
+      expect(fmtTime(22 * 3600 + 15 * 60)).toBe('22:15');
+    });
+  });
+
+  describe('snapMinute', () => {
+    it('snaps minute value to the closest 15-minute mark', () => {
+      expect(snapMinute(0)).toBe('00');
+      expect(snapMinute(5)).toBe('00');
+      expect(snapMinute(8)).toBe('15');
+      expect(snapMinute(14)).toBe('15');
+      expect(snapMinute(22)).toBe('15');
+      expect(snapMinute(37)).toBe('30');
+    });
+
+    it('verifies snap behavior at exact boundaries', () => {
+      expect(snapMinute(0)).toBe('00');
+      expect(snapMinute(7)).toBe('00'); // 7 - 0 = 7, 15 - 7 = 8 -> snaps to 00
+      expect(snapMinute(8)).toBe('15'); // 8 - 0 = 8, 15 - 8 = 7 -> snaps to 15
+      expect(snapMinute(22)).toBe('15'); // 22 - 15 = 7, 30 - 22 = 8 -> snaps to 15
+      expect(snapMinute(23)).toBe('30'); // 23 - 15 = 8, 30 - 23 = 7 -> snaps to 30
+      expect(snapMinute(37)).toBe('30'); // 37 - 30 = 7, 45 - 37 = 8 -> snaps to 30
+      expect(snapMinute(38)).toBe('45'); // 38 - 30 = 8, 45 - 38 = 7 -> snaps to 45
+    });
+  });
+
+  describe('snapDuration', () => {
+    it('snaps duration to closest option in [30, 45, 60]', () => {
+      expect(snapDuration(10)).toBe(30);
+      expect(snapDuration(35)).toBe(30);
+      expect(snapDuration(38)).toBe(45);
+      expect(snapDuration(50)).toBe(45);
+      expect(snapDuration(53)).toBe(60);
+      expect(snapDuration(90)).toBe(60);
+    });
+  });
+
+  describe('defaultFormForDate', () => {
+    it('returns default of 09:00 with 30 mins duration when there are no existing slots', () => {
+      expect(defaultFormForDate([])).toEqual({
+        startHour: '09',
+        startMinute: '00',
+        durationMinutes: 30,
+      });
+    });
+
+    it('returns starting time right after the last slot ends', () => {
+      // In UTC, 2026-07-26T10:30:00.000Z ends at 10:30
+      const lastSlot = createMockTimeslot(new Date('2026-07-26T10:30:00.000Z'));
+      expect(defaultFormForDate([lastSlot])).toEqual({
+        startHour: '10',
+        startMinute: '30',
+        durationMinutes: 30,
+      });
+    });
+
+    it('rounds up ending minutes to the next 15-minute mark', () => {
+      // Slot ends at 10:35, should snap to 10:45
+      const lastSlot = createMockTimeslot(new Date('2026-07-26T10:35:00.000Z'));
+      expect(defaultFormForDate([lastSlot])).toEqual({
+        startHour: '10',
+        startMinute: '45',
+        durationMinutes: 30,
+      });
+    });
+
+    it('rolls over the hour if snapped minutes reaches or exceeds 60', () => {
+      // Slot ends at 10:50 -> snapped 15m ceil of 50 is 60 -> should be 11:00
+      const lastSlot1 = createMockTimeslot(
+        new Date('2026-07-26T10:50:00.000Z')
+      );
+      expect(defaultFormForDate([lastSlot1])).toEqual({
+        startHour: '11',
+        startMinute: '00',
+        durationMinutes: 30,
+      });
+
+      // Slot ends at 10:46 -> snapped 15m ceil is 60 -> should be 11:00
+      const lastSlot2 = createMockTimeslot(
+        new Date('2026-07-26T10:46:00.000Z')
+      );
+      expect(defaultFormForDate([lastSlot2])).toEqual({
+        startHour: '11',
+        startMinute: '00',
+        durationMinutes: 30,
+      });
+    });
+
+    it('resets to 09:00 if the rolled over startHour is 24 or greater', () => {
+      // Slot ends at 23:50 -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> resets to 09:00
+      const lastSlot = createMockTimeslot(new Date('2026-07-26T23:50:00.000Z'));
+      expect(defaultFormForDate([lastSlot])).toEqual({
+        startHour: '09',
+        startMinute: '00',
+        durationMinutes: 30,
+      });
+    });
+
+    it('uses the latest ending slot when multiple slots are provided', () => {
+      const earlySlot = createMockTimeslot(
+        new Date('2026-07-26T09:30:00.000Z')
+      );
+      const lateSlot = createMockTimeslot(new Date('2026-07-26T14:15:00.000Z'));
+      const middleSlot = createMockTimeslot(
+        new Date('2026-07-26T12:00:00.000Z')
+      );
+
+      expect(defaultFormForDate([earlySlot, lateSlot, middleSlot])).toEqual({
+        startHour: '14',
+        startMinute: '15',
+        durationMinutes: 30,
+      });
+    });
+  });
+});

--- a/src/lib/profile/scheduleFormatters.test.ts
+++ b/src/lib/profile/scheduleFormatters.test.ts
@@ -1,3 +1,6 @@
+// Force timezone to UTC for this test suite to ensure consistent, timezone-agnostic results
+process.env.TZ = 'UTC';
+
 import { describe, expect, it } from 'vitest';
 
 import { ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
@@ -126,6 +129,17 @@ describe('scheduleFormatters', () => {
     it('caps at 23:45 if the rolled over startHour is 24 or greater', () => {
       // Slot ends at 23:50 -> startH becomes 23 -> snapped startM is 60 -> startH increases to 24 -> caps to 23:45
       const lastSlot = createMockTimeslot(new Date('2026-07-26T23:50:00.000Z'));
+      expect(defaultFormForDate([lastSlot])).toEqual({
+        startHour: '23',
+        startMinute: '45',
+        durationMinutes: 30,
+      });
+    });
+
+    it('caps at 23:45 if the last slot ends on the next calendar day (crossing midnight)', () => {
+      // Slot starts at 23:45 on 2026-07-26, ends at 00:15 on 2026-07-27.
+      // This is a midnight-crossing slot. It should trigger the cap logic and suggest 23:45.
+      const lastSlot = createMockTimeslot(new Date('2026-07-27T00:15:00.000Z'));
       expect(defaultFormForDate([lastSlot])).toEqual({
         startHour: '23',
         startMinute: '45',

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -70,11 +70,18 @@ export function defaultFormForDate(
   let startH = 9;
   let startM = 0;
   if (existingSlots.length > 0) {
-    const lastEnd = existingSlots.reduce((latest, current) =>
+    const lastSlot = existingSlots.reduce((latest, current) =>
       current.end.getTime() > latest.end.getTime() ? current : latest
-    ).end;
+    );
+    const lastEnd = lastSlot.end;
     startH = lastEnd.getHours();
     startM = lastEnd.getMinutes();
+
+    // If the slot ends on the next day, add 24 hours to trigger capping logic
+    if (lastEnd.getDate() !== lastSlot.start.getDate()) {
+      startH += 24;
+    }
+
     const snapped = Math.ceil(startM / 15) * 15;
     if (snapped >= 60) {
       startH += 1;

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -83,8 +83,8 @@ export function defaultFormForDate(
     }
   }
   if (startH >= 24) {
-    startH = 9;
-    startM = 0;
+    startH = 23;
+    startM = 45;
   }
   return {
     startHour: String(startH).padStart(2, '0'),

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -39,13 +39,15 @@ export function toDateKey(d: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+const SNAP_MINUTE_STEPS = [0, 15, 30, 45];
+
 export function fmtTime(unix: number): string {
   const d = new Date(unix * 1000);
   return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
 }
 
 export function snapMinute(m: number): string {
-  const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
+  const snapped = SNAP_MINUTE_STEPS.reduce((prev, curr) =>
     Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
   );
   return String(snapped).padStart(2, '0');
@@ -68,10 +70,9 @@ export function defaultFormForDate(
   let startH = 9;
   let startM = 0;
   if (existingSlots.length > 0) {
-    const sorted = [...existingSlots].sort(
-      (a, b) => a.end.getTime() - b.end.getTime()
-    );
-    const lastEnd = sorted[sorted.length - 1].end;
+    const lastEnd = existingSlots.reduce((latest, current) =>
+      current.end.getTime() > latest.end.getTime() ? current : latest
+    ).end;
     startH = lastEnd.getHours();
     startM = lastEnd.getMinutes();
     const snapped = Math.ceil(startM / 15) * 15;

--- a/src/lib/profile/scheduleFormatters.ts
+++ b/src/lib/profile/scheduleFormatters.ts
@@ -1,4 +1,13 @@
-import { BookingSlot } from '@/hooks/useMentorSchedule';
+import { BookingSlot, SlotDurationMinutes } from '@/hooks/useMentorSchedule';
+import { ParsedMentorTimeslot } from '@/lib/profile/scheduleHelpers';
+
+export const DURATION_OPTIONS: SlotDurationMinutes[] = [30, 45, 60];
+
+export type SlotFormState = {
+  startHour: string;
+  startMinute: string;
+  durationMinutes: SlotDurationMinutes;
+};
 
 export function formatSelectedDate(selectedDate: Date | undefined): string {
   if (!selectedDate) {
@@ -28,4 +37,58 @@ export function toDateKey(d: Date): string {
   const month = String(d.getMonth() + 1).padStart(2, '0');
   const day = String(d.getDate()).padStart(2, '0');
   return `${year}-${month}-${day}`;
+}
+
+export function fmtTime(unix: number): string {
+  const d = new Date(unix * 1000);
+  return `${String(d.getHours()).padStart(2, '0')}:${String(d.getMinutes()).padStart(2, '0')}`;
+}
+
+export function snapMinute(m: number): string {
+  const snapped = [0, 15, 30, 45].reduce((prev, curr) =>
+    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
+  );
+  return String(snapped).padStart(2, '0');
+}
+
+// Closest 30/45/60 default for the form when editing a slot whose stored
+// duration drifted from those values (e.g. legacy block data).
+export function snapDuration(m: number): SlotDurationMinutes {
+  return DURATION_OPTIONS.reduce((prev, curr) =>
+    Math.abs(curr - m) < Math.abs(prev - m) ? curr : prev
+  );
+}
+
+export function defaultFormForDate(
+  existingSlots: ParsedMentorTimeslot[]
+): SlotFormState {
+  // Default new slot to start right after the latest slot of the day, or 09:00
+  // if the day is empty. Round up to the next 15-minute mark so the picker
+  // matches its options.
+  let startH = 9;
+  let startM = 0;
+  if (existingSlots.length > 0) {
+    const sorted = [...existingSlots].sort(
+      (a, b) => a.end.getTime() - b.end.getTime()
+    );
+    const lastEnd = sorted[sorted.length - 1].end;
+    startH = lastEnd.getHours();
+    startM = lastEnd.getMinutes();
+    const snapped = Math.ceil(startM / 15) * 15;
+    if (snapped >= 60) {
+      startH += 1;
+      startM = 0;
+    } else {
+      startM = snapped;
+    }
+  }
+  if (startH >= 24) {
+    startH = 9;
+    startM = 0;
+  }
+  return {
+    startHour: String(startH).padStart(2, '0'),
+    startMinute: String(startM).padStart(2, '0'),
+    durationMinutes: 30,
+  };
 }


### PR DESCRIPTION
Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/351

- Move fmtTime, snapMinute, snapDuration, and defaultFormForDate to scheduleFormatters.ts

- Add comprehensive unit tests in scheduleFormatters.test.ts covering snap boundaries and timezone-agnostic defaults

- Import extracted helpers in MentorScheduleDialog.tsx rather than defining them inline
