### PR TITLE
refactor(ui): establish global typography scale and clean up primaryAlt variants (X-Tracker #377)

### DIFF
--- a/src/components/profile/edit/MultiSelectField.tsx
+++ b/src/components/profile/edit/MultiSelectField.tsx
@@ -21,7 +21,7 @@ interface MultiSelectFieldProps<T extends FieldValues> {
   }>;
   maxCount?: number;
   animation?: number;
-  variant?: 'default' | 'secondary' | 'destructive' | 'primaryAlt';
+  variant?: 'default' | 'secondary' | 'destructive';
 }
 
 /**

--- a/src/components/profile/view/ProfileBadgeSection.test.tsx
+++ b/src/components/profile/view/ProfileBadgeSection.test.tsx
@@ -1,0 +1,26 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ProfileBadgeSection } from './ProfileBadgeSection';
+
+describe('ProfileBadgeSection', () => {
+  it('renders nothing when items is empty', () => {
+    const { container } = render(
+      <ProfileBadgeSection title="領域技術" items={[]} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders title and tags correctly with default Badge variant', () => {
+    const items = [
+      { subject_group: 'group-1', subject: 'React' },
+      { subject_group: 'group-2', subject: 'TypeScript' },
+    ];
+
+    render(<ProfileBadgeSection title="領域技術" items={items} />);
+
+    expect(screen.getByText('領域技術')).toBeInTheDocument();
+    expect(screen.getByText('React')).toBeInTheDocument();
+    expect(screen.getByText('TypeScript')).toBeInTheDocument();
+  });
+});

--- a/src/components/profile/view/ProfileBadgeSection.tsx
+++ b/src/components/profile/view/ProfileBadgeSection.tsx
@@ -13,7 +13,7 @@ export function ProfileBadgeSection({ title, items }: Props) {
       <p className="mb-4 text-xl font-bold">{title}</p>
       <div className="flex flex-wrap gap-3">
         {items.map((i) => (
-          <Badge variant="primaryAlt" key={i.subject_group}>
+          <Badge variant="default" key={i.subject_group}>
             {i.subject}
           </Badge>
         ))}

--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -15,8 +15,6 @@ const badgeVariants = cva(
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
         outline: 'text-foreground',
-        primaryAlt:
-          'border-transparent bg-primary text-black-foreground hover:bg-primary/90',
         filter:
           'py-1.5 pr-2 pl-3 h-8 border border-background-border rounded-lg gap-2',
       },

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -18,7 +18,6 @@ const buttonVariants = cva(
           'bg-secondary text-secondary-foreground hover:bg-secondary/80',
         ghost: 'hover:bg-accent hover:text-accent-foreground',
         link: 'text-primary underline-offset-4 hover:underline',
-        primaryAlt: 'bg-primary text-black-foreground hover:bg-primary/90',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -36,7 +36,6 @@ const multiSelectVariants = cva(
           'border-foreground/10 bg-secondary text-secondary-foreground hover:bg-secondary/80',
         destructive:
           'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
-        primaryAlt: 'primaryAlt',
       },
     },
     defaultVariants: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -49,6 +49,15 @@ export const theme = {
         foreground: 'hsl(var(--card-foreground) / <alpha-value>)',
       },
     },
+    fontSize: {
+      11: ['11px', { lineHeight: '1' }],
+      13: ['13px', { lineHeight: '1' }],
+      14: ['14px', { lineHeight: '1.4' }],
+      18: ['18px', { lineHeight: '1.4' }],
+      28: ['28px', { lineHeight: '1' }],
+      32: ['32px', { lineHeight: '1.25' }],
+      36: ['36px', { lineHeight: '1.25' }],
+    },
     borderRadius: {
       lg: 'var(--radius)',
       md: 'calc(var(--radius) - 2px)',


### PR DESCRIPTION
- Added a centralized global typography scale (11px, 13px, 14px, 18px, 28px, 32px, 36px) under `theme.extend.fontSize` in `tailwind.config.js` with appropriate line-height settings.
- Cleaned up and removed the invalid and dead `primaryAlt` variants from both `Button` and `Badge` components.
- Standardized `ProfileBadgeSection.tsx` usage to the `default` Badge variant.
- Updated `MultiSelectField` and `MultiSelect` types and configurations to safely remove `primaryAlt` references.
- Introduced `ProfileBadgeSection.test.tsx` unit tests to ensure high test coverage and validation.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/377
