### PR TITLE
feat/272 booking form disabled

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -48,7 +48,7 @@ interface Props {
   selectedSlot: BookingSlot | null;
   setSelectedSlot: (slot: BookingSlot | null) => void;
   isSubmitting: boolean;
-  onConfirmReservation: (question: string) => Promise<boolean>;
+  onConfirmReservation: (question?: string) => Promise<boolean>;
 }
 
 export default function ProfilePageUI({

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -96,9 +96,9 @@ describe('BookingForm', () => {
     expect(submitBtn).toHaveClass('disabled:bg-background-top-active');
     expect(submitBtn).toHaveClass('disabled:text-text-disable');
 
-    // Scenario 2: Select slot, but question is still empty
+    // Scenario 2: Select slot, and question is empty (now allowed)
     rerender(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
-    expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '預約時間' })).not.toBeDisabled();
 
     // Scenario 3: [TEST GAP FIX] selectedSlot is null, but question is filled
     rerender(<BookingForm {...defaultProps} selectedSlot={null} />);

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -87,7 +87,7 @@ describe('BookingForm', () => {
     expect(screen.getByText('無可預約的時段')).toBeInTheDocument();
   });
 
-  it('disables the submit button if slot or question is missing (including test coverage gap)', () => {
+  it('disables the submit button if slot or question is missing (including test coverage gap)', async () => {
     const { rerender } = render(<BookingForm {...defaultProps} />);
 
     // Scenario 1: selectedSlot=null, bookingQuestion=""
@@ -98,7 +98,11 @@ describe('BookingForm', () => {
 
     // Scenario 2: Select slot, and question is empty (now allowed)
     rerender(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
-    expect(screen.getByRole('button', { name: '預約時間' })).not.toBeDisabled();
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: '預約時間' })
+      ).not.toBeDisabled();
+    });
 
     // Scenario 3: [TEST GAP FIX] selectedSlot is null, but question is filled
     rerender(<BookingForm {...defaultProps} selectedSlot={null} />);

--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -109,6 +109,13 @@ describe('BookingForm', () => {
     const textarea = screen.getByPlaceholderText('請在此輸入你的問題...');
     fireEvent.change(textarea, { target: { value: 'How to learn TS?' } });
     expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
+
+    // Scenario 4: [TEST GAP FIX] Select slot, but question is too long (> 1000 chars)
+    rerender(<BookingForm {...defaultProps} selectedSlot={mockSlots[0]} />);
+    fireEvent.change(textarea, { target: { value: 'a'.repeat(1001) } });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: '預約時間' })).toBeDisabled();
+    });
   });
 
   it('enables the submit button, handles confirm, and resets the textarea on success', async () => {

--- a/src/components/profile/reservation/BookingForm.tsx
+++ b/src/components/profile/reservation/BookingForm.tsx
@@ -17,7 +17,7 @@ interface BookingFormProps {
   isSubmitting: boolean;
   selectedDate: string | null;
   onReservation: () => void;
-  onConfirmReservation: (question: string) => Promise<boolean>;
+  onConfirmReservation: (question?: string) => Promise<boolean>;
 }
 
 export function BookingForm({

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { Loader2 } from 'lucide-react';
-import { useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -37,14 +36,8 @@ export function MenteeBookingForm({
     register,
     handleSubmit,
     reset,
-    trigger,
-    formState: { isValid, errors },
+    formState: { errors },
   } = useBookingForm();
-
-  // Validate form default values on mount so isValid is correctly initialized
-  useEffect(() => {
-    trigger();
-  }, [trigger]);
 
   const onSubmit = async (data: BookingFormValues) => {
     const success = await onConfirmReservation(data.bookingQuestion);
@@ -58,7 +51,7 @@ export function MenteeBookingForm({
     !isAuthenticated ||
     !selectedDate ||
     !selectedSlot ||
-    !isValid;
+    Object.keys(errors).length > 0;
 
   return (
     <form

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -18,7 +18,7 @@ interface MenteeBookingFormProps {
   setSelectedSlot: (slot: BookingSlot | null) => void;
   isSubmitting: boolean;
   selectedDate: string | null;
-  onConfirmReservation: (question: string) => Promise<boolean>;
+  onConfirmReservation: (question?: string) => Promise<boolean>;
   isAuthenticated: boolean;
 }
 

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -36,7 +36,7 @@ export function MenteeBookingForm({
     register,
     handleSubmit,
     reset,
-    formState: { isValid, errors },
+    formState: { errors },
   } = useBookingForm();
 
   const onSubmit = async (data: BookingFormValues) => {
@@ -51,7 +51,7 @@ export function MenteeBookingForm({
     !isAuthenticated ||
     !selectedDate ||
     !selectedSlot ||
-    !isValid;
+    !!errors.bookingQuestion;
 
   return (
     <form

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Loader2 } from 'lucide-react';
+import { useEffect } from 'react';
 
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
@@ -36,8 +37,14 @@ export function MenteeBookingForm({
     register,
     handleSubmit,
     reset,
-    formState: { errors },
+    trigger,
+    formState: { isValid, errors },
   } = useBookingForm();
+
+  // Validate form default values on mount so isValid is correctly initialized
+  useEffect(() => {
+    trigger();
+  }, [trigger]);
 
   const onSubmit = async (data: BookingFormValues) => {
     const success = await onConfirmReservation(data.bookingQuestion);
@@ -51,7 +58,7 @@ export function MenteeBookingForm({
     !isAuthenticated ||
     !selectedDate ||
     !selectedSlot ||
-    !!errors.bookingQuestion;
+    !isValid;
 
   return (
     <form

--- a/src/hooks/user/reservation/useBookingConfirmation.test.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.test.ts
@@ -164,6 +164,43 @@ describe('useBookingConfirmation', () => {
     expect(setSelectedSlot).toHaveBeenCalledWith(null);
   });
 
+  it('should successfully book a reservation with messages array empty if the question is blank', async () => {
+    const setSelectedSlot = vi.fn();
+    mockCreateReservation.mockResolvedValue(
+      {} as unknown as components['schemas']['ReservationVO']
+    );
+
+    const { result } = renderHook(() =>
+      useBookingConfirmation({
+        loginUserId: '999',
+        userData: mockUserData,
+        selectedSlot: mockSlot,
+        setSelectedSlot,
+      })
+    );
+
+    let res: boolean | undefined;
+    await act(async () => {
+      res = await result.current.handleConfirmReservation('   \n  ');
+    });
+
+    expect(res).toBe(true);
+    expect(mockCreateReservation).toHaveBeenCalledWith({
+      userId: 999,
+      body: {
+        my_user_id: 999,
+        my_status: 'PENDING',
+        user_id: 123,
+        schedule_id: 456,
+        dtstart: Math.floor(mockSlot.start.getTime() / 1000),
+        dtend: Math.floor(mockSlot.end.getTime() / 1000),
+        messages: [],
+      },
+      debug: false,
+    });
+    expect(setSelectedSlot).toHaveBeenCalledWith(null);
+  });
+
   it('should handle standard errors by logging flow failure and showing failure toast', async () => {
     const setSelectedSlot = vi.fn();
     const err = new Error('Server Crashed');

--- a/src/hooks/user/reservation/useBookingConfirmation.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.ts
@@ -37,6 +37,11 @@ export function useBookingConfirmation({
       setIsSubmitting(true);
       try {
         const menteeId = Number(loginUserId);
+        const trimmedQuestion = question.trim();
+        const messages = trimmedQuestion
+          ? [{ user_id: menteeId, content: trimmedQuestion }]
+          : [];
+
         await createReservation({
           userId: menteeId,
           body: {
@@ -46,7 +51,7 @@ export function useBookingConfirmation({
             schedule_id: selectedSlot.scheduleId,
             dtstart: Math.floor(selectedSlot.start.getTime() / 1000),
             dtend: Math.floor(selectedSlot.end.getTime() / 1000),
-            messages: [{ user_id: menteeId, content: question }],
+            messages,
           },
           debug: process.env.NODE_ENV === 'development',
         });

--- a/src/hooks/user/reservation/useBookingConfirmation.ts
+++ b/src/hooks/user/reservation/useBookingConfirmation.ts
@@ -27,7 +27,7 @@ export function useBookingConfirmation({
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleConfirmReservation = useCallback(
-    async (question: string): Promise<boolean> => {
+    async (question?: string): Promise<boolean> => {
       if (!loginUserId) {
         router.push('/auth/signin');
         return false;
@@ -37,7 +37,7 @@ export function useBookingConfirmation({
       setIsSubmitting(true);
       try {
         const menteeId = Number(loginUserId);
-        const trimmedQuestion = question.trim();
+        const trimmedQuestion = question?.trim() ?? '';
         const messages = trimmedQuestion
           ? [{ user_id: menteeId, content: trimmedQuestion }]
           : [];

--- a/src/schemas/bookingSchema.test.ts
+++ b/src/schemas/bookingSchema.test.ts
@@ -10,22 +10,18 @@ describe('bookingFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
-  it('should fail if question is empty', () => {
+  it('should pass if question is empty', () => {
     const result = bookingFormSchema.safeParse({
       bookingQuestion: '',
     });
-    expect(result.success).toBe(false);
-    const issue = result.error!.issues[0];
-    expect(issue.message).toBe('請輸入你想問導師的問題');
+    expect(result.success).toBe(true);
   });
 
-  it('should fail and trim whitespace-only questions', () => {
+  it('should pass and trim whitespace-only questions', () => {
     const result = bookingFormSchema.safeParse({
       bookingQuestion: '    \n   ',
     });
-    expect(result.success).toBe(false);
-    const issue = result.error!.issues[0];
-    expect(issue.message).toBe('請輸入你想問導師的問題');
+    expect(result.success).toBe(true);
   });
 
   it('should fail if question exceeds 1000 characters', () => {

--- a/src/schemas/bookingSchema.test.ts
+++ b/src/schemas/bookingSchema.test.ts
@@ -17,6 +17,13 @@ describe('bookingFormSchema', () => {
     expect(result.success).toBe(true);
   });
 
+  it('should pass if question is undefined', () => {
+    const result = bookingFormSchema.safeParse({
+      bookingQuestion: undefined,
+    });
+    expect(result.success).toBe(true);
+  });
+
   it('should pass and trim whitespace-only questions', () => {
     const result = bookingFormSchema.safeParse({
       bookingQuestion: '    \n   ',

--- a/src/schemas/bookingSchema.ts
+++ b/src/schemas/bookingSchema.ts
@@ -1,11 +1,7 @@
 import * as z from 'zod';
 
 export const bookingFormSchema = z.object({
-  bookingQuestion: z
-    .string()
-    .trim()
-    .min(1, '請輸入你想問導師的問題')
-    .max(1000, '問題字數請勿超過 1000 字'),
+  bookingQuestion: z.string().trim().max(1000, '問題字數請勿超過 1000 字'),
 });
 
 export type BookingFormValues = z.infer<typeof bookingFormSchema>;

--- a/src/schemas/bookingSchema.ts
+++ b/src/schemas/bookingSchema.ts
@@ -1,7 +1,11 @@
 import * as z from 'zod';
 
 export const bookingFormSchema = z.object({
-  bookingQuestion: z.string().trim().max(1000, '問題字數請勿超過 1000 字'),
+  bookingQuestion: z
+    .string()
+    .trim()
+    .max(1000, '問題字數請勿超過 1000 字')
+    .optional(),
 });
 
 export type BookingFormValues = z.infer<typeof bookingFormSchema>;


### PR DESCRIPTION
- **feat(reservation): 預約時間按鈕 disabled 時套用灰色設計語彙並補齊單元測試 (X-Tracker #272)**
- **refactor(reservation): 依循表單與單一職責原則重構 BookingForm 並補足測試邊界案例 (X-Tracker #272)**
- **refactor(reservation): 增加輸入安全驗證、補齊 Schema 測試並重構消滅重複 UI 邏輯 (X-Tracker #272)**
- **refactor(reservation): 修正成功提交後的表單重置、消滅硬編碼顏色、解決角色閃爍風險並補強測試邊界案例 (X-Tracker #272)**
- **refactor(reservation): 增加驗證失敗錯誤訊息、消滅預設 Tailwind 顏色並統一時段項目樣式 (X-Tracker #272)**
- **refactor(reservation): 修正未登入訪客 Skeleton Regression 缺陷、重用 Zod 導出型別並清理冗餘屬性 (X-Tracker #272)**
- **refactor(reservation): 增加未登入訪客預約按鈕禁用防護並補齊單元測試 (X-Tracker #272)**
- **feat(reservation): 使預約導師之問題欄位變為選填並補齊對應測試與 Payload (X-Tracker #368)**
