### PR TITLE
refactor: consolidate mentor-pool pagination states into a single state and pure reducer (X-Tracker #356)

### DIFF
--- a/src/app/mentor-pool/MentorPoolWithData.tsx
+++ b/src/app/mentor-pool/MentorPoolWithData.tsx
@@ -15,12 +15,10 @@ export default async function MentorPoolWithData() {
     }),
     fetchTagCatalogServer('zh_TW'),
   ]);
-  const initialCursor = initialMentors.at(-1)?.updated_at?.toString() ?? '';
 
   return (
     <MentorPoolContainer
       initialMentors={initialMentors}
-      initialCursor={initialCursor}
       initialMentorCount={initialMentors.length}
       initialTagCatalog={initialTagCatalog}
     />

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -54,14 +54,12 @@ function flattenLeaves(
 
 interface Props {
   initialMentors: MentorType[];
-  initialCursor: string;
   initialMentorCount: number;
   initialTagCatalog: TagCatalogsByBucket;
 }
 
 export default function MentorPoolContainer({
   initialMentors,
-  initialCursor,
   initialMentorCount,
   initialTagCatalog,
 }: Props) {
@@ -96,7 +94,6 @@ export default function MentorPoolContainer({
   const { mentors, mentorCount, isLoading, isNoResults, handleScrollToBottom } =
     useMentorPool({
       initialMentors,
-      initialCursor,
       initialMentorCount,
       params,
       labelMap,

--- a/src/hooks/useMentorPool.test.ts
+++ b/src/hooks/useMentorPool.test.ts
@@ -24,7 +24,11 @@ import {
 import { mockSearchParams } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
 
-import { useMentorPool } from './useMentorPool';
+import {
+  applyMentorPage,
+  type MentorPoolPageState,
+  useMentorPool,
+} from './useMentorPool';
 
 const mockFetchMentors = vi.mocked(fetchMentors);
 
@@ -66,7 +70,6 @@ describe('useMentorPool', () => {
     const { result } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -118,7 +121,6 @@ describe('useMentorPool', () => {
     const { result } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -160,7 +162,6 @@ describe('useMentorPool', () => {
     const { result } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -214,7 +215,6 @@ describe('useMentorPool', () => {
     const { result, rerender } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -272,7 +272,6 @@ describe('useMentorPool', () => {
     const { result } = renderHook(() =>
       useMentorPool({
         initialMentors: largeInitialMentors,
-        initialCursor: '100',
         initialMentorCount: PAGE_LIMIT,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -306,7 +305,6 @@ describe('useMentorPool', () => {
     const { result } = renderHook(() =>
       useMentorPool({
         initialMentors: largeInitialMentors,
-        initialCursor: '100',
         initialMentorCount: PAGE_LIMIT,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -350,7 +348,6 @@ describe('useMentorPool', () => {
     const { result, rerender } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -408,7 +405,6 @@ describe('useMentorPool', () => {
     const { result, rerender } = renderHook(() =>
       useMentorPool({
         initialMentors: mockInitialMentors,
-        initialCursor: '100',
         initialMentorCount: 1,
         params: mockSearchParams as unknown as ReadonlyURLSearchParams,
         labelMap: testLabelMap,
@@ -448,5 +444,100 @@ describe('useMentorPool', () => {
     expect(result.current.mentors[0].user_id).toBe(100);
 
     spyConsoleError.mockRestore();
+  });
+});
+
+describe('applyMentorPage', () => {
+  const initialPageState: MentorPoolPageState = {
+    mentors: [],
+    cursor: undefined,
+    hasMore: true,
+    mentorCount: 0,
+    isNoResults: false,
+  };
+
+  const sampleMentor: MentorType = {
+    user_id: 10,
+    name: 'Sample',
+    avatar: '',
+    job_title: '',
+    company: '',
+    years_of_experience: '',
+    location: '',
+    personal_statement: '',
+    about: '',
+    seniority_level: '',
+    industry: null,
+    want_position: [],
+    want_skill: [],
+    want_topic: [],
+    have_skill: [],
+    have_topic: [],
+    updated_at: 1000,
+  };
+
+  it('handles replace action with non-empty page', () => {
+    const action = { type: 'replace' as const, page: [sampleMentor] };
+    const nextState = applyMentorPage(initialPageState, action);
+
+    expect(nextState.mentors).toEqual([sampleMentor]);
+    expect(nextState.cursor).toBe('1000');
+    expect(nextState.hasMore).toBe(false); // as page length 1 !== PAGE_LIMIT (9)
+    expect(nextState.mentorCount).toBe(1);
+    expect(nextState.isNoResults).toBe(false);
+  });
+
+  it('handles replace action with empty page', () => {
+    const action = { type: 'replace' as const, page: [] };
+    const nextState = applyMentorPage(initialPageState, action);
+
+    expect(nextState.mentors).toEqual([]);
+    expect(nextState.cursor).toBeUndefined();
+    expect(nextState.hasMore).toBe(false);
+    expect(nextState.mentorCount).toBe(0);
+    expect(nextState.isNoResults).toBe(true);
+  });
+
+  it('handles append action with empty page by setting hasMore to false', () => {
+    const state: MentorPoolPageState = {
+      mentors: [sampleMentor],
+      cursor: '1000',
+      hasMore: true,
+      mentorCount: 1,
+      isNoResults: false,
+    };
+    const action = { type: 'append' as const, page: [] };
+    const nextState = applyMentorPage(state, action);
+
+    expect(nextState.mentors).toEqual([sampleMentor]);
+    expect(nextState.cursor).toBe('1000');
+    expect(nextState.hasMore).toBe(false);
+    expect(nextState.mentorCount).toBe(1);
+    expect(nextState.isNoResults).toBe(false);
+  });
+
+  it('handles append action with non-empty page, filters duplicates, and updates count/cursor', () => {
+    const state: MentorPoolPageState = {
+      mentors: [sampleMentor],
+      cursor: '1000',
+      hasMore: true,
+      mentorCount: 1,
+      isNoResults: false,
+    };
+
+    const duplicateMentor = { ...sampleMentor };
+    const newMentor = { ...sampleMentor, user_id: 11, updated_at: 1100 };
+
+    const action = {
+      type: 'append' as const,
+      page: [duplicateMentor, newMentor],
+    };
+    const nextState = applyMentorPage(state, action);
+
+    // Should deduplicate, adding only newMentor (user_id 11)
+    expect(nextState.mentors).toEqual([sampleMentor, newMentor]);
+    expect(nextState.cursor).toBe('1100'); // taken from last element of action.page, which is newMentor
+    expect(nextState.mentorCount).toBe(3); // count is accumulated based on raw page length (1 + 2 = 3)
+    expect(nextState.hasMore).toBe(false);
   });
 });

--- a/src/hooks/useMentorPool.ts
+++ b/src/hooks/useMentorPool.ts
@@ -15,9 +15,64 @@ import {
   type MentorType,
 } from '@/services/search-mentor/mentors';
 
+export interface MentorPoolPageState {
+  mentors: MentorType[];
+  cursor: string | undefined;
+  hasMore: boolean;
+  mentorCount: number;
+  isNoResults: boolean;
+}
+
+export type MentorPageAction =
+  | { type: 'replace'; page: MentorType[] }
+  | { type: 'append'; page: MentorType[] };
+
+export function applyMentorPage(
+  state: MentorPoolPageState,
+  action: MentorPageAction
+): MentorPoolPageState {
+  switch (action.type) {
+    case 'replace': {
+      const { page } = action;
+      return {
+        mentors: page,
+        cursor: page.at(-1)?.updated_at?.toString(),
+        hasMore: page.length === PAGE_LIMIT,
+        mentorCount: page.length,
+        isNoResults: page.length === 0,
+      };
+    }
+    case 'append': {
+      const { page } = action;
+      if (page.length === 0) {
+        return {
+          ...state,
+          hasMore: false,
+        };
+      }
+
+      const newMentors = page.filter(
+        (newMentor) =>
+          !state.mentors.some(
+            (prevMentor) => prevMentor.user_id === newMentor.user_id
+          )
+      );
+
+      return {
+        mentors: [...state.mentors, ...newMentors],
+        cursor: page.at(-1)?.updated_at?.toString(),
+        hasMore: page.length === PAGE_LIMIT,
+        mentorCount: state.mentorCount + page.length,
+        isNoResults: false,
+      };
+    }
+    default:
+      return state;
+  }
+}
+
 interface UseMentorPoolProps {
   initialMentors: MentorType[];
-  initialCursor: string;
   initialMentorCount: number;
   params: ReturnType<typeof useSearchParams>;
   labelMap: Map<string, string>;
@@ -25,7 +80,6 @@ interface UseMentorPoolProps {
 
 export function useMentorPool({
   initialMentors,
-  initialCursor,
   initialMentorCount,
   params,
   labelMap,
@@ -40,26 +94,31 @@ export function useMentorPool({
     [initialMentors]
   );
 
-  const [mentorCount, setMentorCount] = useState<number>(
-    hasInitialFilters ? 0 : initialMentorCount
+  const getInitialUnfilteredState = useCallback(
+    (): MentorPoolPageState => ({
+      mentors: resolvedInitialMentors,
+      cursor: resolvedInitialMentors.at(-1)?.updated_at?.toString(),
+      hasMore: resolvedInitialMentors.length === PAGE_LIMIT,
+      mentorCount: initialMentorCount,
+      isNoResults: resolvedInitialMentors.length === 0,
+    }),
+    [resolvedInitialMentors, initialMentorCount]
   );
 
-  // mentors state holds the fetched mentors with only resolveMentorAvatar applied.
-  // This keeps avatar calculation cached but preserves raw have_topic codes in state for dynamic localization.
-  const [mentors, setMentors] = useState<MentorType[]>(() =>
-    hasInitialFilters ? [] : resolvedInitialMentors
-  );
+  const [pageState, setPageState] = useState<MentorPoolPageState>(() => {
+    if (hasInitialFilters) {
+      return {
+        mentors: [],
+        cursor: undefined,
+        hasMore: true,
+        mentorCount: 0,
+        isNoResults: false,
+      };
+    }
+    return getInitialUnfilteredState();
+  });
 
-  const [isNoResults, setIsNoResults] = useState(
-    hasInitialFilters ? false : initialMentors.length === 0
-  );
   const [isLoading, setIsLoading] = useState(hasInitialFilters);
-  const [cursor, setCursor] = useState<string | undefined>(
-    hasInitialFilters ? undefined : initialCursor
-  );
-  const [hasMore, setHasMore] = useState<boolean>(
-    hasInitialFilters ? true : initialMentors.length === PAGE_LIMIT
-  );
 
   const isLoadingRef = useRef(false);
   const requestIdRef = useRef(0);
@@ -90,11 +149,7 @@ export function useMentorPool({
     const myRequestId = ++requestIdRef.current;
 
     if (!hasAnyCondition(params)) {
-      setMentors(resolvedInitialMentors);
-      setMentorCount(initialMentorCount);
-      setCursor(initialCursor);
-      setIsNoResults(initialMentors.length === 0);
-      setHasMore(initialMentors.length === PAGE_LIMIT);
+      setPageState(getInitialUnfilteredState());
       setIsLoading(false);
       isLoadingRef.current = false;
       return;
@@ -103,18 +158,19 @@ export function useMentorPool({
     const conditions = paramsToFetchConditions(params);
     setIsLoading(true);
     isLoadingRef.current = true;
-    setIsNoResults(false);
-    setHasMore(false);
+    setPageState((prev) => ({
+      ...prev,
+      isNoResults: false,
+      hasMore: false,
+    }));
 
     fetchMentors({ ...conditions, limit: PAGE_LIMIT, cursor: '' })
       .then((list) => {
         if (myRequestId !== requestIdRef.current) return;
         const resolvedList = list.map(resolveMentorAvatar);
-        setMentors(resolvedList);
-        setMentorCount(resolvedList.length);
-        setCursor(resolvedList.at(-1)?.updated_at?.toString());
-        setIsNoResults(resolvedList.length === 0);
-        setHasMore(resolvedList.length === PAGE_LIMIT);
+        setPageState((prev) =>
+          applyMentorPage(prev, { type: 'replace', page: resolvedList })
+        );
         setIsLoading(false);
         isLoadingRef.current = false;
       })
@@ -130,31 +186,17 @@ export function useMentorPool({
     const param = {
       ...conditions,
       limit: PAGE_LIMIT,
-      cursor,
+      cursor: pageState.cursor,
     };
     setIsLoading(true);
     isLoadingRef.current = true;
-    let rtnList: MentorType[] = [];
     try {
-      rtnList = await fetchMentors(param);
+      const rtnList = await fetchMentors(param);
       if (myRequestId === requestIdRef.current) {
-        if (rtnList.length === 0) {
-          setHasMore(false);
-        } else {
-          const resolvedList = rtnList.map(resolveMentorAvatar);
-          setMentors((prevMentors) => {
-            const newMentors = resolvedList.filter(
-              (newMentor) =>
-                !prevMentors.some(
-                  (prevMentor) => prevMentor.user_id === newMentor.user_id
-                )
-            );
-            return [...prevMentors, ...newMentors];
-          });
-          setMentorCount((prev) => prev + rtnList.length);
-          setCursor(rtnList.at(-1)?.updated_at?.toString());
-          setHasMore(rtnList.length === PAGE_LIMIT);
-        }
+        const resolvedList = rtnList.map(resolveMentorAvatar);
+        setPageState((prev) =>
+          applyMentorPage(prev, { type: 'append', page: resolvedList })
+        );
       }
     } catch (error) {
       handleError(myRequestId, 'Fetch more mentors error:', error);
@@ -164,29 +206,29 @@ export function useMentorPool({
         isLoadingRef.current = false;
       }
     }
-  }, [params, cursor, handleError]);
+  }, [params, pageState.cursor, handleError]);
 
   const handleScrollToBottom = useCallback(async () => {
-    if (!hasMore || isLoadingRef.current) return;
+    if (!pageState.hasMore || isLoadingRef.current) return;
     await fetchMoreMentors();
-  }, [hasMore, fetchMoreMentors]);
+  }, [pageState.hasMore, fetchMoreMentors]);
 
   // Dynamically translate tag labels inside useMemo on return. This preserves dynamic localization
   // updates (e.g. language switching) without coupling translation state updates to useEffect fetching.
   const mentorsForUI = useMemo(
     () =>
-      mentors.map((m) => ({
+      pageState.mentors.map((m) => ({
         ...m,
         have_topic: m.have_topic.map((c) => labelMap.get(c) ?? c),
       })),
-    [mentors, labelMap]
+    [pageState.mentors, labelMap]
   );
 
   return {
     mentors: mentorsForUI,
-    mentorCount,
+    mentorCount: pageState.mentorCount,
     isLoading,
-    isNoResults,
+    isNoResults: pageState.isNoResults,
     handleScrollToBottom,
   };
 }


### PR DESCRIPTION
## What Does This PR Do?

Refactors the pagination and state tracking logic of the mentor pool to be single-source-of-truth and highly testable.

### 🛠️ Key Modifications

* **src/hooks/useMentorPool.ts**:
  * Unifies the 5 separate piece-meal pagination states (\mentors\, \cursor\, \hasMore\, \mentorCount\, and \isNoResults\) into a cohesive single \pageState\ object (\MentorPoolPageState\).
  * Extracts a pure state transformation function \pplyMentorPage(state, action)\ that cleanly handles \eplace\ (for initial mount, search param updates, and filter clearing) and \ppend\ (for infinite scrolling / fetch more) operations.
  * Removes the \initialCursor\ prop entirely, deriving the initial cursor internally to simplify the public API.
* **src/app/mentor-pool/MentorPoolWithData.tsx**:
  * Completely removes the redundant \initialCursor\ calculation and prop.
* **src/app/mentor-pool/container.tsx**:
  * Completely removes the \initialCursor\ prop interface and prop-drilling into \useMentorPool\.
* **src/hooks/useMentorPool.test.ts**:
  * Removes the \initialCursor\ property across all hook rendering test setups.
  * Adds comprehensive, dedicated unit tests for the newly extracted pure \pplyMentorPage\ function to verify all transition states (including deduplication, empty responses, replacement, and appending).

### 🔍 Reference

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/356