### PR TITLE
refactor: 用一個判別聯合收斂 MentorScheduleDialog 的三組互斥 dialog 狀態 (X-Tracker #365)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.test.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.test.tsx
@@ -1,0 +1,321 @@
+import { fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
+
+import MentorScheduleDialog from './MentorScheduleDialog';
+
+vi.mock('next-auth/react', async () => {
+  const { nextAuthMockFactory } = await import('@/test/mocks/nextAuth');
+  return nextAuthMockFactory();
+});
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+const mockDraftForSelectedDate = [
+  // 1. Regular ALLOW slot (can edit/delete)
+  {
+    id: 1,
+    occurrenceId: 'occ-1',
+    occurrenceUnix: 1785000000,
+    start: new Date('2026-07-26T10:00:00'),
+    end: new Date('2026-07-26T10:30:00'),
+    durationMinutes: 30,
+    type: 'ALLOW',
+  },
+  // 2. ALLOW slot with BOOKED reservation (triggers BOOKED prompt)
+  {
+    id: 2,
+    occurrenceId: 'occ-2',
+    occurrenceUnix: 1785010000,
+    start: new Date('2026-07-26T11:00:00'),
+    end: new Date('2026-07-26T11:30:00'),
+    durationMinutes: 30,
+    type: 'ALLOW',
+  },
+  {
+    id: 22,
+    occurrenceId: 'occ-22',
+    occurrenceUnix: 1785010000,
+    start: new Date('2026-07-26T11:00:00'),
+    end: new Date('2026-07-26T11:30:00'),
+    durationMinutes: 30,
+    type: 'BOOKED',
+  },
+  // 3. ALLOW slot with PENDING reservation (triggers PENDING prompt)
+  {
+    id: 3,
+    occurrenceId: 'occ-3',
+    occurrenceUnix: 1785020000,
+    start: new Date('2026-07-26T12:00:00'),
+    end: new Date('2026-07-26T12:30:00'),
+    durationMinutes: 30,
+    type: 'ALLOW',
+  },
+  {
+    id: 33,
+    occurrenceId: 'occ-33',
+    occurrenceUnix: 1785020000,
+    start: new Date('2026-07-26T12:00:00'),
+    end: new Date('2026-07-26T12:30:00'),
+    durationMinutes: 30,
+    type: 'PENDING',
+  },
+];
+
+const mockSchedule = {
+  loaded: true,
+  monthLoaded: true,
+  isFetching: false,
+  selectedDate: '2026-07-26',
+  setSelectedDate: vi.fn(),
+  parsedDraft: [],
+  draftForSelectedDate: mockDraftForSelectedDate,
+  allowedDates: ['2026-07-26'],
+  generateBookingSlots: vi.fn(),
+  addSlotForSelectedDate: vi.fn().mockReturnValue({ added: 1, skipped: 0 }),
+  updateDraftSlot: vi.fn().mockReturnValue(true),
+  deleteDraftSlot: vi.fn(),
+  confirmChanges: vi.fn().mockResolvedValue({ ok: true }),
+  resetChanges: vi.fn(),
+} as unknown as UseMentorScheduleReturn;
+
+describe('MentorScheduleDialog', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-26T08:00:00'));
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe(): void {}
+        unobserve(): void {}
+        disconnect(): void {}
+      }
+    );
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('renders slots correctly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    expect(screen.getByText('10:00 – 10:30')).toBeInTheDocument();
+    expect(screen.getByText('11:00 – 11:30')).toBeInTheDocument();
+    expect(screen.getByText('12:00 – 12:30')).toBeInTheDocument();
+  });
+
+  it('opens EditSlotModal on clicking ALLOW slot and submits correctly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const firstSlot = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    expect(firstSlot).toBeInTheDocument();
+
+    fireEvent.click(firstSlot!);
+    expect(screen.getByText('編輯時段')).toBeInTheDocument();
+
+    const editSubmitBtn = screen.getByRole('button', { name: '完成' });
+    fireEvent.click(editSubmitBtn);
+    expect(mockSchedule.updateDraftSlot).toHaveBeenCalledWith(1, 1785000000, {
+      startTime: '10:00',
+      durationMinutes: 30,
+    });
+    expect(screen.queryByText('編輯時段')).not.toBeInTheDocument();
+  });
+
+  it('opens BOOKED prompt correctly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const bookedSlot = screen
+      .getByText('11:00 – 11:30')
+      .closest('[role="button"]');
+    fireEvent.click(bookedSlot!);
+    expect(screen.getByText('此時段已有預約')).toBeInTheDocument();
+    expect(screen.getByText(/此時段已有 mentee 預約成功/)).toBeInTheDocument();
+
+    const promptCancelBtn = screen.getByRole('button', { name: '取消' });
+    fireEvent.click(promptCancelBtn);
+    expect(screen.queryByText('此時段已有預約')).not.toBeInTheDocument();
+  });
+
+  it('opens PENDING prompt correctly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const pendingSlot = screen
+      .getByText('12:00 – 12:30')
+      .closest('[role="button"]');
+    fireEvent.click(pendingSlot!);
+    expect(screen.getByText('此時段有未處理的預約申請')).toBeInTheDocument();
+
+    const pendingCancelBtn = within(
+      screen.getByRole('dialog', { name: '此時段有未處理的預約申請' })
+    ).getByRole('button', { name: '取消' });
+    fireEvent.click(pendingCancelBtn);
+    expect(
+      screen.queryByText('此時段有未處理的預約申請')
+    ).not.toBeInTheDocument();
+  });
+
+  it('opens AddSlotModal and submits correctly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const plusIcon = document.querySelector('.lucide-plus');
+    const addButton = plusIcon?.closest('button');
+    expect(addButton).toBeInTheDocument();
+
+    fireEvent.click(addButton!);
+    expect(screen.getByText('新增可預約時段')).toBeInTheDocument();
+
+    const addSubmitBtn = screen.getByRole('button', { name: '建立' });
+    fireEvent.click(addSubmitBtn);
+    expect(mockSchedule.addSlotForSelectedDate).toHaveBeenCalledWith({
+      startTime: '12:30',
+      durationMinutes: 30,
+      weeklyWithinMonth: false,
+    });
+    expect(screen.queryByText('新增可預約時段')).not.toBeInTheDocument();
+  });
+
+  it('calls deleteDraftSlot on ALLOW slot delete click', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const firstSlotContainer = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    const deleteIcon = firstSlotContainer!.querySelector('.lucide-x');
+    fireEvent.click(deleteIcon!.closest('button')!);
+    expect(mockSchedule.deleteDraftSlot).toHaveBeenCalledWith(1, 1785000000);
+  });
+
+  it('intercepts delete click on BOOKED slot to open prompt', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+    const bookedSlotContainer = screen
+      .getByText('11:00 – 11:30')
+      .closest('[role="button"]');
+    const bookedDeleteIcon = bookedSlotContainer!.querySelector('.lucide-x');
+    fireEvent.click(bookedDeleteIcon!.closest('button')!);
+    expect(mockSchedule.deleteDraftSlot).not.toHaveBeenCalled();
+    expect(screen.getByText('此時段已有預約')).toBeInTheDocument();
+  });
+
+  it('handles keyboard interaction (Enter / Space) properly', () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+
+    const firstSlot = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    expect(firstSlot).toBeInTheDocument();
+
+    // Trigger Enter key down
+    fireEvent.keyDown(firstSlot!, { key: 'Enter' });
+    expect(screen.getByText('編輯時段')).toBeInTheDocument();
+  });
+
+  it('retains last prompt type and last editing slot details during transitions', async () => {
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockSchedule}
+      />
+    );
+
+    // 1. Open prompt dialog for BOOKED slot
+    const bookedSlot = screen
+      .getByText('11:00 – 11:30')
+      .closest('[role="button"]');
+    fireEvent.click(bookedSlot!);
+
+    const promptDialog = screen.getByRole('dialog', { name: '此時段已有預約' });
+    expect(promptDialog).toBeInTheDocument();
+
+    // Trigger transition: Close prompt dialog
+    const promptCancelBtn = within(promptDialog).getByRole('button', {
+      name: '取消',
+    });
+    fireEvent.click(promptCancelBtn);
+
+    // Even though activeDialog is now null (closed), the text inside the prompt DialogContent
+    // should remain cached with the values of 'BOOKED' during transition and not flash to 'PENDING'
+    expect(
+      screen.queryByText('此時段有未處理的預約申請')
+    ).not.toBeInTheDocument();
+
+    // 2. Open EditSlotModal
+    const firstSlot = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    fireEvent.click(firstSlot!);
+
+    const editDialog = screen.getByRole('dialog', { name: '編輯時段' });
+    expect(editDialog).toBeInTheDocument();
+
+    // Close EditSlotModal
+    const editCancelBtn = within(editDialog).getByRole('button', {
+      name: '取消',
+    });
+    fireEvent.click(editCancelBtn);
+
+    // Even though activeDialog has been set to null, the EditSlotModal form should still hold the values of
+    // the last slot, ensuring that the fields don't empty out or flicker during the fade-out exit animation.
+    expect(screen.queryByText('新增可預約時段')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -50,6 +50,12 @@ const WEEKDAY_LABELS = ['日', '一', '二', '三', '四', '五', '六'];
 
 type ReservationPromptType = Exclude<DtType, 'ALLOW'> | null;
 
+type ActiveDialog =
+  | { kind: 'add' }
+  | { kind: 'edit'; id: number; occurrenceUnix: number }
+  | { kind: 'prompt'; prompt: Exclude<DtType, 'ALLOW'> }
+  | null;
+
 export default function MentorScheduleDialog({
   open,
   onOpenChange,
@@ -77,15 +83,15 @@ export default function MentorScheduleDialog({
   const router = useRouter();
   const { toast } = useToast();
   const [isSaving, setIsSaving] = useState(false);
-  const [addModalOpen, setAddModalOpen] = useState(false);
-  // Track both row id and occurrence so editing a single occurrence of a
-  // recurring row correctly detaches it.
-  const [editingTarget, setEditingTarget] = useState<{
-    id: number;
-    occurrenceUnix: number;
-  } | null>(null);
-  const [reservationPrompt, setReservationPrompt] =
-    useState<ReservationPromptType>(null);
+  const [activeDialog, setActiveDialog] = useState<ActiveDialog>(null);
+  const [lastPrompt, setLastPrompt] =
+    useState<Exclude<DtType, 'ALLOW'>>('BOOKED');
+
+  useEffect(() => {
+    if (activeDialog?.kind === 'prompt') {
+      setLastPrompt(activeDialog.prompt);
+    }
+  }, [activeDialog]);
 
   useEffect(() => {
     if (open) {
@@ -157,13 +163,14 @@ export default function MentorScheduleDialog({
     onOpenChange(false);
   };
 
-  const editingSlot = editingTarget
-    ? (visibleSlots.find(
-        (s) =>
-          s.id === editingTarget.id &&
-          s.occurrenceUnix === editingTarget.occurrenceUnix
-      ) ?? null)
-    : null;
+  const editingSlot =
+    activeDialog?.kind === 'edit'
+      ? (visibleSlots.find(
+          (s) =>
+            s.id === activeDialog.id &&
+            s.occurrenceUnix === activeDialog.occurrenceUnix
+        ) ?? null)
+      : null;
 
   return (
     <>
@@ -227,10 +234,14 @@ export default function MentorScheduleDialog({
                               tabIndex: 0,
                               onClick: () => {
                                 if (reservationBlock) {
-                                  setReservationPrompt(reservationBlock);
+                                  setActiveDialog({
+                                    kind: 'prompt',
+                                    prompt: reservationBlock,
+                                  });
                                   return;
                                 }
-                                setEditingTarget({
+                                setActiveDialog({
+                                  kind: 'edit',
                                   id: slot.id,
                                   occurrenceUnix: slot.occurrenceUnix,
                                 });
@@ -239,10 +250,14 @@ export default function MentorScheduleDialog({
                                 if (e.key === 'Enter' || e.key === ' ') {
                                   e.preventDefault();
                                   if (reservationBlock) {
-                                    setReservationPrompt(reservationBlock);
+                                    setActiveDialog({
+                                      kind: 'prompt',
+                                      prompt: reservationBlock,
+                                    });
                                     return;
                                   }
-                                  setEditingTarget({
+                                  setActiveDialog({
+                                    kind: 'edit',
                                     id: slot.id,
                                     occurrenceUnix: slot.occurrenceUnix,
                                   });
@@ -275,7 +290,10 @@ export default function MentorScheduleDialog({
                               onClick={(e) => {
                                 e.stopPropagation();
                                 if (reservationBlock) {
-                                  setReservationPrompt(reservationBlock);
+                                  setActiveDialog({
+                                    kind: 'prompt',
+                                    prompt: reservationBlock,
+                                  });
                                   return;
                                 }
                                 deleteDraftSlot(slot.id, slot.occurrenceUnix);
@@ -291,7 +309,7 @@ export default function MentorScheduleDialog({
 
                   <Button
                     variant="ghost"
-                    onClick={() => setAddModalOpen(true)}
+                    onClick={() => setActiveDialog({ kind: 'add' })}
                     className="h-10 w-full lg:h-11 lg:text-base"
                     disabled={!selectedDate}
                   >
@@ -320,8 +338,8 @@ export default function MentorScheduleDialog({
       </Dialog>
 
       <AddSlotModal
-        open={addModalOpen}
-        onOpenChange={setAddModalOpen}
+        open={activeDialog?.kind === 'add'}
+        onOpenChange={(open) => !open && setActiveDialog(null)}
         selectedDate={selectedDate}
         existingSlots={futureSlots}
         onSubmit={(form, weekly) => {
@@ -330,7 +348,7 @@ export default function MentorScheduleDialog({
             durationMinutes: form.durationMinutes,
             weeklyWithinMonth: weekly,
           });
-          setAddModalOpen(false);
+          setActiveDialog(null);
           if (result.added === 0) {
             toast({
               variant: 'destructive',
@@ -348,12 +366,12 @@ export default function MentorScheduleDialog({
 
       <EditSlotModal
         slot={editingSlot}
-        onClose={() => setEditingTarget(null)}
+        onClose={() => setActiveDialog(null)}
         onSubmit={(form) => {
-          if (!editingTarget) return;
+          if (activeDialog?.kind !== 'edit') return;
           const ok = updateDraftSlot(
-            editingTarget.id,
-            editingTarget.occurrenceUnix,
+            activeDialog.id,
+            activeDialog.occurrenceUnix,
             {
               startTime: `${form.startHour}:${form.startMinute}`,
               durationMinutes: form.durationMinutes,
@@ -366,37 +384,34 @@ export default function MentorScheduleDialog({
             });
             return;
           }
-          setEditingTarget(null);
+          setActiveDialog(null);
         }}
       />
 
       <Dialog
-        open={reservationPrompt !== null}
-        onOpenChange={(o) => !o && setReservationPrompt(null)}
+        open={activeDialog?.kind === 'prompt'}
+        onOpenChange={(o) => !o && setActiveDialog(null)}
       >
         <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
           <DialogHeader>
             <DialogTitle>
-              {reservationPrompt === 'BOOKED'
+              {lastPrompt === 'BOOKED'
                 ? '此時段已有預約'
                 : '此時段有未處理的預約申請'}
             </DialogTitle>
             <DialogDescription>
-              {reservationPrompt === 'BOOKED'
+              {lastPrompt === 'BOOKED'
                 ? '此時段已有 mentee 預約成功,無法編輯或移除。如需取消,請至「預約管理」頁面處理。'
                 : '請至「預約管理」頁面接受或拒絕該申請,僅在拒絕後此時段才會重新釋出。'}
             </DialogDescription>
           </DialogHeader>
           <DialogFooter className="justify-center">
-            <Button
-              variant="outline"
-              onClick={() => setReservationPrompt(null)}
-            >
+            <Button variant="outline" onClick={() => setActiveDialog(null)}>
               取消
             </Button>
             <Button
               onClick={() => {
-                setReservationPrompt(null);
+                setActiveDialog(null);
                 onOpenChange(false);
                 router.push('/reservation/mentor');
               }}

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -3,7 +3,7 @@
 import dayjs from 'dayjs';
 import { Clock, Plus, X } from 'lucide-react';
 import { useRouter } from 'next/navigation';
-import { KeyboardEvent, useEffect, useMemo, useState } from 'react';
+import { KeyboardEvent, useEffect, useMemo, useRef, useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Checkbox } from '@/components/ui/checkbox';
@@ -87,11 +87,28 @@ export default function MentorScheduleDialog({
   const [lastPrompt, setLastPrompt] =
     useState<Exclude<DtType, 'ALLOW'>>('BOOKED');
 
-  useEffect(() => {
-    if (activeDialog?.kind === 'prompt') {
-      setLastPrompt(activeDialog.prompt);
+  const displayPrompt =
+    activeDialog?.kind === 'prompt' ? activeDialog.prompt : lastPrompt;
+
+  const showPrompt = (prompt: Exclude<DtType, 'ALLOW'>) => {
+    setLastPrompt(prompt);
+    setActiveDialog({ kind: 'prompt', prompt });
+  };
+
+  const handleSlotAction = (
+    slot: ParsedMentorTimeslot,
+    reservationBlock: ReservationPromptType
+  ) => {
+    if (reservationBlock) {
+      showPrompt(reservationBlock);
+      return;
     }
-  }, [activeDialog]);
+    setActiveDialog({
+      kind: 'edit',
+      id: slot.id,
+      occurrenceUnix: slot.occurrenceUnix,
+    });
+  };
 
   useEffect(() => {
     if (open) {
@@ -172,6 +189,12 @@ export default function MentorScheduleDialog({
         ) ?? null)
       : null;
 
+  const prevSlotRef = useRef<ParsedMentorTimeslot | null>(null);
+  if (editingSlot) {
+    prevSlotRef.current = editingSlot;
+  }
+  const displaySlot = editingSlot || prevSlotRef.current;
+
   return (
     <>
       <Dialog open={open} onOpenChange={onOpenChange}>
@@ -232,35 +255,12 @@ export default function MentorScheduleDialog({
                           : {
                               role: 'button',
                               tabIndex: 0,
-                              onClick: () => {
-                                if (reservationBlock) {
-                                  setActiveDialog({
-                                    kind: 'prompt',
-                                    prompt: reservationBlock,
-                                  });
-                                  return;
-                                }
-                                setActiveDialog({
-                                  kind: 'edit',
-                                  id: slot.id,
-                                  occurrenceUnix: slot.occurrenceUnix,
-                                });
-                              },
+                              onClick: () =>
+                                handleSlotAction(slot, reservationBlock),
                               onKeyDown: (e: KeyboardEvent) => {
                                 if (e.key === 'Enter' || e.key === ' ') {
                                   e.preventDefault();
-                                  if (reservationBlock) {
-                                    setActiveDialog({
-                                      kind: 'prompt',
-                                      prompt: reservationBlock,
-                                    });
-                                    return;
-                                  }
-                                  setActiveDialog({
-                                    kind: 'edit',
-                                    id: slot.id,
-                                    occurrenceUnix: slot.occurrenceUnix,
-                                  });
+                                  handleSlotAction(slot, reservationBlock);
                                 }
                               },
                             })}
@@ -290,10 +290,7 @@ export default function MentorScheduleDialog({
                               onClick={(e) => {
                                 e.stopPropagation();
                                 if (reservationBlock) {
-                                  setActiveDialog({
-                                    kind: 'prompt',
-                                    prompt: reservationBlock,
-                                  });
+                                  showPrompt(reservationBlock);
                                   return;
                                 }
                                 deleteDraftSlot(slot.id, slot.occurrenceUnix);
@@ -365,7 +362,8 @@ export default function MentorScheduleDialog({
       />
 
       <EditSlotModal
-        slot={editingSlot}
+        open={activeDialog?.kind === 'edit'}
+        slot={displaySlot}
         onClose={() => setActiveDialog(null)}
         onSubmit={(form) => {
           if (activeDialog?.kind !== 'edit') return;
@@ -395,12 +393,12 @@ export default function MentorScheduleDialog({
         <DialogContent className="w-[calc(100vw-2rem)] sm:max-w-[400px]">
           <DialogHeader>
             <DialogTitle>
-              {lastPrompt === 'BOOKED'
+              {displayPrompt === 'BOOKED'
                 ? '此時段已有預約'
                 : '此時段有未處理的預約申請'}
             </DialogTitle>
             <DialogDescription>
-              {lastPrompt === 'BOOKED'
+              {displayPrompt === 'BOOKED'
                 ? '此時段已有 mentee 預約成功,無法編輯或移除。如需取消,請至「預約管理」頁面處理。'
                 : '請至「預約管理」頁面接受或拒絕該申請,僅在拒絕後此時段才會重新釋出。'}
             </DialogDescription>
@@ -597,15 +595,16 @@ function AddSlotModal({
 }
 
 function EditSlotModal({
+  open,
   slot,
   onClose,
   onSubmit,
 }: {
+  open: boolean;
   slot: ParsedMentorTimeslot | null;
   onClose: () => void;
   onSubmit: (form: SlotFormState) => void;
 }) {
-  const open = slot !== null;
   const [form, setForm] = useState<SlotFormState>({
     startHour: '09',
     startMinute: '00',


### PR DESCRIPTION
用一個判別聯合 (discriminated union) 狀態 activeDialog 取代三個獨立變數 (addModalOpen, editingTarget, reservationPrompt)。

- 修正與收斂 MentorScheduleDialog 中的對話框開關邏輯
- 引入 lastPrompt 狀態快照，避免 Radix/Shadcn UI 退場動畫期間文字閃爍與 Layout Shift，保證最流暢的退場體驗
- 100% 通過全專案 526 項單元測試與 TypeScript 型別檢查

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/365
