### PR TITLE
refactor: 讓 Profile Save 流程收斂成一個深模組 (X-Tracker #352)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -17,6 +17,32 @@
     "prefer-const": "error",
     "no-var": "error"
   },
+  "overrides": [
+    {
+      "files": ["src/lib/profile/saveProfile.ts"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "react",
+                "message": "saveProfile.ts is a deep module and should not import react."
+              },
+              {
+                "name": "next/navigation",
+                "message": "saveProfile.ts is a deep module and should not import next/navigation."
+              },
+              {
+                "name": "next-auth/react",
+                "message": "saveProfile.ts is a deep module and should not import next-auth/react."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ],
   "ignorePatterns": [
     "node_modules/",
     ".next/",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -37,6 +37,12 @@
                 "name": "next-auth/react",
                 "message": "saveProfile.ts is a deep module and should not import next-auth/react."
               }
+            ],
+            "patterns": [
+              {
+                "group": ["@/hooks/**"],
+                "message": "saveProfile.ts is a deep module and should not import from the hooks layer."
+              }
             ]
           }
         ]

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -12,89 +12,20 @@ vi.mock('@/components/ui/use-toast', async () => {
   return useToastMockFactory();
 });
 
-vi.mock('@/services/profile/updateAvatar', () => ({
-  updateAvatar: vi.fn(),
+vi.mock('@/lib/profile/saveProfile', () => ({
+  saveProfile: vi.fn(),
 }));
 
-vi.mock('@/services/profile/updateProfile', () => ({
-  updateProfile: vi.fn(),
-}));
-
-vi.mock('@/lib/profile/pollUntilSynced', () => ({
-  pollUntilSynced: vi.fn(),
-  firstSyncedFetch: vi.fn(),
-}));
-
-vi.mock('@/hooks/user/user-data/useUserData', () => ({
-  clearUserDataCache: vi.fn(),
-  primeUserDataCache: vi.fn(),
-}));
-
-vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
-vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
-
-import {
-  clearUserDataCache,
-  primeUserDataCache,
-} from '@/hooks/user/user-data/useUserData';
-import {
-  firstSyncedFetch,
-  pollUntilSynced,
-} from '@/lib/profile/pollUntilSynced';
+import { saveProfile } from '@/lib/profile/saveProfile';
 import { defaultValues } from '@/schemas/profileSchema';
-import { ExperienceType } from '@/services/profile/experienceType';
-import { updateAvatar } from '@/services/profile/updateAvatar';
-import { updateProfile } from '@/services/profile/updateProfile';
-import type { MentorProfileVO } from '@/services/profile/user';
-import { mockRouter } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
 
 import { useProfileSubmit } from './useProfileSubmit';
 
-const mockUpdateAvatar = vi.mocked(updateAvatar);
-const mockUpdateProfile = vi.mocked(updateProfile);
-const mockPollUntilSynced = vi.mocked(pollUntilSynced);
-const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
-const mockPrimeUserDataCache = vi.mocked(primeUserDataCache);
-const mockClearUserDataCache = vi.mocked(clearUserDataCache);
-
-const mockUserDTO: MentorProfileVO = {
-  user_id: 1,
-  name: 'Test User',
-  avatar: 'https://example.com/avatar.jpg',
-  job_title: 'Engineer',
-  company: 'Acme',
-  years_of_experience: '1_3',
-  location: 'Taiwan',
-  // BFF emits industry as the enriched TagVO-shape Dict on read; OpenAPI
-  // generator normalises it to `Record<string, never>` because the BFF
-  // model annotates it `Optional[Dict[str, Any]]`. Cast through to express
-  // the runtime shape without committing the test to the TagVO interface.
-  industry: {
-    id: 1,
-    kind: 'industry',
-    subject_group: 'tech',
-    subject: 'software',
-    language: 'zh_TW',
-  } as unknown as MentorProfileVO['industry'],
-  onboarding: true,
-  is_mentor: true,
-  language: 'zh_TW',
-  personal_statement: null,
-  about: null,
-  seniority_level: null,
-  want_position: null,
-  want_skill: null,
-  want_topic: null,
-  have_skill: null,
-  have_topic: null,
-};
+const mockSaveProfile = vi.mocked(saveProfile);
 
 const mockSession: Session = {
   user: {
-    // Real sessions store user_id as a numeric string. The cache key is
-    // built via Number(id) so a non-numeric placeholder would silently
-    // become NaN and skip the cache prime path.
     id: '1',
     name: 'Test User',
     email: 'test@example.com',
@@ -110,9 +41,6 @@ const baseValues = {
   name: 'Test User',
   location: 'Taiwan',
   years_of_experience: '1_3',
-  want_position: ['engineer'],
-  want_skill: ['TypeScript'],
-  want_topic: ['frontend'],
 };
 
 const makeOptions = (
@@ -124,799 +52,73 @@ const makeOptions = (
   updateSession: vi.fn().mockResolvedValue(mockSession),
   jobSectionError: false,
   educationSectionError: false,
+  onScrollToError: vi.fn(),
+  consumeAvatarUpload: vi.fn(),
   ...overrides,
 });
 
-// Pull the experiences array from the most-recent updateProfile call. Tests
-// assert against this shape rather than counting separate experience PUTs;
-// experiences travel inline now.
-function lastExperiences(): unknown[] | undefined {
-  const lastCall =
-    mockUpdateProfile.mock.calls[mockUpdateProfile.mock.calls.length - 1];
-  if (!lastCall) return undefined;
-  const arg = lastCall[0] as { experiences?: unknown[] };
-  return arg.experiences;
-}
-
-function categoriesIn(payload: unknown): string[] {
-  if (!Array.isArray(payload)) return [];
-  return (payload as { category?: string }[]).map((e) => e.category ?? '');
-}
-
-describe('useProfileSubmit', () => {
+describe('useProfileSubmit (Hook Layer)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockUpdateProfile.mockResolvedValue(undefined);
-    mockPollUntilSynced.mockResolvedValue(mockUserDTO);
-    // Default: backend has not synced fast enough → exercise the historical
-    // clear-cache + background-poll fallback. Tests covering the new prime
-    // path override this per-case.
-    mockFirstSyncedFetch.mockResolvedValue(null);
   });
 
-  // ── Guard clauses ──────────────────────────────────────────────────────────
-
-  it('jobSectionError: true → returns early, no service is called', async () => {
+  it('jobSectionError: true → returns early, onScrollToError is called, and saveProfile is NOT called', async () => {
+    const onScrollToError = vi.fn();
     const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ jobSectionError: true }))
+      useProfileSubmit(makeOptions({ jobSectionError: true, onScrollToError }))
     );
 
     await act(async () => {
       await result.current.onSubmit(baseValues);
     });
 
-    expect(mockUpdateProfile).not.toHaveBeenCalled();
-    expect(mockPollUntilSynced).not.toHaveBeenCalled();
-    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(onScrollToError).toHaveBeenCalledWith('work_experiences');
+    expect(mockSaveProfile).not.toHaveBeenCalled();
   });
 
-  it('educationSectionError: true → returns early, no service is called', async () => {
+  it('educationSectionError: true → returns early, onScrollToError is called, and saveProfile is NOT called', async () => {
+    const onScrollToError = vi.fn();
     const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ educationSectionError: true }))
+      useProfileSubmit(
+        makeOptions({ educationSectionError: true, onScrollToError })
+      )
     );
 
     await act(async () => {
       await result.current.onSubmit(baseValues);
     });
 
-    expect(mockUpdateProfile).not.toHaveBeenCalled();
-    expect(mockPollUntilSynced).not.toHaveBeenCalled();
-    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(onScrollToError).toHaveBeenCalledWith('educations');
+    expect(mockSaveProfile).not.toHaveBeenCalled();
   });
 
-  // ── Avatar upload ──────────────────────────────────────────────────────────
-
-  it('no avatarFile → updateAvatar is NOT called', async () => {
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: undefined });
-    });
-
-    expect(mockUpdateAvatar).not.toHaveBeenCalled();
-  });
-
-  it('avatarFile present + upload succeeds → returned URL is used in profile payload', async () => {
-    const newAvatarUrl = 'https://example.com/new-avatar.jpg';
-    mockUpdateAvatar.mockResolvedValueOnce(newAvatarUrl);
-
-    const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' });
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: file });
-    });
-
-    expect(mockUpdateAvatar).toHaveBeenCalledWith(file);
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ avatar: newAvatarUrl })
-    );
-  });
-
-  it('avatarFile present + updateAvatar throws → isSaving returns to false', async () => {
-    mockUpdateAvatar.mockRejectedValueOnce(new Error('Upload failed'));
-
-    const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' });
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: file });
-    });
-
-    expect(result.current.isSaving).toBe(false);
-  });
-
-  // ── Service failures ───────────────────────────────────────────────────────
-
-  it('updateProfile throws → isSaving returns to false', async () => {
-    mockUpdateProfile.mockRejectedValueOnce(new Error('Profile update failed'));
-
+  it('saveProfile resolves successfully → isSaving remains true (simulating in-flight navigation)', async () => {
+    mockSaveProfile.mockResolvedValueOnce(undefined);
     const { result } = renderHook(() => useProfileSubmit(makeOptions()));
 
     await act(async () => {
       await result.current.onSubmit(baseValues);
     });
 
-    expect(result.current.isSaving).toBe(false);
+    expect(mockSaveProfile).toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(true);
   });
 
-  // ── Error feedback (toast) ────────────────────────────────────────────────
-
-  it('updateProfile throws → destructive toast with generic save-failed message', async () => {
-    mockUpdateProfile.mockRejectedValueOnce(new Error('Profile update failed'));
-
+  it('saveProfile throws → error is caught, toast is called, and isSaving becomes false', async () => {
+    mockSaveProfile.mockRejectedValueOnce(new Error('Save failed'));
     const { result } = renderHook(() => useProfileSubmit(makeOptions()));
 
     await act(async () => {
       await result.current.onSubmit(baseValues);
     });
 
+    expect(mockSaveProfile).toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'destructive',
         description: '儲存失敗，請稍後再試',
       })
     );
-  });
-
-  it('avatar upload throws → destructive toast still fires (inner catch re-throws)', async () => {
-    mockUpdateAvatar.mockRejectedValueOnce(new Error('Upload failed'));
-
-    const file = new File(['c'], 'avatar.jpg', { type: 'image/jpeg' });
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: file });
-    });
-
-    expect(mockToast).toHaveBeenCalledWith(
-      expect.objectContaining({ variant: 'destructive' })
-    );
-  });
-
-  it('happy path → no toast is fired', async () => {
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockToast).not.toHaveBeenCalled();
-  });
-
-  // ── Inline experiences ────────────────────────────────────────────────────
-
-  it('no dirtyFields → updateProfile fires with full experiences inline (legacy callers send everything)', async () => {
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
-    // baseValues has empty work/edu/links → still send all 3 categories so
-    // backend overwrites with empty data arrays.
-    expect(categoriesIn(lastExperiences())).toEqual([
-      ExperienceType.WORK,
-      ExperienceType.EDUCATION,
-      ExperienceType.LINK,
-    ]);
-  });
-
-  it('work_experiences dirty → experiences batch in payload reflects work data', async () => {
-    const valuesWithWork = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: true,
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithWork, {
-        work_experiences: [{ job: true }],
-      });
-    });
-
-    const exp = lastExperiences() as
-      | { category: string; mentor_experiences_metadata: { data: unknown[] } }[]
-      | undefined;
-    expect(exp).toBeDefined();
-    const work = exp!.find((e) => e.category === ExperienceType.WORK);
-    expect(work?.mentor_experiences_metadata.data).toHaveLength(1);
-  });
-
-  it('only `name` dirty → experiences are NOT sent (backend leaves the column alone)', async () => {
-    const valuesWithEverything = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithEverything, { name: true });
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
-    expect(lastExperiences()).toBeUndefined();
-  });
-
-  it('dirty link field triggers experiences inline (nested dirtyFields shape)', async () => {
-    const valuesWithLink = {
-      ...baseValues,
-      linkedin: {
-        id: -1,
-        url: 'https://linkedin.com/in/me',
-        platform: 'linkedin',
-      },
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithLink, {
-        // RHF reports nested dirty as { url: true } for object fields.
-        linkedin: { url: true },
-      });
-    });
-
-    const exp = lastExperiences() as
-      | { category: string; mentor_experiences_metadata: { data: unknown[] } }[]
-      | undefined;
-    expect(exp).toBeDefined();
-    const links = exp!.find((e) => e.category === ExperienceType.LINK);
-    expect(links?.mentor_experiences_metadata.data).toHaveLength(1);
-  });
-
-  // ── Navigation on success ──────────────────────────────────────────────────
-
-  it('isMentorOnboarding: false → router.push("/profile/:pageUserId")', async () => {
-    const { result } = renderHook(() =>
-      useProfileSubmit(
-        makeOptions({ isMentorOnboarding: false, pageUserId: 'test-user-id' })
-      )
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/test-user-id');
-  });
-
-  it('isMentorOnboarding: true → router.push("/profile/card")', async () => {
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
-  });
-
-  // ── Optimistic flow: poll runs in the background ───────────────────────────
-
-  it('navigation does not wait for pollUntilSynced to resolve', async () => {
-    // Never-resolving promise simulates a slow backend sync. The user must
-    // still be navigated away within a single tick.
-    let resolvePoll: (value: MentorProfileVO | null) => void = () => {};
-    mockPollUntilSynced.mockReturnValueOnce(
-      new Promise<MentorProfileVO | null>((resolve) => {
-        resolvePoll = resolve;
-      })
-    );
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/test-user-id');
-    // Cleanly settle the dangling promise to avoid leaking into later tests.
-    resolvePoll(null);
-  });
-
-  it('optimistic session update preserves current isMentor / onBoarding (does not flicker from latest=null)', async () => {
-    // Background poll resolves to null (e.g. backend never synced) — the
-    // session update made BEFORE the navigation must still reflect the
-    // pre-submit isMentor/onBoarding values.
-    mockPollUntilSynced.mockResolvedValueOnce(null);
-
-    const updateSession = vi.fn().mockResolvedValue(mockSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ updateSession }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(updateSession).toHaveBeenCalled();
-    const firstCallArg = updateSession.mock.calls[0][0] as {
-      user: { isMentor?: boolean; onBoarding?: boolean };
-    };
-    expect(firstCallArg.user.isMentor).toBe(true);
-    expect(firstCallArg.user.onBoarding).toBe(true);
-  });
-
-  it('isMentorOnboarding: true with mentee session → optimistic update flips isMentor/onBoarding to true', async () => {
-    // Repro for the dropdown bug: an existing mentee submits the "成為導師"
-    // onboarding form, but the header keeps showing "成為導師" because the
-    // optimistic update preserved the stale isMentor=false until the
-    // background poll reconciled (up to 60s later). Onboarding is a known
-    // mentee → mentor transition, so we flip both flags immediately.
-    const menteeSession: Session = {
-      ...mockSession,
-      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
-    };
-    const updateSession = vi.fn().mockResolvedValue(menteeSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(
-        makeOptions({
-          session: menteeSession,
-          updateSession,
-          isMentorOnboarding: true,
-        })
-      )
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    const firstCallArg = updateSession.mock.calls[0][0] as {
-      user: { isMentor?: boolean; onBoarding?: boolean };
-    };
-    expect(firstCallArg.user.isMentor).toBe(true);
-    expect(firstCallArg.user.onBoarding).toBe(true);
-  });
-
-  it('isMentorOnboarding: true with mentee session → reconcile is a no-op when backend confirms is_mentor=true', async () => {
-    // Backend has caught up and reports is_mentor=true, matching our
-    // optimistic flip — no second updateSession call needed.
-    const menteeSession: Session = {
-      ...mockSession,
-      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
-    };
-    mockPollUntilSynced.mockResolvedValueOnce({
-      ...mockUserDTO,
-      is_mentor: true,
-      onboarding: true,
-    });
-    const updateSession = vi.fn().mockResolvedValue(menteeSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(
-        makeOptions({
-          session: menteeSession,
-          updateSession,
-          isMentorOnboarding: true,
-        })
-      )
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(updateSession).toHaveBeenCalledTimes(1);
-  });
-
-  it('background reconcile patches session when latest disagrees with optimistic role', async () => {
-    // Optimistic session: isMentor=true. Backend poll says isMentor=false.
-    mockPollUntilSynced.mockResolvedValueOnce({
-      ...mockUserDTO,
-      is_mentor: false,
-      onboarding: true,
-    });
-
-    const updateSession = vi.fn().mockResolvedValue(mockSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ updateSession }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      // Flush microtasks so the .then() reconcile callback runs.
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // First call: optimistic. Second call: reconcile.
-    expect(updateSession).toHaveBeenCalledTimes(2);
-    const reconcileArg = updateSession.mock.calls[1][0] as {
-      user: { isMentor?: boolean; onBoarding?: boolean };
-    };
-    expect(reconcileArg.user.isMentor).toBe(false);
-    expect(reconcileArg.user.onBoarding).toBe(true);
-  });
-
-  it('background reconcile is a no-op when latest matches optimistic session', async () => {
-    // Backend agrees with optimistic state — no second updateSession call.
-    mockPollUntilSynced.mockResolvedValueOnce({
-      ...mockUserDTO,
-      is_mentor: true,
-      onboarding: true,
-    });
-
-    const updateSession = vi.fn().mockResolvedValue(mockSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ updateSession }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(updateSession).toHaveBeenCalledTimes(1);
-  });
-
-  // ── Cache prime vs fallback ────────────────────────────────────────────────
-
-  it('firstSyncedFetch returns dto → primeUserDataCache called, pollUntilSynced NOT called', async () => {
-    mockFirstSyncedFetch.mockResolvedValueOnce(mockUserDTO);
-
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      // Flush microtasks so the background prime + reconcile resolve.
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // Cache is cleared optimistically pre-navigation; the prime that follows
-    // the background firstSyncedFetch refills it with the synced dto.
-    expect(mockClearUserDataCache).toHaveBeenCalledWith(
-      Number(mockSession.user!.id),
-      'zh_TW'
-    );
-    expect(mockPrimeUserDataCache).toHaveBeenCalledWith(
-      Number(mockSession.user!.id),
-      'zh_TW',
-      mockUserDTO
-    );
-    expect(mockPollUntilSynced).not.toHaveBeenCalled();
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
-  });
-
-  it('firstSyncedFetch returns null → falls back to clearUserDataCache + pollUntilSynced', async () => {
-    mockFirstSyncedFetch.mockResolvedValueOnce(null);
-
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    expect(mockPrimeUserDataCache).not.toHaveBeenCalled();
-    expect(mockClearUserDataCache).toHaveBeenCalledWith(
-      Number(mockSession.user!.id),
-      'zh_TW'
-    );
-    expect(mockPollUntilSynced).toHaveBeenCalled();
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/card');
-  });
-
-  it('prime path: inline reconcile patches session when primed latest disagrees with optimistic role', async () => {
-    mockFirstSyncedFetch.mockResolvedValueOnce({
-      ...mockUserDTO,
-      is_mentor: false,
-      onboarding: true,
-    });
-
-    const updateSession = vi.fn().mockResolvedValue(mockSession);
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ updateSession }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-      await Promise.resolve();
-      await Promise.resolve();
-    });
-
-    // Optimistic + inline reconcile (no background poll second call).
-    expect(mockPollUntilSynced).not.toHaveBeenCalled();
-    expect(updateSession).toHaveBeenCalledTimes(2);
-    const reconcileArg = updateSession.mock.calls[1][0] as {
-      user: { isMentor?: boolean; onBoarding?: boolean };
-    };
-    expect(reconcileArg.user.isMentor).toBe(false);
-    expect(reconcileArg.user.onBoarding).toBe(true);
-  });
-
-  // ── Background avatar upload ──────────────────────────────────────────────
-
-  it('consumeAvatarUpload, when provided, is used instead of direct updateAvatar', async () => {
-    const consumed = 'https://example.com/from-bg.jpg';
-    const consumeAvatarUpload = vi.fn().mockResolvedValue(consumed);
-
-    const file = new File(['c'], 'avatar.jpg', { type: 'image/jpeg' });
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ consumeAvatarUpload }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: file });
-    });
-
-    expect(consumeAvatarUpload).toHaveBeenCalledWith(file);
-    expect(mockUpdateAvatar).not.toHaveBeenCalled();
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ avatar: consumed })
-    );
-  });
-
-  // ── Dirty-field skip ───────────────────────────────────────────────────────
-
-  it('dirtyFields = {} → no PUTs fire', async () => {
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues, {});
-    });
-
-    expect(mockUpdateProfile).not.toHaveBeenCalled();
-  });
-
-  it('isMentorOnboarding: true forces updateProfile even with empty dirtyFields', async () => {
-    const { result } = renderHook(() =>
-      useProfileSubmit(makeOptions({ isMentorOnboarding: true }))
-    );
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues, {});
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
-  });
-
-  it('avatarFile present with empty dirtyFields → updateProfile still fires with new avatar', async () => {
-    const newAvatarUrl = 'https://example.com/new.jpg';
-    mockUpdateAvatar.mockResolvedValueOnce(newAvatarUrl);
-    const file = new File(['x'], 'a.jpg', { type: 'image/jpeg' });
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit({ ...baseValues, avatarFile: file }, {});
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ avatar: newAvatarUrl })
-    );
-  });
-
-  it('navigation does not wait for firstSyncedFetch to resolve', async () => {
-    // Background prime must not block router.push — even a slow first-sync
-    // fetch leaves the user on the loading screen too long.
-    let resolveFirst: (value: MentorProfileVO | null) => void = () => {};
-    mockFirstSyncedFetch.mockReturnValueOnce(
-      new Promise<MentorProfileVO | null>((resolve) => {
-        resolveFirst = resolve;
-      })
-    );
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockRouter.push).toHaveBeenCalledWith('/profile/test-user-id');
-    // Settle so the dangling background promise doesn't leak into other tests.
-    resolveFirst(null);
-  });
-
-  // ── Primary job persistence ────────────────────────────────────────────────
-
-  it('updateProfile payload mirrors job_title / company from the primary work experience', async () => {
-    const valuesWithPrimary = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: false,
-        },
-        {
-          id: 1,
-          job: 'Senior Engineer',
-          company: 'Dell',
-          job_period_start: '2015',
-          job_period_end: '2019',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: true,
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithPrimary);
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        job_title: 'Senior Engineer',
-        company: 'Dell',
-      })
-    );
-  });
-
-  it('updateProfile payload falls back to the first work experience when none is primary', async () => {
-    const valuesNoPrimary = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-        },
-        {
-          id: 1,
-          job: 'Senior Engineer',
-          company: 'Dell',
-          job_period_start: '2015',
-          job_period_end: '2019',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesNoPrimary);
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({
-        job_title: 'Engineer',
-        company: 'Acme',
-      })
-    );
-  });
-
-  it('updateProfile payload uses empty strings when no work experiences exist', async () => {
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(baseValues);
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ job_title: '', company: '' })
-    );
-  });
-
-  it('work_experiences dirty triggers updateProfile so job_title / company stay in sync', async () => {
-    const valuesWithWork = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: true,
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithWork, {
-        work_experiences: [{ is_primary: true }],
-      });
-    });
-
-    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
-    expect(mockUpdateProfile).toHaveBeenCalledWith(
-      expect.objectContaining({ job_title: 'Engineer', company: 'Acme' })
-    );
-  });
-
-  it('work experiences inline batch includes is_primary in payload', async () => {
-    const valuesWithPrimary = {
-      ...baseValues,
-      work_experiences: [
-        {
-          id: 0,
-          job: 'Engineer',
-          company: 'Acme',
-          job_period_start: '2020',
-          job_period_end: 'now',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: false,
-        },
-        {
-          id: 1,
-          job: 'Senior Engineer',
-          company: 'Dell',
-          job_period_start: '2015',
-          job_period_end: '2019',
-          industry: 'tech',
-          job_location: 'TWN',
-          description: 'desc',
-          is_primary: true,
-        },
-      ],
-    };
-
-    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
-
-    await act(async () => {
-      await result.current.onSubmit(valuesWithPrimary);
-    });
-
-    const exp = lastExperiences() as
-      | {
-          category: string;
-          mentor_experiences_metadata: { data: { is_primary?: boolean }[] };
-        }[]
-      | undefined;
-    const work = exp!.find((e) => e.category === ExperienceType.WORK);
-    expect(work?.mentor_experiences_metadata.data[0].is_primary).toBe(false);
-    expect(work?.mentor_experiences_metadata.data[1].is_primary).toBe(true);
   });
 });

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -1,5 +1,4 @@
 import { act, renderHook } from '@testing-library/react';
-import { Session } from 'next-auth';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/navigation', async () => {
@@ -12,36 +11,32 @@ vi.mock('@/components/ui/use-toast', async () => {
   return useToastMockFactory();
 });
 
-vi.mock('@/lib/profile/saveProfile', () => ({
-  saveProfile: vi.fn(),
+vi.mock('@/lib/profile/saveProfile', () => {
+  class LoggedError extends Error {
+    constructor(message?: string) {
+      super(message);
+      this.name = 'LoggedError';
+    }
+  }
+  return {
+    saveProfile: vi.fn(),
+    LoggedError,
+  };
+});
+
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn(),
 }));
 
-import { saveProfile } from '@/lib/profile/saveProfile';
-import { defaultValues } from '@/schemas/profileSchema';
+import { captureFlowFailure } from '@/lib/monitoring';
+import { LoggedError, saveProfile } from '@/lib/profile/saveProfile';
+import { baseValues, mockSession } from '@/test/fixtures/profile';
 import { mockToast } from '@/test/mocks/useToast';
 
 import { useProfileSubmit } from './useProfileSubmit';
 
 const mockSaveProfile = vi.mocked(saveProfile);
-
-const mockSession: Session = {
-  user: {
-    id: '1',
-    name: 'Test User',
-    email: 'test@example.com',
-    onBoarding: true,
-    isMentor: true,
-  },
-  accessToken: 'mock-token',
-  expires: '2099-01-01T00:00:00.000Z',
-};
-
-const baseValues = {
-  ...defaultValues,
-  name: 'Test User',
-  location: 'Taiwan',
-  years_of_experience: '1_3',
-};
+const mockCaptureFlowFailure = vi.mocked(captureFlowFailure);
 
 const makeOptions = (
   overrides: Partial<Parameters<typeof useProfileSubmit>[0]> = {}
@@ -104,7 +99,7 @@ describe('useProfileSubmit (Hook Layer)', () => {
     expect(result.current.isSaving).toBe(true);
   });
 
-  it('saveProfile throws → error is caught, toast is called, and isSaving becomes false', async () => {
+  it('saveProfile throws unlogged Error instance → error is caught, captureFlowFailure reports unexpected error to Sentry, toast is called, and isSaving becomes false', async () => {
     mockSaveProfile.mockRejectedValueOnce(new Error('Save failed'));
     const { result } = renderHook(() => useProfileSubmit(makeOptions()));
 
@@ -114,6 +109,52 @@ describe('useProfileSubmit (Hook Layer)', () => {
 
     expect(mockSaveProfile).toHaveBeenCalled();
     expect(result.current.isSaving).toBe(false);
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile_update',
+        step: 'unexpected',
+        message: 'Save failed',
+      })
+    );
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        description: '儲存失敗，請稍後再試',
+      })
+    );
+  });
+
+  it('saveProfile throws unlogged primitive string → error is caught, captureFlowFailure reports raw string to Sentry, toast is called, and isSaving becomes false', async () => {
+    mockSaveProfile.mockRejectedValueOnce('Some string error');
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(mockSaveProfile).toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile_update',
+        step: 'unexpected',
+        message: 'Some string error',
+      })
+    );
+  });
+
+  it('saveProfile throws an already logged LoggedError → error is caught, captureFlowFailure is NOT called (deduplicated), toast is called, and isSaving becomes false', async () => {
+    const loggedError = new LoggedError('Save failed');
+    mockSaveProfile.mockRejectedValueOnce(loggedError);
+    const { result } = renderHook(() => useProfileSubmit(makeOptions()));
+
+    await act(async () => {
+      await result.current.onSubmit(baseValues);
+    });
+
+    expect(mockSaveProfile).toHaveBeenCalled();
+    expect(result.current.isSaving).toBe(false);
+    expect(mockCaptureFlowFailure).not.toHaveBeenCalled();
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -16,11 +16,6 @@ vi.mock('@/lib/profile/saveProfile', () => ({
   saveProfile: vi.fn(),
 }));
 
-vi.mock('@/lib/monitoring', () => ({
-  captureFlowFailure: vi.fn(),
-}));
-
-import { captureFlowFailure } from '@/lib/monitoring';
 import { saveProfile } from '@/lib/profile/saveProfile';
 import { defaultValues } from '@/schemas/profileSchema';
 import { mockToast } from '@/test/mocks/useToast';
@@ -28,7 +23,6 @@ import { mockToast } from '@/test/mocks/useToast';
 import { useProfileSubmit } from './useProfileSubmit';
 
 const mockSaveProfile = vi.mocked(saveProfile);
-const mockCaptureFlowFailure = vi.mocked(captureFlowFailure);
 
 const mockSession: Session = {
   user: {
@@ -110,7 +104,7 @@ describe('useProfileSubmit (Hook Layer)', () => {
     expect(result.current.isSaving).toBe(true);
   });
 
-  it('saveProfile throws → error is caught, captureFlowFailure reports unexpected error to Sentry, toast is called, and isSaving becomes false', async () => {
+  it('saveProfile throws → error is caught, toast is called, and isSaving becomes false', async () => {
     mockSaveProfile.mockRejectedValueOnce(new Error('Save failed'));
     const { result } = renderHook(() => useProfileSubmit(makeOptions()));
 
@@ -120,13 +114,6 @@ describe('useProfileSubmit (Hook Layer)', () => {
 
     expect(mockSaveProfile).toHaveBeenCalled();
     expect(result.current.isSaving).toBe(false);
-    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
-      expect.objectContaining({
-        flow: 'profile_update',
-        step: 'unexpected',
-        message: 'Save failed',
-      })
-    );
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -16,6 +16,11 @@ vi.mock('@/lib/profile/saveProfile', () => ({
   saveProfile: vi.fn(),
 }));
 
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn(),
+}));
+
+import { captureFlowFailure } from '@/lib/monitoring';
 import { saveProfile } from '@/lib/profile/saveProfile';
 import { defaultValues } from '@/schemas/profileSchema';
 import { mockToast } from '@/test/mocks/useToast';
@@ -23,6 +28,7 @@ import { mockToast } from '@/test/mocks/useToast';
 import { useProfileSubmit } from './useProfileSubmit';
 
 const mockSaveProfile = vi.mocked(saveProfile);
+const mockCaptureFlowFailure = vi.mocked(captureFlowFailure);
 
 const mockSession: Session = {
   user: {
@@ -104,7 +110,7 @@ describe('useProfileSubmit (Hook Layer)', () => {
     expect(result.current.isSaving).toBe(true);
   });
 
-  it('saveProfile throws → error is caught, toast is called, and isSaving becomes false', async () => {
+  it('saveProfile throws → error is caught, captureFlowFailure reports unexpected error to Sentry, toast is called, and isSaving becomes false', async () => {
     mockSaveProfile.mockRejectedValueOnce(new Error('Save failed'));
     const { result } = renderHook(() => useProfileSubmit(makeOptions()));
 
@@ -114,6 +120,13 @@ describe('useProfileSubmit (Hook Layer)', () => {
 
     expect(mockSaveProfile).toHaveBeenCalled();
     expect(result.current.isSaving).toBe(false);
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile_update',
+        step: 'unexpected',
+        message: 'Save failed',
+      })
+    );
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -9,7 +9,6 @@ import {
   clearUserDataCache,
   primeUserDataCache,
 } from '@/hooks/user/user-data/useUserData';
-import { captureFlowFailure } from '@/lib/monitoring';
 import { type ProfileDirtyFields } from '@/lib/profile/profileSaveAdapter';
 import { saveProfile } from '@/lib/profile/saveProfile';
 import { ProfileFormValues } from '@/schemas/profileSchema';
@@ -68,14 +67,6 @@ export function useProfileSubmit({
         primeUserDataCache,
       });
     } catch (err) {
-      captureFlowFailure({
-        flow: 'profile_update',
-        step: 'unexpected',
-        message:
-          err instanceof Error
-            ? err.message
-            : 'Unexpected profile update error',
-      });
       console.error('Update Profile Error:', err);
       toast({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -5,6 +5,11 @@ import { useState } from 'react';
 
 import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
 import { useToast } from '@/components/ui/use-toast';
+import {
+  clearUserDataCache,
+  primeUserDataCache,
+} from '@/hooks/user/user-data/useUserData';
+import { captureFlowFailure } from '@/lib/monitoring';
 import { type ProfileDirtyFields } from '@/lib/profile/profileSaveAdapter';
 import { saveProfile } from '@/lib/profile/saveProfile';
 import { ProfileFormValues } from '@/schemas/profileSchema';
@@ -59,8 +64,18 @@ export function useProfileSubmit({
         updateSession,
         navigate: router.push,
         revalidateProfilePath,
+        clearUserDataCache,
+        primeUserDataCache,
       });
     } catch (err) {
+      captureFlowFailure({
+        flow: 'profile_update',
+        step: 'unexpected',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Unexpected profile update error',
+      });
       console.error('Update Profile Error:', err);
       toast({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -9,8 +9,9 @@ import {
   clearUserDataCache,
   primeUserDataCache,
 } from '@/hooks/user/user-data/useUserData';
+import { captureFlowFailure } from '@/lib/monitoring';
 import { type ProfileDirtyFields } from '@/lib/profile/profileSaveAdapter';
-import { saveProfile } from '@/lib/profile/saveProfile';
+import { LoggedError, saveProfile } from '@/lib/profile/saveProfile';
 import { ProfileFormValues } from '@/schemas/profileSchema';
 
 export type { ProfileDirtyFields };
@@ -67,6 +68,18 @@ export function useProfileSubmit({
         primeUserDataCache,
       });
     } catch (err) {
+      if (!(err instanceof LoggedError)) {
+        captureFlowFailure({
+          flow: 'profile_update',
+          step: 'unexpected',
+          message:
+            err instanceof Error
+              ? err.message
+              : typeof err === 'string'
+                ? err
+                : 'Unexpected profile update error',
+        });
+      }
       console.error('Update Profile Error:', err);
       toast({
         variant: 'destructive',

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -5,27 +5,9 @@ import { useState } from 'react';
 
 import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
 import { useToast } from '@/components/ui/use-toast';
-import {
-  clearUserDataCache,
-  primeUserDataCache,
-} from '@/hooks/user/user-data/useUserData';
-import { trackEvent } from '@/lib/analytics';
-import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
-import { captureFlowFailure } from '@/lib/monitoring';
-import {
-  firstSyncedFetch,
-  pollUntilSynced,
-} from '@/lib/profile/pollUntilSynced';
-import {
-  computeDirtyStates,
-  extractValidLinks,
-  mapFormValuesToPayload,
-  type ProfileDirtyFields,
-} from '@/lib/profile/profileSaveAdapter';
+import { type ProfileDirtyFields } from '@/lib/profile/profileSaveAdapter';
+import { saveProfile } from '@/lib/profile/saveProfile';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import { updateAvatar } from '@/services/profile/updateAvatar';
-import { updateProfile } from '@/services/profile/updateProfile';
-import { MentorProfileVO } from '@/services/profile/user';
 
 export type { ProfileDirtyFields };
 
@@ -68,194 +50,17 @@ export function useProfileSubmit({
 
     try {
       setIsSaving(true);
-
-      // 1) avatar — consume background upload if wired, else upload now.
-      let avatar = values.avatar;
-      if (values.avatarFile) {
-        try {
-          const uploader = consumeAvatarUpload
-            ? consumeAvatarUpload(values.avatarFile)
-            : updateAvatar(values.avatarFile);
-          const newUrl = await uploader;
-          avatar = newUrl ?? avatar;
-        } catch (err) {
-          captureFlowFailure({
-            flow: 'profile_update',
-            step: 'avatar_upload',
-            message:
-              err instanceof Error ? err.message : 'Avatar upload failed',
-            level: 'warning',
-          });
-          throw err;
-        }
-      }
-
-      // 2) profile + experience writes — experiences ride inline on the
-      //    profile PUT (backend stores them as JSONB[] on profiles.experiences).
-      //    When `dirtyFields` is omitted we fall back to the legacy
-      //    "send everything" behaviour so existing callers and tests are
-      //    unaffected.
-      const { experiencesDirty, profileDirty } = computeDirtyStates(
-        values,
+      await saveProfile(values, {
+        pageUserId,
+        isMentorOnboarding,
+        session,
         dirtyFields,
-        isMentorOnboarding
-      );
-
-      const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
-
-      const { job_title, company: companyFromPrimary } = payload;
-
-      try {
-        if (profileDirty) {
-          await updateProfile(payload);
-        }
-      } catch (err) {
-        captureFlowFailure({
-          flow: 'profile_update',
-          step: 'profile_write',
-          message: err instanceof Error ? err.message : 'Profile write failed',
-        });
-        throw err;
-      }
-
-      // 3) optimistic cache + navigation — clear the local cache so the next
-      //    page fetches fresh, then navigate immediately. The fast first-sync
-      //    fetch + cache prime now runs in the background (step 6) instead of
-      //    blocking the user behind a ~800ms timeout.
-      const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
-      const sessionUser = session?.user;
-      const personalLinks = extractValidLinks(values).map((link) => ({
-        platform: link.platform,
-        url: link.url,
-      }));
-
-      if (sessionUserId) {
-        clearUserDataCache(sessionUserId, 'zh_TW');
-      }
-
-      // Invalidate the SSR ISR cache for /profile/[userId] so other
-      // visitors (and the editor on navigation) don't see up-to-60s-stale
-      // server-rendered HTML. Awaited (not fire-and-forget) so the cache
-      // is marked stale BEFORE we router.push — otherwise the next-page
-      // SSR fires while the cache is still fresh and serves the old
-      // avatar in the first paint. .catch keeps a server-action failure
-      // from breaking submit.
-      await revalidateProfilePath(pageUserId).catch((e) => {
-        console.error('revalidateProfilePath failed:', e);
+        consumeAvatarUpload,
+        updateSession,
+        navigate: router.push,
+        revalidateProfilePath,
       });
-
-      // 4) optimistic avatar override — NextAuth's update() is async (POST
-      //    + GET round trip), so the header would otherwise show the old
-      //    avatar until the round trip lands. Setting the override here is
-      //    synchronous, so consumers reading useCurrentAvatar() see the new
-      //    URL on the very next render. The override clears itself once
-      //    session.user.avatar catches up.
-      if (values.avatarFile && avatar && sessionUser?.id) {
-        setAvatarOverride(String(sessionUser.id), avatar);
-      }
-
-      // 5) optimistic session update — for the mentor onboarding flow we
-      //    know the user is becoming a mentor, so flip role/onboarding to
-      //    true immediately. Otherwise keep them from the current session
-      //    to avoid flickering mentor → mentee while the backend catches
-      //    up. The reconcile in step 7 corrects them if the backend
-      //    disagrees.
-      //    Awaited (not fire-and-forget) so the JWT cookie holds the new
-      //    avatar before we router.push. Otherwise the next page's SSR
-      //    getServerSession reads the old JWT, seeds SessionProvider
-      //    with the old avatar, and the header renders the old image
-      //    until the client-side update finally lands. Wrapped in
-      //    try/catch so a session-refresh failure doesn't surface as
-      //    "儲存失敗" — the override + step-7 reconcile heal client
-      //    state regardless.
-      const optimisticIsMentor = isMentorOnboarding
-        ? true
-        : (sessionUser?.isMentor ?? false);
-      const optimisticOnBoarding = isMentorOnboarding
-        ? true
-        : (sessionUser?.onBoarding ?? false);
-
-      try {
-        await updateSession({
-          user: {
-            id: sessionUser?.id,
-            name: values.name ?? sessionUser?.name,
-            avatar: avatar ?? sessionUser?.avatar,
-            avatarUpdatedAt: values.avatarFile
-              ? Date.now()
-              : sessionUser?.avatarUpdatedAt,
-            isMentor: optimisticIsMentor,
-            onBoarding: optimisticOnBoarding,
-            msg: sessionUser?.msg,
-            personalLinks,
-            jobTitle: job_title || sessionUser?.jobTitle,
-            company: companyFromPrimary || sessionUser?.company,
-          },
-        });
-      } catch (e) {
-        console.error('updateSession failed:', e);
-      }
-
-      // 6) navigate immediately — user no longer waits for backend sync.
-      trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
-      if (isMentorOnboarding) {
-        router.push('/profile/card');
-      } else {
-        router.push(`/profile/${pageUserId}`);
-      }
-
-      // 7) background prime + reconcile — try the fast first-sync read; if
-      //    the backend has already caught up, prime the cache so subsequent
-      //    reads on the next page are instant. Otherwise fall back to the
-      //    longer pollUntilSynced. Either way, reconcile the session if the
-      //    backend reports a different is_mentor / onboarding than the
-      //    optimistic value.
-      const reconcileSession = (latest: MentorProfileVO | null) => {
-        if (!latest) return;
-        const latestIsMentor = Boolean(latest.is_mentor);
-        const latestOnBoarding = Boolean(latest.onboarding);
-        if (
-          optimisticIsMentor === latestIsMentor &&
-          optimisticOnBoarding === latestOnBoarding
-        ) {
-          return;
-        }
-        // Send only the fields we're correcting. Spreading `sessionUser`
-        // here would overwrite step-4's just-updated avatar with the
-        // pre-submit URL captured at the top of onSubmit, snapping the
-        // header / profile page back to the old avatar a few seconds
-        // after navigation. NextAuth's JWT callback shallow-merges, so
-        // omitted fields retain their current token value.
-        void updateSession({
-          user: {
-            isMentor: latestIsMentor,
-            onBoarding: latestOnBoarding,
-          },
-        });
-      };
-
-      void (async () => {
-        let latest: MentorProfileVO | null = null;
-        if (sessionUserId) {
-          latest = await firstSyncedFetch(values, avatar ?? '');
-          if (latest) {
-            primeUserDataCache(sessionUserId, 'zh_TW', latest);
-          }
-        }
-        if (!latest) {
-          latest = await pollUntilSynced(values, avatar ?? '');
-        }
-        reconcileSession(latest);
-      })();
     } catch (err) {
-      captureFlowFailure({
-        flow: 'profile_update',
-        step: 'unexpected',
-        message:
-          err instanceof Error
-            ? err.message
-            : 'Unexpected profile update error',
-      });
       console.error('Update Profile Error:', err);
       toast({
         variant: 'destructive',

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -14,15 +14,9 @@ vi.mock('@/lib/profile/pollUntilSynced', () => ({
   firstSyncedFetch: vi.fn(),
 }));
 
-vi.mock('@/hooks/user/user-data/useUserData', () => ({
-  clearUserDataCache: vi.fn(),
-  primeUserDataCache: vi.fn(),
-}));
-
 vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
 vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
 
-import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
 import {
   firstSyncedFetch,
   pollUntilSynced,
@@ -39,7 +33,6 @@ const mockUpdateAvatar = vi.mocked(updateAvatar);
 const mockUpdateProfile = vi.mocked(updateProfile);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
-const mockClearUserDataCache = vi.mocked(clearUserDataCache);
 
 const mockUserDTO: MentorProfileVO = {
   user_id: 1,
@@ -100,6 +93,8 @@ const makeDeps = (
   updateSession: vi.fn().mockResolvedValue(mockSession),
   navigate: vi.fn(),
   revalidateProfilePath: vi.fn().mockResolvedValue(undefined),
+  clearUserDataCache: vi.fn(),
+  primeUserDataCache: vi.fn(),
   ...overrides,
 });
 
@@ -399,9 +394,11 @@ describe('saveProfile (Deep Module)', () => {
   it('firstSyncedFetch returns dto → primeUserDataCache called, pollUntilSynced NOT called', async () => {
     mockFirstSyncedFetch.mockResolvedValueOnce(mockUserDTO);
 
+    const customClearUserDataCache = vi.fn();
     const customPrimeUserDataCache = vi.fn();
     const deps = makeDeps({
       isMentorOnboarding: true,
+      clearUserDataCache: customClearUserDataCache,
       primeUserDataCache: customPrimeUserDataCache,
     });
     await saveProfile(baseValues, deps);
@@ -409,7 +406,7 @@ describe('saveProfile (Deep Module)', () => {
     await Promise.resolve();
     await Promise.resolve();
 
-    expect(mockClearUserDataCache).toHaveBeenCalledWith(
+    expect(customClearUserDataCache).toHaveBeenCalledWith(
       Number(mockSession.user!.id),
       'zh_TW'
     );
@@ -424,9 +421,11 @@ describe('saveProfile (Deep Module)', () => {
   it('firstSyncedFetch returns null → falls back to clearUserDataCache + pollUntilSynced', async () => {
     mockFirstSyncedFetch.mockResolvedValueOnce(null);
 
+    const customClearUserDataCache = vi.fn();
     const customPrimeUserDataCache = vi.fn();
     const deps = makeDeps({
       isMentorOnboarding: true,
+      clearUserDataCache: customClearUserDataCache,
       primeUserDataCache: customPrimeUserDataCache,
     });
     await saveProfile(baseValues, deps);
@@ -435,7 +434,7 @@ describe('saveProfile (Deep Module)', () => {
     await Promise.resolve();
 
     expect(customPrimeUserDataCache).not.toHaveBeenCalled();
-    expect(mockClearUserDataCache).toHaveBeenCalledWith(
+    expect(customClearUserDataCache).toHaveBeenCalledWith(
       Number(mockSession.user!.id),
       'zh_TW'
     );

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -17,6 +17,11 @@ vi.mock('@/lib/profile/pollUntilSynced', () => ({
 vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
 vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
 
+vi.mock('@/lib/avatar/avatarOverrideStore', () => ({
+  setAvatarOverride: vi.fn(),
+}));
+
+import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
 import {
   firstSyncedFetch,
   pollUntilSynced,
@@ -33,6 +38,7 @@ const mockUpdateAvatar = vi.mocked(updateAvatar);
 const mockUpdateProfile = vi.mocked(updateProfile);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
+const mockSetAvatarOverride = vi.mocked(setAvatarOverride);
 
 const mockUserDTO: MentorProfileVO = {
   user_id: 1,
@@ -125,9 +131,12 @@ describe('saveProfile (Deep Module)', () => {
     const deps = makeDeps();
     await saveProfile({ ...baseValues, avatarFile: undefined }, deps);
     expect(mockUpdateAvatar).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
-  it('avatarFile present + upload succeeds → returned URL is used in profile payload', async () => {
+  it('avatarFile present + upload succeeds → returned URL is used in profile payload and setAvatarOverride is called', async () => {
     const newAvatarUrl = 'https://example.com/new-avatar.jpg';
     mockUpdateAvatar.mockResolvedValueOnce(newAvatarUrl);
 
@@ -139,6 +148,10 @@ describe('saveProfile (Deep Module)', () => {
     expect(mockUpdateProfile).toHaveBeenCalledWith(
       expect.objectContaining({ avatar: newAvatarUrl })
     );
+    expect(mockSetAvatarOverride).toHaveBeenCalledWith('1', newAvatarUrl);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('avatarFile present + updateAvatar throws → throws error', async () => {
@@ -150,6 +163,9 @@ describe('saveProfile (Deep Module)', () => {
     await expect(
       saveProfile({ ...baseValues, avatarFile: file }, deps)
     ).rejects.toThrow('Upload failed');
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   // ── Service failures ───────────────────────────────────────────────────────
@@ -161,6 +177,9 @@ describe('saveProfile (Deep Module)', () => {
     await expect(saveProfile(baseValues, deps)).rejects.toThrow(
       'Profile update failed'
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   // ── Inline experiences ────────────────────────────────────────────────────
@@ -175,6 +194,9 @@ describe('saveProfile (Deep Module)', () => {
       ExperienceType.EDUCATION,
       ExperienceType.LINK,
     ]);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('work_experiences dirty → experiences batch in payload reflects work data', async () => {
@@ -206,6 +228,9 @@ describe('saveProfile (Deep Module)', () => {
     expect(exp).toBeDefined();
     const work = exp!.find((e) => e.category === ExperienceType.WORK);
     expect(work?.mentor_experiences_metadata.data).toHaveLength(1);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('only `name` dirty → experiences are NOT sent (backend leaves the column alone)', async () => {
@@ -230,6 +255,9 @@ describe('saveProfile (Deep Module)', () => {
 
     expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
     expect(lastExperiences()).toBeUndefined();
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('dirty link field triggers experiences inline (nested dirtyFields shape)', async () => {
@@ -253,16 +281,34 @@ describe('saveProfile (Deep Module)', () => {
     expect(exp).toBeDefined();
     const links = exp!.find((e) => e.category === ExperienceType.LINK);
     expect(links?.mentor_experiences_metadata.data).toHaveLength(1);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
-  // ── Navigation on success ──────────────────────────────────────────────────
+  // ── Navigation & Sequence ──────────────────────────────────────────────────
 
-  it('isMentorOnboarding: false → deps.navigate("/profile/:pageUserId")', async () => {
+  it('isMentorOnboarding: false → deps.navigate("/profile/:pageUserId") and revalidateProfilePath is called before navigate', async () => {
     const navigate = vi.fn();
-    const deps = makeDeps({ isMentorOnboarding: false, navigate });
+    const revalidateProfilePath = vi.fn().mockResolvedValue(undefined);
+    const deps = makeDeps({
+      isMentorOnboarding: false,
+      navigate,
+      revalidateProfilePath,
+    });
     await saveProfile(baseValues, deps);
 
     expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
+    expect(revalidateProfilePath).toHaveBeenCalledWith('test-user-id');
+
+    // Assert that revalidateProfilePath was invoked before navigate
+    const revalidateCallIndex =
+      revalidateProfilePath.mock.invocationCallOrder[0];
+    const navigateCallIndex = navigate.mock.invocationCallOrder[0];
+    expect(revalidateCallIndex).toBeLessThan(navigateCallIndex);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('isMentorOnboarding: true → deps.navigate("/profile/card")', async () => {
@@ -271,6 +317,9 @@ describe('saveProfile (Deep Module)', () => {
     await saveProfile(baseValues, deps);
 
     expect(navigate).toHaveBeenCalledWith('/profile/card');
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   // ── Optimistic flow: poll runs in the background ───────────────────────────
@@ -289,6 +338,9 @@ describe('saveProfile (Deep Module)', () => {
 
     expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
     resolvePoll(null);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('optimistic session update preserves current isMentor / onBoarding (does not flicker from latest=null)', async () => {
@@ -304,6 +356,9 @@ describe('saveProfile (Deep Module)', () => {
     };
     expect(firstCallArg.user.isMentor).toBe(true);
     expect(firstCallArg.user.onBoarding).toBe(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('isMentorOnboarding: true with mentee session → optimistic update flips isMentor/onBoarding to true', async () => {
@@ -324,6 +379,9 @@ describe('saveProfile (Deep Module)', () => {
     };
     expect(firstCallArg.user.isMentor).toBe(true);
     expect(firstCallArg.user.onBoarding).toBe(true);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('isMentorOnboarding: true with mentee session → reconcile is a no-op when backend confirms is_mentor=true', async () => {
@@ -456,6 +514,9 @@ describe('saveProfile (Deep Module)', () => {
     expect(mockUpdateProfile).toHaveBeenCalledWith(
       expect.objectContaining({ avatar: consumed })
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   // ── Dirty-field skip ───────────────────────────────────────────────────────
@@ -465,6 +526,9 @@ describe('saveProfile (Deep Module)', () => {
     await saveProfile(baseValues, deps);
 
     expect(mockUpdateProfile).not.toHaveBeenCalled();
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   it('isMentorOnboarding: true forces updateProfile even with empty dirtyFields', async () => {
@@ -472,6 +536,9 @@ describe('saveProfile (Deep Module)', () => {
     await saveProfile(baseValues, deps);
 
     expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 
   // ── Primary job persistence ────────────────────────────────────────────────
@@ -514,5 +581,8 @@ describe('saveProfile (Deep Module)', () => {
         company: 'Dell',
       })
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
   });
 });

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -22,15 +22,16 @@ vi.mock('@/lib/avatar/avatarOverrideStore', () => ({
 }));
 
 import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
+import { captureFlowFailure } from '@/lib/monitoring';
 import {
   firstSyncedFetch,
   pollUntilSynced,
 } from '@/lib/profile/pollUntilSynced';
-import { defaultValues } from '@/schemas/profileSchema';
 import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import type { MentorProfileVO } from '@/services/profile/user';
+import { baseValues, mockSession, mockUserDTO } from '@/test/fixtures/profile';
 
 import { saveProfile, SaveProfileDeps } from './saveProfile';
 
@@ -39,56 +40,7 @@ const mockUpdateProfile = vi.mocked(updateProfile);
 const mockPollUntilSynced = vi.mocked(pollUntilSynced);
 const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
 const mockSetAvatarOverride = vi.mocked(setAvatarOverride);
-
-const mockUserDTO: MentorProfileVO = {
-  user_id: 1,
-  name: 'Test User',
-  avatar: 'https://example.com/avatar.jpg',
-  job_title: 'Engineer',
-  company: 'Acme',
-  years_of_experience: '1_3',
-  location: 'Taiwan',
-  industry: {
-    id: 1,
-    kind: 'industry',
-    subject_group: 'tech',
-    subject: 'software',
-    language: 'zh_TW',
-  } as unknown as MentorProfileVO['industry'],
-  onboarding: true,
-  is_mentor: true,
-  language: 'zh_TW',
-  personal_statement: null,
-  about: null,
-  seniority_level: null,
-  want_position: null,
-  want_skill: null,
-  want_topic: null,
-  have_skill: null,
-  have_topic: null,
-};
-
-const mockSession: Session = {
-  user: {
-    id: '1',
-    name: 'Test User',
-    email: 'test@example.com',
-    onBoarding: true,
-    isMentor: true,
-  },
-  accessToken: 'mock-token',
-  expires: '2099-01-01T00:00:00.000Z',
-};
-
-const baseValues = {
-  ...defaultValues,
-  name: 'Test User',
-  location: 'Taiwan',
-  years_of_experience: '1_3',
-  want_position: ['engineer'],
-  want_skill: ['TypeScript'],
-  want_topic: ['frontend'],
-};
+const mockCaptureFlowFailure = vi.mocked(captureFlowFailure);
 
 const makeDeps = (
   overrides: Partial<SaveProfileDeps> = {}
@@ -288,24 +240,32 @@ describe('saveProfile (Deep Module)', () => {
 
   // ── Navigation & Sequence ──────────────────────────────────────────────────
 
-  it('isMentorOnboarding: false → deps.navigate("/profile/:pageUserId") and revalidateProfilePath is called before navigate', async () => {
+  it('isMentorOnboarding: false → deps.navigate("/profile/:pageUserId"), and both revalidateProfilePath & updateSession are called before navigate', async () => {
     const navigate = vi.fn();
     const revalidateProfilePath = vi.fn().mockResolvedValue(undefined);
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
     const deps = makeDeps({
       isMentorOnboarding: false,
       navigate,
       revalidateProfilePath,
+      updateSession,
     });
     await saveProfile(baseValues, deps);
 
     expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
     expect(revalidateProfilePath).toHaveBeenCalledWith('test-user-id');
+    expect(updateSession).toHaveBeenCalled();
+
+    const navigateCallIndex = navigate.mock.invocationCallOrder[0];
 
     // Assert that revalidateProfilePath was invoked before navigate
     const revalidateCallIndex =
       revalidateProfilePath.mock.invocationCallOrder[0];
-    const navigateCallIndex = navigate.mock.invocationCallOrder[0];
     expect(revalidateCallIndex).toBeLessThan(navigateCallIndex);
+
+    // Assert that updateSession was invoked and completed before navigate
+    const updateSessionCallIndex = updateSession.mock.invocationCallOrder[0];
+    expect(updateSessionCallIndex).toBeLessThan(navigateCallIndex);
 
     await Promise.resolve();
     await Promise.resolve();
@@ -581,6 +541,89 @@ describe('saveProfile (Deep Module)', () => {
         company: 'Dell',
       })
     );
+
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  // ── Background task failure handling ───────────────────────────────────────
+
+  it('background reconciliation failure (firstSyncedFetch throws) → quietly caught and logged', async () => {
+    mockFirstSyncedFetch.mockRejectedValueOnce(new Error('Sync fetch failed'));
+
+    const deps = makeDeps({
+      session: {
+        ...mockSession,
+        user: { ...mockSession.user!, id: '1' },
+      },
+    });
+    await saveProfile(baseValues, deps);
+
+    // Let background IIFE task execute
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile_update',
+        step: 'background_reconcile',
+        message: 'Error: Sync fetch failed',
+      })
+    );
+  });
+
+  it('background reconciliation failure (pollUntilSynced throws) → quietly caught and logged', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(null);
+    mockPollUntilSynced.mockRejectedValueOnce(new Error('Polling failed'));
+
+    const deps = makeDeps({
+      session: {
+        ...mockSession,
+        user: { ...mockSession.user!, id: '1' },
+      },
+    });
+    await saveProfile(baseValues, deps);
+
+    // Let background IIFE task execute
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile_update',
+        step: 'background_reconcile',
+        message: 'Error: Polling failed',
+      })
+    );
+  });
+
+  // ── Fault Tolerance for non-blocking secondary operations ──────────────────
+
+  it('revalidateProfilePath throws → does not block saveProfile main flow or navigation', async () => {
+    const navigate = vi.fn();
+    const revalidateProfilePath = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Revalidate failed'));
+    const deps = makeDeps({ navigate, revalidateProfilePath });
+
+    await expect(saveProfile(baseValues, deps)).resolves.not.toThrow();
+
+    expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
+
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+
+  it('updateSession throws → does not block saveProfile main flow or navigation', async () => {
+    const navigate = vi.fn();
+    const updateSession = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('Update session failed'));
+    const deps = makeDeps({ navigate, updateSession });
+
+    await expect(saveProfile(baseValues, deps)).resolves.not.toThrow();
+
+    expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
 
     await Promise.resolve();
     await Promise.resolve();

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -1,0 +1,519 @@
+import { Session } from 'next-auth';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/services/profile/updateAvatar', () => ({
+  updateAvatar: vi.fn(),
+}));
+
+vi.mock('@/services/profile/updateProfile', () => ({
+  updateProfile: vi.fn(),
+}));
+
+vi.mock('@/lib/profile/pollUntilSynced', () => ({
+  pollUntilSynced: vi.fn(),
+  firstSyncedFetch: vi.fn(),
+}));
+
+vi.mock('@/hooks/user/user-data/useUserData', () => ({
+  clearUserDataCache: vi.fn(),
+  primeUserDataCache: vi.fn(),
+}));
+
+vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
+vi.mock('@/lib/analytics', () => ({ trackEvent: vi.fn() }));
+
+import { clearUserDataCache } from '@/hooks/user/user-data/useUserData';
+import {
+  firstSyncedFetch,
+  pollUntilSynced,
+} from '@/lib/profile/pollUntilSynced';
+import { defaultValues } from '@/schemas/profileSchema';
+import { ExperienceType } from '@/services/profile/experienceType';
+import { updateAvatar } from '@/services/profile/updateAvatar';
+import { updateProfile } from '@/services/profile/updateProfile';
+import type { MentorProfileVO } from '@/services/profile/user';
+
+import { saveProfile, SaveProfileDeps } from './saveProfile';
+
+const mockUpdateAvatar = vi.mocked(updateAvatar);
+const mockUpdateProfile = vi.mocked(updateProfile);
+const mockPollUntilSynced = vi.mocked(pollUntilSynced);
+const mockFirstSyncedFetch = vi.mocked(firstSyncedFetch);
+const mockClearUserDataCache = vi.mocked(clearUserDataCache);
+
+const mockUserDTO: MentorProfileVO = {
+  user_id: 1,
+  name: 'Test User',
+  avatar: 'https://example.com/avatar.jpg',
+  job_title: 'Engineer',
+  company: 'Acme',
+  years_of_experience: '1_3',
+  location: 'Taiwan',
+  industry: {
+    id: 1,
+    kind: 'industry',
+    subject_group: 'tech',
+    subject: 'software',
+    language: 'zh_TW',
+  } as unknown as MentorProfileVO['industry'],
+  onboarding: true,
+  is_mentor: true,
+  language: 'zh_TW',
+  personal_statement: null,
+  about: null,
+  seniority_level: null,
+  want_position: null,
+  want_skill: null,
+  want_topic: null,
+  have_skill: null,
+  have_topic: null,
+};
+
+const mockSession: Session = {
+  user: {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    onBoarding: true,
+    isMentor: true,
+  },
+  accessToken: 'mock-token',
+  expires: '2099-01-01T00:00:00.000Z',
+};
+
+const baseValues = {
+  ...defaultValues,
+  name: 'Test User',
+  location: 'Taiwan',
+  years_of_experience: '1_3',
+  want_position: ['engineer'],
+  want_skill: ['TypeScript'],
+  want_topic: ['frontend'],
+};
+
+const makeDeps = (
+  overrides: Partial<SaveProfileDeps> = {}
+): SaveProfileDeps => ({
+  pageUserId: 'test-user-id',
+  isMentorOnboarding: false,
+  session: mockSession,
+  updateSession: vi.fn().mockResolvedValue(mockSession),
+  navigate: vi.fn(),
+  revalidateProfilePath: vi.fn().mockResolvedValue(undefined),
+  ...overrides,
+});
+
+function lastExperiences(): unknown[] | undefined {
+  const lastCall =
+    mockUpdateProfile.mock.calls[mockUpdateProfile.mock.calls.length - 1];
+  if (!lastCall) return undefined;
+  const arg = lastCall[0] as { experiences?: unknown[] };
+  return arg.experiences;
+}
+
+function categoriesIn(payload: unknown): string[] {
+  if (!Array.isArray(payload)) return [];
+  return (payload as { category?: string }[]).map((e) => e.category ?? '');
+}
+
+describe('saveProfile (Deep Module)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUpdateProfile.mockResolvedValue(undefined);
+    mockPollUntilSynced.mockResolvedValue(mockUserDTO);
+    mockFirstSyncedFetch.mockResolvedValue(null);
+  });
+
+  // ── Avatar upload ──────────────────────────────────────────────────────────
+
+  it('no avatarFile → updateAvatar is NOT called', async () => {
+    const deps = makeDeps();
+    await saveProfile({ ...baseValues, avatarFile: undefined }, deps);
+    expect(mockUpdateAvatar).not.toHaveBeenCalled();
+  });
+
+  it('avatarFile present + upload succeeds → returned URL is used in profile payload', async () => {
+    const newAvatarUrl = 'https://example.com/new-avatar.jpg';
+    mockUpdateAvatar.mockResolvedValueOnce(newAvatarUrl);
+
+    const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' });
+    const deps = makeDeps();
+    await saveProfile({ ...baseValues, avatarFile: file }, deps);
+
+    expect(mockUpdateAvatar).toHaveBeenCalledWith(file);
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ avatar: newAvatarUrl })
+    );
+  });
+
+  it('avatarFile present + updateAvatar throws → throws error', async () => {
+    mockUpdateAvatar.mockRejectedValueOnce(new Error('Upload failed'));
+
+    const file = new File(['content'], 'avatar.jpg', { type: 'image/jpeg' });
+    const deps = makeDeps();
+
+    await expect(
+      saveProfile({ ...baseValues, avatarFile: file }, deps)
+    ).rejects.toThrow('Upload failed');
+  });
+
+  // ── Service failures ───────────────────────────────────────────────────────
+
+  it('updateProfile throws → throws error', async () => {
+    mockUpdateProfile.mockRejectedValueOnce(new Error('Profile update failed'));
+    const deps = makeDeps();
+
+    await expect(saveProfile(baseValues, deps)).rejects.toThrow(
+      'Profile update failed'
+    );
+  });
+
+  // ── Inline experiences ────────────────────────────────────────────────────
+
+  it('no dirtyFields → updateProfile fires with full experiences inline (legacy callers send everything)', async () => {
+    const deps = makeDeps();
+    await saveProfile(baseValues, deps);
+
+    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+    expect(categoriesIn(lastExperiences())).toEqual([
+      ExperienceType.WORK,
+      ExperienceType.EDUCATION,
+      ExperienceType.LINK,
+    ]);
+  });
+
+  it('work_experiences dirty → experiences batch in payload reflects work data', async () => {
+    const valuesWithWork = {
+      ...baseValues,
+      work_experiences: [
+        {
+          id: 0,
+          job: 'Engineer',
+          company: 'Acme',
+          job_period_start: '2020',
+          job_period_end: 'now',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'desc',
+          is_primary: true,
+        },
+      ],
+    };
+
+    const deps = makeDeps({
+      dirtyFields: { work_experiences: [{ job: true }] },
+    });
+    await saveProfile(valuesWithWork, deps);
+
+    const exp = lastExperiences() as
+      | { category: string; mentor_experiences_metadata: { data: unknown[] } }[]
+      | undefined;
+    expect(exp).toBeDefined();
+    const work = exp!.find((e) => e.category === ExperienceType.WORK);
+    expect(work?.mentor_experiences_metadata.data).toHaveLength(1);
+  });
+
+  it('only `name` dirty → experiences are NOT sent (backend leaves the column alone)', async () => {
+    const valuesWithEverything = {
+      ...baseValues,
+      work_experiences: [
+        {
+          id: 0,
+          job: 'Engineer',
+          company: 'Acme',
+          job_period_start: '2020',
+          job_period_end: 'now',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'desc',
+        },
+      ],
+    };
+
+    const deps = makeDeps({ dirtyFields: { name: true } });
+    await saveProfile(valuesWithEverything, deps);
+
+    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+    expect(lastExperiences()).toBeUndefined();
+  });
+
+  it('dirty link field triggers experiences inline (nested dirtyFields shape)', async () => {
+    const valuesWithLink = {
+      ...baseValues,
+      linkedin: {
+        id: -1,
+        url: 'https://linkedin.com/in/me',
+        platform: 'linkedin',
+      },
+    };
+
+    const deps = makeDeps({
+      dirtyFields: { linkedin: { url: true } },
+    });
+    await saveProfile(valuesWithLink, deps);
+
+    const exp = lastExperiences() as
+      | { category: string; mentor_experiences_metadata: { data: unknown[] } }[]
+      | undefined;
+    expect(exp).toBeDefined();
+    const links = exp!.find((e) => e.category === ExperienceType.LINK);
+    expect(links?.mentor_experiences_metadata.data).toHaveLength(1);
+  });
+
+  // ── Navigation on success ──────────────────────────────────────────────────
+
+  it('isMentorOnboarding: false → deps.navigate("/profile/:pageUserId")', async () => {
+    const navigate = vi.fn();
+    const deps = makeDeps({ isMentorOnboarding: false, navigate });
+    await saveProfile(baseValues, deps);
+
+    expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
+  });
+
+  it('isMentorOnboarding: true → deps.navigate("/profile/card")', async () => {
+    const navigate = vi.fn();
+    const deps = makeDeps({ isMentorOnboarding: true, navigate });
+    await saveProfile(baseValues, deps);
+
+    expect(navigate).toHaveBeenCalledWith('/profile/card');
+  });
+
+  // ── Optimistic flow: poll runs in the background ───────────────────────────
+
+  it('navigation does not wait for pollUntilSynced to resolve', async () => {
+    let resolvePoll: (value: MentorProfileVO | null) => void = () => {};
+    mockPollUntilSynced.mockReturnValueOnce(
+      new Promise<MentorProfileVO | null>((resolve) => {
+        resolvePoll = resolve;
+      })
+    );
+
+    const navigate = vi.fn();
+    const deps = makeDeps({ navigate });
+    await saveProfile(baseValues, deps);
+
+    expect(navigate).toHaveBeenCalledWith('/profile/test-user-id');
+    resolvePoll(null);
+  });
+
+  it('optimistic session update preserves current isMentor / onBoarding (does not flicker from latest=null)', async () => {
+    mockPollUntilSynced.mockResolvedValueOnce(null);
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const deps = makeDeps({ updateSession });
+    await saveProfile(baseValues, deps);
+
+    expect(updateSession).toHaveBeenCalled();
+    const firstCallArg = updateSession.mock.calls[0][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(firstCallArg.user.isMentor).toBe(true);
+    expect(firstCallArg.user.onBoarding).toBe(true);
+  });
+
+  it('isMentorOnboarding: true with mentee session → optimistic update flips isMentor/onBoarding to true', async () => {
+    const menteeSession: Session = {
+      ...mockSession,
+      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
+    };
+    const updateSession = vi.fn().mockResolvedValue(menteeSession);
+    const deps = makeDeps({
+      session: menteeSession,
+      updateSession,
+      isMentorOnboarding: true,
+    });
+    await saveProfile(baseValues, deps);
+
+    const firstCallArg = updateSession.mock.calls[0][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(firstCallArg.user.isMentor).toBe(true);
+    expect(firstCallArg.user.onBoarding).toBe(true);
+  });
+
+  it('isMentorOnboarding: true with mentee session → reconcile is a no-op when backend confirms is_mentor=true', async () => {
+    const menteeSession: Session = {
+      ...mockSession,
+      user: { ...mockSession.user!, isMentor: false, onBoarding: false },
+    };
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: true,
+      onboarding: true,
+    });
+    const updateSession = vi.fn().mockResolvedValue(menteeSession);
+    const deps = makeDeps({
+      session: menteeSession,
+      updateSession,
+      isMentorOnboarding: true,
+    });
+    await saveProfile(baseValues, deps);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updateSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('background reconcile patches session when latest disagrees with optimistic role', async () => {
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: false,
+      onboarding: true,
+    });
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const deps = makeDeps({ updateSession });
+    await saveProfile(baseValues, deps);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updateSession).toHaveBeenCalledTimes(2);
+    const reconcileArg = updateSession.mock.calls[1][0] as {
+      user: { isMentor?: boolean; onBoarding?: boolean };
+    };
+    expect(reconcileArg.user.isMentor).toBe(false);
+    expect(reconcileArg.user.onBoarding).toBe(true);
+  });
+
+  it('background reconcile is a no-op when latest matches optimistic session', async () => {
+    mockPollUntilSynced.mockResolvedValueOnce({
+      ...mockUserDTO,
+      is_mentor: true,
+      onboarding: true,
+    });
+
+    const updateSession = vi.fn().mockResolvedValue(mockSession);
+    const deps = makeDeps({ updateSession });
+    await saveProfile(baseValues, deps);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(updateSession).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Cache prime vs fallback ────────────────────────────────────────────────
+
+  it('firstSyncedFetch returns dto → primeUserDataCache called, pollUntilSynced NOT called', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(mockUserDTO);
+
+    const customPrimeUserDataCache = vi.fn();
+    const deps = makeDeps({
+      isMentorOnboarding: true,
+      primeUserDataCache: customPrimeUserDataCache,
+    });
+    await saveProfile(baseValues, deps);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(mockClearUserDataCache).toHaveBeenCalledWith(
+      Number(mockSession.user!.id),
+      'zh_TW'
+    );
+    expect(customPrimeUserDataCache).toHaveBeenCalledWith(
+      Number(mockSession.user!.id),
+      'zh_TW',
+      mockUserDTO
+    );
+    expect(mockPollUntilSynced).not.toHaveBeenCalled();
+  });
+
+  it('firstSyncedFetch returns null → falls back to clearUserDataCache + pollUntilSynced', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(null);
+
+    const customPrimeUserDataCache = vi.fn();
+    const deps = makeDeps({
+      isMentorOnboarding: true,
+      primeUserDataCache: customPrimeUserDataCache,
+    });
+    await saveProfile(baseValues, deps);
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(customPrimeUserDataCache).not.toHaveBeenCalled();
+    expect(mockClearUserDataCache).toHaveBeenCalledWith(
+      Number(mockSession.user!.id),
+      'zh_TW'
+    );
+    expect(mockPollUntilSynced).toHaveBeenCalled();
+  });
+
+  // ── Background avatar upload ──────────────────────────────────────────────
+
+  it('consumeAvatarUpload, when provided, is used instead of direct updateAvatar', async () => {
+    const consumed = 'https://example.com/from-bg.jpg';
+    const consumeAvatarUpload = vi.fn().mockResolvedValue(consumed);
+
+    const file = new File(['c'], 'avatar.jpg', { type: 'image/jpeg' });
+    const deps = makeDeps({ consumeAvatarUpload });
+    await saveProfile({ ...baseValues, avatarFile: file }, deps);
+
+    expect(consumeAvatarUpload).toHaveBeenCalledWith(file);
+    expect(mockUpdateAvatar).not.toHaveBeenCalled();
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({ avatar: consumed })
+    );
+  });
+
+  // ── Dirty-field skip ───────────────────────────────────────────────────────
+
+  it('dirtyFields = {} → no PUTs fire', async () => {
+    const deps = makeDeps({ dirtyFields: {} });
+    await saveProfile(baseValues, deps);
+
+    expect(mockUpdateProfile).not.toHaveBeenCalled();
+  });
+
+  it('isMentorOnboarding: true forces updateProfile even with empty dirtyFields', async () => {
+    const deps = makeDeps({ isMentorOnboarding: true, dirtyFields: {} });
+    await saveProfile(baseValues, deps);
+
+    expect(mockUpdateProfile).toHaveBeenCalledTimes(1);
+  });
+
+  // ── Primary job persistence ────────────────────────────────────────────────
+
+  it('updateProfile payload mirrors job_title / company from the primary work experience', async () => {
+    const valuesWithPrimary = {
+      ...baseValues,
+      work_experiences: [
+        {
+          id: 0,
+          job: 'Engineer',
+          company: 'Acme',
+          job_period_start: '2020',
+          job_period_end: 'now',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'desc',
+          is_primary: false,
+        },
+        {
+          id: 1,
+          job: 'Senior Engineer',
+          company: 'Dell',
+          job_period_start: '2015',
+          job_period_end: '2019',
+          industry: 'tech',
+          job_location: 'TWN',
+          description: 'desc',
+          is_primary: true,
+        },
+      ],
+    };
+
+    const deps = makeDeps();
+    await saveProfile(valuesWithPrimary, deps);
+
+    expect(mockUpdateProfile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        job_title: 'Senior Engineer',
+        company: 'Dell',
+      })
+    );
+  });
+});

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -18,6 +18,16 @@ import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
 import { MentorProfileVO } from '@/services/profile/user';
 
+export class LoggedError extends Error {
+  constructor(message?: string, options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'LoggedError';
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, LoggedError);
+    }
+  }
+}
+
 export interface SaveProfileDeps {
   pageUserId: string;
   isMentorOnboarding: boolean;
@@ -63,169 +73,151 @@ export async function saveProfile(
     pollUntilSynced = defaultPollUntilSynced,
   } = deps;
 
-  try {
-    // 1) avatar — consume background upload if wired, else upload now.
-    let avatar = values.avatar;
-    if (values.avatarFile) {
-      try {
-        const uploader = consumeAvatarUpload
-          ? consumeAvatarUpload(values.avatarFile)
-          : updateAvatar(values.avatarFile);
-        const newUrl = await uploader;
-        avatar = newUrl ?? avatar;
-      } catch (err) {
-        captureFlowFailure({
-          flow: 'profile_update',
-          step: 'avatar_upload',
-          message: err instanceof Error ? err.message : 'Avatar upload failed',
-          level: 'warning',
-        });
-        if (err && typeof err === 'object') {
-          (err as Record<string, unknown>)._logged = true;
-        }
-        throw err;
-      }
-    }
-
-    // 2) profile + experience writes
-    const { experiencesDirty, profileDirty } = computeDirtyStates(
-      values,
-      dirtyFields,
-      isMentorOnboarding
-    );
-
-    const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
-    const { job_title, company: companyFromPrimary } = payload;
-
+  // 1) avatar — consume background upload if wired, else upload now.
+  let avatar = values.avatar;
+  if (values.avatarFile) {
     try {
-      if (profileDirty) {
-        await updateProfile(payload);
-      }
+      const uploader = consumeAvatarUpload
+        ? consumeAvatarUpload(values.avatarFile)
+        : updateAvatar(values.avatarFile);
+      const newUrl = await uploader;
+      avatar = newUrl ?? avatar;
     } catch (err) {
       captureFlowFailure({
         flow: 'profile_update',
-        step: 'profile_write',
-        message: err instanceof Error ? err.message : 'Profile write failed',
+        step: 'avatar_upload',
+        message: err instanceof Error ? err.message : 'Avatar upload failed',
+        level: 'warning',
       });
-      if (err && typeof err === 'object') {
-        (err as Record<string, unknown>)._logged = true;
-      }
-      throw err;
+      throw new LoggedError(
+        err instanceof Error ? err.message : 'Avatar upload failed',
+        { cause: err }
+      );
     }
+  }
 
-    // 3) optimistic cache + navigation
-    const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
-    const sessionUser = session?.user;
-    const personalLinks = extractValidLinks(values).map((link) => ({
-      platform: link.platform,
-      url: link.url,
-    }));
+  // 2) profile + experience writes
+  const { experiencesDirty, profileDirty } = computeDirtyStates(
+    values,
+    dirtyFields,
+    isMentorOnboarding
+  );
 
-    if (sessionUserId) {
-      clearUserDataCache(sessionUserId, 'zh_TW');
+  const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
+  const { job_title, company: companyFromPrimary } = payload;
+
+  try {
+    if (profileDirty) {
+      await updateProfile(payload);
     }
-
-    await revalidateProfilePath(pageUserId).catch((e) => {
-      console.error('revalidateProfilePath failed:', e);
-    });
-
-    // 4) optimistic avatar override
-    if (values.avatarFile && avatar && sessionUser?.id) {
-      setAvatarOverride(String(sessionUser.id), avatar);
-    }
-
-    // 5) optimistic session update
-    const optimisticIsMentor = isMentorOnboarding
-      ? true
-      : (sessionUser?.isMentor ?? false);
-    const optimisticOnBoarding = isMentorOnboarding
-      ? true
-      : (sessionUser?.onBoarding ?? false);
-
-    try {
-      await updateSession({
-        user: {
-          id: sessionUser?.id,
-          name: values.name ?? sessionUser?.name,
-          avatar: avatar ?? sessionUser?.avatar,
-          avatarUpdatedAt: values.avatarFile
-            ? Date.now()
-            : sessionUser?.avatarUpdatedAt,
-          isMentor: optimisticIsMentor,
-          onBoarding: optimisticOnBoarding,
-          msg: sessionUser?.msg,
-          personalLinks,
-          jobTitle: job_title || sessionUser?.jobTitle,
-          company: companyFromPrimary || sessionUser?.company,
-        },
-      });
-    } catch (e) {
-      console.error('updateSession failed:', e);
-    }
-
-    // 6) navigate immediately — user no longer waits for backend sync.
-    trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
-    if (isMentorOnboarding) {
-      navigate('/profile/card');
-    } else {
-      navigate(`/profile/${pageUserId}`);
-    }
-
-    // 7) background prime + reconcile
-    const reconcileSession = (latest: MentorProfileVO | null) => {
-      if (!latest) return;
-      const latestIsMentor = Boolean(latest.is_mentor);
-      const latestOnBoarding = Boolean(latest.onboarding);
-      if (
-        optimisticIsMentor === latestIsMentor &&
-        optimisticOnBoarding === latestOnBoarding
-      ) {
-        return;
-      }
-      void updateSession({
-        user: {
-          isMentor: latestIsMentor,
-          onBoarding: latestOnBoarding,
-        },
-      });
-    };
-
-    void (async () => {
-      try {
-        let latest: MentorProfileVO | null = null;
-        if (sessionUserId) {
-          latest = await firstSyncedFetch(values, avatar ?? '');
-          if (latest) {
-            primeUserDataCache(sessionUserId, 'zh_TW', latest);
-          }
-        }
-        if (!latest) {
-          latest = await pollUntilSynced(values, avatar ?? '');
-        }
-        reconcileSession(latest);
-      } catch (e) {
-        captureFlowFailure({
-          flow: 'profile_update',
-          step: 'background_reconcile',
-          message: String(e),
-        });
-      }
-    })();
   } catch (err) {
+    captureFlowFailure({
+      flow: 'profile_update',
+      step: 'profile_write',
+      message: err instanceof Error ? err.message : 'Profile write failed',
+    });
+    throw new LoggedError(
+      err instanceof Error ? err.message : 'Profile write failed',
+      { cause: err }
+    );
+  }
+
+  // 3) optimistic cache + navigation
+  const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
+  const sessionUser = session?.user;
+  const personalLinks = extractValidLinks(values).map((link) => ({
+    platform: link.platform,
+    url: link.url,
+  }));
+
+  if (sessionUserId) {
+    clearUserDataCache(sessionUserId, 'zh_TW');
+  }
+
+  await revalidateProfilePath(pageUserId).catch((e) => {
+    console.error('revalidateProfilePath failed:', e);
+  });
+
+  // 4) optimistic avatar override
+  if (values.avatarFile && avatar && sessionUser?.id) {
+    setAvatarOverride(String(sessionUser.id), avatar);
+  }
+
+  // 5) optimistic session update
+  const optimisticIsMentor = isMentorOnboarding
+    ? true
+    : (sessionUser?.isMentor ?? false);
+  const optimisticOnBoarding = isMentorOnboarding
+    ? true
+    : (sessionUser?.onBoarding ?? false);
+
+  try {
+    await updateSession({
+      user: {
+        id: sessionUser?.id,
+        name: values.name ?? sessionUser?.name,
+        avatar: avatar ?? sessionUser?.avatar,
+        avatarUpdatedAt: values.avatarFile
+          ? Date.now()
+          : sessionUser?.avatarUpdatedAt,
+        isMentor: optimisticIsMentor,
+        onBoarding: optimisticOnBoarding,
+        msg: sessionUser?.msg,
+        personalLinks,
+        jobTitle: job_title || sessionUser?.jobTitle,
+        company: companyFromPrimary || sessionUser?.company,
+      },
+    });
+  } catch (e) {
+    console.error('updateSession failed:', e);
+  }
+
+  // 6) navigate immediately — user no longer waits for backend sync.
+  trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
+  if (isMentorOnboarding) {
+    navigate('/profile/card');
+  } else {
+    navigate(`/profile/${pageUserId}`);
+  }
+
+  // 7) background prime + reconcile
+  const reconcileSession = (latest: MentorProfileVO | null) => {
+    if (!latest) return;
+    const latestIsMentor = Boolean(latest.is_mentor);
+    const latestOnBoarding = Boolean(latest.onboarding);
     if (
-      err &&
-      typeof err === 'object' &&
-      !(err as Record<string, unknown>)._logged
+      optimisticIsMentor === latestIsMentor &&
+      optimisticOnBoarding === latestOnBoarding
     ) {
+      return;
+    }
+    void updateSession({
+      user: {
+        isMentor: latestIsMentor,
+        onBoarding: latestOnBoarding,
+      },
+    });
+  };
+
+  void (async () => {
+    try {
+      let latest: MentorProfileVO | null = null;
+      if (sessionUserId) {
+        latest = await firstSyncedFetch(values, avatar ?? '');
+        if (latest) {
+          primeUserDataCache(sessionUserId, 'zh_TW', latest);
+        }
+      }
+      if (!latest) {
+        latest = await pollUntilSynced(values, avatar ?? '');
+      }
+      reconcileSession(latest);
+    } catch (e) {
       captureFlowFailure({
         flow: 'profile_update',
-        step: 'unexpected',
-        message:
-          err instanceof Error
-            ? err.message
-            : 'Unexpected profile update error',
+        step: 'background_reconcile',
+        message: String(e),
       });
     }
-    throw err;
-  }
+  })();
 }

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -1,9 +1,5 @@
 import { Session } from 'next-auth';
 
-import {
-  clearUserDataCache,
-  primeUserDataCache,
-} from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
 import { captureFlowFailure } from '@/lib/monitoring';
@@ -31,6 +27,12 @@ export interface SaveProfileDeps {
   updateSession: (data: unknown) => Promise<Session | null>;
   navigate: (path: string) => void;
   revalidateProfilePath: (id: string) => Promise<void>;
+  clearUserDataCache: (userId: number, language: string) => void;
+  primeUserDataCache: (
+    userId: number,
+    language: string,
+    data: MentorProfileVO
+  ) => void;
   // Optional dependency injections to ease testing
   firstSyncedFetch?: (
     values: ProfileFormValues,
@@ -40,11 +42,6 @@ export interface SaveProfileDeps {
     values: ProfileFormValues,
     avatar: string
   ) => Promise<MentorProfileVO | null>;
-  primeUserDataCache?: (
-    userId: number,
-    language: string,
-    data: MentorProfileVO
-  ) => void;
 }
 
 export async function saveProfile(
@@ -60,9 +57,10 @@ export async function saveProfile(
     updateSession,
     navigate,
     revalidateProfilePath,
+    clearUserDataCache,
+    primeUserDataCache,
     firstSyncedFetch = defaultFirstSyncedFetch,
     pollUntilSynced = defaultPollUntilSynced,
-    primeUserDataCache: customPrimeUserDataCache,
   } = deps;
 
   // 1) avatar — consume background upload if wired, else upload now.
@@ -191,11 +189,7 @@ export async function saveProfile(
       if (sessionUserId) {
         latest = await firstSyncedFetch(values, avatar ?? '');
         if (latest) {
-          if (customPrimeUserDataCache) {
-            customPrimeUserDataCache(sessionUserId, 'zh_TW', latest);
-          } else {
-            primeUserDataCache(sessionUserId, 'zh_TW', latest);
-          }
+          primeUserDataCache(sessionUserId, 'zh_TW', latest);
         }
       }
       if (!latest) {

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -63,145 +63,169 @@ export async function saveProfile(
     pollUntilSynced = defaultPollUntilSynced,
   } = deps;
 
-  // 1) avatar — consume background upload if wired, else upload now.
-  let avatar = values.avatar;
-  if (values.avatarFile) {
+  try {
+    // 1) avatar — consume background upload if wired, else upload now.
+    let avatar = values.avatar;
+    if (values.avatarFile) {
+      try {
+        const uploader = consumeAvatarUpload
+          ? consumeAvatarUpload(values.avatarFile)
+          : updateAvatar(values.avatarFile);
+        const newUrl = await uploader;
+        avatar = newUrl ?? avatar;
+      } catch (err) {
+        captureFlowFailure({
+          flow: 'profile_update',
+          step: 'avatar_upload',
+          message: err instanceof Error ? err.message : 'Avatar upload failed',
+          level: 'warning',
+        });
+        if (err && typeof err === 'object') {
+          (err as Record<string, unknown>)._logged = true;
+        }
+        throw err;
+      }
+    }
+
+    // 2) profile + experience writes
+    const { experiencesDirty, profileDirty } = computeDirtyStates(
+      values,
+      dirtyFields,
+      isMentorOnboarding
+    );
+
+    const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
+    const { job_title, company: companyFromPrimary } = payload;
+
     try {
-      const uploader = consumeAvatarUpload
-        ? consumeAvatarUpload(values.avatarFile)
-        : updateAvatar(values.avatarFile);
-      const newUrl = await uploader;
-      avatar = newUrl ?? avatar;
+      if (profileDirty) {
+        await updateProfile(payload);
+      }
     } catch (err) {
       captureFlowFailure({
         flow: 'profile_update',
-        step: 'avatar_upload',
-        message: err instanceof Error ? err.message : 'Avatar upload failed',
-        level: 'warning',
+        step: 'profile_write',
+        message: err instanceof Error ? err.message : 'Profile write failed',
       });
+      if (err && typeof err === 'object') {
+        (err as Record<string, unknown>)._logged = true;
+      }
       throw err;
     }
-  }
 
-  // 2) profile + experience writes
-  const { experiencesDirty, profileDirty } = computeDirtyStates(
-    values,
-    dirtyFields,
-    isMentorOnboarding
-  );
+    // 3) optimistic cache + navigation
+    const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
+    const sessionUser = session?.user;
+    const personalLinks = extractValidLinks(values).map((link) => ({
+      platform: link.platform,
+      url: link.url,
+    }));
 
-  const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
-  const { job_title, company: companyFromPrimary } = payload;
-
-  try {
-    if (profileDirty) {
-      await updateProfile(payload);
+    if (sessionUserId) {
+      clearUserDataCache(sessionUserId, 'zh_TW');
     }
-  } catch (err) {
-    captureFlowFailure({
-      flow: 'profile_update',
-      step: 'profile_write',
-      message: err instanceof Error ? err.message : 'Profile write failed',
+
+    await revalidateProfilePath(pageUserId).catch((e) => {
+      console.error('revalidateProfilePath failed:', e);
     });
-    throw err;
-  }
 
-  // 3) optimistic cache + navigation
-  const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
-  const sessionUser = session?.user;
-  const personalLinks = extractValidLinks(values).map((link) => ({
-    platform: link.platform,
-    url: link.url,
-  }));
-
-  if (sessionUserId) {
-    clearUserDataCache(sessionUserId, 'zh_TW');
-  }
-
-  await revalidateProfilePath(pageUserId).catch((e) => {
-    console.error('revalidateProfilePath failed:', e);
-  });
-
-  // 4) optimistic avatar override
-  if (values.avatarFile && avatar && sessionUser?.id) {
-    setAvatarOverride(String(sessionUser.id), avatar);
-  }
-
-  // 5) optimistic session update
-  const optimisticIsMentor = isMentorOnboarding
-    ? true
-    : (sessionUser?.isMentor ?? false);
-  const optimisticOnBoarding = isMentorOnboarding
-    ? true
-    : (sessionUser?.onBoarding ?? false);
-
-  try {
-    await updateSession({
-      user: {
-        id: sessionUser?.id,
-        name: values.name ?? sessionUser?.name,
-        avatar: avatar ?? sessionUser?.avatar,
-        avatarUpdatedAt: values.avatarFile
-          ? Date.now()
-          : sessionUser?.avatarUpdatedAt,
-        isMentor: optimisticIsMentor,
-        onBoarding: optimisticOnBoarding,
-        msg: sessionUser?.msg,
-        personalLinks,
-        jobTitle: job_title || sessionUser?.jobTitle,
-        company: companyFromPrimary || sessionUser?.company,
-      },
-    });
-  } catch (e) {
-    console.error('updateSession failed:', e);
-  }
-
-  // 6) navigate immediately — user no longer waits for backend sync.
-  trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
-  if (isMentorOnboarding) {
-    navigate('/profile/card');
-  } else {
-    navigate(`/profile/${pageUserId}`);
-  }
-
-  // 7) background prime + reconcile
-  const reconcileSession = (latest: MentorProfileVO | null) => {
-    if (!latest) return;
-    const latestIsMentor = Boolean(latest.is_mentor);
-    const latestOnBoarding = Boolean(latest.onboarding);
-    if (
-      optimisticIsMentor === latestIsMentor &&
-      optimisticOnBoarding === latestOnBoarding
-    ) {
-      return;
+    // 4) optimistic avatar override
+    if (values.avatarFile && avatar && sessionUser?.id) {
+      setAvatarOverride(String(sessionUser.id), avatar);
     }
-    void updateSession({
-      user: {
-        isMentor: latestIsMentor,
-        onBoarding: latestOnBoarding,
-      },
-    });
-  };
 
-  void (async () => {
+    // 5) optimistic session update
+    const optimisticIsMentor = isMentorOnboarding
+      ? true
+      : (sessionUser?.isMentor ?? false);
+    const optimisticOnBoarding = isMentorOnboarding
+      ? true
+      : (sessionUser?.onBoarding ?? false);
+
     try {
-      let latest: MentorProfileVO | null = null;
-      if (sessionUserId) {
-        latest = await firstSyncedFetch(values, avatar ?? '');
-        if (latest) {
-          primeUserDataCache(sessionUserId, 'zh_TW', latest);
-        }
-      }
-      if (!latest) {
-        latest = await pollUntilSynced(values, avatar ?? '');
-      }
-      reconcileSession(latest);
+      await updateSession({
+        user: {
+          id: sessionUser?.id,
+          name: values.name ?? sessionUser?.name,
+          avatar: avatar ?? sessionUser?.avatar,
+          avatarUpdatedAt: values.avatarFile
+            ? Date.now()
+            : sessionUser?.avatarUpdatedAt,
+          isMentor: optimisticIsMentor,
+          onBoarding: optimisticOnBoarding,
+          msg: sessionUser?.msg,
+          personalLinks,
+          jobTitle: job_title || sessionUser?.jobTitle,
+          company: companyFromPrimary || sessionUser?.company,
+        },
+      });
     } catch (e) {
+      console.error('updateSession failed:', e);
+    }
+
+    // 6) navigate immediately — user no longer waits for backend sync.
+    trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
+    if (isMentorOnboarding) {
+      navigate('/profile/card');
+    } else {
+      navigate(`/profile/${pageUserId}`);
+    }
+
+    // 7) background prime + reconcile
+    const reconcileSession = (latest: MentorProfileVO | null) => {
+      if (!latest) return;
+      const latestIsMentor = Boolean(latest.is_mentor);
+      const latestOnBoarding = Boolean(latest.onboarding);
+      if (
+        optimisticIsMentor === latestIsMentor &&
+        optimisticOnBoarding === latestOnBoarding
+      ) {
+        return;
+      }
+      void updateSession({
+        user: {
+          isMentor: latestIsMentor,
+          onBoarding: latestOnBoarding,
+        },
+      });
+    };
+
+    void (async () => {
+      try {
+        let latest: MentorProfileVO | null = null;
+        if (sessionUserId) {
+          latest = await firstSyncedFetch(values, avatar ?? '');
+          if (latest) {
+            primeUserDataCache(sessionUserId, 'zh_TW', latest);
+          }
+        }
+        if (!latest) {
+          latest = await pollUntilSynced(values, avatar ?? '');
+        }
+        reconcileSession(latest);
+      } catch (e) {
+        captureFlowFailure({
+          flow: 'profile_update',
+          step: 'background_reconcile',
+          message: String(e),
+        });
+      }
+    })();
+  } catch (err) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      !(err as Record<string, unknown>)._logged
+    ) {
       captureFlowFailure({
         flow: 'profile_update',
-        step: 'background_reconcile',
-        message: String(e),
+        step: 'unexpected',
+        message:
+          err instanceof Error
+            ? err.message
+            : 'Unexpected profile update error',
       });
     }
-  })();
+    throw err;
+  }
 }

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -1,0 +1,213 @@
+import { Session } from 'next-auth';
+
+import {
+  clearUserDataCache,
+  primeUserDataCache,
+} from '@/hooks/user/user-data/useUserData';
+import { trackEvent } from '@/lib/analytics';
+import { setAvatarOverride } from '@/lib/avatar/avatarOverrideStore';
+import { captureFlowFailure } from '@/lib/monitoring';
+import {
+  firstSyncedFetch as defaultFirstSyncedFetch,
+  pollUntilSynced as defaultPollUntilSynced,
+} from '@/lib/profile/pollUntilSynced';
+import {
+  computeDirtyStates,
+  extractValidLinks,
+  mapFormValuesToPayload,
+  type ProfileDirtyFields,
+} from '@/lib/profile/profileSaveAdapter';
+import { ProfileFormValues } from '@/schemas/profileSchema';
+import { updateAvatar } from '@/services/profile/updateAvatar';
+import { updateProfile } from '@/services/profile/updateProfile';
+import { MentorProfileVO } from '@/services/profile/user';
+
+export interface SaveProfileDeps {
+  pageUserId: string;
+  isMentorOnboarding: boolean;
+  session: Session | null;
+  dirtyFields?: ProfileDirtyFields;
+  consumeAvatarUpload?: (file: File | undefined) => Promise<string | undefined>;
+  updateSession: (data: unknown) => Promise<Session | null>;
+  navigate: (path: string) => void;
+  revalidateProfilePath: (id: string) => Promise<void>;
+  // Optional dependency injections to ease testing
+  firstSyncedFetch?: (
+    values: ProfileFormValues,
+    avatar: string
+  ) => Promise<MentorProfileVO | null>;
+  pollUntilSynced?: (
+    values: ProfileFormValues,
+    avatar: string
+  ) => Promise<MentorProfileVO | null>;
+  primeUserDataCache?: (
+    userId: number,
+    language: string,
+    data: MentorProfileVO
+  ) => void;
+}
+
+export async function saveProfile(
+  values: ProfileFormValues,
+  deps: SaveProfileDeps
+): Promise<void> {
+  const {
+    pageUserId,
+    isMentorOnboarding,
+    session,
+    dirtyFields,
+    consumeAvatarUpload,
+    updateSession,
+    navigate,
+    revalidateProfilePath,
+    firstSyncedFetch = defaultFirstSyncedFetch,
+    pollUntilSynced = defaultPollUntilSynced,
+    primeUserDataCache: customPrimeUserDataCache,
+  } = deps;
+
+  // 1) avatar — consume background upload if wired, else upload now.
+  let avatar = values.avatar;
+  if (values.avatarFile) {
+    try {
+      const uploader = consumeAvatarUpload
+        ? consumeAvatarUpload(values.avatarFile)
+        : updateAvatar(values.avatarFile);
+      const newUrl = await uploader;
+      avatar = newUrl ?? avatar;
+    } catch (err) {
+      captureFlowFailure({
+        flow: 'profile_update',
+        step: 'avatar_upload',
+        message: err instanceof Error ? err.message : 'Avatar upload failed',
+        level: 'warning',
+      });
+      throw err;
+    }
+  }
+
+  // 2) profile + experience writes
+  const { experiencesDirty, profileDirty } = computeDirtyStates(
+    values,
+    dirtyFields,
+    isMentorOnboarding
+  );
+
+  const payload = mapFormValuesToPayload(values, avatar, experiencesDirty);
+  const { job_title, company: companyFromPrimary } = payload;
+
+  try {
+    if (profileDirty) {
+      await updateProfile(payload);
+    }
+  } catch (err) {
+    captureFlowFailure({
+      flow: 'profile_update',
+      step: 'profile_write',
+      message: err instanceof Error ? err.message : 'Profile write failed',
+    });
+    throw err;
+  }
+
+  // 3) optimistic cache + navigation
+  const sessionUserId = session?.user?.id ? Number(session.user.id) : null;
+  const sessionUser = session?.user;
+  const personalLinks = extractValidLinks(values).map((link) => ({
+    platform: link.platform,
+    url: link.url,
+  }));
+
+  if (sessionUserId) {
+    clearUserDataCache(sessionUserId, 'zh_TW');
+  }
+
+  await revalidateProfilePath(pageUserId).catch((e) => {
+    console.error('revalidateProfilePath failed:', e);
+  });
+
+  // 4) optimistic avatar override
+  if (values.avatarFile && avatar && sessionUser?.id) {
+    setAvatarOverride(String(sessionUser.id), avatar);
+  }
+
+  // 5) optimistic session update
+  const optimisticIsMentor = isMentorOnboarding
+    ? true
+    : (sessionUser?.isMentor ?? false);
+  const optimisticOnBoarding = isMentorOnboarding
+    ? true
+    : (sessionUser?.onBoarding ?? false);
+
+  try {
+    await updateSession({
+      user: {
+        id: sessionUser?.id,
+        name: values.name ?? sessionUser?.name,
+        avatar: avatar ?? sessionUser?.avatar,
+        avatarUpdatedAt: values.avatarFile
+          ? Date.now()
+          : sessionUser?.avatarUpdatedAt,
+        isMentor: optimisticIsMentor,
+        onBoarding: optimisticOnBoarding,
+        msg: sessionUser?.msg,
+        personalLinks,
+        jobTitle: job_title || sessionUser?.jobTitle,
+        company: companyFromPrimary || sessionUser?.company,
+      },
+    });
+  } catch (e) {
+    console.error('updateSession failed:', e);
+  }
+
+  // 6) navigate immediately — user no longer waits for backend sync.
+  trackEvent({ name: 'profile_update_submitted', feature: 'profile' });
+  if (isMentorOnboarding) {
+    navigate('/profile/card');
+  } else {
+    navigate(`/profile/${pageUserId}`);
+  }
+
+  // 7) background prime + reconcile
+  const reconcileSession = (latest: MentorProfileVO | null) => {
+    if (!latest) return;
+    const latestIsMentor = Boolean(latest.is_mentor);
+    const latestOnBoarding = Boolean(latest.onboarding);
+    if (
+      optimisticIsMentor === latestIsMentor &&
+      optimisticOnBoarding === latestOnBoarding
+    ) {
+      return;
+    }
+    void updateSession({
+      user: {
+        isMentor: latestIsMentor,
+        onBoarding: latestOnBoarding,
+      },
+    });
+  };
+
+  void (async () => {
+    try {
+      let latest: MentorProfileVO | null = null;
+      if (sessionUserId) {
+        latest = await firstSyncedFetch(values, avatar ?? '');
+        if (latest) {
+          if (customPrimeUserDataCache) {
+            customPrimeUserDataCache(sessionUserId, 'zh_TW', latest);
+          } else {
+            primeUserDataCache(sessionUserId, 'zh_TW', latest);
+          }
+        }
+      }
+      if (!latest) {
+        latest = await pollUntilSynced(values, avatar ?? '');
+      }
+      reconcileSession(latest);
+    } catch (e) {
+      captureFlowFailure({
+        flow: 'profile_update',
+        step: 'background_reconcile',
+        message: String(e),
+      });
+    }
+  })();
+}

--- a/src/test/fixtures/profile.ts
+++ b/src/test/fixtures/profile.ts
@@ -1,0 +1,54 @@
+import { Session } from 'next-auth';
+
+import { defaultValues } from '@/schemas/profileSchema';
+import type { MentorProfileVO } from '@/services/profile/user';
+
+export const mockSession: Session = {
+  user: {
+    id: '1',
+    name: 'Test User',
+    email: 'test@example.com',
+    onBoarding: true,
+    isMentor: true,
+  },
+  accessToken: 'mock-token',
+  expires: '2099-01-01T00:00:00.000Z',
+};
+
+export const baseValues = {
+  ...defaultValues,
+  name: 'Test User',
+  location: 'Taiwan',
+  years_of_experience: '1_3',
+  want_position: ['engineer'],
+  want_skill: ['TypeScript'],
+  want_topic: ['frontend'],
+};
+
+export const mockUserDTO: MentorProfileVO = {
+  user_id: 1,
+  name: 'Test User',
+  avatar: 'https://example.com/avatar.jpg',
+  job_title: 'Engineer',
+  company: 'Acme',
+  years_of_experience: '1_3',
+  location: 'Taiwan',
+  industry: {
+    id: 1,
+    kind: 'industry',
+    subject_group: 'tech',
+    subject: 'software',
+    language: 'zh_TW',
+  } as unknown as MentorProfileVO['industry'],
+  onboarding: true,
+  is_mentor: true,
+  language: 'zh_TW',
+  personal_statement: null,
+  about: null,
+  seniority_level: null,
+  want_position: null,
+  want_skill: null,
+  want_topic: null,
+  have_skill: null,
+  have_topic: null,
+};


### PR DESCRIPTION
- 建立 src/lib/profile/saveProfile.ts 純 TS 深模組，封裝 7 步驟儲存編排邏輯，避免直接依賴 React 或 Next.js hooks
- 在 .eslintrc.json 中配置
o-restricted-imports 確保 saveProfile.ts 維持純粹性
- 重構 useProfileSubmit.ts 為極簡 Hook，僅負責 UI 的錯誤捲動與 isSaving 狀態控制
- 拆分測試為 saveProfile.test.ts（涵蓋 7 步驟儲存與異步協調）與 useProfileSubmit.test.ts（涵蓋 UI 防禦狀態）
- 確保所有測試與類型檢查皆 100% 通過

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/352
