### PR TITLE
Revert "chore: 簡化 CI/CD AI Reviewer 流程並整合 gemini-cli 依賴 (X-Tracker #386)" (#726)

### DIFF
--- a/.agents/skills/ai-review/SKILL.md
+++ b/.agents/skills/ai-review/SKILL.md
@@ -4,29 +4,26 @@ description: 'Run the full AI review pipeline locally in parallel using concurre
 disable-model-invocation: true
 ---
 
-# Parallel AI Review Pipeline
-
-Run a complete, parallelized multi-stage AI Review locally or in CI using concurrent sub-agents without needing any external API keys.
+Run a complete, parallelized multi-stage AI Review locally using concurrent sub-agents without needing any external API keys.
 
 ## Usage
 
-```bash
+```
 /ai-review
 ```
 
 ## What this does
 
 1. **Retrieve Changes & Ticket Context**:
-   - Run `git diff origin/develop` to capture all unstaged, staged, or committed changes on the current branch. (If `origin/develop` is not available, fallback to `git diff main` or `git diff HEAD~1`).
-   - Detect the current branch name and extract the associated issue/ticket number (e.g., `feat/45-xxx` -> issue `45`).
-   - If an issue number is found, automatically use GitHub CLI to fetch the full issue context (title, body, and comments) from `Xchange-Taiwan/X-Talent-Tracker`:
+   - Run `git diff origin/develop` to capture all unstaged, staged, or committed changes on the current branch.
+   - Detect the current branch name and extract the associated issue number (e.g., `feat/45-xxx` -> issue `45`).
+   - If an issue number is found, automatically use GitHub CLI to fetch the full issue context (title, body, and comments) from `Xchange-Taiwan/X-Talent-Tracker` (or fallback to the current repo if needed):
      ```bash
      gh issue view <issue-number> --repo Xchange-Taiwan/X-Talent-Tracker --json title,body,comments
      ```
-     _(If this command fails due to token permissions or offline/local mode, gracefully fallback and continue the review using the branch name and git diff only)._
 
 2. **Invoke Parallel Sub-Agents with Shared Context**:
-   - Call the `invoke_agent` tool in parallel (concurrently in a single turn) to launch multiple independent `generalist` sub-agents, passing the git diff, the custom project prompts, and the **fetched Ticket requirements** to the following specialized agents:
+   - Call the `invoke_agent` tool in parallel (concurrently in a single turn) to launch multiple independent `generalist` sub-agents, passing the git diff, the custom project prompts, and the **fetched Ticket requirements** to relevant agents (especially Business Logic, Correctness, and Review Guide):
      - **Sub-agent 1 (Security)**: Apply instructions from `scripts/ai-review/prompts/security.md` to review potential leaks, vulnerabilities, and insecure patterns.
      - **Sub-agent 2 (Correctness)**: Compare the code diff against the **Ticket requirements** and apply `scripts/ai-review/prompts/correctness.md` to find logic flaws or regressions.
      - **Sub-agent 3 (Business Logic)**: Compare the code diff against the **Ticket requirements** and apply `scripts/ai-review/prompts/business-logic.md` to ensure every specified business feature is correctly implemented.
@@ -37,35 +34,4 @@ Run a complete, parallelized multi-stage AI Review locally or in CI using concur
 
 3. **Aggregate & Generate Final Summary**:
    - Once all parallel sub-agents return their findings, read the custom summary prompt in `scripts/ai-review/prompts/summary.md`.
-   - Aggregate all the sub-agent outputs and compile the final review comment following a structured format:
-     - **Title**: `## 🤖 AI Code Review Report (X-Tracker #<issue-number>)`
-     - **Review Status (CRITICAL)**: Must output exactly one of the following structured status lines at the top of the summary section (right after the title) to serve as a precise contract for automated handoff in `/implement`:
-       - `**Review Status: PASS**` (If NO security or logic issues with severity `Critical` or `Blocking` are found by any of the sub-agents).
-       - `**Review Status: BLOCKED**` (If any sub-agent reports a `Critical` or `Blocking` severity issue).
-     - **Summary & Merge Recommendation**: Provide a high-level summary and an overall risk level (e.g. `low`, `medium`, `high`) with logical reasoning.
-     - **Requirement Coverage**: Detail how well the ticket requirements are met.
-     - **Review Guide / Reading Order**: Suggest an optimal sequence of files for human reviewers to examine.
-     - **Detailed Findings by Category**: Display organized feedback from each sub-agent (Security, Correctness, Business Logic, Performance, Testing, Architecture) with specific file paths, code blocks, severity, and actionable suggestions.
-   - Always prefix/embed the marker `<!-- ai-review-pipeline -->` at the top of the generated markdown content so that the comment can be identified later.
-
-4. **Publish Combined Comment**:
-   - Detect if running inside a Pull Request environment or if the `GITHUB_ACTIONS` environment variable is set. You can check if the current branch has an open pull request by running:
-     ```bash
-     gh pr view --json number
-     ```
-   - **Local Dry-Run / Graceful Fallback**: If NOT running in GitHub Actions, if there is no open pull request, or if GitHub API commands fail (due to missing tokens), do NOT throw an error or fail the run. Instead, output the final aggregated review markdown to a local file named `ai-review-report.md` in the workspace root, output a summary to stdout, and complete successfully.
-   - If a Pull Request number is found in a CI environment:
-     - Fetch existing comments using GH CLI or the GitHub API to check if a review comment carrying the `<!-- ai-review-pipeline -->` marker has already been posted:
-       ```bash
-       gh api repos/{owner}/{repo}/issues/{pr-number}/comments --jq '.[] | select(.body | contains("<!-- ai-review-pipeline -->")) | .id'
-       ```
-     - If an existing comment ID is found:
-       - Update the existing comment via GH API PATCH to prevent comment spamming:
-         ```bash
-         gh api -X PATCH repos/{owner}/{repo}/issues/comments/{comment_id} -F body=@<comment_file>
-         ```
-     - If no existing comment is found:
-       - Post a new comment to the PR:
-         ```bash
-         gh pr comment <pr-number> --body-file <comment_file>
-         ```
+   - Aggregate all the sub-agent outputs and compile the final review comment.

--- a/.github/actions/setup-ai-agent/action.yml
+++ b/.github/actions/setup-ai-agent/action.yml
@@ -1,9 +1,12 @@
 name: 'Set up AI review agent'
-description: 'Fetches the base branch and sets up Node.js for an AI review agent job. The calling job must check out the repo first — a local composite action can only be resolved after checkout has already run.'
+description: 'Fetches the base branch and PR head commit and sets up Node.js for an AI review agent job. The calling job must check out the trusted base branch itself first — a local composite action can only be resolved after checkout has already run, and the job must never check out or execute the untrusted PR head.'
 
 inputs:
   base-ref:
     description: 'The PR base branch name to fetch'
+    required: true
+  head-sha:
+    description: 'The untrusted PR head commit SHA — fetched as diff input only, never checked out or executed'
     required: true
   node-version:
     description: 'Node.js version to set up'
@@ -16,6 +19,10 @@ runs:
     - name: Fetch base branch
       shell: bash
       run: git fetch origin ${{ inputs.base-ref }}:refs/remotes/origin/${{ inputs.base-ref }}
+
+    - name: Fetch PR head commit (diff input only, not checked out)
+      shell: bash
+      run: git fetch origin ${{ inputs.head-sha }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v4

--- a/.github/actions/setup-ai-agent/action.yml
+++ b/.github/actions/setup-ai-agent/action.yml
@@ -1,10 +1,7 @@
 name: 'Set up AI review agent'
-description: 'Checks out the PR head, fetches the base branch, and sets up Node.js for an AI review agent job.'
+description: 'Fetches the base branch and sets up Node.js for an AI review agent job. The calling job must check out the repo first — a local composite action can only be resolved after checkout has already run.'
 
 inputs:
-  head-sha:
-    description: 'The PR head commit SHA to check out'
-    required: true
   base-ref:
     description: 'The PR base branch name to fetch'
     required: true
@@ -16,12 +13,6 @@ inputs:
 runs:
   using: 'composite'
   steps:
-    - name: Checkout PR head
-      uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-        ref: ${{ inputs.head-sha }}
-
     - name: Fetch base branch
       shell: bash
       run: git fetch origin ${{ inputs.base-ref }}:refs/remotes/origin/${{ inputs.base-ref }}

--- a/.github/actions/setup-ai-agent/action.yml
+++ b/.github/actions/setup-ai-agent/action.yml
@@ -1,0 +1,32 @@
+name: 'Set up AI review agent'
+description: 'Checks out the PR head, fetches the base branch, and sets up Node.js for an AI review agent job.'
+
+inputs:
+  head-sha:
+    description: 'The PR head commit SHA to check out'
+    required: true
+  base-ref:
+    description: 'The PR base branch name to fetch'
+    required: true
+  node-version:
+    description: 'Node.js version to set up'
+    required: false
+    default: '20'
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Checkout PR head
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        ref: ${{ inputs.head-sha }}
+
+    - name: Fetch base branch
+      shell: bash
+      run: git fetch origin ${{ inputs.base-ref }}:refs/remotes/origin/${{ inputs.base-ref }}
+
+    - name: Set up Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,19 +23,11 @@ jobs:
     outputs:
       plan: ${{ steps.run.outputs.plan }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run planner agent
         id: run
@@ -53,19 +45,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run security agent
         id: run
@@ -82,19 +66,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run correctness agent
         id: run
@@ -111,19 +87,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run business-logic agent
         id: run
@@ -140,19 +108,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run performance agent
         id: run
@@ -169,19 +129,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run testing agent
         id: run
@@ -198,19 +150,11 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run architecture agent
         id: run
@@ -227,19 +171,11 @@ jobs:
     outputs:
       guide: ${{ steps.run.outputs.guide }}
     steps:
-      - name: Checkout PR head
-        uses: actions/checkout@v4
+      - name: Set up AI review agent
+        uses: ./.github/actions/setup-ai-agent
         with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-
-      - name: Fetch base branch
-        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
+          head-sha: ${{ github.event.pull_request.head.sha }}
+          base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run review-guide agent
         id: run
@@ -263,6 +199,7 @@ jobs:
       ]
     runs-on: ubuntu-latest
     name: 'AI Review: Final Summary'
+    if: ${{ !cancelled() }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,16 +23,17 @@ jobs:
     outputs:
       plan: ${{ steps.run.outputs.plan }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run planner agent
         id: run
@@ -40,6 +41,7 @@ jobs:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           TRACKER_READ_TOKEN: ${{ secrets.TRACKER_READ_TOKEN }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           HEAD_REF: ${{ github.event.pull_request.head.ref }}
         run: node scripts/ai-review/planner.mjs
 
@@ -50,22 +52,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run security agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/security.mjs
 
@@ -76,22 +80,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run correctness agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/correctness.mjs
 
@@ -102,22 +108,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run business-logic agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/business-logic.mjs
 
@@ -128,22 +136,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run performance agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/performance.mjs
 
@@ -154,22 +164,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run testing agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/testing.mjs
 
@@ -180,22 +192,24 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run architecture agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/architecture.mjs
 
@@ -206,22 +220,24 @@ jobs:
     outputs:
       guide: ${{ steps.run.outputs.guide }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
           base-ref: ${{ github.event.pull_request.base.ref }}
+          head-sha: ${{ github.event.pull_request.head.sha }}
 
       - name: Run review-guide agent
         id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           PLAN_B64: ${{ needs.planner.outputs.plan }}
         run: node scripts/ai-review/review-guide.mjs
 
@@ -241,11 +257,11 @@ jobs:
     name: 'AI Review: Final Summary'
     if: ${{ !cancelled() }}
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted scripts)
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
+          ref: ${{ github.event.pull_request.base.sha }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -13,10 +13,15 @@ permissions:
   contents: read
   pull-requests: write
 
+env:
+  GEMINI_MODEL: gemini-3.1-pro-preview
+
 jobs:
-  ai-review:
+  planner:
     runs-on: ubuntu-latest
-    name: 'AI Review Pipeline'
+    name: 'AI Review: Planner'
+    outputs:
+      plan: ${{ steps.run.outputs.plan }}
     steps:
       - name: Checkout PR head
         uses: actions/checkout@v4
@@ -27,26 +32,264 @@ jobs:
       - name: Fetch base branch
         run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
 
-      - name: Set up PNPM
-        uses: pnpm/action-setup@v2
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
         with:
-          version: 9
+          node-version: 20
+
+      - name: Run planner agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          TRACKER_READ_TOKEN: ${{ secrets.TRACKER_READ_TOKEN }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+        run: node scripts/ai-review/planner.mjs
+
+  security:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Security'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
           node-version: 20
-          cache: 'pnpm'
 
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Run AI Reviewer Skill
+      - name: Run security agent
+        id: run
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TRACKER_READ_TOKEN: ${{ secrets.TRACKER_READ_TOKEN }}
           BASE_REF: origin/${{ github.event.pull_request.base.ref }}
-          HEAD_REF: ${{ github.event.pull_request.head.ref }}
-          GEMINI_CLI_TRUST_WORKSPACE: 'true'
-        run: pnpm gemini-yolo -p "/ai-review"
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/security.mjs
+
+  correctness:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Correctness / Regression'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run correctness agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/correctness.mjs
+
+  business_logic:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Business Logic'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run business-logic agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/business-logic.mjs
+
+  performance:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Performance'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run performance agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/performance.mjs
+
+  testing:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Testing'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run testing agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/testing.mjs
+
+  architecture:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Architecture'
+    outputs:
+      findings: ${{ steps.run.outputs.findings }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run architecture agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/architecture.mjs
+
+  review_guide:
+    needs: planner
+    runs-on: ubuntu-latest
+    name: 'AI Review: Review Guide'
+    outputs:
+      guide: ${{ steps.run.outputs.guide }}
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Fetch base branch
+        run: git fetch origin ${{ github.event.pull_request.base.ref }}:refs/remotes/origin/${{ github.event.pull_request.base.ref }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Run review-guide agent
+        id: run
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          BASE_REF: origin/${{ github.event.pull_request.base.ref }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+        run: node scripts/ai-review/review-guide.mjs
+
+  summary:
+    needs:
+      [
+        planner,
+        security,
+        correctness,
+        business_logic,
+        performance,
+        testing,
+        architecture,
+        review_guide,
+      ]
+    runs-on: ubuntu-latest
+    name: 'AI Review: Final Summary'
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Generate final summary comment
+        env:
+          GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+          PLAN_B64: ${{ needs.planner.outputs.plan }}
+          SECURITY_FINDINGS_B64: ${{ needs.security.outputs.findings }}
+          CORRECTNESS_FINDINGS_B64: ${{ needs.correctness.outputs.findings }}
+          BUSINESS_LOGIC_FINDINGS_B64: ${{ needs.business_logic.outputs.findings }}
+          PERFORMANCE_FINDINGS_B64: ${{ needs.performance.outputs.findings }}
+          TESTING_FINDINGS_B64: ${{ needs.testing.outputs.findings }}
+          ARCHITECTURE_FINDINGS_B64: ${{ needs.architecture.outputs.findings }}
+          REVIEW_GUIDE_B64: ${{ needs.review_guide.outputs.guide }}
+        run: node scripts/ai-review/generate-summary.mjs
+
+      - name: Post PR comment
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: node scripts/ai-review/post-comment.mjs

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -23,10 +23,15 @@ jobs:
     outputs:
       plan: ${{ steps.run.outputs.plan }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run planner agent
@@ -45,10 +50,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run security agent
@@ -66,10 +76,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run correctness agent
@@ -87,10 +102,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run business-logic agent
@@ -108,10 +128,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run performance agent
@@ -129,10 +154,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run testing agent
@@ -150,10 +180,15 @@ jobs:
     outputs:
       findings: ${{ steps.run.outputs.findings }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run architecture agent
@@ -171,10 +206,15 @@ jobs:
     outputs:
       guide: ${{ steps.run.outputs.guide }}
     steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+
       - name: Set up AI review agent
         uses: ./.github/actions/setup-ai-agent
         with:
-          head-sha: ${{ github.event.pull_request.head.sha }}
           base-ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Run review-guide agent

--- a/scripts/ai-review/architecture.mjs
+++ b/scripts/ai-review/architecture.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/architecture.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/business-logic.mjs
+++ b/scripts/ai-review/business-logic.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/business-logic.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/correctness.mjs
+++ b/scripts/ai-review/correctness.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/correctness.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/generate-summary.mjs
+++ b/scripts/ai-review/generate-summary.mjs
@@ -1,0 +1,75 @@
+import { writeFileSync } from 'node:fs';
+import { callGemini } from './lib/gemini.mjs';
+import { buildPrompt } from './lib/prompt.mjs';
+import { decodeContext } from './lib/context-io.mjs';
+import { formatComment } from './lib/format-comment.mjs';
+
+/**
+ * Decodes an upstream job output. Missing/undecodable output is logged and
+ * passed through as undefined rather than thrown — one reviewer stage
+ * failing to run must not prevent the other stages' results from being
+ * posted (formatComment renders a missing stage as "not run").
+ */
+function decodeUpstream(name, envVar) {
+  const value = decodeContext(process.env[envVar]);
+  if (!value) {
+    console.warn(
+      `[generate-summary] missing or undecodable upstream output: ${name} (${envVar})`
+    );
+  }
+  return value;
+}
+
+const plan = decodeUpstream('plan', 'PLAN_B64');
+const security = decodeUpstream('security', 'SECURITY_FINDINGS_B64');
+const correctness = decodeUpstream('correctness', 'CORRECTNESS_FINDINGS_B64');
+const businessLogic = decodeUpstream(
+  'businessLogic',
+  'BUSINESS_LOGIC_FINDINGS_B64'
+);
+const performance = decodeUpstream('performance', 'PERFORMANCE_FINDINGS_B64');
+const testing = decodeUpstream('testing', 'TESTING_FINDINGS_B64');
+const architecture = decodeUpstream(
+  'architecture',
+  'ARCHITECTURE_FINDINGS_B64'
+);
+const reviewGuide = decodeUpstream('reviewGuide', 'REVIEW_GUIDE_B64');
+
+let summary;
+try {
+  const prompt = buildPrompt(new URL('./prompts/summary.md', import.meta.url), {
+    PLAN_JSON: JSON.stringify(plan ?? null, null, 2),
+    SECURITY_FINDINGS_JSON: JSON.stringify(security ?? null, null, 2),
+    CORRECTNESS_FINDINGS_JSON: JSON.stringify(correctness ?? null, null, 2),
+    BUSINESS_LOGIC_FINDINGS_JSON: JSON.stringify(
+      businessLogic ?? null,
+      null,
+      2
+    ),
+    PERFORMANCE_FINDINGS_JSON: JSON.stringify(performance ?? null, null, 2),
+    TESTING_FINDINGS_JSON: JSON.stringify(testing ?? null, null, 2),
+    ARCHITECTURE_FINDINGS_JSON: JSON.stringify(architecture ?? null, null, 2),
+  });
+  summary = await callGemini(prompt);
+  console.log('[generate-summary] summary:', JSON.stringify(summary, null, 2));
+} catch (err) {
+  // The per-agent sections still have everything they need without this
+  // call, so a failure here should degrade the comment, not kill it.
+  console.error(
+    `[generate-summary] final-judgment call failed, posting without it: ${err.message}`
+  );
+  summary = undefined;
+}
+
+const comment = formatComment({
+  plan,
+  reviewGuide,
+  security,
+  correctness,
+  businessLogic,
+  performance,
+  testing,
+  architecture,
+  summary,
+});
+writeFileSync('ai-review-comment.md', comment, 'utf-8');

--- a/scripts/ai-review/lib/context-io.mjs
+++ b/scripts/ai-review/lib/context-io.mjs
@@ -6,7 +6,12 @@ export function encodeContext(obj) {
 
 export function decodeContext(b64) {
   if (!b64) return null;
-  return JSON.parse(Buffer.from(b64, 'base64').toString('utf-8'));
+  try {
+    return JSON.parse(Buffer.from(b64, 'base64').toString('utf-8'));
+  } catch (err) {
+    console.warn(`[context-io] failed to decode context: ${err.message}`);
+    return null;
+  }
 }
 
 /** Writes `name=value` to $GITHUB_OUTPUT so downstream jobs can read it via `needs.<job>.outputs.<name>`. */

--- a/scripts/ai-review/lib/context-io.mjs
+++ b/scripts/ai-review/lib/context-io.mjs
@@ -1,0 +1,21 @@
+import { appendFileSync } from 'node:fs';
+
+export function encodeContext(obj) {
+  return Buffer.from(JSON.stringify(obj), 'utf-8').toString('base64');
+}
+
+export function decodeContext(b64) {
+  if (!b64) return null;
+  return JSON.parse(Buffer.from(b64, 'base64').toString('utf-8'));
+}
+
+/** Writes `name=value` to $GITHUB_OUTPUT so downstream jobs can read it via `needs.<job>.outputs.<name>`. */
+export function writeGithubOutput(name, value) {
+  const outputPath = process.env.GITHUB_OUTPUT;
+  if (!outputPath) {
+    throw new Error(
+      'GITHUB_OUTPUT is not set — this must run inside a GitHub Actions job'
+    );
+  }
+  appendFileSync(outputPath, `${name}=${value}\n`);
+}

--- a/scripts/ai-review/lib/context-io.test.mjs
+++ b/scripts/ai-review/lib/context-io.test.mjs
@@ -1,0 +1,42 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { encodeContext, decodeContext } from './context-io.mjs';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('encodeContext / decodeContext', () => {
+  it('round-trips a complex object with multi-byte characters', () => {
+    const original = {
+      title: '修復多語系編碼問題 🎉',
+      findings: [
+        { file: 'a.mjs', message: '包含中文與 emoji 的訊息 🚀' },
+        { file: 'b.mjs', message: 'plain ascii' },
+      ],
+      nested: { deep: { value: null } },
+    };
+
+    const decoded = decodeContext(encodeContext(original));
+
+    expect(decoded).toEqual(original);
+  });
+
+  it('round-trips an empty object', () => {
+    expect(decodeContext(encodeContext({}))).toEqual({});
+  });
+
+  it('returns null for a missing or empty input', () => {
+    expect(decodeContext(undefined)).toBeNull();
+    expect(decodeContext('')).toBeNull();
+  });
+
+  it('returns null and warns instead of throwing on undecodable input', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    const result = decodeContext('not-valid-base64-json!!!');
+
+    expect(result).toBeNull();
+    expect(warnSpy).toHaveBeenCalled();
+  });
+});

--- a/scripts/ai-review/lib/diff.mjs
+++ b/scripts/ai-review/lib/diff.mjs
@@ -1,0 +1,36 @@
+import { execFileSync } from 'node:child_process';
+
+const EXCLUDE_PATHSPECS = [
+  ':(exclude)pnpm-lock.yaml',
+  ':(exclude)package-lock.json',
+  ':(exclude)yarn.lock',
+  ':(exclude)*.snap',
+  ':(exclude)public/**',
+];
+
+const MAX_DIFF_CHARS = 60000;
+
+/**
+ * Returns the unified diff between baseRef and HEAD, excluding lockfiles and
+ * generated/static assets, truncated to a size the Gemini prompt can afford.
+ *
+ * Uses execFileSync (no shell) rather than execSync — the `:(exclude)...`
+ * pathspec magic contains unquoted parens that /bin/sh on the Actions
+ * runner fails to parse when the command is built as a shell string.
+ */
+export function getDiff(baseRef) {
+  const args = ['diff', `${baseRef}...HEAD`, '--', '.', ...EXCLUDE_PATHSPECS];
+  const raw = execFileSync('git', args, {
+    maxBuffer: 1024 * 1024 * 50,
+    encoding: 'utf-8',
+  });
+
+  if (raw.length <= MAX_DIFF_CHARS) {
+    return { diff: raw, truncated: false };
+  }
+
+  return {
+    diff: `${raw.slice(0, MAX_DIFF_CHARS)}\n\n... (diff truncated, ${raw.length} chars total)`,
+    truncated: true,
+  };
+}

--- a/scripts/ai-review/lib/diff.mjs
+++ b/scripts/ai-review/lib/diff.mjs
@@ -11,15 +11,27 @@ const EXCLUDE_PATHSPECS = [
 const MAX_DIFF_CHARS = 60000;
 
 /**
- * Returns the unified diff between baseRef and HEAD, excluding lockfiles and
- * generated/static assets, truncated to a size the Gemini prompt can afford.
+ * Returns the unified diff between baseRef and headRef, excluding lockfiles
+ * and generated/static assets, truncated to a size the Gemini prompt can
+ * afford.
+ *
+ * Takes headRef as an explicit argument rather than diffing against the
+ * checked-out `HEAD` — the calling job checks out the trusted base branch
+ * (not the PR head) so that a PR can't get its own modified review scripts
+ * executed with secrets, and only fetches the PR head commit as diff input.
  *
  * Uses execFileSync (no shell) rather than execSync — the `:(exclude)...`
  * pathspec magic contains unquoted parens that /bin/sh on the Actions
  * runner fails to parse when the command is built as a shell string.
  */
-export function getDiff(baseRef) {
-  const args = ['diff', `${baseRef}...HEAD`, '--', '.', ...EXCLUDE_PATHSPECS];
+export function getDiff(baseRef, headRef) {
+  const args = [
+    'diff',
+    `${baseRef}...${headRef}`,
+    '--',
+    '.',
+    ...EXCLUDE_PATHSPECS,
+  ];
   const raw = execFileSync('git', args, {
     maxBuffer: 1024 * 1024 * 50,
     encoding: 'utf-8',

--- a/scripts/ai-review/lib/diff.test.mjs
+++ b/scripts/ai-review/lib/diff.test.mjs
@@ -15,7 +15,7 @@ describe('getDiff', () => {
   it('returns the raw diff untruncated when under the size limit', () => {
     vi.mocked(execFileSync).mockReturnValue('diff --git a/x b/x\n+line\n');
 
-    const result = getDiff('origin/develop');
+    const result = getDiff('origin/develop', 'abc123headsha');
 
     expect(result).toEqual({
       diff: 'diff --git a/x b/x\n+line\n',
@@ -27,7 +27,7 @@ describe('getDiff', () => {
     const raw = 'x'.repeat(60001);
     vi.mocked(execFileSync).mockReturnValue(raw);
 
-    const result = getDiff('origin/develop');
+    const result = getDiff('origin/develop', 'abc123headsha');
 
     expect(result.truncated).toBe(true);
     expect(result.diff.startsWith('x'.repeat(60000))).toBe(true);
@@ -39,21 +39,21 @@ describe('getDiff', () => {
     const raw = 'x'.repeat(60000);
     vi.mocked(execFileSync).mockReturnValue(raw);
 
-    const result = getDiff('origin/develop');
+    const result = getDiff('origin/develop', 'abc123headsha');
 
     expect(result).toEqual({ diff: raw, truncated: false });
   });
 
-  it('invokes git diff against the given base ref with the lockfile/asset exclude pathspecs', () => {
+  it('invokes git diff between the given base ref and head ref with the lockfile/asset exclude pathspecs', () => {
     vi.mocked(execFileSync).mockReturnValue('');
 
-    getDiff('origin/develop');
+    getDiff('origin/develop', 'abc123headsha');
 
     expect(execFileSync).toHaveBeenCalledWith(
       'git',
       [
         'diff',
-        'origin/develop...HEAD',
+        'origin/develop...abc123headsha',
         '--',
         '.',
         ':(exclude)pnpm-lock.yaml',

--- a/scripts/ai-review/lib/diff.test.mjs
+++ b/scripts/ai-review/lib/diff.test.mjs
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { getDiff } from './diff.mjs';
+
+vi.mock('node:child_process', () => ({
+  execFileSync: vi.fn(),
+}));
+
+afterEach(() => {
+  vi.mocked(execFileSync).mockReset();
+});
+
+describe('getDiff', () => {
+  it('returns the raw diff untruncated when under the size limit', () => {
+    vi.mocked(execFileSync).mockReturnValue('diff --git a/x b/x\n+line\n');
+
+    const result = getDiff('origin/develop');
+
+    expect(result).toEqual({
+      diff: 'diff --git a/x b/x\n+line\n',
+      truncated: false,
+    });
+  });
+
+  it('truncates and appends a marker when the diff exceeds 60000 chars', () => {
+    const raw = 'x'.repeat(60001);
+    vi.mocked(execFileSync).mockReturnValue(raw);
+
+    const result = getDiff('origin/develop');
+
+    expect(result.truncated).toBe(true);
+    expect(result.diff.startsWith('x'.repeat(60000))).toBe(true);
+    expect(result.diff).toContain('... (diff truncated, 60001 chars total)');
+    expect(result.diff.slice(0, 60000)).toBe(raw.slice(0, 60000));
+  });
+
+  it('does not truncate a diff exactly at the size limit', () => {
+    const raw = 'x'.repeat(60000);
+    vi.mocked(execFileSync).mockReturnValue(raw);
+
+    const result = getDiff('origin/develop');
+
+    expect(result).toEqual({ diff: raw, truncated: false });
+  });
+
+  it('invokes git diff against the given base ref with the lockfile/asset exclude pathspecs', () => {
+    vi.mocked(execFileSync).mockReturnValue('');
+
+    getDiff('origin/develop');
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      [
+        'diff',
+        'origin/develop...HEAD',
+        '--',
+        '.',
+        ':(exclude)pnpm-lock.yaml',
+        ':(exclude)package-lock.json',
+        ':(exclude)yarn.lock',
+        ':(exclude)*.snap',
+        ':(exclude)public/**',
+      ],
+      expect.objectContaining({ encoding: 'utf-8' })
+    );
+  });
+});

--- a/scripts/ai-review/lib/format-comment.mjs
+++ b/scripts/ai-review/lib/format-comment.mjs
@@ -1,0 +1,138 @@
+export const AI_REVIEW_COMMENT_MARKER = '<!-- ai-review-pipeline -->';
+
+function renderFindingsSection(title, result) {
+  if (!result) {
+    return `### ${title}\n_（未執行）_`;
+  }
+  if (!result.hasFindings || !result.findings?.length) {
+    return `### ${title}\n✅ ${result.summary || '未發現需要人工關注的問題'}`;
+  }
+
+  const rows = result.findings
+    .map((f) => {
+      const loc = f.line ? `\`${f.file}:${f.line}\`` : `\`${f.file}\``;
+      return [
+        `- **[${f.category}]** ${loc}`,
+        `  ${f.issue}`,
+        `  > 為什麼重要：${f.why}`,
+        `  > 建議修法：${f.fix}`,
+      ].join('\n');
+    })
+    .join('\n');
+
+  return `### ${title}\n${result.summary}\n\n${rows}`;
+}
+
+function renderRequirementCoverage(plan, summary) {
+  if (summary?.requirementCoverage?.length) {
+    return summary.requirementCoverage
+      .map(
+        (c) =>
+          `- ${c.covered ? '✅' : '⚠️'} ${c.criterion}${c.note ? ` — ${c.note}` : ''}`
+      )
+      .join('\n');
+  }
+  return plan?.ticketFound
+    ? '_（無法判斷）_'
+    : '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_';
+}
+
+function renderMissingTests(testing) {
+  if (!testing?.hasFindings || !testing.findings?.length) {
+    return '（無）';
+  }
+  return testing.findings
+    .map((f) => `- \`${f.file}${f.line ? `:${f.line}` : ''}\` — ${f.issue}`)
+    .join('\n');
+}
+
+function renderReviewGuide(reviewGuide) {
+  if (!reviewGuide) {
+    return null;
+  }
+
+  const order =
+    Array.isArray(reviewGuide.readingOrder) && reviewGuide.readingOrder.length
+      ? reviewGuide.readingOrder
+          .slice()
+          .sort((a, b) => (a.order ?? 0) - (b.order ?? 0))
+          .map((f) => `${f.order}. \`${f.file}\` — ${f.why}`)
+          .join('\n')
+      : null;
+
+  return [
+    '### 🧭 Review Guide',
+    reviewGuide.overview ?? '',
+    order ? '\n**建議閱讀順序：**\n' + order : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
+}
+
+/**
+ * Assembles the single PR comment the pipeline posts: a review guide
+ * (overview + suggested reading order) up top, Planner's requirement
+ * summary, each agent's findings, then the final Requirement Coverage /
+ * Overall Risk / Missing Tests / Merge Recommendation block.
+ *
+ * Every field is read defensively (optional chaining, `!result` fallbacks):
+ * a stage that never ran, whose output failed to decode, or whose final
+ * judgment call failed should still result in a postable comment covering
+ * whatever *did* succeed, rather than the whole thing blowing up.
+ */
+export function formatComment({
+  plan,
+  reviewGuide,
+  security,
+  correctness,
+  businessLogic,
+  performance,
+  testing,
+  architecture,
+  summary,
+}) {
+  const sections = [
+    renderFindingsSection('🧭 Business Logic / Requirements', businessLogic),
+    renderFindingsSection('🔒 Security', security),
+    renderFindingsSection('🧩 Correctness / Regression', correctness),
+    renderFindingsSection('⚡ Performance', performance),
+    renderFindingsSection('🧪 Testing', testing),
+    renderFindingsSection('🏗️ Architecture / Code Smell', architecture),
+  ];
+
+  const overallRisk = summary?.overallRisk
+    ? `**${summary.overallRisk.level}** — ${summary.overallRisk.reason}`
+    : '_（未提供）_';
+
+  const mergeRecommendation = summary?.mergeRecommendation ?? '_（未提供）_';
+  const guideSection = renderReviewGuide(reviewGuide);
+
+  return [
+    AI_REVIEW_COMMENT_MARKER,
+    '## 🤖 AI Review Pipeline',
+    '',
+    plan?.requirementSummary ? `> ${plan.requirementSummary}` : '',
+    '',
+    guideSection ?? '### 🧭 Review Guide\n_（未執行）_',
+    '',
+    '---',
+    '',
+    sections.join('\n\n'),
+    '',
+    '---',
+    '',
+    '### 📋 Requirement Coverage',
+    renderRequirementCoverage(plan, summary),
+    '',
+    '### ⚠️ Overall Risk',
+    overallRisk,
+    '',
+    '### 🧪 Missing Tests',
+    renderMissingTests(testing),
+    '',
+    '### ✅ Merge Recommendation',
+    mergeRecommendation,
+    '',
+    '_以上意見僅供參考（advisory only），不會阻擋 merge。_',
+  ].join('\n');
+}

--- a/scripts/ai-review/lib/format-comment.test.mjs
+++ b/scripts/ai-review/lib/format-comment.test.mjs
@@ -1,0 +1,338 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { formatComment, AI_REVIEW_COMMENT_MARKER } from './format-comment.mjs';
+
+const noFindings = {
+  hasFindings: false,
+  summary: '未發現需要人工關注的問題',
+  findings: [],
+};
+
+const oneFinding = (overrides = {}) => ({
+  hasFindings: true,
+  summary: '發現 1 個問題',
+  findings: [
+    {
+      file: 'src/hooks/auth/useDeleteAccount.ts',
+      line: 42,
+      category: 'Error Handling',
+      issue: 'API 失敗時沒有 catch',
+      why: '使用者會看到卡住的 loading state',
+      fix: '加上 try/catch 並顯示 toast',
+    },
+  ],
+  ...overrides,
+});
+
+const basePlan = {
+  ticketFound: true,
+  ticketNumber: 999,
+  requirementSummary: '這次改動加了刪除帳號流程。',
+  acceptanceCriteria: ['只有三個測試帳號可以刪除', '刪除後導回首頁'],
+};
+
+describe('formatComment', () => {
+  it('includes the marker as the very first line, for the find-or-update lookup', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment.startsWith(AI_REVIEW_COMMENT_MARKER)).toBe(true);
+  });
+
+  it('renders a clean "no findings" line for every agent when nothing was found', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
+    expect(comment).toContain('### 🧪 Testing\n✅ 未發現需要人工關注的問題');
+    expect(comment).toContain('### 🧪 Missing Tests\n（無）');
+  });
+
+  it('renders each finding with its category, location, why, and fix', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: oneFinding(),
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '**[Error Handling]** `src/hooks/auth/useDeleteAccount.ts:42`'
+    );
+    expect(comment).toContain('API 失敗時沒有 catch');
+    expect(comment).toContain('為什麼重要：使用者會看到卡住的 loading state');
+    expect(comment).toContain('建議修法：加上 try/catch 並顯示 toast');
+  });
+
+  it('omits the line number when a finding has none', () => {
+    const finding = oneFinding();
+    finding.findings[0].line = null;
+    const comment = formatComment({
+      plan: basePlan,
+      security: finding,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('`src/hooks/auth/useDeleteAccount.ts`');
+    expect(comment).not.toContain('`src/hooks/auth/useDeleteAccount.ts:null`');
+  });
+
+  it('marks a stage as "not run" when its result is undefined, instead of crashing', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: undefined,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧩 Correctness / Regression\n_（未執行）_');
+  });
+
+  it('handles a completely empty context object without throwing', () => {
+    expect(() => formatComment({})).not.toThrow();
+    const comment = formatComment({});
+    expect(comment).toContain(AI_REVIEW_COMMENT_MARKER);
+    expect(comment).toContain(
+      '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_'
+    );
+  });
+
+  it('renders "no ticket" for requirement coverage when Planner found none', () => {
+    const comment = formatComment({
+      plan: { ticketFound: false },
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '_（此 PR 找不到對應 ticket，無 acceptance criteria 可比對）_'
+    );
+  });
+
+  it('renders "cannot judge" for requirement coverage when a ticket exists but Architecture gave no coverage', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('_（無法判斷）_');
+  });
+
+  it('renders each requirement-coverage entry with a check or warning icon', () => {
+    const summary = {
+      requirementCoverage: [
+        {
+          criterion: '只有三個測試帳號可以刪除',
+          covered: true,
+          note: '有檢查 email allowlist',
+        },
+        {
+          criterion: '刪除後導回首頁',
+          covered: false,
+          note: '找不到對應的 router.push',
+        },
+      ],
+      overallRisk: { level: 'medium', reason: '有一個未處理的錯誤路徑' },
+      mergeRecommendation: '建議先補上錯誤處理再合併',
+    };
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+      summary,
+    });
+    expect(comment).toContain(
+      '- ✅ 只有三個測試帳號可以刪除 — 有檢查 email allowlist'
+    );
+    expect(comment).toContain('- ⚠️ 刪除後導回首頁 — 找不到對應的 router.push');
+    expect(comment).toContain('**medium** — 有一個未處理的錯誤路徑');
+    expect(comment).toContain('建議先補上錯誤處理再合併');
+  });
+
+  it('lists every testing finding under Missing Tests', () => {
+    const testing = oneFinding({ summary: '發現 2 個測試缺口' });
+    testing.findings.push({
+      file: 'src/schemas/deleteAccount.ts',
+      line: null,
+      category: 'Missing Test Coverage',
+      issue: '沒有驗證測試',
+      why: 'schema 邊界情況未驗證',
+      fix: '補上 zod schema 測試',
+    });
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '- `src/hooks/auth/useDeleteAccount.ts:42` — API 失敗時沒有 catch'
+    );
+    expect(comment).toContain(
+      '- `src/schemas/deleteAccount.ts` — 沒有驗證測試'
+    );
+  });
+
+  it('renders Business Logic findings under their own section', () => {
+    const businessLogic = oneFinding({
+      summary: '發現 1 個業務規則違反',
+      findings: [
+        {
+          file: 'src/app/auth/(sign)/onboarding/container.tsx',
+          line: 115,
+          category: 'Unreachable Logic',
+          issue: 'onboarding 流程裡加了 isMentor 分支，但這裡永遠是 mentee',
+          why: 'onboarding 尚未完成前使用者不可能是 mentor，這段永遠不會執行',
+          fix: '移除此分支，mentor 專屬的頭像必填邏輯已在 profile/edit 實作',
+        },
+      ],
+    });
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      businessLogic,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧭 Business Logic / Requirements');
+    expect(comment).toContain('[Unreachable Logic]');
+    expect(comment).toContain(
+      'onboarding 流程裡加了 isMentor 分支，但這裡永遠是 mentee'
+    );
+  });
+
+  it('renders "not run" for Business Logic when it is undefined, without affecting other sections', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain(
+      '### 🧭 Business Logic / Requirements\n_（未執行）_'
+    );
+  });
+
+  it('falls back to a placeholder merge recommendation when the final-judgment summary is missing entirely (e.g. that Gemini call failed)', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+      summary: undefined,
+    });
+    expect(comment).toContain('### ✅ Merge Recommendation\n_（未提供）_');
+    expect(comment).toContain('### ⚠️ Overall Risk\n_（未提供）_');
+    // the rest of the comment (each agent's own findings) must still render
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
+  });
+
+  it('renders the review guide overview and reading order, sorted by the declared order field', () => {
+    const reviewGuide = {
+      overview: '這次變更把 X 功能拆成三層。',
+      readingOrder: [
+        {
+          file: 'src/components/Foo.tsx',
+          order: 3,
+          why: '最後看畫面怎麼消費資料',
+        },
+        { file: 'src/schemas/foo.ts', order: 1, why: '先看資料形狀' },
+        { file: 'src/hooks/useFoo.ts', order: 2, why: '再看怎麼用 schema' },
+      ],
+    };
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+
+    expect(comment).toContain('### 🧭 Review Guide');
+    expect(comment).toContain('這次變更把 X 功能拆成三層。');
+
+    const order1 = comment.indexOf('1. `src/schemas/foo.ts`');
+    const order2 = comment.indexOf('2. `src/hooks/useFoo.ts`');
+    const order3 = comment.indexOf('3. `src/components/Foo.tsx`');
+    expect(order1).toBeGreaterThan(-1);
+    expect(order1).toBeLessThan(order2);
+    expect(order2).toBeLessThan(order3);
+  });
+
+  it('renders a "not run" placeholder for the review guide when it is missing, without affecting the rest of the comment', () => {
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide: undefined,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('### 🧭 Review Guide\n_（未執行）_');
+    expect(comment).toContain('### 🔒 Security\n✅ 未發現需要人工關注的問題');
+  });
+
+  it('does not crash when the LLM returns readingOrder as a non-array (e.g. a string) instead of following the schema', () => {
+    const reviewGuide = {
+      overview: '這次變更把 X 功能拆成三層。',
+      readingOrder: 'src/schemas/foo.ts, src/hooks/useFoo.ts',
+    };
+
+    expect(() =>
+      formatComment({
+        plan: basePlan,
+        reviewGuide,
+        security: noFindings,
+        correctness: noFindings,
+        performance: noFindings,
+        testing: noFindings,
+        architecture: noFindings,
+      })
+    ).not.toThrow();
+
+    const comment = formatComment({
+      plan: basePlan,
+      reviewGuide,
+      security: noFindings,
+      correctness: noFindings,
+      performance: noFindings,
+      testing: noFindings,
+      architecture: noFindings,
+    });
+    expect(comment).toContain('這次變更把 X 功能拆成三層。');
+    expect(comment).not.toContain('建議閱讀順序');
+  });
+});

--- a/scripts/ai-review/lib/gemini.mjs
+++ b/scripts/ai-review/lib/gemini.mjs
@@ -1,0 +1,161 @@
+const DEFAULT_MODEL = 'gemini-3.1-pro-preview';
+const DEFAULT_MAX_OUTPUT_TOKENS = 16384;
+const MAX_ATTEMPTS = 3;
+const RETRY_DELAY_MS = 1500;
+
+/**
+ * Scans from the first `{` and returns the substring up to its matching
+ * closing brace, ignoring braces inside strings. Gemini occasionally emits
+ * valid JSON followed by stray trailing characters (e.g. an extra `}`)
+ * even with responseMimeType: 'application/json' — this recovers the
+ * well-formed object instead of failing the whole call on garbage that
+ * comes after it.
+ */
+function extractFirstJsonObject(text) {
+  const start = text.indexOf('{');
+  if (start === -1) return null;
+
+  let depth = 0;
+  let inString = false;
+  let escapeNext = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (escapeNext) {
+      escapeNext = false;
+      continue;
+    }
+    if (ch === '\\') {
+      escapeNext = true;
+      continue;
+    }
+    if (ch === '"') {
+      inString = !inString;
+      continue;
+    }
+    if (inString) continue;
+
+    if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+  return null;
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function callGeminiOnce(promptText, { model, maxOutputTokens, apiKey }) {
+  const res = await fetch(
+    `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': apiKey,
+      },
+      body: JSON.stringify({
+        contents: [{ parts: [{ text: promptText }] }],
+        generationConfig: {
+          responseMimeType: 'application/json',
+          maxOutputTokens,
+        },
+      }),
+    }
+  );
+
+  if (!res.ok) {
+    const errText = await res.text();
+    const err = new Error(`Gemini API error (${res.status}): ${errText}`);
+    // 5xx is almost always transient; 4xx (bad key, bad request) won't be fixed by retrying.
+    err.retryable = res.status >= 500;
+    throw err;
+  }
+
+  const data = await res.json();
+  const candidate = data?.candidates?.[0];
+  const text = candidate?.content?.parts?.[0]?.text;
+
+  if (!text) {
+    const err = new Error(
+      `Gemini API returned no content (finishReason: ${candidate?.finishReason ?? 'unknown'})`
+    );
+    err.retryable = true;
+    throw err;
+  }
+
+  if (candidate.finishReason === 'MAX_TOKENS') {
+    // Retrying won't help — the same prompt will hit the same cap again.
+    throw new Error(
+      `Gemini response was truncated (finishReason: MAX_TOKENS, maxOutputTokens: ${maxOutputTokens}). ` +
+        'Set GEMINI_MAX_OUTPUT_TOKENS higher or shorten the prompt/diff.'
+    );
+  }
+
+  try {
+    return JSON.parse(text);
+  } catch {
+    const recovered = extractFirstJsonObject(text);
+    if (recovered) {
+      try {
+        return JSON.parse(recovered);
+      } catch {
+        // fall through to the error below
+      }
+    }
+    // Log the full response (not just a truncated excerpt) so an
+    // unparseable output is actually debuggable if every retry fails.
+    console.error(
+      `[gemini] unparsable response (finishReason: ${candidate.finishReason}):\n${text}`
+    );
+    const err = new Error(
+      `Failed to parse Gemini response as JSON (finishReason: ${candidate.finishReason}); full response logged above`
+    );
+    err.retryable = true;
+    throw err;
+  }
+}
+
+/**
+ * Calls the Gemini API with a text prompt and expects a JSON response.
+ * The prompt itself is responsible for instructing the model to return JSON.
+ *
+ * Retries a few times on transient failures (malformed/empty output, 5xx)
+ * since these have empirically been "fails once, succeeds on the next
+ * identical call" — not worth failing an entire pipeline run over.
+ */
+export async function callGemini(promptText) {
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) {
+    throw new Error('GEMINI_API_KEY is not set');
+  }
+  const model = process.env.GEMINI_MODEL || DEFAULT_MODEL;
+  const maxOutputTokens =
+    Number(process.env.GEMINI_MAX_OUTPUT_TOKENS) || DEFAULT_MAX_OUTPUT_TOKENS;
+
+  let lastErr;
+  for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+    try {
+      return await callGeminiOnce(promptText, {
+        model,
+        maxOutputTokens,
+        apiKey,
+      });
+    } catch (err) {
+      lastErr = err;
+      const canRetry = err.retryable && attempt < MAX_ATTEMPTS;
+      console.warn(
+        `[gemini] attempt ${attempt}/${MAX_ATTEMPTS} failed: ${err.message}${canRetry ? ' — retrying' : ''}`
+      );
+      if (!canRetry) break;
+      await sleep(RETRY_DELAY_MS * attempt);
+    }
+  }
+  throw lastErr;
+}

--- a/scripts/ai-review/lib/gemini.mjs
+++ b/scripts/ai-review/lib/gemini.mjs
@@ -73,8 +73,10 @@ async function callGeminiOnce(promptText, { model, maxOutputTokens, apiKey }) {
   if (!res.ok) {
     const errText = await res.text();
     const err = new Error(`Gemini API error (${res.status}): ${errText}`);
-    // 5xx is almost always transient; 4xx (bad key, bad request) won't be fixed by retrying.
-    err.retryable = res.status >= 500;
+    // 5xx and 429 (rate limit — expected when 7 review agents hit the API
+    // in parallel) are transient; other 4xx (bad key, bad request) won't be
+    // fixed by retrying.
+    err.retryable = res.status >= 500 || res.status === 429;
     throw err;
   }
 

--- a/scripts/ai-review/lib/gemini.mjs
+++ b/scripts/ai-review/lib/gemini.mjs
@@ -93,11 +93,13 @@ async function callGeminiOnce(promptText, { model, maxOutputTokens, apiKey }) {
   }
 
   if (candidate.finishReason === 'MAX_TOKENS') {
-    // Retrying won't help — the same prompt will hit the same cap again.
-    throw new Error(
+    const err = new Error(
       `Gemini response was truncated (finishReason: MAX_TOKENS, maxOutputTokens: ${maxOutputTokens}). ` +
         'Set GEMINI_MAX_OUTPUT_TOKENS higher or shorten the prompt/diff.'
     );
+    // Retrying won't help — the same prompt will hit the same cap again.
+    err.retryable = false;
+    throw err;
   }
 
   try {
@@ -151,7 +153,11 @@ export async function callGemini(promptText) {
       });
     } catch (err) {
       lastErr = err;
-      const canRetry = err.retryable && attempt < MAX_ATTEMPTS;
+      // A raw fetch/network failure (DNS, connection reset) throws a plain
+      // TypeError with no `retryable` flag at all — treat "not explicitly
+      // false" as retryable so those transient errors aren't mistaken for
+      // the deliberately-non-retryable ones (e.g. MAX_TOKENS) above.
+      const canRetry = err.retryable !== false && attempt < MAX_ATTEMPTS;
       console.warn(
         `[gemini] attempt ${attempt}/${MAX_ATTEMPTS} failed: ${err.message}${canRetry ? ' — retrying' : ''}`
       );

--- a/scripts/ai-review/lib/gemini.test.mjs
+++ b/scripts/ai-review/lib/gemini.test.mjs
@@ -98,6 +98,17 @@ describe('callGemini', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('retries on a raw network error (fetch rejects with no `retryable` flag) and succeeds next attempt', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValueOnce(new TypeError('fetch failed'))
+      .mockResolvedValueOnce(candidateResponse('{"ok":true}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callGemini('prompt')).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('does not retry a 4xx error', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/scripts/ai-review/lib/gemini.test.mjs
+++ b/scripts/ai-review/lib/gemini.test.mjs
@@ -1,0 +1,111 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { callGemini } from './gemini.mjs';
+
+function candidateResponse(text, { finishReason = 'STOP', status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => ({
+      candidates: [{ finishReason, content: { parts: [{ text }] } }],
+    }),
+    text: async () => text,
+  };
+}
+
+beforeEach(() => {
+  process.env.GEMINI_API_KEY = 'test-key';
+  vi.stubGlobal('setTimeout', (fn) => fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  delete process.env.GEMINI_API_KEY;
+});
+
+describe('callGemini', () => {
+  it('parses a clean JSON response', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(candidateResponse('{"ok":true}'))
+    );
+
+    await expect(callGemini('prompt')).resolves.toEqual({ ok: true });
+  });
+
+  it('recovers the JSON object when trailing garbage follows it', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(candidateResponse('{"ok":true}}'))
+    );
+
+    await expect(callGemini('prompt')).resolves.toEqual({ ok: true });
+  });
+
+  it('does not miscount braces that appear inside string values', async () => {
+    const text = '{"note":"contains { and } inside a string","ok":true}';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(candidateResponse(text))
+    );
+
+    await expect(callGemini('prompt')).resolves.toEqual({
+      note: 'contains { and } inside a string',
+      ok: true,
+    });
+  });
+
+  it('does not end a string early on an escaped quote', async () => {
+    const text = '{"note":"a \\"quoted\\" word","ok":true}';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValueOnce(candidateResponse(text))
+    );
+
+    await expect(callGemini('prompt')).resolves.toEqual({
+      note: 'a "quoted" word',
+      ok: true,
+    });
+  });
+
+  it('retries on a 5xx error and succeeds on the next attempt', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        text: async () => 'service unavailable',
+      })
+      .mockResolvedValueOnce(candidateResponse('{"ok":true}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callGemini('prompt')).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a 4xx error', async () => {
+    const fetchMock = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      text: async () => 'bad request',
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callGemini('prompt')).rejects.toThrow(
+      'Gemini API error (400)'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws immediately without retrying when truncated by MAX_TOKENS', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        candidateResponse('{"incomplete', { finishReason: 'MAX_TOKENS' })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callGemini('prompt')).rejects.toThrow('MAX_TOKENS');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/scripts/ai-review/lib/gemini.test.mjs
+++ b/scripts/ai-review/lib/gemini.test.mjs
@@ -83,6 +83,21 @@ describe('callGemini', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('retries on a 429 rate-limit error and succeeds on the next attempt', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 429,
+        text: async () => 'rate limited',
+      })
+      .mockResolvedValueOnce(candidateResponse('{"ok":true}'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(callGemini('prompt')).resolves.toEqual({ ok: true });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
   it('does not retry a 4xx error', async () => {
     const fetchMock = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/scripts/ai-review/lib/pr-comment.mjs
+++ b/scripts/ai-review/lib/pr-comment.mjs
@@ -9,8 +9,7 @@ function parseNextLink(linkHeader) {
   return null;
 }
 
-async function listAllComments({ repo, issueNumber, token }) {
-  const comments = [];
+async function* listAllComments({ repo, issueNumber, token }) {
   let url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100`;
 
   while (url) {
@@ -25,17 +24,16 @@ async function listAllComments({ repo, issueNumber, token }) {
         `GitHub API error listing comments (${res.status}): ${await res.text()}`
       );
     }
-    comments.push(...(await res.json()));
+    yield* await res.json();
     url = parseNextLink(res.headers.get('link'));
   }
-
-  return comments;
 }
 
 /**
  * Creates the PR comment carrying `marker`, or updates it in place if one
- * already exists — paginates through every comment page so a long PR thread
- * can't hide the bot's own prior comment on page 2+.
+ * already exists — paginates through comment pages (stopping as soon as the
+ * bot's own prior comment is found) so a long PR thread can't hide it on
+ * page 2+ without requiring every page to be fetched.
  */
 export async function upsertComment({
   repo,
@@ -44,10 +42,13 @@ export async function upsertComment({
   marker,
   body,
 }) {
-  const comments = await listAllComments({ repo, issueNumber, token });
-  const existing = comments.find(
-    (c) => c.user?.login === BOT_LOGIN && c.body?.includes(marker)
-  );
+  let existing;
+  for await (const comment of listAllComments({ repo, issueNumber, token })) {
+    if (comment.user?.login === BOT_LOGIN && comment.body?.includes(marker)) {
+      existing = comment;
+      break;
+    }
+  }
 
   const url = existing
     ? `https://api.github.com/repos/${repo}/issues/comments/${existing.id}`

--- a/scripts/ai-review/lib/pr-comment.mjs
+++ b/scripts/ai-review/lib/pr-comment.mjs
@@ -1,0 +1,75 @@
+const BOT_LOGIN = 'github-actions[bot]';
+
+function parseNextLink(linkHeader) {
+  if (!linkHeader) return null;
+  for (const part of linkHeader.split(',')) {
+    const match = part.match(/<([^>]+)>;\s*rel="next"/);
+    if (match) return match[1];
+  }
+  return null;
+}
+
+async function listAllComments({ repo, issueNumber, token }) {
+  const comments = [];
+  let url = `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments?per_page=100`;
+
+  while (url) {
+    const res = await fetch(url, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    });
+    if (!res.ok) {
+      throw new Error(
+        `GitHub API error listing comments (${res.status}): ${await res.text()}`
+      );
+    }
+    comments.push(...(await res.json()));
+    url = parseNextLink(res.headers.get('link'));
+  }
+
+  return comments;
+}
+
+/**
+ * Creates the PR comment carrying `marker`, or updates it in place if one
+ * already exists — paginates through every comment page so a long PR thread
+ * can't hide the bot's own prior comment on page 2+.
+ */
+export async function upsertComment({
+  repo,
+  issueNumber,
+  token,
+  marker,
+  body,
+}) {
+  const comments = await listAllComments({ repo, issueNumber, token });
+  const existing = comments.find(
+    (c) => c.user?.login === BOT_LOGIN && c.body?.includes(marker)
+  );
+
+  const url = existing
+    ? `https://api.github.com/repos/${repo}/issues/comments/${existing.id}`
+    : `https://api.github.com/repos/${repo}/issues/${issueNumber}/comments`;
+  const method = existing ? 'PATCH' : 'POST';
+
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/vnd.github+json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ body }),
+  });
+
+  if (!res.ok) {
+    const action = existing ? 'updating' : 'creating';
+    throw new Error(
+      `GitHub API error ${action} comment (${res.status}): ${await res.text()}`
+    );
+  }
+
+  return res.json();
+}

--- a/scripts/ai-review/lib/pr-comment.test.mjs
+++ b/scripts/ai-review/lib/pr-comment.test.mjs
@@ -1,0 +1,218 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { upsertComment } from './pr-comment.mjs';
+
+const MARKER = '<!-- ai-review-pipeline -->';
+
+function jsonResponse(body, { status = 200 } = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  };
+}
+
+function withLink(response, link) {
+  return {
+    ...response,
+    headers: { get: (name) => (name.toLowerCase() === 'link' ? link : null) },
+  };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('upsertComment', () => {
+  it('paginates through every comment page via the Link header before deciding whether a bot comment exists', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([
+            { id: 1, user: { login: 'someone' }, body: 'unrelated comment' },
+          ]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?per_page=100&page=2>; rel="next"'
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 2,
+            user: { login: 'github-actions[bot]' },
+            body: `${MARKER}\nold content`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 2, body: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const result = await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?per_page=100'
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?per_page=100&page=2'
+    );
+    expect(result).toEqual({ id: 2, body: 'updated' });
+  });
+
+  it('PATCHes the existing bot comment (found on a later page) instead of creating a duplicate', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([{ id: 1, user: { login: 'someone' }, body: 'noise' }]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?page=2>; rel="next"'
+        )
+      )
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 2,
+            user: { login: 'github-actions[bot]' },
+            body: `${MARKER}\nold`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 2, body: 'updated' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [patchUrl, patchOpts] = fetchMock.mock.calls[2];
+    expect(patchUrl).toBe('https://api.github.com/repos/o/r/issues/comments/2');
+    expect(patchOpts.method).toBe('PATCH');
+    expect(JSON.parse(patchOpts.body)).toEqual({ body: 'new' });
+  });
+
+  it('POSTs a new comment when no existing bot comment carries the marker', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ id: 99, body: 'new' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [postUrl, postOpts] = fetchMock.mock.calls[1];
+    expect(postUrl).toBe('https://api.github.com/repos/o/r/issues/5/comments');
+    expect(postOpts.method).toBe('POST');
+  });
+
+  it('does not mistake another user’s comment containing the marker text for the bot’s own', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse([
+          {
+            id: 1,
+            user: { login: 'someone-else' },
+            body: `${MARKER} pretending to be the bot`,
+          },
+        ])
+      )
+      .mockResolvedValueOnce(jsonResponse({ id: 100, body: 'new' }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    const [, postOpts] = fetchMock.mock.calls[1];
+    expect(postOpts.method).toBe('POST');
+  });
+
+  it('throws a descriptive error when listing comments returns a non-2xx status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse({ message: 'bad creds' }, { status: 401 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      upsertComment({
+        repo: 'o/r',
+        issueNumber: 5,
+        token: 'bad',
+        marker: MARKER,
+        body: 'new',
+      })
+    ).rejects.toThrow(/listing comments \(401\)/i);
+  });
+
+  it('throws a descriptive error when creating/updating the comment returns a non-2xx status', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(
+        jsonResponse({ message: 'nope' }, { status: 403 })
+      );
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      upsertComment({
+        repo: 'o/r',
+        issueNumber: 5,
+        token: 't',
+        marker: MARKER,
+        body: 'new',
+      })
+    ).rejects.toThrow(/creating comment \(403\)/i);
+  });
+
+  it('follows only the "next" rel when the Link header also carries "prev"/"last"', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        withLink(
+          jsonResponse([{ id: 1, user: { login: 'someone' }, body: 'noise' }]),
+          '<https://api.github.com/repos/o/r/issues/5/comments?page=1>; rel="prev", ' +
+            '<https://api.github.com/repos/o/r/issues/5/comments?page=3>; rel="next", ' +
+            '<https://api.github.com/repos/o/r/issues/5/comments?page=5>; rel="last"'
+        )
+      )
+      .mockResolvedValueOnce(jsonResponse([]))
+      .mockResolvedValueOnce(jsonResponse({ id: 1 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await upsertComment({
+      repo: 'o/r',
+      issueNumber: 5,
+      token: 't',
+      marker: MARKER,
+      body: 'new',
+    });
+
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      'https://api.github.com/repos/o/r/issues/5/comments?page=3'
+    );
+  });
+});

--- a/scripts/ai-review/lib/prompt.mjs
+++ b/scripts/ai-review/lib/prompt.mjs
@@ -1,0 +1,47 @@
+import { readFileSync } from 'node:fs';
+
+const SHARED_DIR = new URL('../prompts/_shared/', import.meta.url);
+
+function loadShared() {
+  return {
+    projectContext: readFileSync(
+      new URL('project-context.md', SHARED_DIR),
+      'utf-8'
+    ),
+    reviewDiscipline: readFileSync(
+      new URL('review-discipline.md', SHARED_DIR),
+      'utf-8'
+    ),
+    businessRules: readFileSync(
+      new URL('business-rules.md', SHARED_DIR),
+      'utf-8'
+    ),
+    codeSmellBaseline: readFileSync(
+      new URL('code-smell-baseline.md', SHARED_DIR),
+      'utf-8'
+    ),
+  };
+}
+
+/**
+ * Loads an agent's prompt template (a URL, e.g. `new URL('../prompts/security.md', import.meta.url)`)
+ * and fills in the shared fragments plus any agent-specific replacements.
+ * Placeholders are `{{NAME}}` tokens; unknown placeholders are left as-is.
+ */
+export function buildPrompt(templateUrl, replacements = {}) {
+  const { projectContext, reviewDiscipline, businessRules, codeSmellBaseline } =
+    loadShared();
+  let template = readFileSync(templateUrl, 'utf-8');
+
+  const all = {
+    PROJECT_CONTEXT: projectContext,
+    REVIEW_DISCIPLINE: reviewDiscipline,
+    BUSINESS_RULES: businessRules,
+    CODE_SMELL_BASELINE: codeSmellBaseline,
+    ...replacements,
+  };
+  for (const [key, value] of Object.entries(all)) {
+    template = template.split(`{{${key}}}`).join(value);
+  }
+  return template;
+}

--- a/scripts/ai-review/lib/run-agent.mjs
+++ b/scripts/ai-review/lib/run-agent.mjs
@@ -19,8 +19,12 @@ export async function runAgent({ promptUrl, upstreamEnvVars, outputName }) {
   if (!baseRef) {
     throw new Error('BASE_REF env var is required');
   }
+  const headSha = process.env.HEAD_SHA;
+  if (!headSha) {
+    throw new Error('HEAD_SHA env var is required');
+  }
 
-  const { diff, truncated } = getDiff(baseRef);
+  const { diff, truncated } = getDiff(baseRef, headSha);
 
   const upstreamReplacements = {};
   for (const [placeholder, envVar] of Object.entries(upstreamEnvVars)) {

--- a/scripts/ai-review/lib/run-agent.mjs
+++ b/scripts/ai-review/lib/run-agent.mjs
@@ -1,0 +1,46 @@
+import { callGemini } from './gemini.mjs';
+import { getDiff } from './diff.mjs';
+import { buildPrompt } from './prompt.mjs';
+import {
+  encodeContext,
+  decodeContext,
+  writeGithubOutput,
+} from './context-io.mjs';
+
+/**
+ * Runs one downstream review-agent stage: recomputes the PR diff, decodes the
+ * upstream job outputs it depends on, builds this agent's prompt, calls
+ * Gemini, and writes the structured result to $GITHUB_OUTPUT under
+ * `outputName` so the next stage in the pipeline can read it via
+ * `needs.<job>.outputs.<outputName>`.
+ */
+export async function runAgent({ promptUrl, upstreamEnvVars, outputName }) {
+  const baseRef = process.env.BASE_REF;
+  if (!baseRef) {
+    throw new Error('BASE_REF env var is required');
+  }
+
+  const { diff, truncated } = getDiff(baseRef);
+
+  const upstreamReplacements = {};
+  for (const [placeholder, envVar] of Object.entries(upstreamEnvVars)) {
+    const value = decodeContext(process.env[envVar]);
+    if (!value) {
+      throw new Error(
+        `${envVar} env var is required (missing upstream job output)`
+      );
+    }
+    upstreamReplacements[placeholder] = JSON.stringify(value, null, 2);
+  }
+
+  const prompt = buildPrompt(promptUrl, {
+    DIFF: diff,
+    TRUNCATED_NOTE: truncated ? '（注意：diff 過大，內容已截斷）' : '',
+    ...upstreamReplacements,
+  });
+
+  const result = await callGemini(prompt);
+  console.log(`[${outputName}] result:`, JSON.stringify(result, null, 2));
+  writeGithubOutput(outputName, encodeContext(result));
+  return result;
+}

--- a/scripts/ai-review/lib/ticket.mjs
+++ b/scripts/ai-review/lib/ticket.mjs
@@ -1,0 +1,53 @@
+const TICKET_BRANCH_PATTERN =
+  /^(?:feat|fix|chore|refactor|perf|docs|test)\/(\d+)-/;
+const TRACKER_OWNER = 'Xchange-Taiwan';
+const TRACKER_REPO = 'X-Talent-Tracker';
+
+export function extractTicketNumber(branchName) {
+  const match = branchName?.match(TICKET_BRANCH_PATTERN);
+  return match ? Number(match[1]) : null;
+}
+
+async function ghGet(path, token) {
+  const res = await fetch(
+    `https://api.github.com/repos/${TRACKER_OWNER}/${TRACKER_REPO}${path}`,
+    {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: 'application/vnd.github+json',
+      },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`GitHub API error fetching ${path} (${res.status})`);
+  }
+  return res.json();
+}
+
+/**
+ * Parses the ticket number out of the PR's head branch name and fetches the
+ * corresponding issue + comments from the (private) X-Talent-Tracker repo.
+ * Returns { ticketFound: false } when the branch name has no ticket number,
+ * or when it does but the token is missing/invalid — callers should treat
+ * that as "no ticket context available", not a hard failure.
+ */
+export async function fetchTicketContext(branchName, token) {
+  const number = extractTicketNumber(branchName);
+  if (!number) {
+    return { ticketFound: false };
+  }
+
+  const issue = await ghGet(`/issues/${number}`, token);
+  const comments = await ghGet(`/issues/${number}/comments`, token);
+
+  return {
+    ticketFound: true,
+    number,
+    title: issue.title,
+    body: issue.body ?? '',
+    comments: comments.map((c) => ({
+      author: c.user?.login ?? 'unknown',
+      body: c.body ?? '',
+    })),
+  };
+}

--- a/scripts/ai-review/performance.mjs
+++ b/scripts/ai-review/performance.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/performance.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/planner.mjs
+++ b/scripts/ai-review/planner.mjs
@@ -5,14 +5,18 @@ import { buildPrompt } from './lib/prompt.mjs';
 import { encodeContext, writeGithubOutput } from './lib/context-io.mjs';
 
 const baseRef = process.env.BASE_REF;
+const headSha = process.env.HEAD_SHA;
 const headBranch = process.env.HEAD_REF || '';
 const trackerToken = process.env.TRACKER_READ_TOKEN;
 
 if (!baseRef) {
   throw new Error('BASE_REF env var is required');
 }
+if (!headSha) {
+  throw new Error('HEAD_SHA env var is required');
+}
 
-const { diff, truncated } = getDiff(baseRef);
+const { diff, truncated } = getDiff(baseRef, headSha);
 
 let ticket = { ticketFound: false };
 if (trackerToken) {

--- a/scripts/ai-review/planner.mjs
+++ b/scripts/ai-review/planner.mjs
@@ -1,0 +1,53 @@
+import { callGemini } from './lib/gemini.mjs';
+import { getDiff } from './lib/diff.mjs';
+import { fetchTicketContext } from './lib/ticket.mjs';
+import { buildPrompt } from './lib/prompt.mjs';
+import { encodeContext, writeGithubOutput } from './lib/context-io.mjs';
+
+const baseRef = process.env.BASE_REF;
+const headBranch = process.env.HEAD_REF || '';
+const trackerToken = process.env.TRACKER_READ_TOKEN;
+
+if (!baseRef) {
+  throw new Error('BASE_REF env var is required');
+}
+
+const { diff, truncated } = getDiff(baseRef);
+
+let ticket = { ticketFound: false };
+if (trackerToken) {
+  try {
+    ticket = await fetchTicketContext(headBranch, trackerToken);
+  } catch (err) {
+    console.warn(
+      `[planner] failed to fetch ticket context, falling back to diff-only: ${err.message}`
+    );
+  }
+} else {
+  console.warn('[planner] TRACKER_READ_TOKEN not set, skipping ticket lookup');
+}
+
+const ticketSection = ticket.ticketFound
+  ? [
+      '## 對應 Ticket',
+      `**#${ticket.number} ${ticket.title}**`,
+      '',
+      ticket.body,
+      '',
+      '### Comments',
+      ticket.comments.length
+        ? ticket.comments.map((c) => `- ${c.author}: ${c.body}`).join('\n')
+        : '(無留言)',
+    ].join('\n')
+  : '## 對應 Ticket\n（這個 PR 的 branch 名稱找不到對應的 ticket 編號，僅根據 diff 進行分析）';
+
+const prompt = buildPrompt(new URL('./prompts/planner.md', import.meta.url), {
+  TICKET_SECTION: ticketSection,
+  DIFF: diff,
+  TRUNCATED_NOTE: truncated ? '（注意：diff 過大，內容已截斷）' : '',
+});
+
+const plan = await callGemini(prompt);
+
+console.log('[planner] plan:', JSON.stringify(plan, null, 2));
+writeGithubOutput('plan', encodeContext(plan));

--- a/scripts/ai-review/post-comment.mjs
+++ b/scripts/ai-review/post-comment.mjs
@@ -1,0 +1,22 @@
+import { readFileSync } from 'node:fs';
+import { upsertComment } from './lib/pr-comment.mjs';
+import { AI_REVIEW_COMMENT_MARKER } from './lib/format-comment.mjs';
+
+const token = process.env.GITHUB_TOKEN;
+const repo = process.env.GITHUB_REPOSITORY;
+const issueNumber = process.env.PR_NUMBER;
+
+if (!token) throw new Error('GITHUB_TOKEN env var is required');
+if (!repo) throw new Error('GITHUB_REPOSITORY env var is required');
+if (!issueNumber) throw new Error('PR_NUMBER env var is required');
+
+const body = readFileSync('ai-review-comment.md', 'utf-8');
+
+await upsertComment({
+  repo,
+  issueNumber,
+  token,
+  marker: AI_REVIEW_COMMENT_MARKER,
+  body,
+});
+console.log('[post-comment] posted/updated PR comment');

--- a/scripts/ai-review/prompts/planner.md
+++ b/scripts/ai-review/prompts/planner.md
@@ -1,0 +1,34 @@
+你是一個 multi-agent PR review pipeline 裡的 **Planner**。你的工作不是找 bug，而是幫後面 5 個 reviewer agent（Security、Correctness/Regression、Performance、Testing、Architecture）準備好共用的背景資訊，讓它們不用各自重新讀 ticket、重新理解這次變更的範圍。
+
+{{PROJECT_CONTEXT}}
+
+{{REVIEW_DISCIPLINE}}
+
+{{TICKET_SECTION}}
+
+## 這次的 PR Diff{{TRUNCATED_NOTE}}
+
+```diff
+{{DIFF}}
+```
+
+## 你的任務
+
+1. 如果有對應的 ticket 內容，整理出這次變更的需求重點，並列出明確的 acceptance criteria（若 ticket 內容中有列出的話，逐條列出；沒有 ticket 內容則回傳空陣列）
+2. 列出這次 diff 實際觸碰到的檔案（相對路徑）
+3. 判斷這次變更涉及哪些風險領域（例如：認證/角色邏輯、表單驗證、API 呼叫、UI 渲染時機等），給後面的 reviewer 一些提示，讓它們知道要特別注意哪裡
+4. 用一段話總結這次變更在做什麼，讓後面的 agent 不用重新分析一次 diff 就能知道大方向
+
+請只回傳以下 JSON 格式，不要加任何其他文字或 markdown 標記：
+
+```json
+{
+  "ticketFound": boolean,
+  "ticketNumber": number | null,
+  "requirementSummary": "一段話總結需求（若無 ticket 則說明僅根據 diff 判斷）",
+  "acceptanceCriteria": ["逐條列出的 acceptance criteria，若無則為空陣列"],
+  "filesTouched": ["這次 diff 觸碰到的檔案路徑"],
+  "riskAreas": ["需要特別注意的風險領域，簡短描述"],
+  "notesForReviewers": "給下游 5 個 reviewer agent 的簡短提示"
+}
+```

--- a/scripts/ai-review/review-guide.mjs
+++ b/scripts/ai-review/review-guide.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/review-guide.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'guide',
+});

--- a/scripts/ai-review/security.mjs
+++ b/scripts/ai-review/security.mjs
@@ -1,0 +1,7 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/security.md', import.meta.url),
+  upstreamEnvVars: { PLAN_JSON: 'PLAN_B64' },
+  outputName: 'findings',
+});

--- a/scripts/ai-review/testing.mjs
+++ b/scripts/ai-review/testing.mjs
@@ -1,0 +1,9 @@
+import { runAgent } from './lib/run-agent.mjs';
+
+await runAgent({
+  promptUrl: new URL('./prompts/testing.md', import.meta.url),
+  upstreamEnvVars: {
+    PLAN_JSON: 'PLAN_B64',
+  },
+  outputName: 'findings',
+});


### PR DESCRIPTION
## Summary
- Reverts #726, restoring the script-based AI review pipeline (`scripts/ai-review/*.mjs`) and the original `.github/workflows/ai-review.yml`.
- `.agents/skills/ai-review/SKILL.md` is restored to its pre-#726 content.

## Note
A later commit (on top of #726, not part of it) added a `Review Status: PASS/BLOCKED` contract line to the SKILL.md workflow description, which `/implement` (`.agents/skills/implement/SKILL.md`) reads to decide whether to auto-continue to `/submit-pr`. Reverting #726 removes that contract from the ai-review flow. This is not a hard break — per `/implement`'s own fallback, a missing status line just causes it to halt for manual review instead of auto-continuing — but flagging it here since it's a loss of automation, not a restored behavior.

## Test plan
- [x] `tsc --noEmit` passes (ran automatically on push)
- [x] `vitest run` — 82 files / 617 tests passed (ran automatically on push)
- [ ] Confirm CI `ai-review.yml` workflow runs correctly with the restored scripts