### PR TITLE
refactor: 把 mentee 端預約確認邏輯從頁面容器抽成深模組 (X-Tracker #355)

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -6,18 +6,16 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
-import { useToast } from '@/components/ui/use-toast';
 import { BookingSlot, useMentorSchedule } from '@/hooks/useMentorSchedule';
 import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
+import { useBookingConfirmation } from '@/hooks/user/reservation/useBookingConfirmation';
+import { useReservationDateClamp } from '@/hooks/user/reservation/useReservationDateClamp';
 import { primeTagCatalogCacheIfEmpty } from '@/hooks/user/tags/useTagCatalog';
 import useUserData from '@/hooks/user/user-data/useUserData';
 import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
-import { trackEvent } from '@/lib/analytics';
-import { captureFlowFailure } from '@/lib/monitoring';
 import { getMentorOnboardingUrl } from '@/lib/routes';
 import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
-import { createReservation } from '@/services/reservations';
 
 import { ProfilePageSkeleton } from './skeleton';
 
@@ -66,35 +64,10 @@ export default function ProfilePageContainer({
 
   const [openReservationDialog, setOpenReservationDialog] = useState(false);
   const [selectedSlot, setSelectedSlot] = useState<BookingSlot | null>(null);
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { toast } = useToast();
 
   useEffect(() => {
     setSelectedSlot(null);
   }, [selectedDate]);
-
-  const handleScheduleMonthChange = (date: Date) => {
-    const newYear = date.getFullYear();
-    const newMonth = date.getMonth() + 1;
-    setYear(newYear);
-    setMonth(newMonth);
-    // Carry the viewed month into the booking dialogs by anchoring
-    // selectedDate to the new month. Skip while a dialog is open so
-    // in-dialog month navigation does not clobber the user's day pick.
-    // Clamp to today so a past month never anchors to an un-editable
-    // past day (which would let the dialog render its slot editor on
-    // a date the mentor cannot configure).
-    if (!openReservationDialog) {
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      const monthStart = new Date(newYear, newMonth - 1, 1);
-      const anchor = monthStart < today ? today : monthStart;
-      const pad = (n: number) => String(n).padStart(2, '0');
-      setSelectedDate(
-        `${anchor.getFullYear()}-${pad(anchor.getMonth() + 1)}-${pad(anchor.getDate())}`
-      );
-    }
-  };
 
   // Auto-select the first available date once schedule is loaded
   useEffect(() => {
@@ -132,6 +105,24 @@ export default function ProfilePageContainer({
     : userData?.avatar;
   const avatarSrc = resolvedAvatar || DefaultAvatarImgUrl;
 
+  const { handleScheduleMonthChange, clampSelectedDateToToday } =
+    useReservationDateClamp({
+      selectedDate,
+      setSelectedDate,
+      year,
+      setYear,
+      month,
+      setMonth,
+      openReservationDialog,
+    });
+
+  const { isSubmitting, handleConfirmReservation } = useBookingConfirmation({
+    loginUserId,
+    userData,
+    selectedSlot,
+    setSelectedSlot,
+  });
+
   if (!userLoading && !userData) {
     return (
       <div className="flex h-[50vh] items-center justify-center text-gray-500">
@@ -150,98 +141,10 @@ export default function ProfilePageContainer({
     // (still possible when that day has saved slots), snap selectedDate
     // forward to today so the dialog never opens on an un-editable past
     // date with its slot editor primed.
-    if (selectedDate) {
-      const sel = new Date(selectedDate + 'T00:00:00');
-      const today = new Date();
-      today.setHours(0, 0, 0, 0);
-      if (sel < today) {
-        const pad = (n: number) => String(n).padStart(2, '0');
-        setSelectedDate(
-          `${today.getFullYear()}-${pad(today.getMonth() + 1)}-${pad(today.getDate())}`
-        );
-        const todayYear = today.getFullYear();
-        const todayMonth = today.getMonth() + 1;
-        if (todayYear !== year || todayMonth !== month) {
-          setYear(todayYear);
-          setMonth(todayMonth);
-        }
-      }
-    }
+    clampSelectedDateToToday();
     if (userData.is_mentor && pageUserId === loginUserId) {
       setOpenReservationDialog(true);
       return;
-    }
-  };
-
-  const handleConfirmReservation = async (
-    question: string
-  ): Promise<boolean> => {
-    if (!loginUserId) {
-      router.push('/auth/signin');
-      return false;
-    }
-    if (!selectedSlot || !userData) return false;
-
-    setIsSubmitting(true);
-    try {
-      const menteeId = Number(loginUserId);
-      await createReservation({
-        userId: menteeId,
-        body: {
-          my_user_id: menteeId,
-          my_status: 'PENDING',
-          user_id: userData.user_id,
-          schedule_id: selectedSlot.scheduleId,
-          dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
-          dtend: Math.floor(selectedSlot.end.getTime() / 1000),
-          messages: [{ user_id: menteeId, content: question }],
-        },
-        debug: process.env.NODE_ENV === 'development',
-      });
-
-      trackEvent({
-        name: 'reservation_booking_confirmed',
-        feature: 'reservation',
-      });
-
-      toast({
-        title: '預約已送出，等待導師回復',
-        description: '導師接受後預約才會成立，可至「我的預約」追蹤狀態。',
-      });
-
-      setSelectedSlot(null);
-      return true;
-    } catch (error) {
-      console.error('Failed to create reservation:', error);
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-      const isDuplicate =
-        msg.includes('409') ||
-        msg.toLowerCase().includes('conflict') ||
-        msg.toLowerCase().includes('already');
-
-      captureFlowFailure({
-        flow: 'reservation_create',
-        step: 'create_reservation',
-        message: msg,
-        ...(isDuplicate ? { level: 'info' as const } : {}),
-      });
-
-      if (isDuplicate) {
-        toast({
-          title: '預約時間重疊',
-          description: '該時段您已有其他預約，請重新選擇其他時段。',
-          variant: 'destructive',
-        });
-      } else {
-        toast({
-          title: '預約失敗',
-          description: msg,
-          variant: 'destructive',
-        });
-      }
-      return false;
-    } finally {
-      setIsSubmitting(false);
     }
   };
 

--- a/src/hooks/user/reservation/useBookingConfirmation.test.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.test.ts
@@ -1,0 +1,233 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn(),
+}));
+
+vi.mock('@/services/reservations', () => ({
+  createReservation: vi.fn(),
+}));
+
+import { BookingSlot } from '@/hooks/useMentorSchedule';
+import { trackEvent } from '@/lib/analytics';
+import { FetchApiError } from '@/lib/apiClient';
+import { captureFlowFailure } from '@/lib/monitoring';
+import { createReservation } from '@/services/reservations';
+import { mockRouter } from '@/test/mocks/navigation';
+import { mockToast } from '@/test/mocks/useToast';
+
+import { useBookingConfirmation } from './useBookingConfirmation';
+
+const mockCreateReservation = vi.mocked(createReservation);
+const mockTrackEvent = vi.mocked(trackEvent);
+const mockCaptureFlowFailure = vi.mocked(captureFlowFailure);
+
+describe('useBookingConfirmation', () => {
+  const mockUserData = {
+    user_id: 123,
+    is_mentor: true,
+  } as any;
+
+  const mockSlot: BookingSlot = {
+    scheduleId: 456,
+    start: new Date('2026-07-26T14:00:00Z'),
+    end: new Date('2026-07-26T15:00:00Z'),
+    isBooked: false,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should redirect to sign-in page and return false if loginUserId is missing', async () => {
+    const setSelectedSlot = vi.fn();
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: null,
+        userData: mockUserData,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('some question');
+    });
+
+    expect(res).toBe(false);
+    expect(mockRouter.push).toHaveBeenCalledWith('/auth/signin');
+    expect(mockCreateReservation).not.toHaveBeenCalled();
+  });
+
+  it('should return false if selectedSlot is missing', async () => {
+    const setSelectedSlot = vi.fn();
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: mockUserData,
+        selectedSlot: null,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('some question');
+    });
+
+    expect(res).toBe(false);
+    expect(mockCreateReservation).not.toHaveBeenCalled();
+  });
+
+  it('should return false if userData is missing', async () => {
+    const setSelectedSlot = vi.fn();
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: undefined,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('some question');
+    });
+
+    expect(res).toBe(false);
+    expect(mockCreateReservation).not.toHaveBeenCalled();
+  });
+
+  it('should successfully book a reservation and clean up states', async () => {
+    const setSelectedSlot = vi.fn();
+    mockCreateReservation.mockResolvedValue({} as any);
+
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: mockUserData,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation(
+        'Hello mentor, please help!'
+      );
+    });
+
+    expect(res).toBe(true);
+    expect(mockCreateReservation).toHaveBeenCalledWith({
+      userId: 999,
+      body: {
+        my_user_id: 999,
+        my_status: 'PENDING',
+        user_id: 123,
+        schedule_id: 456,
+        dtstart: Math.floor(mockSlot.start.getTime() / 1000),
+        dtend: Math.floor(mockSlot.end.getTime() / 1000),
+        messages: [{ user_id: 999, content: 'Hello mentor, please help!' }],
+      },
+      debug: false,
+    });
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'reservation_booking_confirmed',
+      feature: 'reservation',
+    });
+    expect(mockToast).toHaveBeenCalledWith({
+      title: '預約已送出，等待導師回復',
+      description: '導師接受後預約才會成立，可至「我的預約」追蹤狀態。',
+    });
+    expect(setSelectedSlot).toHaveBeenCalledWith(null);
+  });
+
+  it('should handle standard errors by logging flow failure and showing failure toast', async () => {
+    const setSelectedSlot = vi.fn();
+    const err = new Error('Server Crashed');
+    mockCreateReservation.mockRejectedValue(err);
+
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: mockUserData,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('Hello');
+    });
+
+    expect(res).toBe(false);
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith({
+      flow: 'reservation_create',
+      step: 'create_reservation',
+      message: 'Server Crashed',
+    });
+    expect(mockToast).toHaveBeenCalledWith({
+      title: '預約失敗',
+      description: 'Server Crashed',
+      variant: 'destructive',
+    });
+    expect(setSelectedSlot).not.toHaveBeenCalled();
+  });
+
+  it('should handle 409 Conflict duplicate error structurally and show conflict toast', async () => {
+    const setSelectedSlot = vi.fn();
+    const conflictError = new FetchApiError(
+      '409',
+      'Conflict booking',
+      '/v1/users/999/reservations'
+    );
+    mockCreateReservation.mockRejectedValue(conflictError);
+
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: mockUserData,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('Hello');
+    });
+
+    expect(res).toBe(false);
+    expect(mockCaptureFlowFailure).toHaveBeenCalledWith({
+      flow: 'reservation_create',
+      step: 'create_reservation',
+      message: conflictError.message,
+      level: 'info',
+    });
+    expect(mockToast).toHaveBeenCalledWith({
+      title: '預約時間重疊',
+      description: '該時段您已有其他預約，請重新選擇其他時段。',
+      variant: 'destructive',
+    });
+    expect(setSelectedSlot).not.toHaveBeenCalled();
+  });
+});

--- a/src/hooks/user/reservation/useBookingConfirmation.test.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.test.ts
@@ -24,12 +24,14 @@ vi.mock('@/services/reservations', () => ({
 }));
 
 import { BookingSlot } from '@/hooks/useMentorSchedule';
+import { UserType } from '@/hooks/user/user-data/useUserData';
 import { trackEvent } from '@/lib/analytics';
 import { FetchApiError } from '@/lib/apiClient';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { createReservation } from '@/services/reservations';
 import { mockRouter } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
+import { components } from '@/types/api';
 
 import { useBookingConfirmation } from './useBookingConfirmation';
 
@@ -41,7 +43,7 @@ describe('useBookingConfirmation', () => {
   const mockUserData = {
     user_id: 123,
     is_mentor: true,
-  } as any;
+  } as unknown as UserType;
 
   const mockSlot: BookingSlot = {
     scheduleId: 456,
@@ -117,7 +119,9 @@ describe('useBookingConfirmation', () => {
 
   it('should successfully book a reservation and clean up states', async () => {
     const setSelectedSlot = vi.fn();
-    mockCreateReservation.mockResolvedValue({} as any);
+    mockCreateReservation.mockResolvedValue(
+      {} as unknown as components['schemas']['ReservationVO']
+    );
 
     const { result } = renderHook(() =>
       useBookingConfirmation({

--- a/src/hooks/user/reservation/useBookingConfirmation.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.ts
@@ -1,0 +1,104 @@
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { BookingSlot } from '@/hooks/useMentorSchedule';
+import { UserType } from '@/hooks/user/user-data/useUserData';
+import { trackEvent } from '@/lib/analytics';
+import { FetchApiError } from '@/lib/apiClient';
+import { captureFlowFailure } from '@/lib/monitoring';
+import { createReservation } from '@/services/reservations';
+
+interface UseBookingConfirmationParams {
+  loginUserId: string | null;
+  userData: UserType | null | undefined;
+  selectedSlot: BookingSlot | null;
+  setSelectedSlot: (slot: BookingSlot | null) => void;
+}
+
+export function useBookingConfirmation({
+  loginUserId,
+  userData,
+  selectedSlot,
+  setSelectedSlot,
+}: UseBookingConfirmationParams) {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleConfirmReservation = async (
+    question: string
+  ): Promise<boolean> => {
+    if (!loginUserId) {
+      router.push('/auth/signin');
+      return false;
+    }
+    if (!selectedSlot || !userData) return false;
+
+    setIsSubmitting(true);
+    try {
+      const menteeId = Number(loginUserId);
+      await createReservation({
+        userId: menteeId,
+        body: {
+          my_user_id: menteeId,
+          my_status: 'PENDING',
+          user_id: userData.user_id,
+          schedule_id: selectedSlot.scheduleId,
+          dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
+          dtend: Math.floor(selectedSlot.end.getTime() / 1000),
+          messages: [{ user_id: menteeId, content: question }],
+        },
+        debug: process.env.NODE_ENV === 'development',
+      });
+
+      trackEvent({
+        name: 'reservation_booking_confirmed',
+        feature: 'reservation',
+      });
+
+      toast({
+        title: '預約已送出，等待導師回復',
+        description: '導師接受後預約才會成立，可至「我的預約」追蹤狀態。',
+      });
+
+      setSelectedSlot(null);
+      return true;
+    } catch (error) {
+      console.error('Failed to create reservation:', error);
+
+      const isDuplicate =
+        error instanceof FetchApiError && error.code === '409';
+      const msg = error instanceof Error ? error.message : 'Unknown error';
+
+      captureFlowFailure({
+        flow: 'reservation_create',
+        step: 'create_reservation',
+        message: msg,
+        ...(isDuplicate ? { level: 'info' as const } : {}),
+      });
+
+      if (isDuplicate) {
+        toast({
+          title: '預約時間重疊',
+          description: '該時段您已有其他預約，請重新選擇其他時段。',
+          variant: 'destructive',
+        });
+      } else {
+        toast({
+          title: '預約失敗',
+          description: msg,
+          variant: 'destructive',
+        });
+      }
+      return false;
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    isSubmitting,
+    handleConfirmReservation,
+  };
+}

--- a/src/hooks/user/reservation/useBookingConfirmation.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.ts
@@ -1,5 +1,5 @@
 import { useRouter } from 'next/navigation';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { useToast } from '@/components/ui/use-toast';
 import { BookingSlot } from '@/hooks/useMentorSchedule';
@@ -26,76 +26,77 @@ export function useBookingConfirmation({
   const { toast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleConfirmReservation = async (
-    question: string
-  ): Promise<boolean> => {
-    if (!loginUserId) {
-      router.push('/auth/signin');
-      return false;
-    }
-    if (!selectedSlot || !userData) return false;
-
-    setIsSubmitting(true);
-    try {
-      const menteeId = Number(loginUserId);
-      await createReservation({
-        userId: menteeId,
-        body: {
-          my_user_id: menteeId,
-          my_status: 'PENDING',
-          user_id: userData.user_id,
-          schedule_id: selectedSlot.scheduleId,
-          dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
-          dtend: Math.floor(selectedSlot.end.getTime() / 1000),
-          messages: [{ user_id: menteeId, content: question }],
-        },
-        debug: process.env.NODE_ENV === 'development',
-      });
-
-      trackEvent({
-        name: 'reservation_booking_confirmed',
-        feature: 'reservation',
-      });
-
-      toast({
-        title: '預約已送出，等待導師回復',
-        description: '導師接受後預約才會成立，可至「我的預約」追蹤狀態。',
-      });
-
-      setSelectedSlot(null);
-      return true;
-    } catch (error) {
-      console.error('Failed to create reservation:', error);
-
-      const isDuplicate =
-        error instanceof FetchApiError && error.code === '409';
-      const msg = error instanceof Error ? error.message : 'Unknown error';
-
-      captureFlowFailure({
-        flow: 'reservation_create',
-        step: 'create_reservation',
-        message: msg,
-        ...(isDuplicate ? { level: 'info' as const } : {}),
-      });
-
-      if (isDuplicate) {
-        toast({
-          title: '預約時間重疊',
-          description: '該時段您已有其他預約，請重新選擇其他時段。',
-          variant: 'destructive',
-        });
-      } else {
-        toast({
-          title: '預約失敗',
-          description: msg,
-          variant: 'destructive',
-        });
+  const handleConfirmReservation = useCallback(
+    async (question: string): Promise<boolean> => {
+      if (!loginUserId) {
+        router.push('/auth/signin');
+        return false;
       }
-      return false;
-    } finally {
-      setIsSubmitting(false);
-    }
-  };
+      if (!selectedSlot || !userData) return false;
+
+      setIsSubmitting(true);
+      try {
+        const menteeId = Number(loginUserId);
+        await createReservation({
+          userId: menteeId,
+          body: {
+            my_user_id: menteeId,
+            my_status: 'PENDING',
+            user_id: userData.user_id,
+            schedule_id: selectedSlot.scheduleId,
+            dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
+            dtend: Math.floor(selectedSlot.end.getTime() / 1000),
+            messages: [{ user_id: menteeId, content: question }],
+          },
+          debug: process.env.NODE_ENV === 'development',
+        });
+
+        trackEvent({
+          name: 'reservation_booking_confirmed',
+          feature: 'reservation',
+        });
+
+        toast({
+          title: '預約已送出，等待導師回復',
+          description: '導師接受後預約才會成立，可至「我的預約」追蹤狀態。',
+        });
+
+        setSelectedSlot(null);
+        return true;
+      } catch (error) {
+        console.error('Failed to create reservation:', error);
+
+        const isDuplicate =
+          error instanceof FetchApiError && error.code === '409';
+        const msg = error instanceof Error ? error.message : 'Unknown error';
+
+        captureFlowFailure({
+          flow: 'reservation_create',
+          step: 'create_reservation',
+          message: msg,
+          ...(isDuplicate ? { level: 'info' as const } : {}),
+        });
+
+        if (isDuplicate) {
+          toast({
+            title: '預約時間重疊',
+            description: '該時段您已有其他預約，請重新選擇其他時段。',
+            variant: 'destructive',
+          });
+        } else {
+          toast({
+            title: '預約失敗',
+            description: msg,
+            variant: 'destructive',
+          });
+        }
+        return false;
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [loginUserId, selectedSlot, userData, setSelectedSlot, router, toast]
+  );
 
   return {
     isSubmitting,

--- a/src/hooks/user/reservation/useReservationDateClamp.test.ts
+++ b/src/hooks/user/reservation/useReservationDateClamp.test.ts
@@ -1,0 +1,150 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useReservationDateClamp } from './useReservationDateClamp';
+
+describe('useReservationDateClamp', () => {
+  const systemDate = new Date('2026-07-26T12:00:00');
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(systemDate);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('handleScheduleMonthChange should change year/month and update selectedDate to 1st of month if future', () => {
+    const setSelectedDate = vi.fn();
+    const setYear = vi.fn();
+    const setMonth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReservationDateClamp({
+        selectedDate: '2026-07-26',
+        setSelectedDate,
+        year: 2026,
+        setYear,
+        month: 7,
+        setMonth,
+        openReservationDialog: false,
+      })
+    );
+
+    act(() => {
+      // Navigate to August 2026
+      result.current.handleScheduleMonthChange(new Date('2026-08-01T00:00:00'));
+    });
+
+    expect(setYear).toHaveBeenCalledWith(2026);
+    expect(setMonth).toHaveBeenCalledWith(8);
+    expect(setSelectedDate).toHaveBeenCalledWith('2026-08-01');
+  });
+
+  it('handleScheduleMonthChange should clamp selectedDate to today if navigating to a past month', () => {
+    const setSelectedDate = vi.fn();
+    const setYear = vi.fn();
+    const setMonth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReservationDateClamp({
+        selectedDate: '2026-07-26',
+        setSelectedDate,
+        year: 2026,
+        setYear,
+        month: 7,
+        setMonth,
+        openReservationDialog: false,
+      })
+    );
+
+    act(() => {
+      // Navigate to June 2026 (past)
+      result.current.handleScheduleMonthChange(new Date('2026-06-01T00:00:00'));
+    });
+
+    expect(setYear).toHaveBeenCalledWith(2026);
+    expect(setMonth).toHaveBeenCalledWith(6);
+    // Since June 1st is before July 26th, it clamps to July 26th (today)
+    expect(setSelectedDate).toHaveBeenCalledWith('2026-07-26');
+  });
+
+  it('handleScheduleMonthChange should not update selectedDate if openReservationDialog is true', () => {
+    const setSelectedDate = vi.fn();
+    const setYear = vi.fn();
+    const setMonth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReservationDateClamp({
+        selectedDate: '2026-07-26',
+        setSelectedDate,
+        year: 2026,
+        setYear,
+        month: 7,
+        setMonth,
+        openReservationDialog: true,
+      })
+    );
+
+    act(() => {
+      result.current.handleScheduleMonthChange(new Date('2026-08-01T00:00:00'));
+    });
+
+    expect(setYear).toHaveBeenCalledWith(2026);
+    expect(setMonth).toHaveBeenCalledWith(8);
+    expect(setSelectedDate).not.toHaveBeenCalled();
+  });
+
+  it('clampSelectedDateToToday should do nothing if selectedDate is in the future', () => {
+    const setSelectedDate = vi.fn();
+    const setYear = vi.fn();
+    const setMonth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReservationDateClamp({
+        selectedDate: '2026-08-01',
+        setSelectedDate,
+        year: 2026,
+        setYear,
+        month: 8,
+        setMonth,
+        openReservationDialog: false,
+      })
+    );
+
+    act(() => {
+      result.current.clampSelectedDateToToday();
+    });
+
+    expect(setSelectedDate).not.toHaveBeenCalled();
+    expect(setYear).not.toHaveBeenCalled();
+    expect(setMonth).not.toHaveBeenCalled();
+  });
+
+  it('clampSelectedDateToToday should snap selectedDate to today and update year/month if selectedDate is in the past', () => {
+    const setSelectedDate = vi.fn();
+    const setYear = vi.fn();
+    const setMonth = vi.fn();
+
+    const { result } = renderHook(() =>
+      useReservationDateClamp({
+        selectedDate: '2026-06-15',
+        setSelectedDate,
+        year: 2026,
+        setYear,
+        month: 6,
+        setMonth,
+        openReservationDialog: false,
+      })
+    );
+
+    act(() => {
+      result.current.clampSelectedDateToToday();
+    });
+
+    expect(setSelectedDate).toHaveBeenCalledWith('2026-07-26');
+    expect(setYear).toHaveBeenCalledWith(2026);
+    expect(setMonth).toHaveBeenCalledWith(7);
+  });
+});

--- a/src/hooks/user/reservation/useReservationDateClamp.ts
+++ b/src/hooks/user/reservation/useReservationDateClamp.ts
@@ -1,0 +1,68 @@
+import { useCallback } from 'react';
+
+import { toDateKey } from '@/lib/profile/scheduleFormatters';
+
+interface UseReservationDateClampParams {
+  selectedDate: string | null;
+  setSelectedDate: (date: string | null) => void;
+  year: number;
+  setYear: (year: number) => void;
+  month: number;
+  setMonth: (month: number) => void;
+  openReservationDialog: boolean;
+}
+
+export function useReservationDateClamp({
+  selectedDate,
+  setSelectedDate,
+  year,
+  setYear,
+  month,
+  setMonth,
+  openReservationDialog,
+}: UseReservationDateClampParams) {
+  const handleScheduleMonthChange = useCallback(
+    (date: Date) => {
+      const newYear = date.getFullYear();
+      const newMonth = date.getMonth() + 1;
+      setYear(newYear);
+      setMonth(newMonth);
+
+      // Carry the viewed month into the booking dialogs by anchoring
+      // selectedDate to the new month. Skip while a dialog is open so
+      // in-dialog month navigation does not clobber the user's day pick.
+      // Clamp to today so a past month never anchors to an un-editable
+      // past day (which would let the dialog render its slot editor on
+      // a date the mentor cannot configure).
+      if (!openReservationDialog) {
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        const monthStart = new Date(newYear, newMonth - 1, 1);
+        const anchor = monthStart < today ? today : monthStart;
+        setSelectedDate(toDateKey(anchor));
+      }
+    },
+    [openReservationDialog, setSelectedDate, setYear, setMonth]
+  );
+
+  const clampSelectedDateToToday = useCallback(() => {
+    if (!selectedDate) return;
+    const sel = new Date(selectedDate + 'T00:00:00');
+    const today = new Date();
+    today.setHours(0, 0, 0, 0);
+    if (sel < today) {
+      setSelectedDate(toDateKey(today));
+      const todayYear = today.getFullYear();
+      const todayMonth = today.getMonth() + 1;
+      if (todayYear !== year || todayMonth !== month) {
+        setYear(todayYear);
+        setMonth(todayMonth);
+      }
+    }
+  }, [selectedDate, setSelectedDate, year, month, setYear, setMonth]);
+
+  return {
+    handleScheduleMonthChange,
+    clampSelectedDateToToday,
+  };
+}

--- a/src/services/reservations/reservationService.test.ts
+++ b/src/services/reservations/reservationService.test.ts
@@ -1,0 +1,146 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiClient: {
+    get: vi.fn(),
+    put: vi.fn(),
+    post: vi.fn(),
+  },
+  FetchApiError: class FetchApiError extends Error {
+    constructor(
+      public readonly code: string,
+      message: string,
+      public readonly path: string
+    ) {
+      super(`fetch ${path} API error (${code}): ${message}`);
+      this.name = 'FetchApiError';
+    }
+  },
+}));
+
+import { apiClient, FetchApiError } from '@/lib/apiClient';
+import { components } from '@/types/api';
+
+import {
+  createReservation,
+  fetchReservations,
+  updateReservationStatus,
+} from './reservationService';
+
+const mockGet = vi.mocked(apiClient.get);
+const mockPut = vi.mocked(apiClient.put);
+const mockPost = vi.mocked(apiClient.post);
+
+describe('reservationService API Error Handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('createReservation', () => {
+    it('should throw FetchApiError with correct code, message and path if API returns non-0 code', async () => {
+      mockPost.mockResolvedValue({
+        code: '409',
+        msg: 'Conflict booking',
+        data: null,
+      });
+
+      await expect(
+        createReservation({
+          userId: 123,
+          body: {} as unknown as components['schemas']['ReservationDTO'],
+        })
+      ).rejects.toThrow(FetchApiError);
+
+      try {
+        await createReservation({
+          userId: 123,
+          body: {} as unknown as components['schemas']['ReservationDTO'],
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchApiError);
+        const apiError = err as FetchApiError;
+        expect(apiError.code).toBe('409');
+        expect(apiError.message).toContain('Conflict booking');
+        expect(apiError.path).toBe('/v1/users/123/reservations');
+      }
+    });
+
+    it('should return data successfully if code is 0', async () => {
+      const mockResult = { id: 789 };
+      mockPost.mockResolvedValue({
+        code: '0',
+        msg: 'success',
+        data: mockResult,
+      });
+
+      const res = await createReservation({
+        userId: 123,
+        body: {} as unknown as components['schemas']['ReservationDTO'],
+      });
+
+      expect(res).toEqual(mockResult);
+    });
+  });
+
+  describe('updateReservationStatus', () => {
+    it('should throw FetchApiError with correct code, message and path if API returns non-0 code', async () => {
+      mockPut.mockResolvedValue({
+        code: '500',
+        msg: 'Internal Server Error',
+        data: null,
+      });
+
+      await expect(
+        updateReservationStatus({
+          userId: 123,
+          reservationId: 456,
+          body: {} as unknown as components['schemas']['UpdateReservationDTO'],
+        })
+      ).rejects.toThrow(FetchApiError);
+
+      try {
+        await updateReservationStatus({
+          userId: 123,
+          reservationId: 456,
+          body: {} as unknown as components['schemas']['UpdateReservationDTO'],
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchApiError);
+        const apiError = err as FetchApiError;
+        expect(apiError.code).toBe('500');
+        expect(apiError.message).toContain('Internal Server Error');
+        expect(apiError.path).toBe('/v1/users/123/reservations/456');
+      }
+    });
+  });
+
+  describe('fetchReservations', () => {
+    it('should throw FetchApiError with correct code, message and path if API returns non-0 code', async () => {
+      mockGet.mockResolvedValue({
+        code: '400',
+        msg: 'Bad Request',
+        data: null,
+      });
+
+      await expect(
+        fetchReservations({
+          userId: 123,
+          state: 'MENTEE_PENDING',
+        })
+      ).rejects.toThrow(FetchApiError);
+
+      try {
+        await fetchReservations({
+          userId: 123,
+          state: 'MENTEE_PENDING',
+        });
+      } catch (err) {
+        expect(err).toBeInstanceOf(FetchApiError);
+        const apiError = err as FetchApiError;
+        expect(apiError.code).toBe('400');
+        expect(apiError.message).toContain('Bad Request');
+        expect(apiError.path).toBe('/v1/users/123/reservations');
+      }
+    });
+  });
+});

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -1,7 +1,7 @@
 import dayjs from 'dayjs';
 
 import { TotalWorkSpanEnum } from '@/components/onboarding/steps/constant';
-import { apiClient } from '@/lib/apiClient';
+import { apiClient, FetchApiError } from '@/lib/apiClient';
 import { Reservation, ReservationMessage } from '@/services/reservations/types';
 import { components } from '@/types/api';
 
@@ -156,16 +156,16 @@ export async function fetchReservations(
   if (debug)
     console.debug('[reservations] GET', { userId, state, batch, nextDtend });
 
+  const path = `/v1/users/${userId}/reservations`;
   const json = await apiClient.get<
     components['schemas']['ApiResponse_ReservationInfoListVO_']
-  >(`/v1/users/${userId}/reservations`, {
+  >(path, {
     params: { state, batch, next_dtend: nextDtend },
   });
 
   if (debug) console.debug('[reservations] GET parsed', json);
 
-  if (json.code !== '0')
-    throw new Error(`API error: code=${json.code}, msg=${json.msg}`);
+  if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
     mapToReservation(reservation)
@@ -192,14 +192,14 @@ export async function updateReservationStatus(opts: {
       body,
     });
 
+  const path = `/v1/users/${userId}/reservations/${reservationId}`;
   const json = await apiClient.put<
     components['schemas']['ApiResponse_ReservationVO_']
-  >(`/v1/users/${userId}/reservations/${reservationId}`, body);
+  >(path, body);
 
   if (debug) console.debug('[reservations] PUT parsed', json);
 
-  if (json.code !== '0')
-    throw new Error(`API error: code=${json.code}, msg=${json.msg}`);
+  if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   if (!json.data) throw new Error('API error: missing data in response');
 
@@ -225,14 +225,14 @@ export async function createReservation(opts: {
 
   if (debug) console.debug('[reservations] POST request', { userId, body });
 
+  const path = `/v1/users/${userId}/reservations`;
   const json = await apiClient.post<
     components['schemas']['ApiResponse_ReservationVO_']
-  >(`/v1/users/${userId}/reservations`, body);
+  >(path, body);
 
   if (debug) console.debug('[reservations] POST parsed', json);
 
-  if (json.code !== '0')
-    throw new Error(`API error: code=${json.code}, msg=${json.msg}`);
+  if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   if (!json.data) throw new Error('API error: missing data in response');
 


### PR DESCRIPTION
Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/355

- 建立 useBookingConfirmation hook 封裝 API payload 組裝、提交狀態與重複預約結構化 409 偵測
- 建立 useReservationDateClamp hook 整合原有的日期 clamp 邏輯
- 修改 reservationService.ts 改為拋出結構化的 FetchApiError 取代脆弱的字串比對
- 補齊兩個新 hook 的單元測試 (共 11 個 test cases)
