### PR TITLE
fix(profile): 修正導師 onboarding 流程中大頭貼與其他欄位未顯示必填提示之問題 (X-Tracker #367)

### DIFF
--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -74,8 +74,25 @@ vi.mock('@/components/profile/edit/EditPageHeader', () => ({
   EditPageHeader: () => <div data-testid="edit-header" />,
 }));
 vi.mock('@/components/profile/edit/AvatarSection', () => ({
-  AvatarSection: ({ id }: { id?: string }) => (
-    <div id={id} data-testid="avatar-section" />
+  AvatarSection: ({ id, isMentor }: { id?: string; isMentor?: boolean }) => (
+    <div
+      id={id}
+      data-testid="avatar-section"
+      data-is-mentor={String(isMentor)}
+    />
+  ),
+}));
+vi.mock('@/components/profile/edit/JobExperienceSection', () => ({
+  JobExperienceSection: ({ isMentor }: { isMentor?: boolean }) => (
+    <div
+      data-testid="job-experience-section"
+      data-is-mentor={String(isMentor)}
+    />
+  ),
+}));
+vi.mock('@/components/profile/edit/educationSection/educationSection', () => ({
+  EducationSection: ({ isMentor }: { isMentor?: boolean }) => (
+    <div data-testid="education-section" data-is-mentor={String(isMentor)} />
   ),
 }));
 vi.mock('@/components/profile/edit/Fields', () => ({
@@ -517,5 +534,104 @@ describe('EditProfileContainer error handling and scrolling', () => {
     );
 
     useEditProfileFormSpy.mockRestore();
+  });
+});
+
+describe('EditProfileContainer isMentorFlow logic', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('passes isMentor as true to child sections when isMentorOnboarding is true', () => {
+    mockSearchParamsGet.mockImplementation((key) => {
+      if (key === MENTOR_ONBOARDING_KEY) return 'true';
+      return null;
+    });
+
+    mockUseEditProfileData.mockReturnValue({
+      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
+      isMentor: false,
+      isError: false,
+    });
+
+    const { getByTestId } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(getByTestId('avatar-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+    expect(getByTestId('job-experience-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+    expect(getByTestId('education-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+  });
+
+  it('passes isMentor as true to child sections when isMentor is true', () => {
+    mockSearchParamsGet.mockImplementation(() => null);
+
+    mockUseEditProfileData.mockReturnValue({
+      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
+      isMentor: true,
+      isError: false,
+    });
+
+    const { getByTestId } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(getByTestId('avatar-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+    expect(getByTestId('job-experience-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+    expect(getByTestId('education-section')).toHaveAttribute(
+      'data-is-mentor',
+      'true'
+    );
+  });
+
+  it('passes isMentor as false to child sections when both isMentorOnboarding and isMentor are false', () => {
+    mockSearchParamsGet.mockImplementation(() => null);
+
+    mockUseEditProfileData.mockReturnValue({
+      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
+      isMentor: false,
+      isError: false,
+    });
+
+    const { getByTestId } = render(
+      <EditProfileContainer
+        pageUserId="1"
+        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+      />
+    );
+
+    expect(getByTestId('avatar-section')).toHaveAttribute(
+      'data-is-mentor',
+      'false'
+    );
+    expect(getByTestId('job-experience-section')).toHaveAttribute(
+      'data-is-mentor',
+      'false'
+    );
+    expect(getByTestId('education-section')).toHaveAttribute(
+      'data-is-mentor',
+      'false'
+    );
   });
 });

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -595,153 +595,93 @@ describe('EditProfileContainer isMentorRole logic', () => {
     vi.clearAllMocks();
   });
 
-  it('passes isMentor as true to child sections and displays required hints when isMentorOnboarding is true', () => {
-    mockSearchParamsGet.mockImplementation((key) => {
-      if (key === MENTOR_ONBOARDING_KEY) return 'true';
-      return null;
-    });
+  it.each([
+    {
+      onboardingParam: 'true',
+      isMentorDb: false,
+      expectedIsMentor: true,
+      desc: 'when isMentorOnboarding is true',
+    },
+    {
+      onboardingParam: null,
+      isMentorDb: true,
+      expectedIsMentor: true,
+      desc: 'when isMentor is true',
+    },
+    {
+      onboardingParam: null,
+      isMentorDb: false,
+      expectedIsMentor: false,
+      desc: 'when both isMentorOnboarding and isMentor are false',
+    },
+  ])(
+    'correctly propagates parameters and displays hints $desc',
+    ({ onboardingParam, isMentorDb, expectedIsMentor }) => {
+      mockSearchParamsGet.mockImplementation((key) => {
+        if (key === MENTOR_ONBOARDING_KEY) return onboardingParam;
+        return null;
+      });
 
-    mockUseEditProfileData.mockReturnValue({
-      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
-      isMentor: false,
-      isError: false,
-    });
+      mockUseEditProfileData.mockReturnValue({
+        userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
+        isMentor: isMentorDb,
+        isError: false,
+      });
 
-    const useEditProfileFormSpy = vi.spyOn(
-      useEditProfileFormModule,
-      'useEditProfileForm'
-    );
+      const useEditProfileFormSpy = vi.spyOn(
+        useEditProfileFormModule,
+        'useEditProfileForm'
+      );
 
-    const { getByTestId, queryByTestId } = render(
-      <EditProfileContainer
-        pageUserId="1"
-        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
-      />
-    );
+      const { getByTestId, queryByTestId } = render(
+        <EditProfileContainer
+          pageUserId="1"
+          initialTagCatalog={{} as unknown as TagCatalogsByBucket}
+        />
+      );
 
-    // Verify useEditProfileForm was called with true
-    expect(useEditProfileFormSpy).toHaveBeenCalledWith(true);
+      // Verify useEditProfileForm parameter passing
+      expect(useEditProfileFormSpy).toHaveBeenCalledWith(expectedIsMentor);
 
-    // Verify child props
-    expect(getByTestId('avatar-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
-    expect(getByTestId('job-experience-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
-    expect(getByTestId('education-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
+      // Verify child props
+      expect(getByTestId('avatar-section')).toHaveAttribute(
+        'data-is-mentor',
+        String(expectedIsMentor)
+      );
+      expect(getByTestId('job-experience-section')).toHaveAttribute(
+        'data-is-mentor',
+        String(expectedIsMentor)
+      );
+      expect(getByTestId('education-section')).toHaveAttribute(
+        'data-is-mentor',
+        String(expectedIsMentor)
+      );
 
-    // Verify asterisks on about and industry sections
-    expect(getByTestId('section-about-title')).toHaveTextContent('* 關於我');
-    expect(getByTestId('section-industry-title')).toHaveTextContent('* 產業');
+      if (expectedIsMentor) {
+        // Verify asterisks on about and industry sections
+        expect(getByTestId('section-about-title')).toHaveTextContent(
+          '* 關於我'
+        );
+        expect(getByTestId('section-industry-title')).toHaveTextContent(
+          '* 產業'
+        );
 
-    // Verify mentor-only sections render
-    expect(queryByTestId('section-have_topic')).toBeInTheDocument();
-    expect(queryByTestId('section-have_skill')).toBeInTheDocument();
+        // Verify mentor-only sections render
+        expect(queryByTestId('section-have_topic')).toBeInTheDocument();
+        expect(queryByTestId('section-have_skill')).toBeInTheDocument();
+      } else {
+        // Verify NO asterisks on about and industry sections
+        expect(getByTestId('section-about-title')).not.toHaveTextContent('*');
+        expect(getByTestId('section-industry-title')).not.toHaveTextContent(
+          '*'
+        );
 
-    useEditProfileFormSpy.mockRestore();
-  });
+        // Verify mentor-only sections do NOT render
+        expect(queryByTestId('section-have_topic')).not.toBeInTheDocument();
+        expect(queryByTestId('section-have_skill')).not.toBeInTheDocument();
+      }
 
-  it('passes isMentor as true to child sections and displays required hints when isMentor is true', () => {
-    mockSearchParamsGet.mockImplementation(() => null);
-
-    mockUseEditProfileData.mockReturnValue({
-      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
-      isMentor: true,
-      isError: false,
-    });
-
-    const useEditProfileFormSpy = vi.spyOn(
-      useEditProfileFormModule,
-      'useEditProfileForm'
-    );
-
-    const { getByTestId, queryByTestId } = render(
-      <EditProfileContainer
-        pageUserId="1"
-        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
-      />
-    );
-
-    // Verify useEditProfileForm was called with true
-    expect(useEditProfileFormSpy).toHaveBeenCalledWith(true);
-
-    // Verify child props
-    expect(getByTestId('avatar-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
-    expect(getByTestId('job-experience-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
-    expect(getByTestId('education-section')).toHaveAttribute(
-      'data-is-mentor',
-      'true'
-    );
-
-    // Verify asterisks on about and industry sections
-    expect(getByTestId('section-about-title')).toHaveTextContent('* 關於我');
-    expect(getByTestId('section-industry-title')).toHaveTextContent('* 產業');
-
-    // Verify mentor-only sections render
-    expect(queryByTestId('section-have_topic')).toBeInTheDocument();
-    expect(queryByTestId('section-have_skill')).toBeInTheDocument();
-
-    useEditProfileFormSpy.mockRestore();
-  });
-
-  it('passes isMentor as false to child sections and hides required hints when both isMentorOnboarding and isMentor are false', () => {
-    mockSearchParamsGet.mockImplementation(() => null);
-
-    mockUseEditProfileData.mockReturnValue({
-      userDto: { user_id: 1, name: 'Test' } as unknown as MentorProfileVO,
-      isMentor: false,
-      isError: false,
-    });
-
-    const useEditProfileFormSpy = vi.spyOn(
-      useEditProfileFormModule,
-      'useEditProfileForm'
-    );
-
-    const { getByTestId, queryByTestId } = render(
-      <EditProfileContainer
-        pageUserId="1"
-        initialTagCatalog={{} as unknown as TagCatalogsByBucket}
-      />
-    );
-
-    // Verify useEditProfileForm was called with false
-    expect(useEditProfileFormSpy).toHaveBeenCalledWith(false);
-
-    // Verify child props
-    expect(getByTestId('avatar-section')).toHaveAttribute(
-      'data-is-mentor',
-      'false'
-    );
-    expect(getByTestId('job-experience-section')).toHaveAttribute(
-      'data-is-mentor',
-      'false'
-    );
-    expect(getByTestId('education-section')).toHaveAttribute(
-      'data-is-mentor',
-      'false'
-    );
-
-    // Verify NO asterisks on about and industry sections
-    expect(getByTestId('section-about-title')).not.toHaveTextContent('*');
-    expect(getByTestId('section-industry-title')).not.toHaveTextContent('*');
-
-    // Verify mentor-only sections do NOT render
-    expect(queryByTestId('section-have_topic')).not.toBeInTheDocument();
-    expect(queryByTestId('section-have_skill')).not.toBeInTheDocument();
-
-    useEditProfileFormSpy.mockRestore();
-  });
+      useEditProfileFormSpy.mockRestore();
+    }
+  );
 });

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -98,7 +98,9 @@ export default function EditProfileContainer({
     isAuthorized,
   });
 
-  const { form } = useEditProfileForm(isMentorOnboarding || isMentor);
+  const isMentorFlow = isMentorOnboarding || isMentor;
+
+  const { form } = useEditProfileForm(isMentorFlow);
 
   const { formRef, onError, scrollToField } =
     useFormErrorScroll<ProfileFormValues>();
@@ -193,7 +195,7 @@ export default function EditProfileContainer({
             id="avatarFile"
             control={form.control}
             name="avatarFile"
-            isMentor={isMentor}
+            isMentor={isMentorFlow}
             onFileChange={(file) =>
               avatarUpload.kickOff(file, form.getValues('avatar'))
             }
@@ -214,7 +216,7 @@ export default function EditProfileContainer({
             id="about"
             title={
               <>
-                {isMentor && <span className="text-status-200">* </span>}
+                {isMentorFlow && <span className="text-status-200">* </span>}
                 關於我
               </>
             }
@@ -222,7 +224,7 @@ export default function EditProfileContainer({
             <TextareaField form={form} name="about" rows={10} />
           </Section>
 
-          {isMentor && (
+          {isMentorFlow && (
             <Section
               id="have_topic"
               title={
@@ -241,7 +243,7 @@ export default function EditProfileContainer({
             </Section>
           )}
 
-          {isMentor && (
+          {isMentorFlow && (
             <Section
               id="have_skill"
               title={
@@ -299,7 +301,7 @@ export default function EditProfileContainer({
             id="industry"
             title={
               <>
-                {isMentor && <span className="text-status-200">* </span>}
+                {isMentorFlow && <span className="text-status-200">* </span>}
                 產業
               </>
             }
@@ -371,7 +373,7 @@ export default function EditProfileContainer({
               industries={industries}
               locations={locations}
               form={form}
-              isMentor={isMentor}
+              isMentor={isMentorFlow}
               onValidationChange={setJobSectionError}
             />
           </div>
@@ -379,7 +381,7 @@ export default function EditProfileContainer({
           <div id="educations">
             <EducationSection
               form={form}
-              isMentor={isMentor}
+              isMentor={isMentorFlow}
               onValidationChange={setEducationSectionError}
             />
           </div>


### PR DESCRIPTION
## What Does This PR Do?
此 PR 修正了在導師 onboarding 流程中，大頭貼及部分欄位未顯示必填提示（紅星 \*\）與相關區塊未渲染的問題。

### 變更檔案：
- **\src/app/profile/[pageUserId]/edit/container.tsx\**：
  - 統一定義 \isMentorFlow\ 變數 (\isMentorOnboarding || isMentor\)，以確保必填提示、欄位驗證與特定區塊顯示邏輯一致。
  - 將 **\AvatarSection\**、**\JobExperienceSection\** 與 **\EducationSection\** 接收的 \isMentor\ prop 統一改為 \isMentorFlow\。
  - 將 \bout\ 欄位星號、\industry\ 欄位星號、\have_topic\ 區塊與 \have_skill\ 區塊的顯示判斷一併從 \isMentor\ 替換為 \isMentorFlow\。
- **\src/app/profile/[pageUserId]/edit/container.test.tsx\**：
  - 更新 mock 以支持 \isMentor\ prop 驗證。
  - 新增完整的 \isMentorFlow\ 邏輯單元測試，涵蓋 onboarding 與正式導師等各個分支。

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/367