### PR TITLE
fix: show have_topic/have_skill sections during mentor onboarding

### DIFF
--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -164,6 +164,48 @@ describe('EditProfileContainer isMentorOnboarding parsing', () => {
   });
 });
 
+describe('EditProfileContainer mentor-only section visibility', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseEditProfileData.mockReturnValue({
+      userDto: {} as unknown as MentorProfileVO,
+      isMentor: false,
+      isError: false,
+    });
+  });
+
+  it('renders have_topic/have_skill sections during mentor onboarding even though isMentor (DB flag) is still false', () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === MENTOR_ONBOARDING_KEY) return 'true';
+      return null;
+    });
+
+    const { container } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(container.querySelector('#have_topic')).not.toBeNull();
+    expect(container.querySelector('#have_skill')).not.toBeNull();
+  });
+
+  it('does not render have_topic/have_skill sections for a plain mentee (not onboarding, not a mentor)', () => {
+    mockSearchParamsGet.mockImplementation(() => null);
+
+    const { container } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(container.querySelector('#have_topic')).toBeNull();
+    expect(container.querySelector('#have_skill')).toBeNull();
+  });
+});
+
 describe('EditProfileContainer error handling and scrolling', () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -214,7 +214,9 @@ export default function EditProfileContainer({
             id="about"
             title={
               <>
-                {isMentor && <span className="text-status-200">* </span>}
+                {(isMentor || isMentorOnboarding) && (
+                  <span className="text-status-200">* </span>
+                )}
                 關於我
               </>
             }
@@ -222,7 +224,7 @@ export default function EditProfileContainer({
             <TextareaField form={form} name="about" rows={10} />
           </Section>
 
-          {isMentor && (
+          {(isMentor || isMentorOnboarding) && (
             <Section
               id="have_topic"
               title={
@@ -241,7 +243,7 @@ export default function EditProfileContainer({
             </Section>
           )}
 
-          {isMentor && (
+          {(isMentor || isMentorOnboarding) && (
             <Section
               id="have_skill"
               title={
@@ -299,7 +301,9 @@ export default function EditProfileContainer({
             id="industry"
             title={
               <>
-                {isMentor && <span className="text-status-200">* </span>}
+                {(isMentor || isMentorOnboarding) && (
+                  <span className="text-status-200">* </span>
+                )}
                 產業
               </>
             }

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -98,7 +98,14 @@ export default function EditProfileContainer({
     isAuthorized,
   });
 
-  const { form } = useEditProfileForm(isMentorOnboarding || isMentor);
+  // Effective mentor-mode flag: true once the user is already a mentor OR is
+  // going through the "become a mentor" onboarding flow. Drives both the Zod
+  // schema's required fields (via useEditProfileForm) and which mentor-only
+  // sections render below — the two must stay in sync or required fields can
+  // end up invisible while still blocking submit.
+  const isMentorRole = isMentor || isMentorOnboarding;
+
+  const { form } = useEditProfileForm(isMentorRole);
 
   const { formRef, onError, scrollToField } =
     useFormErrorScroll<ProfileFormValues>();
@@ -214,9 +221,7 @@ export default function EditProfileContainer({
             id="about"
             title={
               <>
-                {(isMentor || isMentorOnboarding) && (
-                  <span className="text-status-200">* </span>
-                )}
+                {isMentorRole && <span className="text-status-200">* </span>}
                 關於我
               </>
             }
@@ -224,7 +229,7 @@ export default function EditProfileContainer({
             <TextareaField form={form} name="about" rows={10} />
           </Section>
 
-          {(isMentor || isMentorOnboarding) && (
+          {isMentorRole && (
             <Section
               id="have_topic"
               title={
@@ -243,7 +248,7 @@ export default function EditProfileContainer({
             </Section>
           )}
 
-          {(isMentor || isMentorOnboarding) && (
+          {isMentorRole && (
             <Section
               id="have_skill"
               title={
@@ -301,9 +306,7 @@ export default function EditProfileContainer({
             id="industry"
             title={
               <>
-                {(isMentor || isMentorOnboarding) && (
-                  <span className="text-status-200">* </span>
-                )}
+                {isMentorRole && <span className="text-status-200">* </span>}
                 產業
               </>
             }


### PR DESCRIPTION
## What Does This PR Do?

- Mentee → mentor onboarding (`/profile/[pageUserId]/edit?mentor-onboarding=true`) requires `have_topic` (我能提供的服務) and `have_skill` (專業能力) via the form schema (`isMentorOnboarding || isMentor`), but the two sections rendering those fields were gated on the bare DB flag `isMentor` only
- For a mentee who isn't a mentor yet, `isMentor` is `false`, so the required fields never rendered while validation still required them — submit silently failed forever with no visible error
- Fix the two section guards (and the matching required-field `*` markers on `about`/`industry`, same bug) to use `isMentor || isMentorOnboarding`, consistent with the rest of this file

## Demo

http://localhost:3000/profile/{userId}/edit?mentor-onboarding=true

## Screenshot

N/A

## Anything to Note?

Existing profile-edit e2e (4/4) and unit tests (11/11) still pass. Verified the fix with a one-off Playwright repro simulating a mentee (`is_mentor: false`) hitting the onboarding URL — the sections now render and are fillable.
