### PR TITLE
refactor: 把 resolveMentorAvatar 組合進 mapMentor (X-Tracker #364)

### DIFF
--- a/src/hooks/useMentorPool.test.ts
+++ b/src/hooks/useMentorPool.test.ts
@@ -17,6 +17,7 @@ vi.mock('@/services/search-mentor/mentors', () => ({
 }));
 
 import { PAGE_LIMIT } from '@/app/mentor-pool/constants';
+import avatarImage from '@/assets/default-avatar.png';
 import {
   fetchMentors,
   type MentorType,
@@ -36,7 +37,7 @@ const mockInitialMentors: MentorType[] = [
   {
     user_id: 1,
     name: 'Initial Mentor',
-    avatar: '',
+    avatar: avatarImage,
     job_title: '',
     company: '',
     years_of_experience: '3_5',
@@ -94,7 +95,7 @@ describe('useMentorPool', () => {
       {
         user_id: 2,
         name: 'Fetched Mentor',
-        avatar: '',
+        avatar: avatarImage,
         job_title: '',
         company: '',
         years_of_experience: '5_8',
@@ -761,6 +762,19 @@ describe('useMentorPool', () => {
     expect(result.current.mentors[0].name).toBe('Initial Mentor');
     expect(mockFetchMentors).toHaveBeenCalledTimes(1);
   });
+
+  it('preserves the resolved avatar and other fields of initial mentors without double-processing', () => {
+    const { result } = renderHook(() =>
+      useMentorPool({
+        initialMentors: mockInitialMentors,
+        initialMentorCount: 1,
+        params: mockSearchParams as unknown as ReadonlyURLSearchParams,
+        labelMap: testLabelMap,
+      })
+    );
+
+    expect(result.current.mentors[0].avatar).toBe(avatarImage);
+  });
 });
 
 describe('applyMentorPage', () => {
@@ -776,7 +790,7 @@ describe('applyMentorPage', () => {
   const sampleMentor: MentorType = {
     user_id: 10,
     name: 'Sample',
-    avatar: '',
+    avatar: avatarImage,
     job_title: '',
     company: '',
     years_of_experience: '',

--- a/src/hooks/useMentorPool.ts
+++ b/src/hooks/useMentorPool.ts
@@ -101,12 +101,7 @@ export function useMentorPool({
       isNoResults: initialMentors.length === 0,
       hasError: hasInitialFilters ? false : (initialError ?? false),
     }),
-    [
-      initialMentors,
-      initialMentorCount,
-      hasInitialFilters,
-      initialError,
-    ]
+    [initialMentors, initialMentorCount, hasInitialFilters, initialError]
   );
 
   const [pageState, setPageState] = useState<MentorPoolPageState>(() => {

--- a/src/hooks/useMentorPool.ts
+++ b/src/hooks/useMentorPool.ts
@@ -9,7 +9,6 @@ import {
   paramsToFetchConditions,
 } from '@/app/mentor-pool/searchParams';
 import { useToast } from '@/components/ui/use-toast';
-import { resolveMentorAvatar } from '@/services/search-mentor/mapMentor';
 import {
   fetchMentors,
   type MentorType,
@@ -93,23 +92,17 @@ export function useMentorPool({
 
   const hasInitialFilters = hasAnyCondition(params);
 
-  // Cache resolved initial mentors to trigger React's state bailout on mount, preventing redundant list re-renders.
-  const resolvedInitialMentors = useMemo(
-    () => initialMentors.map(resolveMentorAvatar),
-    [initialMentors]
-  );
-
   const getInitialUnfilteredState = useCallback(
     (): MentorPoolPageState => ({
-      mentors: resolvedInitialMentors,
-      cursor: resolvedInitialMentors.at(-1)?.updated_at?.toString(),
-      hasMore: resolvedInitialMentors.length === PAGE_LIMIT,
+      mentors: initialMentors,
+      cursor: initialMentors.at(-1)?.updated_at?.toString(),
+      hasMore: initialMentors.length === PAGE_LIMIT,
       mentorCount: initialMentorCount,
-      isNoResults: resolvedInitialMentors.length === 0,
+      isNoResults: initialMentors.length === 0,
       hasError: hasInitialFilters ? false : (initialError ?? false),
     }),
     [
-      resolvedInitialMentors,
+      initialMentors,
       initialMentorCount,
       hasInitialFilters,
       initialError,
@@ -206,9 +199,8 @@ export function useMentorPool({
     fetchMentors({ ...conditions, limit: PAGE_LIMIT, cursor: '' })
       .then((list) => {
         if (myRequestId !== requestIdRef.current) return;
-        const resolvedList = list.map(resolveMentorAvatar);
         setPageState((prev) =>
-          applyMentorPage(prev, { type: 'replace', page: resolvedList })
+          applyMentorPage(prev, { type: 'replace', page: list })
         );
         setIsLoading(false);
         isLoadingRef.current = false;
@@ -233,9 +225,8 @@ export function useMentorPool({
     try {
       const rtnList = await fetchMentors(param);
       if (myRequestId === requestIdRef.current) {
-        const resolvedList = rtnList.map(resolveMentorAvatar);
         setPageState((prev) =>
-          applyMentorPage(prev, { type: 'append', page: resolvedList })
+          applyMentorPage(prev, { type: 'append', page: rtnList })
         );
       }
     } catch (error) {

--- a/src/services/search-mentor/mapMentor.test.ts
+++ b/src/services/search-mentor/mapMentor.test.ts
@@ -77,7 +77,7 @@ describe('mapMentor', () => {
     expect(mapped).toEqual({
       user_id: 123,
       name: 'John Doe',
-      avatar: 'https://example.com/avatar.jpg',
+      avatar: 'https://example.com/avatar.jpg?cb=1610000000',
       job_title: 'Software Engineer',
       company: 'Tech Corp',
       years_of_experience: '3_5',
@@ -105,7 +105,7 @@ describe('mapMentor', () => {
     expect(mapped).toEqual({
       user_id: 456,
       name: '',
-      avatar: '',
+      avatar: avatarImage,
       job_title: '',
       company: '',
       years_of_experience: '',
@@ -121,6 +121,33 @@ describe('mapMentor', () => {
       have_topic: [],
       updated_at: null,
     });
+  });
+
+  it('combines resolveMentorAvatar behavior inside mapMentor', () => {
+    // 1. empty avatar falls back to default image
+    const rawNoAvatar = createRawMentor({ user_id: 777, avatar: null });
+    const mappedNoAvatar = mapMentor(rawNoAvatar);
+    expect(mappedNoAvatar.avatar).toBe(avatarImage);
+
+    // 2. presence of avatar without updated_at does not cache-bust
+    const rawNoUpdated = createRawMentor({
+      user_id: 888,
+      avatar: 'https://example.com/avatar.jpg',
+      updated_at: null,
+    });
+    const mappedNoUpdated = mapMentor(rawNoUpdated);
+    expect(mappedNoUpdated.avatar).toBe('https://example.com/avatar.jpg');
+
+    // 3. presence of avatar with updated_at applies cache-busting
+    const rawWithUpdated = createRawMentor({
+      user_id: 999,
+      avatar: 'https://example.com/avatar.jpg',
+      updated_at: 1620000000,
+    });
+    const mappedWithUpdated = mapMentor(rawWithUpdated);
+    expect(mappedWithUpdated.avatar).toBe(
+      'https://example.com/avatar.jpg?cb=1620000000'
+    );
   });
 });
 

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -58,7 +58,7 @@ export function mapMentor(raw: RawMentor): MentorType {
   // the User-service GET response. The runtime value is a string here.
   const industry = raw.industry as unknown as string | null | undefined;
 
-  return {
+  const mapped: MentorType = {
     user_id: raw.user_id,
     name: raw.name ?? '',
     avatar: raw.avatar ?? '',
@@ -77,6 +77,8 @@ export function mapMentor(raw: RawMentor): MentorType {
     have_topic: readCodes(raw.have_topic),
     updated_at: raw.updated_at ?? null,
   };
+
+  return resolveMentorAvatar(mapped);
 }
 
 // Cache-busts the avatar URL by updated_at so a re-uploaded photo isn't


### PR DESCRIPTION
將處理頭像快取與預設圖的邏輯收斂組合至 mapMentor 內部，確保所有回傳的 MentorType 均處於已解析之可顯示狀態。

**修改檔案：**
- **`src/services/search-mentor/mapMentor.ts`**：在 `mapMentor` 內自動調用 `resolveMentorAvatar`
- **`src/hooks/useMentorPool.ts`**：移除呼叫端多餘的 manual resolveMentorAvatar 解析與 `resolvedInitialMentors` useMemo
- **`src/services/search-mentor/mapMentor.test.ts`**：更新斷言以驗證組合後的對應與預設頭像 fallback 行為

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/364
