### PR TITLE
feat(reservation): 預約時間按鈕 disabled 時套用灰色設計語彙並補齊單元測試 (X-Tracker #272)

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -294,6 +294,7 @@ export default function ProfilePageUI({
                   </div>
                   <BookingForm
                     isOwnMentorProfile={isOwnMentorProfile}
+                    isUserDataLoading={userLoading}
                     slots={
                       selectedDate ? generateBookingSlots(selectedDate) : []
                     }
@@ -301,7 +302,6 @@ export default function ProfilePageUI({
                     selectedSlot={selectedSlot}
                     setSelectedSlot={setSelectedSlot}
                     isSubmitting={isSubmitting}
-                    userData={userData}
                     selectedDate={selectedDate}
                     onReservation={onReservation}
                     onConfirmReservation={onConfirmReservation}

--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -295,6 +295,7 @@ export default function ProfilePageUI({
                   <BookingForm
                     isOwnMentorProfile={isOwnMentorProfile}
                     isUserDataLoading={userLoading}
+                    isAuthenticated={!!loginUserId}
                     slots={
                       selectedDate ? generateBookingSlots(selectedDate) : []
                     }

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -104,7 +104,9 @@ describe('BookingForm', () => {
     fireEvent.change(textarea, { target: { value: 'How to learn TS?' } });
 
     const submitBtn = screen.getByRole('button', { name: '預約時間' });
-    expect(submitBtn).not.toBeDisabled();
+    await waitFor(() => {
+      expect(submitBtn).not.toBeDisabled();
+    });
 
     fireEvent.click(submitBtn);
 

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -40,6 +40,22 @@ describe('BookingForm', () => {
     onConfirmReservation: vi.fn().mockResolvedValue(true),
   };
 
+  it('renders a loading skeleton when userData is null to prevent view flash', () => {
+    render(<BookingForm {...defaultProps} userData={null} />);
+    expect(screen.getByTestId('booking-form-skeleton')).toBeInTheDocument();
+  });
+
+  it('disables the submit button if selectedDate is null, or isSubmitting is true', () => {
+    const { rerender } = render(
+      <BookingForm {...defaultProps} selectedDate={null} />
+    );
+    const submitBtn = screen.getByRole('button', { name: '預約時間' });
+    expect(submitBtn).toBeDisabled();
+
+    rerender(<BookingForm {...defaultProps} isSubmitting={true} />);
+    expect(screen.getByRole('button', { name: '處理中...' })).toBeDisabled();
+  });
+
   it('renders booking slots and the question input when not own profile', () => {
     render(<BookingForm {...defaultProps} />);
 
@@ -90,7 +106,7 @@ describe('BookingForm', () => {
     expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
   });
 
-  it('enables the submit button and handles confirm when slot and question are present', async () => {
+  it('enables the submit button, handles confirm, and resets the textarea on success', async () => {
     const onConfirmReservation = vi.fn().mockResolvedValue(true);
     render(
       <BookingForm
@@ -100,7 +116,9 @@ describe('BookingForm', () => {
       />
     );
 
-    const textarea = screen.getByPlaceholderText('請在此輸入你的問題...');
+    const textarea = screen.getByPlaceholderText(
+      '請在此輸入你的問題...'
+    ) as HTMLTextAreaElement;
     fireEvent.change(textarea, { target: { value: 'How to learn TS?' } });
 
     const submitBtn = screen.getByRole('button', { name: '預約時間' });
@@ -112,6 +130,10 @@ describe('BookingForm', () => {
 
     await waitFor(() => {
       expect(onConfirmReservation).toHaveBeenCalledWith('How to learn TS?');
+    });
+
+    await waitFor(() => {
+      expect(textarea.value).toBe('');
     });
   });
 

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -137,6 +137,17 @@ describe('BookingForm', () => {
     });
   });
 
+  it('displays validation error message when question is invalid (e.g. exceeds 1000 chars)', async () => {
+    render(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
+
+    const textarea = screen.getByPlaceholderText('請在此輸入你的問題...');
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(1001) } });
+
+    await waitFor(() => {
+      expect(screen.getByText('問題字數請勿超過 1000 字')).toBeInTheDocument();
+    });
+  });
+
   it('renders config mode instead of booking mode when isOwnMentorProfile is true', () => {
     render(<BookingForm {...defaultProps} isOwnMentorProfile={true} />);
 

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
@@ -70,17 +70,23 @@ describe('BookingForm', () => {
     expect(screen.getByText('無可預約的時段')).toBeInTheDocument();
   });
 
-  it('disables the submit button if slot or question is missing', () => {
+  it('disables the submit button if slot or question is missing (including test coverage gap)', () => {
     const { rerender } = render(<BookingForm {...defaultProps} />);
 
-    // Initially with selectedSlot=null, bookingQuestion=""
+    // Scenario 1: selectedSlot=null, bookingQuestion=""
     const submitBtn = screen.getByRole('button', { name: '預約時間' });
     expect(submitBtn).toBeDisabled();
     expect(submitBtn).toHaveClass('disabled:bg-background-top-active');
     expect(submitBtn).toHaveClass('disabled:text-text-disable');
 
-    // Select slot, but question is still empty
+    // Scenario 2: Select slot, but question is still empty
     rerender(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
+    expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
+
+    // Scenario 3: [TEST GAP FIX] selectedSlot is null, but question is filled
+    rerender(<BookingForm {...defaultProps} selectedSlot={null} />);
+    const textarea = screen.getByPlaceholderText('請在此輸入你的問題...');
+    fireEvent.change(textarea, { target: { value: 'How to learn TS?' } });
     expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
   });
 
@@ -101,7 +107,10 @@ describe('BookingForm', () => {
     expect(submitBtn).not.toBeDisabled();
 
     fireEvent.click(submitBtn);
-    expect(onConfirmReservation).toHaveBeenCalledWith('How to learn TS?');
+
+    await waitFor(() => {
+      expect(onConfirmReservation).toHaveBeenCalledWith('How to learn TS?');
+    });
   });
 
   it('renders config mode instead of booking mode when isOwnMentorProfile is true', () => {

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -2,16 +2,10 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
-import type { UserType } from '@/hooks/user/user-data/useUserData';
 
 import { BookingForm } from './BookingForm';
 
 describe('BookingForm', () => {
-  const mockUserData = {
-    user_id: 123,
-    is_mentor: true,
-  } as unknown as UserType;
-
   const mockSlots: BookingSlot[] = [
     {
       scheduleId: 101,
@@ -29,19 +23,19 @@ describe('BookingForm', () => {
 
   const defaultProps = {
     isOwnMentorProfile: false,
+    isUserDataLoading: false,
     slots: mockSlots,
     monthLoaded: true,
     selectedSlot: null,
     setSelectedSlot: vi.fn(),
     isSubmitting: false,
-    userData: mockUserData,
     selectedDate: '2026-07-26',
     onReservation: vi.fn(),
     onConfirmReservation: vi.fn().mockResolvedValue(true),
   };
 
-  it('renders a loading skeleton when userData is null to prevent view flash', () => {
-    render(<BookingForm {...defaultProps} userData={null} />);
+  it('renders a loading skeleton when isUserDataLoading is true to prevent view flash', () => {
+    render(<BookingForm {...defaultProps} isUserDataLoading={true} />);
     expect(screen.getByTestId('booking-form-skeleton')).toBeInTheDocument();
   });
 

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -1,0 +1,123 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import type { BookingSlot } from '@/hooks/useMentorSchedule';
+import type { UserType } from '@/hooks/user/user-data/useUserData';
+
+import { BookingForm } from './BookingForm';
+
+describe('BookingForm', () => {
+  const mockUserData = {
+    user_id: 123,
+    is_mentor: true,
+  } as unknown as UserType;
+
+  const mockSlots: BookingSlot[] = [
+    {
+      scheduleId: 101,
+      start: new Date('2026-07-26T10:00:00Z'),
+      end: new Date('2026-07-26T10:30:00Z'),
+      isBooked: false,
+    },
+    {
+      scheduleId: 102,
+      start: new Date('2026-07-26T11:00:00Z'),
+      end: new Date('2026-07-26T11:30:00Z'),
+      isBooked: true,
+    },
+  ];
+
+  const defaultProps = {
+    isOwnMentorProfile: false,
+    slots: mockSlots,
+    monthLoaded: true,
+    selectedSlot: null,
+    setSelectedSlot: vi.fn(),
+    isSubmitting: false,
+    userData: mockUserData,
+    selectedDate: '2026-07-26',
+    onReservation: vi.fn(),
+    onConfirmReservation: vi.fn().mockResolvedValue(true),
+  };
+
+  it('renders booking slots and the question input when not own profile', () => {
+    render(<BookingForm {...defaultProps} />);
+
+    // Renders slots
+    expect(screen.getByText('當日可預約時段')).toBeInTheDocument();
+    // Non-booked slot is a button
+    const slotBtn = screen.getByRole('button', { name: /10:00/i });
+    expect(slotBtn).toBeInTheDocument();
+
+    // Booked slot has booked indicator / disabled
+    const bookedSlotBtn = screen.getByRole('button', { name: /11:00/i });
+    expect(bookedSlotBtn).toBeDisabled();
+
+    // Renders question input
+    expect(screen.getByLabelText('你想問導師的問題')).toBeInTheDocument();
+    expect(
+      screen.getByPlaceholderText('請在此輸入你的問題...')
+    ).toBeInTheDocument();
+  });
+
+  it('renders Loading state when monthLoaded is false', () => {
+    render(<BookingForm {...defaultProps} monthLoaded={false} />);
+    expect(screen.getByText('讀取中…')).toBeInTheDocument();
+  });
+
+  it('renders No Slots state when slots are empty', () => {
+    render(<BookingForm {...defaultProps} slots={[]} />);
+    expect(screen.getByText('無可預約的時段')).toBeInTheDocument();
+  });
+
+  it('disables the submit button if slot or question is missing', () => {
+    const { rerender } = render(<BookingForm {...defaultProps} />);
+
+    // Initially with selectedSlot=null, bookingQuestion=""
+    const submitBtn = screen.getByRole('button', { name: '預約時間' });
+    expect(submitBtn).toBeDisabled();
+    expect(submitBtn).toHaveClass('disabled:bg-background-top-active');
+    expect(submitBtn).toHaveClass('disabled:text-text-disable');
+
+    // Select slot, but question is still empty
+    rerender(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
+    expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
+  });
+
+  it('enables the submit button and handles confirm when slot and question are present', async () => {
+    const onConfirmReservation = vi.fn().mockResolvedValue(true);
+    render(
+      <BookingForm
+        {...defaultProps}
+        selectedSlot={mockSlots[0]}
+        onConfirmReservation={onConfirmReservation}
+      />
+    );
+
+    const textarea = screen.getByPlaceholderText('請在此輸入你的問題...');
+    fireEvent.change(textarea, { target: { value: 'How to learn TS?' } });
+
+    const submitBtn = screen.getByRole('button', { name: '預約時間' });
+    expect(submitBtn).not.toBeDisabled();
+
+    fireEvent.click(submitBtn);
+    expect(onConfirmReservation).toHaveBeenCalledWith('How to learn TS?');
+  });
+
+  it('renders config mode instead of booking mode when isOwnMentorProfile is true', () => {
+    render(<BookingForm {...defaultProps} isOwnMentorProfile={true} />);
+
+    // No question input
+    expect(screen.queryByLabelText('你想問導師的問題')).not.toBeInTheDocument();
+
+    // Slots are shown but not as buttons
+    expect(
+      screen.queryByRole('button', { name: /10:00/i })
+    ).not.toBeInTheDocument();
+    expect(screen.getByText(/10:00/i)).toBeInTheDocument();
+
+    // Button text is "預約設定"
+    const btn = screen.getByRole('button', { name: '預約設定' });
+    expect(btn).toBeInTheDocument();
+  });
+});

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -24,6 +24,7 @@ describe('BookingForm', () => {
   const defaultProps = {
     isOwnMentorProfile: false,
     isUserDataLoading: false,
+    isAuthenticated: true,
     slots: mockSlots,
     monthLoaded: true,
     selectedSlot: null,
@@ -48,6 +49,12 @@ describe('BookingForm', () => {
 
     rerender(<BookingForm {...defaultProps} isSubmitting={true} />);
     expect(screen.getByRole('button', { name: '處理中...' })).toBeDisabled();
+  });
+
+  it('disables the submit button if isAuthenticated is false', () => {
+    render(<BookingForm {...defaultProps} isAuthenticated={false} />);
+    const submitBtn = screen.getByRole('button', { name: '預約時間' });
+    expect(submitBtn).toBeDisabled();
   });
 
   it('renders booking slots and the question input when not own profile', () => {

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -1,19 +1,19 @@
 'use client';
 
+import { Skeleton } from '@/components/ui/skeleton';
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
-import type { UserType } from '@/hooks/user/user-data/useUserData';
 
 import { MenteeBookingForm } from './MenteeBookingForm';
 import { MentorScheduleConfig } from './MentorScheduleConfig';
 
 interface BookingFormProps {
   isOwnMentorProfile: boolean;
+  isUserDataLoading: boolean;
   slots: BookingSlot[];
   monthLoaded: boolean;
   selectedSlot: BookingSlot | null;
   setSelectedSlot: (slot: BookingSlot | null) => void;
   isSubmitting: boolean;
-  userData: UserType | null;
   selectedDate: string | null;
   onReservation: () => void;
   onConfirmReservation: (question: string) => Promise<boolean>;
@@ -21,35 +21,35 @@ interface BookingFormProps {
 
 export function BookingForm({
   isOwnMentorProfile,
+  isUserDataLoading,
   slots,
   monthLoaded,
   selectedSlot,
   setSelectedSlot,
   isSubmitting,
-  userData,
   selectedDate,
   onReservation,
   onConfirmReservation,
 }: BookingFormProps) {
   // Prevent view flash: if userData is loading/unresolved, render a loading skeleton
-  if (!userData) {
+  if (isUserDataLoading) {
     return (
       <div
         className="flex w-full max-w-[335px] animate-pulse flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]"
         data-testid="booking-form-skeleton"
       >
         <div className="flex flex-col gap-2">
-          <div className="h-4 w-28 rounded bg-gray-200" />
+          <Skeleton className="h-4 w-28" />
           <div className="grid grid-cols-2 gap-2">
-            <div className="h-10 rounded-lg bg-gray-200" />
-            <div className="h-10 rounded-lg bg-gray-200" />
+            <Skeleton className="h-10 w-full rounded-lg" />
+            <Skeleton className="h-10 w-full rounded-lg" />
           </div>
         </div>
         <div className="flex flex-col gap-2">
-          <div className="h-4 w-32 rounded bg-gray-200" />
-          <div className="h-40 rounded-lg bg-gray-200" />
+          <Skeleton className="h-4 w-32" />
+          <Skeleton className="h-40 w-full rounded-lg" />
         </div>
-        <div className="h-12 w-full rounded-full bg-gray-200" />
+        <Skeleton className="h-12 w-full rounded-full" />
       </div>
     );
   }
@@ -60,7 +60,6 @@ export function BookingForm({
         <MentorScheduleConfig
           slots={slots}
           monthLoaded={monthLoaded}
-          userData={userData}
           onReservation={onReservation}
         />
       ) : (
@@ -70,7 +69,6 @@ export function BookingForm({
           selectedSlot={selectedSlot}
           setSelectedSlot={setSelectedSlot}
           isSubmitting={isSubmitting}
-          userData={userData}
           selectedDate={selectedDate}
           onConfirmReservation={onConfirmReservation}
         />

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -31,27 +31,50 @@ export function BookingForm({
   onReservation,
   onConfirmReservation,
 }: BookingFormProps) {
-  if (isOwnMentorProfile) {
+  // Prevent view flash: if userData is loading/unresolved, render a loading skeleton
+  if (!userData) {
     return (
-      <MentorScheduleConfig
-        slots={slots}
-        monthLoaded={monthLoaded}
-        userData={userData}
-        onReservation={onReservation}
-      />
+      <div
+        className="flex w-full max-w-[335px] animate-pulse flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]"
+        data-testid="booking-form-skeleton"
+      >
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-28 rounded bg-gray-200" />
+          <div className="grid grid-cols-2 gap-2">
+            <div className="h-10 rounded-lg bg-gray-200" />
+            <div className="h-10 rounded-lg bg-gray-200" />
+          </div>
+        </div>
+        <div className="flex flex-col gap-2">
+          <div className="h-4 w-32 rounded bg-gray-200" />
+          <div className="h-40 rounded-lg bg-gray-200" />
+        </div>
+        <div className="h-12 w-full rounded-full bg-gray-200" />
+      </div>
     );
   }
 
   return (
-    <MenteeBookingForm
-      slots={slots}
-      monthLoaded={monthLoaded}
-      selectedSlot={selectedSlot}
-      setSelectedSlot={setSelectedSlot}
-      isSubmitting={isSubmitting}
-      userData={userData}
-      selectedDate={selectedDate}
-      onConfirmReservation={onConfirmReservation}
-    />
+    <div className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]">
+      {isOwnMentorProfile ? (
+        <MentorScheduleConfig
+          slots={slots}
+          monthLoaded={monthLoaded}
+          userData={userData}
+          onReservation={onReservation}
+        />
+      ) : (
+        <MenteeBookingForm
+          slots={slots}
+          monthLoaded={monthLoaded}
+          selectedSlot={selectedSlot}
+          setSelectedSlot={setSelectedSlot}
+          isSubmitting={isSubmitting}
+          userData={userData}
+          selectedDate={selectedDate}
+          onConfirmReservation={onConfirmReservation}
+        />
+      )}
+    </div>
   );
 }

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -116,7 +116,7 @@ export function BookingForm({
 
       <Button
         variant="default"
-        className="w-full rounded-full px-6 py-3"
+        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
         onClick={isOwnMentorProfile ? onReservation : handleConfirm}
         disabled={
           isOwnMentorProfile

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -1,13 +1,10 @@
 'use client';
 
-import { Loader2 } from 'lucide-react';
-import { useState } from 'react';
-
-import { Button } from '@/components/ui/button';
-import { Textarea } from '@/components/ui/textarea';
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
 import type { UserType } from '@/hooks/user/user-data/useUserData';
-import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
+
+import { MenteeBookingForm } from './MenteeBookingForm';
+import { MentorScheduleConfig } from './MentorScheduleConfig';
 
 interface BookingFormProps {
   isOwnMentorProfile: boolean;
@@ -34,111 +31,27 @@ export function BookingForm({
   onReservation,
   onConfirmReservation,
 }: BookingFormProps) {
-  const [bookingQuestion, setBookingQuestion] = useState('');
-
-  const handleConfirm = async () => {
-    const success = await onConfirmReservation(bookingQuestion);
-    if (success) {
-      setBookingQuestion('');
-    }
-  };
+  if (isOwnMentorProfile) {
+    return (
+      <MentorScheduleConfig
+        slots={slots}
+        monthLoaded={monthLoaded}
+        userData={userData}
+        onReservation={onReservation}
+      />
+    );
+  }
 
   return (
-    <div className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]">
-      <div className="flex w-full flex-col items-start gap-4">
-        <p>當日可預約時段</p>
-        {!monthLoaded ? (
-          <div
-            aria-busy="true"
-            aria-live="polite"
-            className="flex min-h-10 items-center text-gray-400"
-          >
-            讀取中…
-          </div>
-        ) : slots.length === 0 ? (
-          <div className="flex min-h-10 items-center text-gray-400">
-            無可預約的時段
-          </div>
-        ) : (
-          <div className="grid w-full grid-cols-2 gap-2">
-            {slots.map((slot) => {
-              const isSelected =
-                selectedSlot?.start.getTime() === slot.start.getTime();
-              if (isOwnMentorProfile) {
-                return (
-                  <div
-                    key={slot.start.getTime()}
-                    className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
-                      slot.isBooked
-                        ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
-                        : 'border-[#E6E8EA]'
-                    }`}
-                  >
-                    {formatBookingSlotTime(slot)}
-                  </div>
-                );
-              }
-              return (
-                <Button
-                  key={slot.start.getTime()}
-                  variant={isSelected ? 'default' : 'outline'}
-                  disabled={slot.isBooked}
-                  onClick={() => setSelectedSlot(slot)}
-                  className={`h-10 w-full text-sm ${
-                    slot.isBooked
-                      ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
-                      : ''
-                  }`}
-                >
-                  {formatBookingSlotTime(slot)}
-                </Button>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
-      {!isOwnMentorProfile && (
-        <div className="flex w-full flex-col gap-2">
-          <label htmlFor="booking-question" className="text-sm font-semibold">
-            你想問導師的問題
-          </label>
-          <Textarea
-            id="booking-question"
-            placeholder="請在此輸入你的問題..."
-            className="h-[156px] w-full max-w-[335px] rounded-lg border-[#E6E8EA] focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0 md:max-w-[695px] 2xl:max-w-[404px]"
-            value={bookingQuestion}
-            onChange={(e) => setBookingQuestion(e.target.value)}
-            disabled={isSubmitting}
-          />
-        </div>
-      )}
-
-      <Button
-        variant="default"
-        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
-        onClick={isOwnMentorProfile ? onReservation : handleConfirm}
-        disabled={
-          isOwnMentorProfile
-            ? !userData
-            : isSubmitting ||
-              !userData ||
-              !selectedDate ||
-              !selectedSlot ||
-              !bookingQuestion.trim()
-        }
-      >
-        {isSubmitting ? (
-          <>
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-            處理中...
-          </>
-        ) : isOwnMentorProfile ? (
-          '預約設定'
-        ) : (
-          '預約時間'
-        )}
-      </Button>
-    </div>
+    <MenteeBookingForm
+      slots={slots}
+      monthLoaded={monthLoaded}
+      selectedSlot={selectedSlot}
+      setSelectedSlot={setSelectedSlot}
+      isSubmitting={isSubmitting}
+      userData={userData}
+      selectedDate={selectedDate}
+      onConfirmReservation={onConfirmReservation}
+    />
   );
 }

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -9,6 +9,7 @@ import { MentorScheduleConfig } from './MentorScheduleConfig';
 interface BookingFormProps {
   isOwnMentorProfile: boolean;
   isUserDataLoading: boolean;
+  isAuthenticated: boolean;
   slots: BookingSlot[];
   monthLoaded: boolean;
   selectedSlot: BookingSlot | null;
@@ -22,6 +23,7 @@ interface BookingFormProps {
 export function BookingForm({
   isOwnMentorProfile,
   isUserDataLoading,
+  isAuthenticated,
   slots,
   monthLoaded,
   selectedSlot,
@@ -71,6 +73,7 @@ export function BookingForm({
           isSubmitting={isSubmitting}
           selectedDate={selectedDate}
           onConfirmReservation={onConfirmReservation}
+          isAuthenticated={isAuthenticated}
         />
       )}
     </div>

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -35,14 +35,14 @@ export function MenteeBookingForm({
   const {
     register,
     handleSubmit,
-    setValue,
+    reset,
     formState: { isValid },
   } = useBookingForm();
 
   const onSubmit = async (data: { bookingQuestion: string }) => {
     const success = await onConfirmReservation(data.bookingQuestion);
     if (success) {
-      setValue('bookingQuestion', '');
+      reset();
     }
   };
 
@@ -52,7 +52,7 @@ export function MenteeBookingForm({
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
-      className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]"
+      className="flex w-full flex-col gap-4"
     >
       <ScheduleSlotList
         slots={slots}
@@ -86,7 +86,7 @@ export function MenteeBookingForm({
         <Textarea
           id="booking-question"
           placeholder="請在此輸入你的問題..."
-          className="h-[156px] w-full max-w-[335px] rounded-lg border-[#E6E8EA] focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0 md:max-w-[695px] 2xl:max-w-[404px]"
+          className="h-[156px] w-full rounded-lg border-background-border focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0"
           disabled={isSubmitting}
           {...register('bookingQuestion')}
         />

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -9,6 +9,8 @@ import { useBookingForm } from '@/hooks/user/reservation/useBookingForm';
 import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
 
+import { ScheduleSlotList } from './ScheduleSlotList';
+
 interface MenteeBookingFormProps {
   slots: BookingSlot[];
   monthLoaded: boolean;
@@ -30,8 +32,12 @@ export function MenteeBookingForm({
   selectedDate,
   onConfirmReservation,
 }: MenteeBookingFormProps) {
-  const { register, handleSubmit, watch, setValue } = useBookingForm();
-  const bookingQuestion = watch('bookingQuestion') || '';
+  const {
+    register,
+    handleSubmit,
+    setValue,
+    formState: { isValid },
+  } = useBookingForm();
 
   const onSubmit = async (data: { bookingQuestion: string }) => {
     const success = await onConfirmReservation(data.bookingQuestion);
@@ -41,56 +47,37 @@ export function MenteeBookingForm({
   };
 
   const isButtonDisabled =
-    isSubmitting ||
-    !userData ||
-    !selectedDate ||
-    !selectedSlot ||
-    !bookingQuestion.trim();
+    isSubmitting || !userData || !selectedDate || !selectedSlot || !isValid;
 
   return (
     <form
       onSubmit={handleSubmit(onSubmit)}
       className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]"
     >
-      <div className="flex w-full flex-col items-start gap-4">
-        <p>當日可預約時段</p>
-        {!monthLoaded ? (
-          <div
-            aria-busy="true"
-            aria-live="polite"
-            className="flex min-h-10 items-center text-gray-400"
-          >
-            讀取中…
-          </div>
-        ) : slots.length === 0 ? (
-          <div className="flex min-h-10 items-center text-gray-400">
-            無可預約的時段
-          </div>
-        ) : (
-          <div className="grid w-full grid-cols-2 gap-2">
-            {slots.map((slot) => {
-              const isSelected =
-                selectedSlot?.start.getTime() === slot.start.getTime();
-              return (
-                <Button
-                  key={slot.start.getTime()}
-                  type="button"
-                  variant={isSelected ? 'default' : 'outline'}
-                  disabled={slot.isBooked}
-                  onClick={() => setSelectedSlot(slot)}
-                  className={`h-10 w-full text-sm ${
-                    slot.isBooked
-                      ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
-                      : ''
-                  }`}
-                >
-                  {formatBookingSlotTime(slot)}
-                </Button>
-              );
-            })}
-          </div>
-        )}
-      </div>
+      <ScheduleSlotList
+        slots={slots}
+        monthLoaded={monthLoaded}
+        renderSlot={(slot) => {
+          const isSelected =
+            selectedSlot?.start.getTime() === slot.start.getTime();
+          return (
+            <Button
+              key={slot.start.getTime()}
+              type="button"
+              variant={isSelected ? 'default' : 'outline'}
+              disabled={slot.isBooked}
+              onClick={() => setSelectedSlot(slot)}
+              className={`h-10 w-full text-sm ${
+                slot.isBooked
+                  ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
+                  : ''
+              }`}
+            >
+              {formatBookingSlotTime(slot)}
+            </Button>
+          );
+        }}
+      />
 
       <div className="flex w-full flex-col gap-2">
         <label htmlFor="booking-question" className="text-sm font-semibold">

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -19,6 +19,7 @@ interface MenteeBookingFormProps {
   isSubmitting: boolean;
   selectedDate: string | null;
   onConfirmReservation: (question: string) => Promise<boolean>;
+  isAuthenticated: boolean;
 }
 
 export function MenteeBookingForm({
@@ -29,6 +30,7 @@ export function MenteeBookingForm({
   isSubmitting,
   selectedDate,
   onConfirmReservation,
+  isAuthenticated,
 }: MenteeBookingFormProps) {
   const {
     register,
@@ -45,7 +47,11 @@ export function MenteeBookingForm({
   };
 
   const isButtonDisabled =
-    isSubmitting || !selectedDate || !selectedSlot || !isValid;
+    isSubmitting ||
+    !isAuthenticated ||
+    !selectedDate ||
+    !selectedSlot ||
+    !isValid;
 
   return (
     <form

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -9,7 +9,7 @@ import { useBookingForm } from '@/hooks/user/reservation/useBookingForm';
 import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
 
-import { ScheduleSlotList } from './ScheduleSlotList';
+import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
 
 interface MenteeBookingFormProps {
   slots: BookingSlot[];
@@ -36,7 +36,7 @@ export function MenteeBookingForm({
     register,
     handleSubmit,
     reset,
-    formState: { isValid },
+    formState: { isValid, errors },
   } = useBookingForm();
 
   const onSubmit = async (data: { bookingQuestion: string }) => {
@@ -68,9 +68,7 @@ export function MenteeBookingForm({
               disabled={slot.isBooked}
               onClick={() => setSelectedSlot(slot)}
               className={`h-10 w-full text-sm ${
-                slot.isBooked
-                  ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
-                  : ''
+                slot.isBooked ? BOOKED_SLOT_CLASSES : ''
               }`}
             >
               {formatBookingSlotTime(slot)}
@@ -90,6 +88,11 @@ export function MenteeBookingForm({
           disabled={isSubmitting}
           {...register('bookingQuestion')}
         />
+        {errors.bookingQuestion && (
+          <p className="mt-1 text-sm text-status-200">
+            {errors.bookingQuestion.message}
+          </p>
+        )}
       </div>
 
       <Button

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -6,8 +6,8 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
 import { useBookingForm } from '@/hooks/user/reservation/useBookingForm';
-import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
+import type { BookingFormValues } from '@/schemas/bookingSchema';
 
 import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
 
@@ -17,7 +17,6 @@ interface MenteeBookingFormProps {
   selectedSlot: BookingSlot | null;
   setSelectedSlot: (slot: BookingSlot | null) => void;
   isSubmitting: boolean;
-  userData: UserType | null;
   selectedDate: string | null;
   onConfirmReservation: (question: string) => Promise<boolean>;
 }
@@ -28,7 +27,6 @@ export function MenteeBookingForm({
   selectedSlot,
   setSelectedSlot,
   isSubmitting,
-  userData,
   selectedDate,
   onConfirmReservation,
 }: MenteeBookingFormProps) {
@@ -39,7 +37,7 @@ export function MenteeBookingForm({
     formState: { isValid, errors },
   } = useBookingForm();
 
-  const onSubmit = async (data: { bookingQuestion: string }) => {
+  const onSubmit = async (data: BookingFormValues) => {
     const success = await onConfirmReservation(data.bookingQuestion);
     if (success) {
       reset();
@@ -47,7 +45,7 @@ export function MenteeBookingForm({
   };
 
   const isButtonDisabled =
-    isSubmitting || !userData || !selectedDate || !selectedSlot || !isValid;
+    isSubmitting || !selectedDate || !selectedSlot || !isValid;
 
   return (
     <form

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -1,0 +1,125 @@
+'use client';
+
+import { Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import type { BookingSlot } from '@/hooks/useMentorSchedule';
+import { useBookingForm } from '@/hooks/user/reservation/useBookingForm';
+import type { UserType } from '@/hooks/user/user-data/useUserData';
+import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
+
+interface MenteeBookingFormProps {
+  slots: BookingSlot[];
+  monthLoaded: boolean;
+  selectedSlot: BookingSlot | null;
+  setSelectedSlot: (slot: BookingSlot | null) => void;
+  isSubmitting: boolean;
+  userData: UserType | null;
+  selectedDate: string | null;
+  onConfirmReservation: (question: string) => Promise<boolean>;
+}
+
+export function MenteeBookingForm({
+  slots,
+  monthLoaded,
+  selectedSlot,
+  setSelectedSlot,
+  isSubmitting,
+  userData,
+  selectedDate,
+  onConfirmReservation,
+}: MenteeBookingFormProps) {
+  const { register, handleSubmit, watch, setValue } = useBookingForm();
+  const bookingQuestion = watch('bookingQuestion') || '';
+
+  const onSubmit = async (data: { bookingQuestion: string }) => {
+    const success = await onConfirmReservation(data.bookingQuestion);
+    if (success) {
+      setValue('bookingQuestion', '');
+    }
+  };
+
+  const isButtonDisabled =
+    isSubmitting ||
+    !userData ||
+    !selectedDate ||
+    !selectedSlot ||
+    !bookingQuestion.trim();
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]"
+    >
+      <div className="flex w-full flex-col items-start gap-4">
+        <p>當日可預約時段</p>
+        {!monthLoaded ? (
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            className="flex min-h-10 items-center text-gray-400"
+          >
+            讀取中…
+          </div>
+        ) : slots.length === 0 ? (
+          <div className="flex min-h-10 items-center text-gray-400">
+            無可預約的時段
+          </div>
+        ) : (
+          <div className="grid w-full grid-cols-2 gap-2">
+            {slots.map((slot) => {
+              const isSelected =
+                selectedSlot?.start.getTime() === slot.start.getTime();
+              return (
+                <Button
+                  key={slot.start.getTime()}
+                  type="button"
+                  variant={isSelected ? 'default' : 'outline'}
+                  disabled={slot.isBooked}
+                  onClick={() => setSelectedSlot(slot)}
+                  className={`h-10 w-full text-sm ${
+                    slot.isBooked
+                      ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400 disabled:opacity-100'
+                      : ''
+                  }`}
+                >
+                  {formatBookingSlotTime(slot)}
+                </Button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div className="flex w-full flex-col gap-2">
+        <label htmlFor="booking-question" className="text-sm font-semibold">
+          你想問導師的問題
+        </label>
+        <Textarea
+          id="booking-question"
+          placeholder="請在此輸入你的問題..."
+          className="h-[156px] w-full max-w-[335px] rounded-lg border-[#E6E8EA] focus-visible:ring-1 focus-visible:ring-primary focus-visible:ring-offset-0 md:max-w-[695px] 2xl:max-w-[404px]"
+          disabled={isSubmitting}
+          {...register('bookingQuestion')}
+        />
+      </div>
+
+      <Button
+        type="submit"
+        variant="default"
+        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
+        disabled={isButtonDisabled}
+      >
+        {isSubmitting ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            處理中...
+          </>
+        ) : (
+          '預約時間'
+        )}
+      </Button>
+    </form>
+  );
+}

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -5,7 +5,7 @@ import type { BookingSlot } from '@/hooks/useMentorSchedule';
 import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
 
-import { ScheduleSlotList } from './ScheduleSlotList';
+import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
 
 interface MentorScheduleConfigProps {
   slots: BookingSlot[];
@@ -28,9 +28,7 @@ export function MentorScheduleConfig({
         renderSlot={(slot) => (
           <div
             className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
-              slot.isBooked
-                ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
-                : 'border-background-border'
+              slot.isBooked ? BOOKED_SLOT_CLASSES : 'border-background-border'
             }`}
           >
             {formatBookingSlotTime(slot)}

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -2,7 +2,6 @@
 
 import { Button } from '@/components/ui/button';
 import type { BookingSlot } from '@/hooks/useMentorSchedule';
-import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
 
 import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
@@ -10,14 +9,12 @@ import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
 interface MentorScheduleConfigProps {
   slots: BookingSlot[];
   monthLoaded: boolean;
-  userData: UserType | null;
   onReservation: () => void;
 }
 
 export function MentorScheduleConfig({
   slots,
   monthLoaded,
-  userData,
   onReservation,
 }: MentorScheduleConfigProps) {
   return (
@@ -40,7 +37,6 @@ export function MentorScheduleConfig({
         variant="default"
         className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
         onClick={onReservation}
-        disabled={!userData}
       >
         預約設定
       </Button>

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import type { BookingSlot } from '@/hooks/useMentorSchedule';
+import type { UserType } from '@/hooks/user/user-data/useUserData';
+import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
+
+interface MentorScheduleConfigProps {
+  slots: BookingSlot[];
+  monthLoaded: boolean;
+  userData: UserType | null;
+  onReservation: () => void;
+}
+
+export function MentorScheduleConfig({
+  slots,
+  monthLoaded,
+  userData,
+  onReservation,
+}: MentorScheduleConfigProps) {
+  return (
+    <div className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]">
+      <div className="flex w-full flex-col items-start gap-4">
+        <p>當日可預約時段</p>
+        {!monthLoaded ? (
+          <div
+            aria-busy="true"
+            aria-live="polite"
+            className="flex min-h-10 items-center text-gray-400"
+          >
+            讀取中…
+          </div>
+        ) : slots.length === 0 ? (
+          <div className="flex min-h-10 items-center text-gray-400">
+            無可預約的時段
+          </div>
+        ) : (
+          <div className="grid w-full grid-cols-2 gap-2">
+            {slots.map((slot) => (
+              <div
+                key={slot.start.getTime()}
+                className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
+                  slot.isBooked
+                    ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
+                    : 'border-[#E6E8EA]'
+                }`}
+              >
+                {formatBookingSlotTime(slot)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <Button
+        variant="default"
+        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
+        onClick={onReservation}
+        disabled={!userData}
+      >
+        預約設定
+      </Button>
+    </div>
+  );
+}

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -21,7 +21,7 @@ export function MentorScheduleConfig({
   onReservation,
 }: MentorScheduleConfigProps) {
   return (
-    <div className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]">
+    <div className="flex w-full flex-col gap-4">
       <ScheduleSlotList
         slots={slots}
         monthLoaded={monthLoaded}
@@ -30,7 +30,7 @@ export function MentorScheduleConfig({
             className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
               slot.isBooked
                 ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
-                : 'border-[#E6E8EA]'
+                : 'border-background-border'
             }`}
           >
             {formatBookingSlotTime(slot)}

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -5,6 +5,8 @@ import type { BookingSlot } from '@/hooks/useMentorSchedule';
 import type { UserType } from '@/hooks/user/user-data/useUserData';
 import { formatBookingSlotTime } from '@/lib/profile/scheduleFormatters';
 
+import { ScheduleSlotList } from './ScheduleSlotList';
+
 interface MentorScheduleConfigProps {
   slots: BookingSlot[];
   monthLoaded: boolean;
@@ -20,37 +22,21 @@ export function MentorScheduleConfig({
 }: MentorScheduleConfigProps) {
   return (
     <div className="flex w-full max-w-[335px] flex-col gap-4 md:max-w-[695px] 2xl:max-w-[414px]">
-      <div className="flex w-full flex-col items-start gap-4">
-        <p>當日可預約時段</p>
-        {!monthLoaded ? (
+      <ScheduleSlotList
+        slots={slots}
+        monthLoaded={monthLoaded}
+        renderSlot={(slot) => (
           <div
-            aria-busy="true"
-            aria-live="polite"
-            className="flex min-h-10 items-center text-gray-400"
+            className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
+              slot.isBooked
+                ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
+                : 'border-[#E6E8EA]'
+            }`}
           >
-            讀取中…
-          </div>
-        ) : slots.length === 0 ? (
-          <div className="flex min-h-10 items-center text-gray-400">
-            無可預約的時段
-          </div>
-        ) : (
-          <div className="grid w-full grid-cols-2 gap-2">
-            {slots.map((slot) => (
-              <div
-                key={slot.start.getTime()}
-                className={`flex h-10 select-none items-center justify-center rounded-lg border text-sm font-medium ${
-                  slot.isBooked
-                    ? 'cursor-not-allowed border-gray-200 bg-gray-100 text-gray-400'
-                    : 'border-[#E6E8EA]'
-                }`}
-              >
-                {formatBookingSlotTime(slot)}
-              </div>
-            ))}
+            {formatBookingSlotTime(slot)}
           </div>
         )}
-      </div>
+      />
 
       <Button
         variant="default"

--- a/src/components/profile/reservation/ScheduleSlotList.tsx
+++ b/src/components/profile/reservation/ScheduleSlotList.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import React from 'react';
+
+import type { BookingSlot } from '@/hooks/useMentorSchedule';
+
+interface ScheduleSlotListProps {
+  slots: BookingSlot[];
+  monthLoaded: boolean;
+  renderSlot: (slot: BookingSlot) => React.ReactNode;
+}
+
+export function ScheduleSlotList({
+  slots,
+  monthLoaded,
+  renderSlot,
+}: ScheduleSlotListProps) {
+  return (
+    <div className="flex w-full flex-col items-start gap-4">
+      <p>當日可預約時段</p>
+      {!monthLoaded ? (
+        <div
+          aria-busy="true"
+          aria-live="polite"
+          className="flex min-h-10 items-center text-gray-400"
+        >
+          讀取中…
+        </div>
+      ) : slots.length === 0 ? (
+        <div className="flex min-h-10 items-center text-gray-400">
+          無可預約的時段
+        </div>
+      ) : (
+        <div className="grid w-full grid-cols-2 gap-2">
+          {slots.map((slot) => (
+            <React.Fragment key={slot.start.getTime()}>
+              {renderSlot(slot)}
+            </React.Fragment>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/profile/reservation/ScheduleSlotList.tsx
+++ b/src/components/profile/reservation/ScheduleSlotList.tsx
@@ -10,6 +10,9 @@ interface ScheduleSlotListProps {
   renderSlot: (slot: BookingSlot) => React.ReactNode;
 }
 
+export const BOOKED_SLOT_CLASSES =
+  'cursor-not-allowed border-background-border bg-background-bottom text-text-disable disabled:opacity-100';
+
 export function ScheduleSlotList({
   slots,
   monthLoaded,
@@ -22,12 +25,12 @@ export function ScheduleSlotList({
         <div
           aria-busy="true"
           aria-live="polite"
-          className="flex min-h-10 items-center text-gray-400"
+          className="flex min-h-10 items-center text-text-disable"
         >
           讀取中…
         </div>
       ) : slots.length === 0 ? (
-        <div className="flex min-h-10 items-center text-gray-400">
+        <div className="flex min-h-10 items-center text-text-disable">
           無可預約的時段
         </div>
       ) : (

--- a/src/hooks/user/reservation/useBookingForm.ts
+++ b/src/hooks/user/reservation/useBookingForm.ts
@@ -1,0 +1,16 @@
+'use client';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+
+import { bookingFormSchema, BookingFormValues } from '@/schemas/bookingSchema';
+
+export function useBookingForm() {
+  return useForm<BookingFormValues>({
+    resolver: zodResolver(bookingFormSchema),
+    defaultValues: {
+      bookingQuestion: '',
+    },
+    mode: 'onChange',
+  });
+}

--- a/src/schemas/bookingSchema.test.ts
+++ b/src/schemas/bookingSchema.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { bookingFormSchema } from './bookingSchema';
+
+describe('bookingFormSchema', () => {
+  it('should pass with a valid question', () => {
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: 'Hello, I want to learn React and TypeScript!',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('should fail if question is empty', () => {
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: '',
+    });
+    expect(result.success).toBe(false);
+    const issue = result.error!.issues[0];
+    expect(issue.message).toBe('請輸入你想問導師的問題');
+  });
+
+  it('should fail and trim whitespace-only questions', () => {
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: '    \n   ',
+    });
+    expect(result.success).toBe(false);
+    const issue = result.error!.issues[0];
+    expect(issue.message).toBe('請輸入你想問導師的問題');
+  });
+
+  it('should fail if question exceeds 1000 characters', () => {
+    const longQuestion = 'a'.repeat(1001);
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: longQuestion,
+    });
+    expect(result.success).toBe(false);
+    const issue = result.error!.issues[0];
+    expect(issue.message).toBe('問題字數請勿超過 1000 字');
+  });
+
+  it('should pass if question is exactly 1000 characters', () => {
+    const exactQuestion = 'a'.repeat(1000);
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: exactQuestion,
+    });
+    expect(result.success).toBe(true);
+  });
+});

--- a/src/schemas/bookingSchema.ts
+++ b/src/schemas/bookingSchema.ts
@@ -1,7 +1,11 @@
 import * as z from 'zod';
 
 export const bookingFormSchema = z.object({
-  bookingQuestion: z.string().trim().min(1, '請輸入你想問導師的問題'),
+  bookingQuestion: z
+    .string()
+    .trim()
+    .min(1, '請輸入你想問導師的問題')
+    .max(1000, '問題字數請勿超過 1000 字'),
 });
 
 export type BookingFormValues = z.infer<typeof bookingFormSchema>;

--- a/src/schemas/bookingSchema.ts
+++ b/src/schemas/bookingSchema.ts
@@ -1,0 +1,7 @@
+import * as z from 'zod';
+
+export const bookingFormSchema = z.object({
+  bookingQuestion: z.string().trim().min(1, '請輸入你想問導師的問題'),
+});
+
+export type BookingFormValues = z.infer<typeof bookingFormSchema>;


### PR DESCRIPTION
## What Does This PR Do?

- 在 `BookingForm.tsx` 的預約按鈕添加 `disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100` 類別，使按鈕在 `disabled` 狀態下呈現實心灰色（符合設計指定的設計語彙 Token），而非預設的半透明藍綠色。
- 新增 `BookingForm.test.tsx` 完整補足按鈕的狀態測試（包括 loading、空時段、disabled、填寫完成後 enabled 點擊確認、以及導師預約設定模式等）。

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

N/A