### PR TITLE
refactor: 抽出共用的 useConfirmActionDialog，收斂三個預約 dialog 的重複生命週期 (X-Tracker #359)

### DIFF
--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { useToast } from '@/components/ui/use-toast';
+import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDialog';
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
@@ -35,16 +35,12 @@ export default function AcceptReservationDialog({
   disabled = false,
   onAccept,
 }: Props) {
-  const [open, setOpen] = useState(false);
   const [replyOpen, setReplyOpen] = useState(false);
   const [reply, setReply] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { toast } = useToast();
 
-  function onOpenChange(next: boolean) {
-    if (isSubmitting) return;
-    setOpen(next);
-    if (next) {
+  const { open, isSubmitting, onOpenChange, execute } = useConfirmActionDialog({
+    errorMessage: '接受預約失敗,請稍後再試',
+    onOpen: () => {
       setReply('');
       setReplyOpen(false);
       trackEvent({
@@ -52,28 +48,19 @@ export default function AcceptReservationDialog({
         feature: 'reservation',
         metadata: { dialog: 'accept_reservation' },
       });
-    }
-  }
+    },
+  });
 
-  async function handleAccept() {
-    setIsSubmitting(true);
-    try {
+  const handleAccept = () => {
+    execute(async () => {
       await onAccept?.({ id: reservation.id, message: reply.trim() });
       trackEvent({
         name: 'reservation_accepted',
         feature: 'reservation',
         metadata: { has_reply: reply.trim().length > 0 },
       });
-      setIsSubmitting(false);
-      setOpen(false);
-    } catch {
-      toast({
-        variant: 'destructive',
-        description: '接受預約失敗,請稍後再試',
-      });
-      setIsSubmitting(false);
-    }
-  }
+    });
+  };
 
   const menteeMessage = reservation.menteeMessage?.content;
 

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { useToast } from '@/components/ui/use-toast';
+import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDialog';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
@@ -37,38 +37,25 @@ export default function CancelReservationDialog({
   disabled = false,
   onConfirmCancel,
 }: Props) {
-  const [open, setOpen] = useState(false);
   const [reason, setReason] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { toast } = useToast();
 
-  function onOpenChange(next: boolean) {
-    if (isSubmitting) return;
-    setOpen(next);
-    if (next) {
+  const { open, isSubmitting, onOpenChange, execute } = useConfirmActionDialog({
+    errorMessage: '取消預約失敗,請稍後再試',
+    onOpen: () => {
       setReason('');
       trackEvent({
         name: 'feature_opened',
         feature: 'reservation',
         metadata: { dialog: 'cancel_reservation' },
       });
-    }
-  }
+    },
+  });
 
-  async function handleConfirm() {
-    setIsSubmitting(true);
-    try {
+  const handleConfirm = () => {
+    execute(async () => {
       await onConfirmCancel?.({ id: reservation.id, reason });
-      setIsSubmitting(false);
-      setOpen(false);
-    } catch {
-      toast({
-        variant: 'destructive',
-        description: '取消預約失敗,請稍後再試',
-      });
-      setIsSubmitting(false);
-    }
-  }
+    });
+  };
 
   const canSubmit = reason.trim().length > 0 && !isSubmitting;
 

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -15,7 +15,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog';
 import { Textarea } from '@/components/ui/textarea';
-import { useToast } from '@/components/ui/use-toast';
+import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDialog';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
 
@@ -34,38 +34,25 @@ export default function RejectReservationDialog({
   disabled = false,
   onReject,
 }: Props) {
-  const [open, setOpen] = useState(false);
   const [reason, setReason] = useState('');
-  const [isSubmitting, setIsSubmitting] = useState(false);
-  const { toast } = useToast();
 
-  function onOpenChange(next: boolean) {
-    if (isSubmitting) return;
-    setOpen(next);
-    if (next) {
+  const { open, isSubmitting, onOpenChange, execute } = useConfirmActionDialog({
+    errorMessage: '拒絕預約失敗,請稍後再試',
+    onOpen: () => {
       setReason('');
       trackEvent({
         name: 'feature_opened',
         feature: 'reservation',
         metadata: { dialog: 'reject_reservation' },
       });
-    }
-  }
+    },
+  });
 
-  async function handleReject() {
-    setIsSubmitting(true);
-    try {
+  const handleReject = () => {
+    execute(async () => {
       await onReject?.({ id: reservation.id, reason });
-      setIsSubmitting(false);
-      setOpen(false);
-    } catch {
-      toast({
-        variant: 'destructive',
-        description: '拒絕預約失敗,請稍後再試',
-      });
-      setIsSubmitting(false);
-    }
-  }
+    });
+  };
 
   const trimmedReason = reason.trim();
   const canSubmit = trimmedReason.length > 0 && !isSubmitting;

--- a/src/hooks/reservation/useConfirmActionDialog.test.ts
+++ b/src/hooks/reservation/useConfirmActionDialog.test.ts
@@ -1,0 +1,133 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+import { mockToast } from '@/test/mocks/useToast';
+
+import { useConfirmActionDialog } from './useConfirmActionDialog';
+
+describe('useConfirmActionDialog', () => {
+  const errorMessage = '動作失敗，請稍後再試';
+  const onOpenMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with correct default states', () => {
+    const { result } = renderHook(() =>
+      useConfirmActionDialog({ errorMessage, onOpen: onOpenMock })
+    );
+
+    expect(result.current.open).toBe(false);
+    expect(result.current.isSubmitting).toBe(false);
+  });
+
+  it('should handle onOpenChange and call onOpen when opening', () => {
+    const { result } = renderHook(() =>
+      useConfirmActionDialog({ errorMessage, onOpen: onOpenMock })
+    );
+
+    act(() => {
+      result.current.onOpenChange(true);
+    });
+
+    expect(result.current.open).toBe(true);
+    expect(onOpenMock).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      result.current.onOpenChange(false);
+    });
+
+    expect(result.current.open).toBe(false);
+    // Should not call onOpen again when closing
+    expect(onOpenMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should block onOpenChange when submitting', async () => {
+    const { result } = renderHook(() =>
+      useConfirmActionDialog({ errorMessage, onOpen: onOpenMock })
+    );
+
+    act(() => {
+      result.current.onOpenChange(true);
+    });
+
+    let promiseResolve!: () => void;
+    const actionPromise = new Promise<void>((resolve) => {
+      promiseResolve = resolve;
+    });
+
+    // Start executing
+    let executePromise: Promise<void>;
+    act(() => {
+      executePromise = result.current.execute(() => actionPromise);
+    });
+
+    expect(result.current.isSubmitting).toBe(true);
+
+    // Try to close dialog while submitting - should be ignored
+    act(() => {
+      result.current.onOpenChange(false);
+    });
+    expect(result.current.open).toBe(true);
+
+    // Resolve action and wait for execution to finish
+    await act(async () => {
+      promiseResolve();
+      await executePromise;
+    });
+
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.open).toBe(false);
+  });
+
+  it('should handle successful execution and close dialog', async () => {
+    const { result } = renderHook(() =>
+      useConfirmActionDialog({ errorMessage, onOpen: onOpenMock })
+    );
+
+    act(() => {
+      result.current.onOpenChange(true);
+    });
+
+    const action = vi.fn().mockResolvedValue(undefined);
+
+    await act(async () => {
+      await result.current.execute(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.open).toBe(false);
+  });
+
+  it('should handle failed execution, show toast, keep isSubmitting false, and keep dialog open', async () => {
+    const { result } = renderHook(() =>
+      useConfirmActionDialog({ errorMessage, onOpen: onOpenMock })
+    );
+
+    act(() => {
+      result.current.onOpenChange(true);
+    });
+
+    const action = vi.fn().mockRejectedValue(new Error('API Error'));
+
+    await act(async () => {
+      await result.current.execute(action);
+    });
+
+    expect(action).toHaveBeenCalledTimes(1);
+    expect(result.current.isSubmitting).toBe(false);
+    expect(result.current.open).toBe(true); // Should not close on error
+
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      description: errorMessage,
+    });
+  });
+});

--- a/src/hooks/reservation/useConfirmActionDialog.ts
+++ b/src/hooks/reservation/useConfirmActionDialog.ts
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+
+interface UseConfirmActionDialogOptions {
+  errorMessage: string;
+  onOpen?: () => void;
+}
+
+export function useConfirmActionDialog({
+  errorMessage,
+  onOpen,
+}: UseConfirmActionDialogOptions) {
+  const [open, setOpen] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const { toast } = useToast();
+
+  const onOpenChange = (next: boolean) => {
+    if (isSubmitting) return;
+    setOpen(next);
+    if (next) {
+      onOpen?.();
+    }
+  };
+
+  const execute = async (action: () => Promise<void> | void) => {
+    setIsSubmitting(true);
+    try {
+      await action();
+      setIsSubmitting(false);
+      setOpen(false);
+    } catch (error) {
+      toast({
+        variant: 'destructive',
+        description: errorMessage,
+      });
+      setIsSubmitting(false);
+    }
+  };
+
+  return {
+    open,
+    setOpen,
+    isSubmitting,
+    onOpenChange,
+    execute,
+  };
+}


### PR DESCRIPTION
- 抽出並實作泛用型確認對話框 Hook `useConfirmActionDialog` (提供 `open` / `isSubmitting` / 錯誤 toast / 執行 wrapper等生命週期)
- 重構 `AcceptReservationDialog`、`CancelReservationDialog` 與 `RejectReservationDialog` 使其共用該 Hook
- 完整保留各 dialog 的自訂驗證邏輯 (例如：取消原因必填、回覆選填)、onOpen 清除表單與 analytics 追蹤等特定行為
- 為 `useConfirmActionDialog` 新增完整 unit tests 覆蓋 normal、failure、submitting block 與重置等邊界測試

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/359
