### PR TITLE
chore(style): remove unused dark mode configuration and styles (X-Tracker #378)

### DIFF
--- a/src/components/filter/MentorFilterDropdown.tsx
+++ b/src/components/filter/MentorFilterDropdown.tsx
@@ -74,7 +74,7 @@ const MentorFilterDropdown = ({
 
       <Popover.Portal>
         <Popover.Content
-          className="dark:bg-white z-[55] flex max-h-[calc(var(--radix-popover-content-available-height)-8px)] w-[320px] flex-col rounded-md border border-gray-200 bg-background-white shadow-xl"
+          className="z-[55] flex max-h-[calc(var(--radix-popover-content-available-height)-8px)] w-[320px] flex-col rounded-md border border-gray-200 bg-background-white shadow-xl"
           sideOffset={8}
           collisionPadding={8}
         >

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -94,36 +94,6 @@
     --color-avatar-border: 180 16% 76%; /* #B7CBCB */
     --color-avatar-overlay: 0 0% 44%; /* #6F6F6F */
   }
-
-  .dark {
-    --background: 222.2 84% 4.9%;
-    --foreground: 210 40% 98%;
-
-    --card: 222.2 84% 4.9%;
-    --card-foreground: 210 40% 98%;
-
-    --popover: 222.2 84% 4.9%;
-    --popover-foreground: 210 40% 98%;
-
-    --primary: 210 40% 98%;
-    --primary-foreground: 222.2 47.4% 11.2%;
-
-    --secondary: 217.2 32.6% 17.5%;
-    --secondary-foreground: 210 40% 98%;
-
-    --muted: 217.2 32.6% 17.5%;
-    --muted-foreground: 215 20.2% 65.1%;
-
-    --accent: 217.2 32.6% 17.5%;
-    --accent-foreground: 210 40% 98%;
-
-    --destructive: 0 62.8% 30.6%;
-    --destructive-foreground: 210 40% 98%;
-
-    --border: 217.2 32.6% 17.5%;
-    --input: 217.2 32.6% 17.5%;
-    --ring: 212.7 26.8% 83.9%;
-  }
 }
 
 @layer base {


### PR DESCRIPTION
- Removed .dark CSS variables block from \src/styles/global.css\ as dark mode is currently unused.
- Cleaned up the residual \dark:bg-white\ variant from the Popover content inside \MentorFilterDropdown.tsx\.
- Kept \darkMode: ['class']\ untouched in \	ailwind.config.js\ to serve as a safety mechanism against accidental dark variant triggers from prefers-color-scheme.
- Retained the legitimate \dark\ color design tokens in \color.ts\ and \global.css\.
- Passed all typechecking, ESLint guidelines, Vitest unit tests, and Next.js production builds successfully.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/378
