### PR TITLE
refactor: sanitizePublicProfile directly uses experienceCodec.decode (X-Tracker #362)

### DIFF
--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -40,15 +40,24 @@ describe('sanitizePublicProfile', () => {
     expect(sanitized.isMentor).toBe(true);
   });
 
-  it('should fallback to outer job_title and company when experiences is empty or null', () => {
-    const profile: MentorProfileVO = {
+  it('should fallback to outer job_title and company when experiences is empty, null, or contains no WORK experiences', () => {
+    // Case 1: Null
+    const profileNull: MentorProfileVO = {
       ...baseProfile,
       experiences: null,
     };
-    const sanitized = sanitizePublicProfile(profile);
+    const sanitizedNull = sanitizePublicProfile(profileNull);
+    expect(sanitizedNull.jobTitle).toBe('Global Developer');
+    expect(sanitizedNull.company).toBe('Base Inc');
 
-    expect(sanitized.jobTitle).toBe('Global Developer');
-    expect(sanitized.company).toBe('Base Inc');
+    // Case 2: Empty Array []
+    const profileEmpty: MentorProfileVO = {
+      ...baseProfile,
+      experiences: [],
+    };
+    const sanitizedEmpty = sanitizePublicProfile(profileEmpty);
+    expect(sanitizedEmpty.jobTitle).toBe('Global Developer');
+    expect(sanitizedEmpty.company).toBe('Base Inc');
   });
 
   it('should use primary work experience from experiences if available', () => {
@@ -120,9 +129,11 @@ describe('sanitizePublicProfile', () => {
     expect(sanitized.company).toBe('');
   });
 
-  it('should filter, deduplicate and check safe URLs for public links', () => {
+  it('should filter, deduplicate and check safe URLs for public links, and fallback jobTitle/company if no WORK category exists', () => {
     const profile: MentorProfileVO = {
       ...baseProfile,
+      job_title: 'Global Developer',
+      company: 'Base Inc',
       experiences: [
         {
           category: ExperienceType.LINK,
@@ -144,6 +155,11 @@ describe('sanitizePublicProfile', () => {
     };
 
     const sanitized = sanitizePublicProfile(profile);
+
+    // Verify correct fallback because there are no WORK experiences in profile
+    expect(sanitized.jobTitle).toBe('Global Developer');
+    expect(sanitized.company).toBe('Base Inc');
+
     expect(sanitized.personalLinks).toEqual([
       { platform: 'linkedin', url: 'https://linkedin.com/in/first' },
       { platform: 'facebook', url: 'https://facebook.com/me' },

--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -129,6 +129,32 @@ describe('sanitizePublicProfile', () => {
     expect(sanitized.company).toBe('');
   });
 
+  it('should handle experiences with null or missing mentor_experiences_metadata gracefully without throwing', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      job_title: 'Global Developer',
+      company: 'Base Inc',
+      experiences: [
+        {
+          category: ExperienceType.WORK,
+          order: 1,
+          mentor_experiences_metadata: null as any,
+        },
+        {
+          category: ExperienceType.LINK,
+          order: 2,
+        } as unknown as NonNullable<MentorProfileVO['experiences']>[number],
+      ] as unknown as MentorProfileVO['experiences'],
+    };
+
+    expect(() => sanitizePublicProfile(profile)).not.toThrow();
+
+    const sanitized = sanitizePublicProfile(profile);
+    expect(sanitized.jobTitle).toBe('Global Developer');
+    expect(sanitized.company).toBe('Base Inc');
+    expect(sanitized.personalLinks).toEqual([]);
+  });
+
   it('should filter, deduplicate and check safe URLs for public links, and fallback jobTitle/company if no WORK category exists', () => {
     const profile: MentorProfileVO = {
       ...baseProfile,

--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -138,7 +138,7 @@ describe('sanitizePublicProfile', () => {
         {
           category: ExperienceType.WORK,
           order: 1,
-          mentor_experiences_metadata: null as any,
+          mentor_experiences_metadata: null as unknown as Record<string, never>,
         },
         {
           category: ExperienceType.LINK,

--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -69,7 +69,7 @@ describe('sanitizePublicProfile', () => {
             ],
           },
         },
-      ] as any,
+      ] as unknown as MentorProfileVO['experiences'],
     };
 
     const sanitized = sanitizePublicProfile(profile);
@@ -91,12 +91,33 @@ describe('sanitizePublicProfile', () => {
             ],
           },
         },
-      ] as any,
+      ] as unknown as MentorProfileVO['experiences'],
     };
 
     const sanitized = sanitizePublicProfile(profile);
     expect(sanitized.jobTitle).toBe('First Job');
     expect(sanitized.company).toBe('First Co');
+  });
+
+  it('should preserve empty string for jobTitle or company from experiences and not fallback to outer profile', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      job_title: 'Global Developer',
+      company: 'Base Inc',
+      experiences: [
+        {
+          category: ExperienceType.WORK,
+          order: 1,
+          mentor_experiences_metadata: {
+            data: [{ job: '', company: '', is_primary: true }],
+          },
+        },
+      ] as unknown as MentorProfileVO['experiences'],
+    };
+
+    const sanitized = sanitizePublicProfile(profile);
+    expect(sanitized.jobTitle).toBe('');
+    expect(sanitized.company).toBe('');
   });
 
   it('should filter, deduplicate and check safe URLs for public links', () => {
@@ -119,7 +140,7 @@ describe('sanitizePublicProfile', () => {
             ],
           },
         },
-      ] as any,
+      ] as unknown as MentorProfileVO['experiences'],
     };
 
     const sanitized = sanitizePublicProfile(profile);

--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -1,0 +1,148 @@
+import { describe, expect, it } from 'vitest';
+
+import { ExperienceType } from '@/services/profile/experienceType';
+import type { MentorProfileVO } from '@/services/profile/user';
+
+import { sanitizePublicProfile } from './sanitizePublicProfile';
+
+const baseProfile: MentorProfileVO = {
+  user_id: 123,
+  name: 'John Doe',
+  avatar: 'https://example.com/avatar.png',
+  job_title: 'Global Developer',
+  company: 'Base Inc',
+  years_of_experience: '3',
+  location: 'Taipei',
+  industry: null,
+  onboarding: true,
+  is_mentor: true,
+  language: 'zh_TW',
+  personal_statement: 'Statement',
+  about: 'About John',
+  seniority_level: null,
+  experiences: [],
+  want_position: [],
+  want_skill: [],
+  want_topic: [],
+  have_skill: [],
+  have_topic: [],
+};
+
+describe('sanitizePublicProfile', () => {
+  it('should map simple profile properties', () => {
+    const profile = { ...baseProfile };
+    const sanitized = sanitizePublicProfile(profile);
+
+    expect(sanitized.userId).toBe(123);
+    expect(sanitized.name).toBe('John Doe');
+    expect(sanitized.avatar).toBe('https://example.com/avatar.png');
+    expect(sanitized.about).toBe('About John');
+    expect(sanitized.isMentor).toBe(true);
+  });
+
+  it('should fallback to outer job_title and company when experiences is empty or null', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      experiences: null,
+    };
+    const sanitized = sanitizePublicProfile(profile);
+
+    expect(sanitized.jobTitle).toBe('Global Developer');
+    expect(sanitized.company).toBe('Base Inc');
+  });
+
+  it('should use primary work experience from experiences if available', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      experiences: [
+        {
+          category: ExperienceType.WORK,
+          order: 1,
+          mentor_experiences_metadata: {
+            data: [
+              {
+                job: 'Secondary Job',
+                company: 'Secondary Co',
+                is_primary: false,
+              },
+              { job: 'Primary Job', company: 'Primary Co', is_primary: true },
+            ],
+          },
+        },
+      ] as any,
+    };
+
+    const sanitized = sanitizePublicProfile(profile);
+    expect(sanitized.jobTitle).toBe('Primary Job');
+    expect(sanitized.company).toBe('Primary Co');
+  });
+
+  it('should fallback to the first work experience if none is marked primary', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      experiences: [
+        {
+          category: ExperienceType.WORK,
+          order: 1,
+          mentor_experiences_metadata: {
+            data: [
+              { job: 'First Job', company: 'First Co', is_primary: false },
+              { job: 'Second Job', company: 'Second Co', is_primary: false },
+            ],
+          },
+        },
+      ] as any,
+    };
+
+    const sanitized = sanitizePublicProfile(profile);
+    expect(sanitized.jobTitle).toBe('First Job');
+    expect(sanitized.company).toBe('First Co');
+  });
+
+  it('should filter, deduplicate and check safe URLs for public links', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      experiences: [
+        {
+          category: ExperienceType.LINK,
+          order: 1,
+          mentor_experiences_metadata: {
+            data: [
+              { platform: 'linkedin', url: 'https://linkedin.com/in/first' },
+              {
+                platform: 'linkedin',
+                url: 'https://linkedin.com/in/duplicate',
+              }, // duplicate platform
+              { platform: 'facebook', url: 'javascript:alert(1)' }, // unsafe URL
+              { platform: 'unsupported', url: 'https://unsupported.com' }, // non-whitelisted platform
+              { platform: 'facebook', url: 'https://facebook.com/me' }, // whitelisted platform
+            ],
+          },
+        },
+      ] as any,
+    };
+
+    const sanitized = sanitizePublicProfile(profile);
+    expect(sanitized.personalLinks).toEqual([
+      { platform: 'linkedin', url: 'https://linkedin.com/in/first' },
+      { platform: 'facebook', url: 'https://facebook.com/me' },
+    ]);
+  });
+
+  it('should resolve expertises and topics with labelMap if provided', () => {
+    const profile: MentorProfileVO = {
+      ...baseProfile,
+      have_skill: ['skill_1', 'skill_2'],
+      have_topic: ['topic_1'],
+    };
+
+    const labelMap = new Map<string, string>([
+      ['skill_1', 'TypeScript'],
+      ['topic_1', 'Career growth'],
+    ]);
+
+    const sanitized = sanitizePublicProfile(profile, labelMap);
+    expect(sanitized.expertises).toEqual(['TypeScript', 'skill_2']);
+    expect(sanitized.topics).toEqual(['Career growth']);
+  });
+});

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -57,8 +57,8 @@ function pickCurrentJob(
     workExperiences.find((entry) => entry.is_primary) ?? workExperiences[0];
 
   return {
-    jobTitle: current.job || profile.job_title || '',
-    company: current.company || profile.company || '',
+    jobTitle: current.job ?? profile.job_title ?? '',
+    company: current.company ?? profile.company ?? '',
   };
 }
 
@@ -105,7 +105,9 @@ export function sanitizePublicProfile(
   labelMap?: Map<string, string>
 ): PublicMentorProfile {
   const decoded = decode(
-    profile.experiences as unknown as MentorExperiencePayload[] | undefined
+    (profile.experiences ?? undefined) as unknown as
+      | MentorExperiencePayload[]
+      | undefined
   );
 
   const { jobTitle, company } = pickCurrentJob(

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -39,6 +39,20 @@ export interface PublicMentorProfile {
   personalLinks: PublicPersonalLink[];
 }
 
+function mapExperiences(
+  experiences: MentorProfileVO['experiences'] | null | undefined
+): MentorExperiencePayload[] | undefined {
+  if (!experiences) return undefined;
+  return experiences.map((exp) => ({
+    category: exp.category ?? '',
+    mentor_experiences_metadata: exp.mentor_experiences_metadata as Record<
+      string,
+      unknown
+    >,
+    order: exp.order ?? 0,
+  }));
+}
+
 function pickCurrentJob(
   profile: MentorProfileVO,
   workExperiences: ReturnType<typeof decode>['workExperiences']
@@ -104,11 +118,7 @@ export function sanitizePublicProfile(
   profile: MentorProfileVO,
   labelMap?: Map<string, string>
 ): PublicMentorProfile {
-  const decoded = decode(
-    (profile.experiences ?? undefined) as unknown as
-      | MentorExperiencePayload[]
-      | undefined
-  );
+  const decoded = decode(mapExperiences(profile.experiences));
 
   const { jobTitle, company } = pickCurrentJob(
     profile,

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -1,6 +1,6 @@
+import type { MentorExperiencePayload } from '@/lib/profile/experienceCodec';
+import { decode } from '@/lib/profile/experienceCodec';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
-import { isSafeUrl } from '@/lib/url/isSafeUrl';
-import { ExperienceType } from '@/services/profile/experienceType';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 export type SocialPlatform =
@@ -39,46 +39,14 @@ export interface PublicMentorProfile {
   personalLinks: PublicPersonalLink[];
 }
 
-interface ExperienceBlock {
-  category?: string | null;
-  mentor_experiences_metadata?: { data?: unknown[] } | null;
-}
-
-interface WorkMetadata {
-  job?: string;
-  company?: string;
-  is_primary?: boolean;
-}
-
-interface LinkMetadata {
-  platform?: string;
-  url?: string;
-}
-
-function getBlocks(
-  experiences: MentorProfileVO['experiences'] | null | undefined,
-  category: string
-): ExperienceBlock[] {
-  if (!experiences) return [];
-  return (experiences as unknown as ExperienceBlock[]).filter(
-    (e) => e.category === category
-  );
-}
-
-function getMetadataItems<T>(block: ExperienceBlock): T[] {
-  return (block.mentor_experiences_metadata?.data ?? []) as T[];
-}
-
-function pickCurrentJob(profile: MentorProfileVO): {
+function pickCurrentJob(
+  profile: MentorProfileVO,
+  workExperiences: ReturnType<typeof decode>['workExperiences']
+): {
   jobTitle: string;
   company: string;
 } {
-  const workEntries = getBlocks(
-    profile.experiences,
-    ExperienceType.WORK
-  ).flatMap((block) => getMetadataItems<WorkMetadata>(block));
-
-  if (workEntries.length === 0) {
+  if (workExperiences.length === 0) {
     return {
       jobTitle: profile.job_title ?? '',
       company: profile.company ?? '',
@@ -86,29 +54,26 @@ function pickCurrentJob(profile: MentorProfileVO): {
   }
 
   const current =
-    workEntries.find((entry) => entry.is_primary) ?? workEntries[0];
+    workExperiences.find((entry) => entry.is_primary) ?? workExperiences[0];
 
   return {
-    jobTitle: current.job ?? profile.job_title ?? '',
-    company: current.company ?? profile.company ?? '',
+    jobTitle: current.job || profile.job_title || '',
+    company: current.company || profile.company || '',
   };
 }
 
-function pickPublicLinks(profile: MentorProfileVO): PublicPersonalLink[] {
-  const links = getBlocks(profile.experiences, ExperienceType.LINK).flatMap(
-    (block) => getMetadataItems<LinkMetadata>(block)
-  );
-
+function pickPublicLinks(
+  decodedLinks: ReturnType<typeof decode>['personalLinks']
+): PublicPersonalLink[] {
   const seen = new Set<SocialPlatform>();
   const result: PublicPersonalLink[] = [];
 
-  for (const link of links) {
+  for (const link of decodedLinks) {
     const platform = link.platform as SocialPlatform | undefined;
-    const url = link.url ?? '';
+    const url = link.url;
     if (
       platform &&
       SOCIAL_PLATFORMS.includes(platform) &&
-      isSafeUrl(url) &&
       !seen.has(platform)
     ) {
       seen.add(platform);
@@ -139,7 +104,14 @@ export function sanitizePublicProfile(
   profile: MentorProfileVO,
   labelMap?: Map<string, string>
 ): PublicMentorProfile {
-  const { jobTitle, company } = pickCurrentJob(profile);
+  const decoded = decode(
+    profile.experiences as unknown as MentorExperiencePayload[] | undefined
+  );
+
+  const { jobTitle, company } = pickCurrentJob(
+    profile,
+    decoded.workExperiences
+  );
 
   const expertises = resolveLabels(profile.have_skill, labelMap);
   const topics = resolveLabels(profile.have_topic, labelMap);
@@ -161,6 +133,6 @@ export function sanitizePublicProfile(
     expertises,
     topics,
     isMentor: Boolean(profile.is_mentor),
-    personalLinks: pickPublicLinks(profile),
+    personalLinks: pickPublicLinks(decoded.personalLinks),
   };
 }

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -1,6 +1,7 @@
 import type { MentorExperiencePayload } from '@/lib/profile/experienceCodec';
 import { decode } from '@/lib/profile/experienceCodec';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
+import { isSafeUrl } from '@/lib/url/isSafeUrl';
 import type { MentorProfileVO } from '@/services/profile/user';
 
 export type SocialPlatform =
@@ -45,10 +46,8 @@ function mapExperiences(
   if (!experiences) return undefined;
   return experiences.map((exp) => ({
     category: exp.category ?? '',
-    mentor_experiences_metadata: exp.mentor_experiences_metadata as Record<
-      string,
-      unknown
-    >,
+    mentor_experiences_metadata: (exp.mentor_experiences_metadata ??
+      {}) as Record<string, unknown>,
     order: exp.order ?? 0,
   }));
 }
@@ -88,6 +87,8 @@ function pickPublicLinks(
     if (
       platform &&
       SOCIAL_PLATFORMS.includes(platform) &&
+      url &&
+      isSafeUrl(url) &&
       !seen.has(platform)
     ) {
       seen.add(platform);


### PR DESCRIPTION
Replace shadow/duplicated JSONB experiences parsing with experienceCodec.decode()

Preserve fallback logic to profile.job_title/company when experiences is empty

Keep whitelist filtering and deduplication of public links (personalLinks)

Add comprehensive vitest unit tests in sanitizePublicProfile.test.ts to prevent regressions

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/362
