### PR TITLE
feat: simplify gemini-cli startup command in package.json

### DIFF
--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,7 +9,7 @@
 ### 1.1 安裝與啟動
 
 1. **安裝依賴**：`pnpm install` (本專案已將 `gemini-cli` 納入 `devDependencies`)
-2. **啟動會話**：`pnpm exec gemini` (欲開啟無人值守自主模式，請加 `--yolo`)
+2. **啟動會話**：直接執行 `pnpm gemini` 即可（此指令已簡化為自動帶入 `--approval-mode=yolo --skip-trust`）。如果想使用預設互動模式，可執行 `pnpm exec gemini`。
 
 ### 1.2 啟用本地信任 (CRITICAL)
 

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -9,7 +9,9 @@
 ### 1.1 安裝與啟動
 
 1. **安裝依賴**：`pnpm install` (本專案已將 `gemini-cli` 納入 `devDependencies`)
-2. **啟動會話**：直接執行 `pnpm gemini` 即可（此指令已簡化為自動帶入 `--approval-mode=yolo --skip-trust`）。如果想使用預設互動模式，可執行 `pnpm exec gemini`。
+2. **啟動會話**：
+   - **標準互動模式**：`pnpm gemini`（啟動標準的互動式對話）
+   - **自主開發模式 (YOLO)**：`pnpm gemini-yolo`（自動帶入 `--approval-mode=yolo --skip-trust` 參數）
 
 ### 1.2 啟用本地信任 (CRITICAL)
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "prepare": "husky install",
+    "gemini": "gemini --approval-mode=yolo --skip-trust",
     "generate:types": "node scripts/generate-types.mjs"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "prepare": "husky install",
-    "gemini": "gemini --approval-mode=yolo --skip-trust",
+    "gemini": "gemini",
+    "gemini-yolo": "gemini --approval-mode=yolo --skip-trust",
     "generate:types": "node scripts/generate-types.mjs"
   },
   "dependencies": {


### PR DESCRIPTION
Simplified starting Gemini CLI by adding a 'gemini' npm script with default yolo and skip-trust parameters. Updated GEMINI.md instructions.
