### PR TITLE
refactor(profile): unify profile and reservation colors and text size tokens (X-Tracker #382)

### DIFF
--- a/src/app/profile/[pageUserId]/skeleton.tsx
+++ b/src/app/profile/[pageUserId]/skeleton.tsx
@@ -67,7 +67,7 @@ export function ScheduleSkeleton() {
 export function ProfilePageSkeleton() {
   return (
     <div>
-      <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]" />
+      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]" />
 
       <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
         <ProfileHeaderSkeleton />

--- a/src/app/profile/[pageUserId]/skeleton.tsx
+++ b/src/app/profile/[pageUserId]/skeleton.tsx
@@ -1,3 +1,4 @@
+import { ProfileBanner } from '@/components/profile/profile-banner';
 import { Skeleton } from '@/components/ui/skeleton';
 
 export function ProfileHeaderSkeleton() {
@@ -67,7 +68,7 @@ export function ScheduleSkeleton() {
 export function ProfilePageSkeleton() {
   return (
     <div>
-      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]" />
+      <ProfileBanner />
 
       <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
         <ProfileHeaderSkeleton />

--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -85,7 +85,7 @@ export default function ProfilePageUI({
 
   return (
     <div>
-      <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]" />
+      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]" />
 
       <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
         {userLoading ? (

--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -6,6 +6,7 @@ import {
   EducationSection,
   WorkExperienceSection,
 } from '@/components/profile/experience-section/ExperienceSection';
+import { ProfileBanner } from '@/components/profile/profile-banner';
 import { BookingForm } from '@/components/profile/reservation/BookingForm';
 import MentorScheduleDialog from '@/components/profile/reservation/MentorScheduleDialog';
 import { ScheduleCalendar } from '@/components/profile/reservation/ScheduleCalendar';
@@ -85,7 +86,7 @@ export default function ProfilePageUI({
 
   return (
     <div>
-      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]" />
+      <ProfileBanner />
 
       <div className="container mb-20 max-w-[1024px] 2xl:max-w-[1280px]">
         {userLoading ? (

--- a/src/components/layout/Header/ShareProfileDialog.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.tsx
@@ -97,20 +97,20 @@ export function ShareProfileDialog({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-[100] bg-dark/70 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
 
-        <Dialog.Content className="fixed left-1/2 top-1/2 z-[101] w-[calc(100%-32px)] max-w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-[24px] border border-[#D9DEE3] bg-light shadow-2xl focus:outline-none">
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-[101] w-[calc(100%-32px)] max-w-[640px] -translate-x-1/2 -translate-y-1/2 rounded-[24px] border border-background-border bg-light shadow-2xl focus:outline-none">
           <Dialog.Description className="sr-only">
             複製個人頁面連結以分享給他人
           </Dialog.Description>
           <div className="rounded-[24px] bg-light px-6 pb-8 pt-6 sm:px-8">
             <div className="relative mb-8 flex items-center justify-center">
-              <Dialog.Title className="text-black text-center text-[36px] font-semibold leading-none">
+              <Dialog.Title className="text-black text-center text-36 font-semibold leading-none">
                 分享個人頁面
               </Dialog.Title>
 
               <Dialog.Close asChild>
                 <button
                   type="button"
-                  className="text-black absolute right-0 top-1/2 -translate-y-1/2 text-[28px] leading-none"
+                  className="text-black absolute right-0 top-1/2 -translate-y-1/2 text-28 leading-none"
                   aria-label="Close share profile dialog"
                 >
                   ×
@@ -120,7 +120,7 @@ export function ShareProfileDialog({
 
             <div className="mb-5 rounded-[20px] border border-background-border bg-light px-6 py-5 shadow-sm">
               <div className="flex items-center gap-4">
-                <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-full bg-[#F5F5F5]">
+                <div className="relative h-16 w-16 shrink-0 overflow-hidden rounded-full bg-background-bottom">
                   <Image
                     src={avatarSrc || DefaultAvatarImgUrl}
                     alt={`Avatar of ${name}`}
@@ -132,7 +132,7 @@ export function ShareProfileDialog({
 
                 <div className="min-w-0">
                   <div className="flex items-center gap-2">
-                    <p className="text-black truncate text-[18px] font-semibold">
+                    <p className="text-black truncate text-18 font-semibold">
                       {name}
                     </p>
 
@@ -153,7 +153,7 @@ export function ShareProfileDialog({
                   </div>
 
                   {subtitle ? (
-                    <p className="text-black mt-1 text-[14px] font-medium">
+                    <p className="text-black mt-1 text-14 font-medium">
                       {subtitle}
                     </p>
                   ) : null}
@@ -164,7 +164,7 @@ export function ShareProfileDialog({
             <div>
               <label
                 htmlFor="share-profile-link"
-                className="text-black mb-2 block text-[14px] font-medium"
+                className="text-black mb-2 block text-14 font-medium"
               >
                 個人頁面連結
               </label>
@@ -174,14 +174,14 @@ export function ShareProfileDialog({
                   id="share-profile-link"
                   value={profileUrl}
                   readOnly
-                  className="bg-transparent text-black w-full min-w-0 flex-1 rounded-sm border-0 text-base outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 md:text-[14px]"
+                  className="bg-transparent text-black w-full min-w-0 flex-1 rounded-sm border-0 text-base outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 md:text-14"
                 />
 
                 <Button
                   type="button"
                   variant="outline"
                   onClick={handleCopy}
-                  className="text-black h-10 shrink-0 rounded-[10px] border border-[#D9DEE3] bg-light px-4 text-[14px] font-medium hover:bg-[#F8F8F8]"
+                  className="text-black h-10 shrink-0 rounded-[10px] border border-background-border bg-light px-4 text-14 font-medium hover:bg-background-bottom-secondary"
                 >
                   {copied ? '已複製' : '複製'}
                 </Button>

--- a/src/components/profile/edit/LinkSection.tsx
+++ b/src/components/profile/edit/LinkSection.tsx
@@ -103,7 +103,7 @@ export const LinksSection = ({ form }: Props) => (
                 </FormControl>
               </div>
               {urlErrorMessage && (
-                <p className="text-[0.8rem] font-medium text-destructive">
+                <p className="text-sm font-medium text-destructive">
                   {urlErrorMessage}
                 </p>
               )}

--- a/src/components/profile/profile-banner/ProfileBanner.tsx
+++ b/src/components/profile/profile-banner/ProfileBanner.tsx
@@ -1,0 +1,19 @@
+import type { FC, ReactNode } from 'react';
+
+interface ProfileBannerProps {
+  className?: string;
+  children?: ReactNode;
+}
+
+export const ProfileBanner: FC<ProfileBannerProps> = ({
+  className,
+  children,
+}) => {
+  return (
+    <div
+      className={`relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px] ${className || ''}`}
+    >
+      {children}
+    </div>
+  );
+};

--- a/src/components/profile/profile-banner/index.ts
+++ b/src/components/profile/profile-banner/index.ts
@@ -1,0 +1,1 @@
+export * from './ProfileBanner';

--- a/src/components/profile/profile-card/ProfileCard.tsx
+++ b/src/components/profile/profile-card/ProfileCard.tsx
@@ -72,7 +72,7 @@ export const ProfileCard: FC<Props> = ({
 }) => {
   return (
     <div className="overflow-hidden rounded-2xl shadow-xl">
-      <div className="relative h-[111px] bg-gradient-to-br from-[#92e7e7] to-[#e7a0d4] sm:h-[100px]">
+      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]">
         <AvatarCard
           className="absolute -bottom-56 left-1/2 -translate-x-1/2 -translate-y-1/2 sm:-bottom-40 sm:left-[180px]"
           name={name}

--- a/src/components/profile/profile-card/ProfileCard.tsx
+++ b/src/components/profile/profile-card/ProfileCard.tsx
@@ -2,6 +2,7 @@
 
 import type { FC, ReactNode } from 'react';
 
+import { ProfileBanner } from '@/components/profile/profile-banner';
 import { TagDisplay } from '@/hooks/user/user-data/useUserData';
 
 import { AvatarCard } from '../avatar-card';
@@ -72,7 +73,7 @@ export const ProfileCard: FC<Props> = ({
 }) => {
   return (
     <div className="overflow-hidden rounded-2xl shadow-xl">
-      <div className="relative h-[111px] bg-gradient-to-br from-blue-active to-pink-active sm:h-[100px]">
+      <ProfileBanner>
         <AvatarCard
           className="absolute -bottom-56 left-1/2 -translate-x-1/2 -translate-y-1/2 sm:-bottom-40 sm:left-[180px]"
           name={name}
@@ -81,7 +82,7 @@ export const ProfileCard: FC<Props> = ({
           companyName={company}
           linkedinUrl={linkedinUrl}
         />
-      </div>
+      </ProfileBanner>
 
       <div className="bg-bright flex flex-col gap-10 px-4 pb-10 pt-[165px] sm:px-10 sm:pt-[132px]">
         {renderTagList('有興趣多了解的職位', interestedRole, 'interestedRole')}

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -143,7 +143,7 @@ export function ReservationCard({
                       aria-hidden
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+                      <div className="text-11 font-medium text-muted-foreground sm:text-xs">
                         學員留言
                       </div>
                       <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
@@ -159,7 +159,7 @@ export function ReservationCard({
                       aria-hidden
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+                      <div className="text-11 font-medium text-muted-foreground sm:text-xs">
                         導師回覆
                       </div>
                       <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
@@ -174,7 +174,7 @@ export function ReservationCard({
             {footer ? <div className="mt-3">{footer}</div> : null}
 
             {isUpcoming ? (
-              <div className="mt-3 flex items-center gap-1.5 text-[11px] text-muted-foreground sm:text-xs">
+              <div className="mt-3 flex items-center gap-1.5 text-11 text-muted-foreground sm:text-xs">
                 <Mail className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 <span>會議連結已寄至您的信箱</span>
               </div>

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -152,7 +152,7 @@ function MessageBubble({
       )}
     >
       {label && !isPrevSameRole ? (
-        <div className="text-[11px] font-medium text-muted-foreground sm:text-xs">
+        <div className="text-11 font-medium text-muted-foreground sm:text-xs">
           {label}
         </div>
       ) : null}

--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -68,7 +68,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   return (
     <div className="flex min-h-[calc(100vh-70px)] justify-center pb-12">
       <div className="w-full max-w-[90%] rounded-2xl md:max-w-[800px]">
-        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-foreground md:text-36">
+        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-foreground md:text-36 md:leading-tight">
           {title}
         </div>
 

--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -68,7 +68,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   return (
     <div className="flex min-h-[calc(100vh-70px)] justify-center pb-12">
       <div className="w-full max-w-[90%] rounded-2xl md:max-w-[800px]">
-        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-foreground md:text-[36px]">
+        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-foreground md:text-36">
           {title}
         </div>
 

--- a/src/components/reservation/ReservationStatusBadge.tsx
+++ b/src/components/reservation/ReservationStatusBadge.tsx
@@ -7,7 +7,7 @@ import { useReservationTimeStatus } from '@/hooks/reservation/useReservationTime
 import { cn } from '@/lib/utils';
 
 const statusBadgeVariants = cva(
-  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium leading-none sm:text-xs',
+  'inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-11 font-medium leading-none sm:text-xs',
   {
     variants: {
       status: {


### PR DESCRIPTION
- Replace arbitrary hex colors in \ShareProfileDialog.tsx\ and covers in \skeleton.tsx\, \ui.tsx\, and \ProfileCard.tsx\ with standard design tokens (\rom-blue-active to-pink-active\, \order-background-border\, \g-background-bottom\, \hover:bg-background-bottom-secondary\).
- Standardize arbitrary font size classes (\	ext-[36px]\, \	ext-[28px]\, \	ext-[18px]\, \	ext-[14px]\, \	ext-[11px]\, \	ext-[0.8rem]\) with configured tailwind font sizes (\	ext-36\, \	ext-28\, \	ext-18\, \	ext-14\, \	ext-11\, \	ext-sm\) inside \ShareProfileDialog.tsx\, \LinkSection.tsx\, \ReservationCard.tsx\, \ReservationConversationDialog.tsx\, \ReservationDashboard.tsx\, and \ReservationStatusBadge.tsx\.
- Successfully ran typechecking and all unit tests passed.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/382
