### PR TITLE
refactor: extract generic TagMultiSelect component (X-Tracker #361)

### DIFF
--- a/src/components/onboarding/steps/InterestedPosition.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@/components/ui/form';
-import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
-import { cn } from '@/lib/utils';
 import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
 
-import { GroupedSelections } from './GroupedSelections';
 import { step3Schema } from './index';
+import { TagMultiSelect } from './TagMultiSelect';
 
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step3Schema>>>;
@@ -24,47 +15,11 @@ interface Props {
 }
 
 export const InterestedPosition: FC<Props> = ({ form, wantPositionGroups }) => {
-  const categories = useMemo(
-    () => tagGroupsToCategories(wantPositionGroups),
-    [wantPositionGroups]
-  );
-
   return (
-    <FormField
+    <TagMultiSelect
       control={form.control}
       name="want_position"
-      render={({ field }) => (
-        <FormItem>
-          <FormControl>
-            <GroupedSelections
-              categories={categories}
-              value={field.value ?? []}
-              onChange={field.onChange}
-              maxSelected={10}
-              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
-              renderItem={(opt, { checked, disabled, onToggle }) => (
-                <label
-                  className={cn(
-                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
-                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
-                    disabled && 'cursor-not-allowed opacity-50'
-                  )}
-                >
-                  <Checkbox
-                    checked={checked}
-                    disabled={disabled}
-                    onCheckedChange={onToggle}
-                  />
-                  <span className="text-base text-text-primary">
-                    {opt.label}
-                  </span>
-                </label>
-              )}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
-      )}
+      groups={wantPositionGroups}
     />
   );
 };

--- a/src/components/onboarding/steps/SkillsToImprove.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@/components/ui/form';
-import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
-import { cn } from '@/lib/utils';
 import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
 
-import { GroupedSelections } from './GroupedSelections';
 import { step4Schema } from './index';
+import { TagMultiSelect } from './TagMultiSelect';
 
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step4Schema>>>;
@@ -24,47 +15,11 @@ interface Props {
 }
 
 export const SkillsToImprove: FC<Props> = ({ form, wantSkillGroups }) => {
-  const categories = useMemo(
-    () => tagGroupsToCategories(wantSkillGroups),
-    [wantSkillGroups]
-  );
-
   return (
-    <FormField
+    <TagMultiSelect
       control={form.control}
       name="want_skill"
-      render={({ field }) => (
-        <FormItem>
-          <FormControl>
-            <GroupedSelections
-              categories={categories}
-              value={field.value ?? []}
-              onChange={field.onChange}
-              maxSelected={10}
-              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
-              renderItem={(opt, { checked, disabled, onToggle }) => (
-                <label
-                  className={cn(
-                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
-                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
-                    disabled && 'cursor-not-allowed opacity-50'
-                  )}
-                >
-                  <Checkbox
-                    checked={checked}
-                    disabled={disabled}
-                    onCheckedChange={onToggle}
-                  />
-                  <span className="text-base text-text-primary">
-                    {opt.label}
-                  </span>
-                </label>
-              )}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
-      )}
+      groups={wantSkillGroups}
     />
   );
 };

--- a/src/components/onboarding/steps/TagMultiSelect.test.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.test.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
-import { describe, expect, it } from 'vitest';
+import { beforeEach,describe, expect, it, vi } from 'vitest';
 import * as z from 'zod';
 
 import { Form } from '@/components/ui/form';
@@ -54,17 +54,31 @@ const TestComponent = ({ maxSelected = 2 }: { maxSelected?: number }) => {
 
   return (
     <Form {...form}>
-      <TagMultiSelect
-        control={form.control}
-        name="test_field"
-        groups={mockGroups}
-        maxSelected={maxSelected}
-      />
+      <form onSubmit={form.handleSubmit(() => {})}>
+        <TagMultiSelect
+          control={form.control}
+          name="test_field"
+          groups={mockGroups}
+          maxSelected={maxSelected}
+        />
+        <button type="submit">提交</button>
+      </form>
     </Form>
   );
 };
 
 describe('TagMultiSelect', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+    );
+  });
+
   it('renders correctly and toggles selection', async () => {
     render(<TestComponent />);
 
@@ -114,5 +128,17 @@ describe('TagMultiSelect', () => {
     // Check Tag 3
     fireEvent.click(checkbox3);
     expect(checkbox3).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('shows error message when validation fails upon submission', async () => {
+    render(<TestComponent />);
+
+    const submitBtn = screen.getByRole('button', { name: '提交' });
+
+    // Click submit with empty selection to trigger validation
+    fireEvent.click(submitBtn);
+
+    // Verify validation error message is rendered
+    expect(await screen.findByText('請至少選擇一個項目')).toBeInTheDocument();
   });
 });

--- a/src/components/onboarding/steps/TagMultiSelect.test.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.test.tsx
@@ -1,7 +1,7 @@
 import { zodResolver } from '@hookform/resolvers/zod';
 import { fireEvent, render, screen } from '@testing-library/react';
 import { useForm } from 'react-hook-form';
-import { beforeEach,describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod';
 
 import { Form } from '@/components/ui/form';

--- a/src/components/onboarding/steps/TagMultiSelect.test.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.test.tsx
@@ -1,0 +1,118 @@
+import { zodResolver } from '@hookform/resolvers/zod';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { useForm } from 'react-hook-form';
+import { describe, expect, it } from 'vitest';
+import * as z from 'zod';
+
+import { Form } from '@/components/ui/form';
+import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+
+import { TagMultiSelect } from './TagMultiSelect';
+
+const testSchema = z.object({
+  test_field: z
+    .array(z.string())
+    .min(1, '請至少選擇一個項目')
+    .max(2, '最多選 2 個'),
+});
+
+const mockGroups: TagCatalogGroupVO[] = [
+  {
+    subject_group: 'g1',
+    subject: 'Group 1',
+    language: 'zh-TW',
+    leaves: [
+      {
+        tag_id: 1,
+        subject_group: 'tag1',
+        subject: 'Tag 1',
+        language: 'zh-TW',
+      },
+      {
+        tag_id: 2,
+        subject_group: 'tag2',
+        subject: 'Tag 2',
+        language: 'zh-TW',
+      },
+      {
+        tag_id: 3,
+        subject_group: 'tag3',
+        subject: 'Tag 3',
+        language: 'zh-TW',
+      },
+    ],
+  },
+];
+
+const TestComponent = ({ maxSelected = 2 }: { maxSelected?: number }) => {
+  const form = useForm<z.infer<typeof testSchema>>({
+    resolver: zodResolver(testSchema),
+    defaultValues: {
+      test_field: [],
+    },
+  });
+
+  return (
+    <Form {...form}>
+      <TagMultiSelect
+        control={form.control}
+        name="test_field"
+        groups={mockGroups}
+        maxSelected={maxSelected}
+      />
+    </Form>
+  );
+};
+
+describe('TagMultiSelect', () => {
+  it('renders correctly and toggles selection', async () => {
+    render(<TestComponent />);
+
+    // Verify categories and tags render
+    expect(screen.getByText('Group 1')).toBeInTheDocument();
+    expect(screen.getByText('Tag 1')).toBeInTheDocument();
+    expect(screen.getByText('Tag 2')).toBeInTheDocument();
+    expect(screen.getByText('Tag 3')).toBeInTheDocument();
+
+    const checkbox1 = screen.getByLabelText('Tag 1');
+    expect(checkbox1).toHaveAttribute('aria-checked', 'false');
+
+    // Click Tag 1 to check it
+    fireEvent.click(checkbox1);
+    expect(checkbox1).toHaveAttribute('aria-checked', 'true');
+
+    // Click Tag 1 again to uncheck it
+    fireEvent.click(checkbox1);
+    expect(checkbox1).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('respects the maxSelected limit', () => {
+    render(<TestComponent maxSelected={2} />);
+
+    const checkbox1 = screen.getByLabelText('Tag 1');
+    const checkbox2 = screen.getByLabelText('Tag 2');
+    const checkbox3 = screen.getByLabelText('Tag 3');
+
+    // Check Tag 1 and Tag 2
+    fireEvent.click(checkbox1);
+    fireEvent.click(checkbox2);
+
+    expect(checkbox1).toHaveAttribute('aria-checked', 'true');
+    expect(checkbox2).toHaveAttribute('aria-checked', 'true');
+
+    // Since maxSelected is 2, Tag 3 should be disabled
+    expect(checkbox3).toBeDisabled();
+
+    // Try to click Tag 3 (should not change checked state)
+    fireEvent.click(checkbox3);
+    expect(checkbox3).toHaveAttribute('aria-checked', 'false');
+
+    // Uncheck Tag 1, Tag 3 should become enabled again
+    fireEvent.click(checkbox1);
+    expect(checkbox3).not.toBeDisabled();
+
+    // Check Tag 3
+    fireEvent.click(checkbox3);
+    expect(checkbox3).toHaveAttribute('aria-checked', 'true');
+  });
+});

--- a/src/components/onboarding/steps/TagMultiSelect.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Control, FieldValues, Path } from 'react-hook-form';
+
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from '@/components/ui/form';
+import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
+import { cn } from '@/lib/utils';
+import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+
+import { GroupedSelections } from './GroupedSelections';
+
+interface TagMultiSelectProps<TFieldValues extends FieldValues> {
+  control: Control<TFieldValues>;
+  name: Path<TFieldValues>;
+  groups: TagCatalogGroupVO[];
+  maxSelected?: number;
+}
+
+export function TagMultiSelect<TFieldValues extends FieldValues>({
+  control,
+  name,
+  groups,
+  maxSelected = 10,
+}: TagMultiSelectProps<TFieldValues>) {
+  const categories = useMemo(() => tagGroupsToCategories(groups), [groups]);
+
+  return (
+    <FormField
+      control={control}
+      name={name}
+      render={({ field }) => (
+        <FormItem>
+          <FormControl>
+            <GroupedSelections
+              categories={categories}
+              value={(field.value as string[]) ?? []}
+              onChange={field.onChange}
+              maxSelected={maxSelected}
+              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
+              renderItem={(opt, { checked, disabled, onToggle }) => (
+                <label
+                  className={cn(
+                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
+                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
+                    disabled && 'cursor-not-allowed opacity-50'
+                  )}
+                >
+                  <Checkbox
+                    checked={checked}
+                    disabled={disabled}
+                    onCheckedChange={onToggle}
+                  />
+                  <span className="text-base text-text-primary">
+                    {opt.label}
+                  </span>
+                </label>
+              )}
+            />
+          </FormControl>
+          <FormMessage />
+        </FormItem>
+      )}
+    />
+  );
+}

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -1,22 +1,13 @@
 'use client';
 
-import { FC, useMemo } from 'react';
+import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { Checkbox } from '@/components/ui/checkbox';
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@/components/ui/form';
-import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
-import { cn } from '@/lib/utils';
 import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
 
-import { GroupedSelections } from './GroupedSelections';
 import { step5Schema } from './index';
+import { TagMultiSelect } from './TagMultiSelect';
 
 interface Props {
   form: ReturnType<typeof useForm<z.infer<typeof step5Schema>>>;
@@ -24,47 +15,11 @@ interface Props {
 }
 
 export const TopicsToDiscuss: FC<Props> = ({ form, wantTopicGroups }) => {
-  const categories = useMemo(
-    () => tagGroupsToCategories(wantTopicGroups),
-    [wantTopicGroups]
-  );
-
   return (
-    <FormField
+    <TagMultiSelect
       control={form.control}
       name="want_topic"
-      render={({ field }) => (
-        <FormItem>
-          <FormControl>
-            <GroupedSelections
-              categories={categories}
-              value={field.value ?? []}
-              onChange={field.onChange}
-              maxSelected={10}
-              layoutClass="grid grid-cols-1 gap-4 sm:grid-cols-2"
-              renderItem={(opt, { checked, disabled, onToggle }) => (
-                <label
-                  className={cn(
-                    'flex cursor-pointer items-center gap-3 rounded-xl border px-3 py-3',
-                    checked ? 'border-primary bg-secondary' : 'border-gray-200',
-                    disabled && 'cursor-not-allowed opacity-50'
-                  )}
-                >
-                  <Checkbox
-                    checked={checked}
-                    disabled={disabled}
-                    onCheckedChange={onToggle}
-                  />
-                  <span className="text-base text-text-primary">
-                    {opt.label}
-                  </span>
-                </label>
-              )}
-            />
-          </FormControl>
-          <FormMessage />
-        </FormItem>
-      )}
+      groups={wantTopicGroups}
     />
   );
 };


### PR DESCRIPTION
Extract generic TagMultiSelect component to eliminate code duplication across three onboarding step files (InterestedPosition, SkillsToImprove, TopicsToDiscuss).

- Created TagMultiSelect.tsx with generic react-hook-form schema types (Control<TFieldValues>, Path<TFieldValues>).

- Rewrote InterestedPosition.tsx, SkillsToImprove.tsx, and TopicsToDiscuss.tsx to use the new component.

- Added thorough unit tests in TagMultiSelect.test.tsx to verify component rendering, selection toggle, and selection limits.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/361
