### PR TITLE
fix: 導師重開已刪除的週期性時段時改為復原而非新增重複列

### DIFF
--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -202,6 +202,109 @@ describe('useMentorSchedule', () => {
     expect(detachedOcc?.durationMinutes).toBe(45);
   });
 
+  it('restores a deleted occurrence of a recurring slot into the same row when re-added with matching time and duration', async () => {
+    const { result } = setupSchedule([]);
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    act(() => {
+      result.current.setSelectedDate('2026-03-24');
+    });
+
+    act(() => {
+      // March 24 2026 is a Tuesday; within March this produces exactly two
+      // weekly occurrences (24th and 31st) before crossing into April.
+      result.current.addSlotForSelectedDate({
+        startTime: '22:06',
+        durationMinutes: 30,
+        weeklyWithinMonth: true,
+      });
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(2);
+    const recurringRowId = result.current.parsedDraft[0].id;
+    const secondOccurrence = result.current.parsedDraft[1];
+
+    act(() => {
+      result.current.deleteDraftSlot(
+        recurringRowId,
+        secondOccurrence.occurrenceUnix
+      );
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(1);
+
+    act(() => {
+      result.current.setSelectedDate(secondOccurrence.dateKey);
+    });
+
+    act(() => {
+      // Re-add the exact same time/duration that was just deleted.
+      result.current.addSlotForSelectedDate({
+        startTime: '22:06',
+        durationMinutes: 30,
+      });
+    });
+
+    // The occurrence should be restored into the ORIGINAL recurring row
+    // (same id, no second row created at the same time) rather than
+    // producing a duplicate row that would look like an overlap when saved.
+    expect(result.current.parsedDraft).toHaveLength(2);
+    expect(
+      result.current.parsedDraft.every((s) => s.id === recurringRowId)
+    ).toBe(true);
+  });
+
+  it('creates a new independent row instead of restoring when the re-added duration differs', async () => {
+    const { result } = setupSchedule([]);
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    act(() => {
+      result.current.setSelectedDate('2026-03-24');
+    });
+
+    act(() => {
+      result.current.addSlotForSelectedDate({
+        startTime: '22:06',
+        durationMinutes: 30,
+        weeklyWithinMonth: true,
+      });
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(2);
+    const recurringRowId = result.current.parsedDraft[0].id;
+    const secondOccurrence = result.current.parsedDraft[1];
+
+    act(() => {
+      result.current.deleteDraftSlot(
+        recurringRowId,
+        secondOccurrence.occurrenceUnix
+      );
+    });
+
+    act(() => {
+      result.current.setSelectedDate(secondOccurrence.dateKey);
+    });
+
+    act(() => {
+      // Same start time, but a different duration than the deleted
+      // occurrence — should NOT be treated as a restore.
+      result.current.addSlotForSelectedDate({
+        startTime: '22:06',
+        durationMinutes: 45,
+      });
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(2);
+    const idsPresent = new Set(result.current.parsedDraft.map((s) => s.id));
+    expect(idsPresent.size).toBe(2);
+  });
+
   it('correctly exdates a single occurrence of a recurring slot on delete', async () => {
     const mockRaws: RawMentorTimeslot[] = [
       {

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -11,6 +11,7 @@ import {
   BookingSlot,
   buildDateTime,
   expandRrule,
+  findRestorableExdatedRow,
   formatTimeslot,
   hasAnyOccurrenceOverlap,
   MonthKey,
@@ -448,6 +449,30 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           ) {
             skipped = candidateOccurrences.length;
             return prev;
+          }
+
+          // Re-adding a single, previously-deleted occurrence of a still
+          // -recurring slot restores it (undoes the exdate) instead of
+          // creating a duplicate row at the same time.
+          if (candidateOccurrences.length === 1) {
+            const restoreTarget = findRestorableExdatedRow(
+              prev,
+              candidateOccurrences[0],
+              durationSeconds
+            );
+            if (restoreTarget) {
+              added = 1;
+              return prev.map((r) =>
+                r.id === restoreTarget.id
+                  ? {
+                      ...r,
+                      exdate: r.exdate.filter(
+                        (x) => x !== candidateOccurrences[0]
+                      ),
+                    }
+                  : r
+              );
+            }
           }
 
           const dtstart = candidateOccurrences[0];

--- a/src/lib/profile/scheduleHelpers.test.ts
+++ b/src/lib/profile/scheduleHelpers.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  findRestorableExdatedRow,
+  RawMentorTimeslot,
+} from '@/lib/profile/scheduleHelpers';
+
+describe('findRestorableExdatedRow', () => {
+  const recurringRow: RawMentorTimeslot = {
+    id: 101,
+    type: 'ALLOW',
+    dtstart: 1774390000, // week 1
+    dtend: 1774391800, // +30 min
+    rrule: 'FREQ=WEEKLY;COUNT=4',
+    exdate: [1774994800], // week 2 deleted
+  };
+
+  it('finds the row when re-adding a previously deleted occurrence with matching duration', () => {
+    const result = findRestorableExdatedRow([recurringRow], 1774994800, 1800);
+    expect(result?.id).toBe(101);
+  });
+
+  it('returns null when the occurrence is not in any row exdate', () => {
+    const result = findRestorableExdatedRow(
+      [recurringRow],
+      1774390000, // still active, never deleted
+      1800
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the duration does not match', () => {
+    const result = findRestorableExdatedRow(
+      [recurringRow],
+      1774994800,
+      2700 // 45 min instead of 30 min
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null for a non-recurring row even if the timestamp matches', () => {
+    const nonRecurringRow: RawMentorTimeslot = {
+      id: 102,
+      type: 'ALLOW',
+      dtstart: 1774994800,
+      dtend: 1774996600,
+      rrule: undefined,
+      exdate: [1774994800],
+    };
+    const result = findRestorableExdatedRow(
+      [nonRecurringRow],
+      1774994800,
+      1800
+    );
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the row type is not ALLOW', () => {
+    const bookedRow: RawMentorTimeslot = {
+      ...recurringRow,
+      type: 'BOOKED',
+    };
+    const result = findRestorableExdatedRow([bookedRow], 1774994800, 1800);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when the occurrence would not actually be produced by the rrule', () => {
+    const rowWithUnrelatedExdate: RawMentorTimeslot = {
+      ...recurringRow,
+      exdate: [1774994800 + 3600], // an exdate value the rrule never produces
+    };
+    const result = findRestorableExdatedRow(
+      [rowWithUnrelatedExdate],
+      1774994800 + 3600,
+      1800
+    );
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -159,6 +159,31 @@ export function buildDateTime(dateStr: string, timeStr: string) {
  * `ignoreRowId` to skip a row being edited (its current occurrences are
  * excluded entirely); pass `null` when adding a brand-new slot.
  */
+/**
+ * Find an existing recurring ALLOW row whose `occurrenceUnix` was previously
+ * exdated (i.e. the user deleted just that one week) and whose duration
+ * matches. Re-adding such an occurrence should undo the exdate on the
+ * existing row rather than create a second, independent row at the same
+ * time — submitting both together in one save otherwise reads as two
+ * overlapping rows to the backend's conflict validation.
+ */
+export function findRestorableExdatedRow(
+  rows: RawMentorTimeslot[],
+  occurrenceUnix: number,
+  durationSeconds: number
+): RawMentorTimeslot | null {
+  return (
+    rows.find(
+      (r) =>
+        r.type === 'ALLOW' &&
+        !!r.rrule &&
+        r.exdate.includes(occurrenceUnix) &&
+        r.dtend - r.dtstart === durationSeconds &&
+        expandRrule(r.dtstart, r.rrule).includes(occurrenceUnix)
+    ) ?? null
+  );
+}
+
 export function hasAnyOccurrenceOverlap(
   rows: RawMentorTimeslot[],
   ignoreRowId: number | null,

--- a/src/lib/profile/scheduleHelpers.ts
+++ b/src/lib/profile/scheduleHelpers.ts
@@ -154,12 +154,6 @@ export function buildDateTime(dateStr: string, timeStr: string) {
 }
 
 /**
- * Whether any of the candidate occurrences (each `[unix, unix+durationSeconds)`)
- * overlap any active occurrence of an existing ALLOW row in `rows`. Pass
- * `ignoreRowId` to skip a row being edited (its current occurrences are
- * excluded entirely); pass `null` when adding a brand-new slot.
- */
-/**
  * Find an existing recurring ALLOW row whose `occurrenceUnix` was previously
  * exdated (i.e. the user deleted just that one week) and whose duration
  * matches. Re-adding such an occurrence should undo the exdate on the
@@ -184,6 +178,12 @@ export function findRestorableExdatedRow(
   );
 }
 
+/**
+ * Whether any of the candidate occurrences (each `[unix, unix+durationSeconds)`)
+ * overlap any active occurrence of an existing ALLOW row in `rows`. Pass
+ * `ignoreRowId` to skip a row being edited (its current occurrences are
+ * excluded entirely); pass `null` when adding a brand-new slot.
+ */
 export function hasAnyOccurrenceOverlap(
   rows: RawMentorTimeslot[],
   ignoreRowId: number | null,


### PR DESCRIPTION
## What Does This PR Do?

- 修正導師刪除週期性可預約時段中的單一次(occurrence)後，於同一時間重新開啟該時段並儲存時，被誤判為衝突而無法儲存的問題 (X-Tracker #369)
- 新增 `findRestorableExdatedRow`：偵測新增的時段是否命中某個既有週期性 ALLOW 列先前被 exdate 的那一次，且時長相符
- `addSlotForSelectedDate` 命中時改為復原(移除該次的 exdate)，而非額外新增一列，避免同一次儲存把「已 exdate 的原列」與「新的一列」一起送出造成誤判衝突
- 補上對應單元測試：`scheduleHelpers.test.ts`(`findRestorableExdatedRow`) 與 `useMentorSchedule.test.ts`(復原情境 / 時長不同時退回建新列的情境)

## Demo

http://localhost:3000/profile/[pageUserId] (導師身分，開啟「可預約時段」設定)

## Screenshot

N/A

## Anything to Note?

此修正處理的是回報情境本身(同時段、同時長重新開啟)。若重開時時長或諮詢類型不同，仍會退回建立新列的舊行為，該情境是否會被後端誤判仍待後端確認(見 X-Tracker #369 的 AI review 留言)。
