### PR TITLE
docs(ui): add Storybook stories for 21 remaining UI components (X-Tracker #390)

### DIFF
--- a/src/components/ui/avatar.stories.tsx
+++ b/src/components/ui/avatar.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Avatar, AvatarFallback, AvatarImage } from './avatar';
+
+const meta: Meta<typeof Avatar> = {
+  title: 'Components/UI/Avatar',
+  component: Avatar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Avatar>;
+
+// 1. With Image
+export const WithImage: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
+      <AvatarFallback>CN</AvatarFallback>
+    </Avatar>
+  ),
+};
+
+// 2. Fallback Only
+export const FallbackOnly: Story = {
+  render: (args) => (
+    <Avatar {...args}>
+      <AvatarImage src="" alt="Nonexistent User" />
+      <AvatarFallback>XT</AvatarFallback>
+    </Avatar>
+  ),
+};

--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React, { useState } from 'react';
+
+import { Calendar } from './calendar';
+
+const meta: Meta<typeof Calendar> = {
+  title: 'Components/UI/Calendar',
+  component: Calendar,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Calendar>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [date, setDate] = useState<Date | undefined>(new Date());
+    return (
+      <div className="w-fit rounded-lg border bg-card p-4 shadow">
+        <Calendar {...args} mode="single" selected={date} onSelect={setDate} />
+        {date && (
+          <p className="mt-4 text-center text-sm text-muted-foreground">
+            您選取的日期是: {date.toLocaleDateString()}
+          </p>
+        )}
+      </div>
+    );
+  },
+};
+
+// 2. Profile Variant
+export const ProfileVariant: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [date, setDate] = useState<Date | undefined>(new Date());
+    return (
+      <div className="w-fit rounded-lg border bg-card p-4 shadow">
+        <Calendar
+          {...args}
+          variant="profile"
+          mode="single"
+          selected={date}
+          onSelect={setDate}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -12,39 +12,41 @@ const meta: Meta<typeof Calendar> = {
 export default meta;
 type Story = StoryObj<typeof Calendar>;
 
+const CalendarDemo = (args: React.ComponentProps<typeof Calendar>) => {
+  const [date, setDate] = useState<Date | undefined>(new Date());
+  return (
+    <div className="w-fit rounded-lg border bg-card p-4 shadow">
+      <Calendar {...args} mode="single" selected={date} onSelect={setDate} />
+      {date && (
+        <p className="mt-4 text-center text-sm text-muted-foreground">
+          您選取的日期是: {date.toLocaleDateString()}
+        </p>
+      )}
+    </div>
+  );
+};
+
+const CalendarProfileDemo = (args: React.ComponentProps<typeof Calendar>) => {
+  const [date, setDate] = useState<Date | undefined>(new Date());
+  return (
+    <div className="w-fit rounded-lg border bg-card p-4 shadow">
+      <Calendar
+        {...args}
+        variant="profile"
+        mode="single"
+        selected={date}
+        onSelect={setDate}
+      />
+    </div>
+  );
+};
+
 // 1. Basic Interactive Demo
 export const Default: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [date, setDate] = useState<Date | undefined>(new Date());
-    return (
-      <div className="w-fit rounded-lg border bg-card p-4 shadow">
-        <Calendar {...args} mode="single" selected={date} onSelect={setDate} />
-        {date && (
-          <p className="mt-4 text-center text-sm text-muted-foreground">
-            您選取的日期是: {date.toLocaleDateString()}
-          </p>
-        )}
-      </div>
-    );
-  },
+  render: (args) => <CalendarDemo {...args} />,
 };
 
 // 2. Profile Variant
 export const ProfileVariant: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [date, setDate] = useState<Date | undefined>(new Date());
-    return (
-      <div className="w-fit rounded-lg border bg-card p-4 shadow">
-        <Calendar
-          {...args}
-          variant="profile"
-          mode="single"
-          selected={date}
-          onSelect={setDate}
-        />
-      </div>
-    );
-  },
+  render: (args) => <CalendarProfileDemo {...args} />,
 };

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from './button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from './card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/UI/Card',
+  component: Card,
+  tags: ['autodocs'],
+  argTypes: {
+    className: {
+      control: 'text',
+      description: 'Custom CSS classes for styling the card',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <Card {...args} className="w-[350px]">
+      <CardHeader>
+        <CardTitle>建立專案</CardTitle>
+        <CardDescription>一鍵部署您的新專案與相關設定。</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="grid w-full items-center gap-4">
+          <div className="flex flex-col space-y-1.5">
+            <span className="text-sm font-medium">專案名稱</span>
+            <div className="bg-slate-50 rounded border p-2 text-sm text-muted-foreground">
+              My New Awesome Project
+            </div>
+          </div>
+        </div>
+      </CardContent>
+      <CardFooter className="flex justify-between">
+        <Button variant="outline">取消</Button>
+        <Button>部署</Button>
+      </CardFooter>
+    </Card>
+  ),
+};
+
+// 2. Simple Card (No Header/Footer)
+export const ContentOnly: Story = {
+  render: (args) => (
+    <Card {...args} className="w-[350px]">
+      <CardContent className="pt-6">
+        <p className="text-sm text-muted-foreground">
+          這是一個極簡卡片，只包含內容區塊，適合用在格狀版面 (Grid)
+          中展示簡單的統計數據或資訊卡片。
+        </p>
+      </CardContent>
+    </Card>
+  ),
+};
+
+// 3. Status Card Demo
+export const StatusCard: Story = {
+  render: (args) => (
+    <div className="flex flex-wrap gap-4">
+      <Card {...args} className="border-l-emerald-500 w-[250px] border-l-4">
+        <CardHeader className="pb-2">
+          <CardDescription>已同步導師</CardDescription>
+          <CardTitle className="text-emerald-600 text-3xl font-bold">
+            128 位
+          </CardTitle>
+        </CardHeader>
+      </Card>
+      <Card {...args} className="border-l-amber-500 w-[250px] border-l-4">
+        <CardHeader className="pb-2">
+          <CardDescription>待審核清單</CardDescription>
+          <CardTitle className="text-amber-600 text-3xl font-bold">
+            12 筆
+          </CardTitle>
+        </CardHeader>
+      </Card>
+    </div>
+  ),
+};

--- a/src/components/ui/category-multi-select.stories.tsx
+++ b/src/components/ui/category-multi-select.stories.tsx
@@ -1,0 +1,73 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React, { useState } from 'react';
+
+import { CategoryMultiSelect } from './category-multi-select';
+
+const meta: Meta<typeof CategoryMultiSelect> = {
+  title: 'Components/UI/CategoryMultiSelect',
+  component: CategoryMultiSelect,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof CategoryMultiSelect>;
+
+const CATEGORIES = [
+  {
+    key: 'tech',
+    label: '技術開發',
+    options: [
+      { value: 'frontend', label: '前端開發 (Frontend)' },
+      { value: 'backend', label: '後端開發 (Backend)' },
+      { value: 'devops', label: '雲端運維 (DevOps)' },
+    ],
+  },
+  {
+    key: 'design',
+    label: '設計與行銷',
+    options: [
+      { value: 'uiux', label: 'UI/UX 設計' },
+      { value: 'marketing', label: '社群行銷' },
+    ],
+  },
+];
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selected, setSelected] = useState<string[]>(['frontend']);
+    return (
+      <div className="max-w-md">
+        <CategoryMultiSelect
+          {...args}
+          categories={CATEGORIES}
+          value={selected}
+          onChange={setSelected}
+        />
+        <div className="mt-4 text-sm text-muted-foreground">
+          已選取: {selected.join(', ') || '無'}
+        </div>
+      </div>
+    );
+  },
+};
+
+// 2. Flat List Demo
+export const FlatList: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selected, setSelected] = useState<string[]>([]);
+    return (
+      <div className="max-w-md">
+        <CategoryMultiSelect
+          {...args}
+          flat
+          categories={CATEGORIES}
+          value={selected}
+          onChange={setSelected}
+        />
+      </div>
+    );
+  },
+};

--- a/src/components/ui/category-multi-select.stories.tsx
+++ b/src/components/ui/category-multi-select.stories.tsx
@@ -32,42 +32,48 @@ const CATEGORIES = [
   },
 ];
 
+const CategoryMultiSelectDemo = (
+  args: React.ComponentProps<typeof CategoryMultiSelect>
+) => {
+  const [selected, setSelected] = useState<string[]>(['frontend']);
+  return (
+    <div className="max-w-md">
+      <CategoryMultiSelect
+        {...args}
+        categories={CATEGORIES}
+        value={selected}
+        onChange={setSelected}
+      />
+      <div className="mt-4 text-sm text-muted-foreground">
+        已選取: {selected.join(', ') || '無'}
+      </div>
+    </div>
+  );
+};
+
+const CategoryMultiSelectFlatDemo = (
+  args: React.ComponentProps<typeof CategoryMultiSelect>
+) => {
+  const [selected, setSelected] = useState<string[]>([]);
+  return (
+    <div className="max-w-md">
+      <CategoryMultiSelect
+        {...args}
+        flat
+        categories={CATEGORIES}
+        value={selected}
+        onChange={setSelected}
+      />
+    </div>
+  );
+};
+
 // 1. Basic Interactive Demo
 export const Default: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string[]>(['frontend']);
-    return (
-      <div className="max-w-md">
-        <CategoryMultiSelect
-          {...args}
-          categories={CATEGORIES}
-          value={selected}
-          onChange={setSelected}
-        />
-        <div className="mt-4 text-sm text-muted-foreground">
-          已選取: {selected.join(', ') || '無'}
-        </div>
-      </div>
-    );
-  },
+  render: (args) => <CategoryMultiSelectDemo {...args} />,
 };
 
 // 2. Flat List Demo
 export const FlatList: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string[]>([]);
-    return (
-      <div className="max-w-md">
-        <CategoryMultiSelect
-          {...args}
-          flat
-          categories={CATEGORIES}
-          value={selected}
-          onChange={setSelected}
-        />
-      </div>
-    );
-  },
+  render: (args) => <CategoryMultiSelectFlatDemo {...args} />,
 };

--- a/src/components/ui/checkbox.stories.tsx
+++ b/src/components/ui/checkbox.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Checkbox } from './checkbox';
+import { Label } from './label';
+
+const meta: Meta<typeof Checkbox> = {
+  title: 'Components/UI/Checkbox',
+  component: Checkbox,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the checkbox is disabled',
+    },
+    checked: {
+      control: 'boolean',
+      description: 'Whether the checkbox is checked',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Checkbox>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <div className="flex items-center space-x-2">
+      <Checkbox id="terms" {...args} />
+      <Label htmlFor="terms">我同意服務條款與隱私權政策</Label>
+    </div>
+  ),
+};
+
+// 2. Disabled Checkbox
+export const Disabled: Story = {
+  render: (args) => (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center space-x-2">
+        <Checkbox id="terms-disabled" {...args} disabled />
+        <Label htmlFor="terms-disabled">未勾選且禁用</Label>
+      </div>
+      <div className="flex items-center space-x-2">
+        <Checkbox
+          id="terms-disabled-checked"
+          {...args}
+          disabled
+          defaultChecked
+        />
+        <Label htmlFor="terms-disabled-checked">已勾選且禁用</Label>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from './button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from './dialog';
+
+const meta: Meta<typeof Dialog> = {
+  title: 'Components/UI/Dialog',
+  component: Dialog,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Dialog>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="outline">開啟對話框</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[425px]">
+        <DialogHeader>
+          <DialogTitle>編輯個人資料</DialogTitle>
+          <DialogDescription>
+            在此修改您的帳戶資訊。完成後點擊儲存。
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid gap-4 py-4">
+          <div className="grid grid-cols-4 items-center gap-4">
+            <label className="text-right text-sm font-medium">姓名</label>
+            <input
+              className="col-span-3 rounded border p-2 text-sm"
+              defaultValue="Alex Chen"
+            />
+          </div>
+          <div className="grid grid-cols-4 items-center gap-4">
+            <label className="text-right text-sm font-medium">電子信箱</label>
+            <input
+              className="col-span-3 rounded border p-2 text-sm"
+              defaultValue="alex@xchange.tw"
+            />
+          </div>
+        </div>
+        <DialogFooter>
+          <Button type="submit">儲存變更</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};
+
+// 2. Alert/Confirm Style Dialog
+export const Confirmation: Story = {
+  render: (args) => (
+    <Dialog {...args}>
+      <DialogTrigger asChild>
+        <Button variant="destructive">刪除帳號</Button>
+      </DialogTrigger>
+      <DialogContent className="sm:max-w-[400px]">
+        <DialogHeader>
+          <DialogTitle>您確定要刪除帳號嗎？</DialogTitle>
+          <DialogDescription>
+            此動作無法復原。這將永久刪除您的帳號並從我們的伺服器中移除您的所有資料。
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="gap-2 sm:gap-0">
+          <Button variant="outline">取消</Button>
+          <Button variant="destructive">確定刪除</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  ),
+};

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -47,7 +47,7 @@ export const Default: Story = {
             <label className="text-right text-sm font-medium">電子信箱</label>
             <input
               className="col-span-3 rounded border p-2 text-sm"
-              defaultValue="alex@xchange.tw"
+              defaultValue="alex@example.com"
             />
           </div>
         </div>

--- a/src/components/ui/dropdown-menu.stories.tsx
+++ b/src/components/ui/dropdown-menu.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from './button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuGroup,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from './dropdown-menu';
+
+const meta: Meta<typeof DropdownMenu> = {
+  title: 'Components/UI/DropdownMenu',
+  component: DropdownMenu,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropdownMenu>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <DropdownMenu {...args}>
+      <DropdownMenuTrigger asChild>
+        <Button variant="outline">個人選單</Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent className="w-56">
+        <DropdownMenuGroup>
+          <DropdownMenuItem>個人檔案</DropdownMenuItem>
+          <DropdownMenuItem>帳戶與設定</DropdownMenuItem>
+        </DropdownMenuGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuSub>
+          <DropdownMenuSubTrigger>邀請好友</DropdownMenuSubTrigger>
+          <DropdownMenuSubContent>
+            <DropdownMenuItem>透過 Email 邀請</DropdownMenuItem>
+            <DropdownMenuItem>複製邀請連結</DropdownMenuItem>
+          </DropdownMenuSubContent>
+        </DropdownMenuSub>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem className="text-destructive">登出</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  ),
+};

--- a/src/components/ui/label.stories.tsx
+++ b/src/components/ui/label.stories.tsx
@@ -1,0 +1,17 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Label } from './label';
+
+const meta: Meta<typeof Label> = {
+  title: 'Components/UI/Label',
+  component: Label,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Label>;
+
+export const Default: Story = {
+  render: (args) => <Label {...args}>姓名 (Name)</Label>,
+};

--- a/src/components/ui/loading-spinner.stories.tsx
+++ b/src/components/ui/loading-spinner.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { LoadingSpinner, PageLoading } from './loading-spinner';
+
+const meta: Meta<typeof LoadingSpinner> = {
+  title: 'Components/UI/LoadingSpinner',
+  component: LoadingSpinner,
+  tags: ['autodocs'],
+  argTypes: {
+    size: {
+      control: 'select',
+      options: ['sm', 'md', 'lg'],
+      description: 'The size of the loading spinner',
+    },
+    label: {
+      control: 'text',
+      description: 'The accessibility label for screen readers',
+    },
+  },
+  args: {
+    size: 'md',
+    label: '載入中',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof LoadingSpinner>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  args: {},
+};
+
+// 2. All Sizes Comparison
+export const AllSizes: Story = {
+  render: (args) => (
+    <div className="flex items-center gap-6">
+      <div className="flex flex-col items-center gap-1.5">
+        <LoadingSpinner {...args} size="sm" />
+        <span className="text-xs text-muted-foreground">小 (sm)</span>
+      </div>
+      <div className="flex flex-col items-center gap-1.5">
+        <LoadingSpinner {...args} size="md" />
+        <span className="text-xs text-muted-foreground">中 (md)</span>
+      </div>
+      <div className="flex flex-col items-center gap-1.5">
+        <LoadingSpinner {...args} size="lg" />
+        <span className="text-xs text-muted-foreground">大 (lg)</span>
+      </div>
+    </div>
+  ),
+};
+
+// 3. Full Page Loading State
+export const PageLoadingDemo: Story = {
+  render: () => <PageLoading />,
+};

--- a/src/components/ui/multi-select.stories.tsx
+++ b/src/components/ui/multi-select.stories.tsx
@@ -21,24 +21,25 @@ const OPTIONS = [
   { label: 'UI/UX 設計 (Design)', value: 'design', icon: Sparkles },
 ];
 
+const MultiSelectDemo = (args: React.ComponentProps<typeof MultiSelect>) => {
+  const [selected, setSelected] = useState<string[]>(['coding']);
+  return (
+    <div className="max-w-md">
+      <MultiSelect
+        {...args}
+        options={OPTIONS}
+        value={selected}
+        onValueChange={setSelected}
+        placeholder="請選擇您的興趣愛好..."
+      />
+      <div className="mt-4 text-sm text-muted-foreground">
+        目前選取值: {selected.join(', ') || '無'}
+      </div>
+    </div>
+  );
+};
+
 // 1. Basic Interactive Demo
 export const Default: Story = {
-  render: (args) => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const [selected, setSelected] = useState<string[]>(['coding']);
-    return (
-      <div className="max-w-md">
-        <MultiSelect
-          {...args}
-          options={OPTIONS}
-          value={selected}
-          onValueChange={setSelected}
-          placeholder="請選擇您的興趣愛好..."
-        />
-        <div className="mt-4 text-sm text-muted-foreground">
-          目前選取值: {selected.join(', ') || '無'}
-        </div>
-      </div>
-    );
-  },
+  render: (args) => <MultiSelectDemo {...args} />,
 };

--- a/src/components/ui/multi-select.stories.tsx
+++ b/src/components/ui/multi-select.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { Calendar, Code, Heart, Music, Sparkles } from 'lucide-react';
+import React, { useState } from 'react';
+
+import { MultiSelect } from './multi-select';
+
+const meta: Meta<typeof MultiSelect> = {
+  title: 'Components/UI/MultiSelect',
+  component: MultiSelect,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof MultiSelect>;
+
+const OPTIONS = [
+  { label: '程式開發 (Coding)', value: 'coding', icon: Code },
+  { label: '音樂創作 (Music)', value: 'music', icon: Music },
+  { label: '運動健身 (Sports)', value: 'sports', icon: Heart },
+  { label: '活動策劃 (Events)', value: 'events', icon: Calendar },
+  { label: 'UI/UX 設計 (Design)', value: 'design', icon: Sparkles },
+];
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    const [selected, setSelected] = useState<string[]>(['coding']);
+    return (
+      <div className="max-w-md">
+        <MultiSelect
+          {...args}
+          options={OPTIONS}
+          value={selected}
+          onValueChange={setSelected}
+          placeholder="請選擇您的興趣愛好..."
+        />
+        <div className="mt-4 text-sm text-muted-foreground">
+          目前選取值: {selected.join(', ') || '無'}
+        </div>
+      </div>
+    );
+  },
+};

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -25,7 +25,7 @@ export const Default: Story = {
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Alex Chen</h4>
             <p className="font-mono text-xs text-muted-foreground">
-              alex@xchange.tw
+              alex@example.com
             </p>
           </div>
           <div className="border-t pt-2">

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from './button';
+import { Popover, PopoverContent, PopoverTrigger } from './popover';
+
+const meta: Meta<typeof Popover> = {
+  title: 'Components/UI/Popover',
+  component: Popover,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Popover>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <Popover {...args}>
+      <PopoverTrigger asChild>
+        <Button variant="outline">聯絡資訊</Button>
+      </PopoverTrigger>
+      <PopoverContent className="w-80">
+        <div className="grid gap-4">
+          <div className="space-y-2">
+            <h4 className="font-medium leading-none">Alex Chen</h4>
+            <p className="font-mono text-xs text-muted-foreground">
+              alex@xchange.tw
+            </p>
+          </div>
+          <div className="border-t pt-2">
+            <p className="text-sm">歡迎透過電子信箱與我們聯絡！</p>
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  ),
+};

--- a/src/components/ui/progress.stories.tsx
+++ b/src/components/ui/progress.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Progress } from './progress';
+
+const meta: Meta<typeof Progress> = {
+  title: 'Components/UI/Progress',
+  component: Progress,
+  tags: ['autodocs'],
+  argTypes: {
+    value: {
+      control: { type: 'number', min: 0, max: 100 },
+      description: 'The completion value of the progress bar',
+    },
+  },
+  args: {
+    value: 60,
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Progress>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  args: {
+    value: 33,
+  },
+};
+
+// 2. Comparison of Values
+export const Comparisons: Story = {
+  render: () => (
+    <div className="flex max-w-md flex-col gap-4">
+      <div className="space-y-1.5">
+        <span className="text-xs text-muted-foreground">進度：0%</span>
+        <Progress value={0} />
+      </div>
+      <div className="space-y-1.5">
+        <span className="text-xs text-muted-foreground">進度：50%</span>
+        <Progress value={50} />
+      </div>
+      <div className="space-y-1.5">
+        <span className="text-xs text-muted-foreground">進度：100%</span>
+        <Progress value={100} />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/search-bar.stories.tsx
+++ b/src/components/ui/search-bar.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import SearchBar from './search-bar';
+
+const meta: Meta<typeof SearchBar> = {
+  title: 'Components/UI/SearchBar',
+  component: SearchBar,
+  tags: ['autodocs'],
+  argTypes: {
+    placeholder: {
+      control: 'text',
+      description: 'The placeholder text of the search bar',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof SearchBar>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  args: {
+    onSearch: async (query) => {
+      alert(`正在搜尋: ${query}`);
+    },
+    placeholder: '搜尋想精進的領域、導師姓名或產業關鍵字...',
+  },
+};

--- a/src/components/ui/select-options.stories.tsx
+++ b/src/components/ui/select-options.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { SelectOptions } from './select-options';
+
+const meta: Meta<typeof SelectOptions> = {
+  title: 'Components/UI/SelectOptions',
+  component: SelectOptions,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof SelectOptions>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  args: {
+    selectItemData: {
+      label: '請選擇您的專業領域',
+      placeholder: '選擇領域',
+      options: ['UI/UX 設計', '前端開發', '後端開發', '產品管理', '行銷企劃'],
+    },
+  },
+};

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -1,0 +1,59 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import {
+  Select,
+  SelectContent,
+  SelectGroup,
+  SelectItem,
+  SelectLabel,
+  SelectTrigger,
+  SelectValue,
+} from './select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/UI/Select',
+  component: Select,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Select>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <div className="w-[180px]">
+      <Select {...args}>
+        <SelectTrigger>
+          <SelectValue placeholder="選擇主題" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectGroup>
+            <SelectLabel>主題</SelectLabel>
+            <SelectItem value="light">淺色模式 (Light)</SelectItem>
+            <SelectItem value="dark">深色模式 (Dark)</SelectItem>
+            <SelectItem value="system">系統預設 (System)</SelectItem>
+          </SelectGroup>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+};
+
+// 2. Disabled Select
+export const Disabled: Story = {
+  render: (args) => (
+    <div className="w-[180px]">
+      <Select {...args} disabled>
+        <SelectTrigger>
+          <SelectValue placeholder="選擇城市" />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="tpe">台北市</SelectItem>
+          <SelectItem value="khh">高雄市</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  ),
+};

--- a/src/components/ui/separator.stories.tsx
+++ b/src/components/ui/separator.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Separator } from './separator';
+
+const meta: Meta<typeof Separator> = {
+  title: 'Components/UI/Separator',
+  component: Separator,
+  tags: ['autodocs'],
+  argTypes: {
+    orientation: {
+      control: 'select',
+      options: ['horizontal', 'vertical'],
+      description: 'The orientation of the separator',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Separator>;
+
+// 1. Horizontal Demo
+export const Horizontal: Story = {
+  render: (args) => (
+    <div className="max-w-md">
+      <div className="space-y-1">
+        <h4 className="text-sm font-medium leading-none">X-Talent UI</h4>
+        <p className="text-sm text-muted-foreground">
+          為 Xchange 建立的高品質前端元件庫。
+        </p>
+      </div>
+      <Separator className="my-4" {...args} orientation="horizontal" />
+      <div className="flex h-5 items-center space-x-4 text-sm">
+        <div>React</div>
+        <div>TypeScript</div>
+        <div>Tailwind CSS</div>
+      </div>
+    </div>
+  ),
+};
+
+// 2. Vertical Demo
+export const Vertical: Story = {
+  render: (args) => (
+    <div className="flex h-5 items-center space-x-4 text-sm">
+      <span>設計圖 (UI)</span>
+      <Separator {...args} orientation="vertical" />
+      <span>前端開發 (FE)</span>
+      <Separator {...args} orientation="vertical" />
+      <span>後端開發 (BE)</span>
+    </div>
+  ),
+};

--- a/src/components/ui/sheet.stories.tsx
+++ b/src/components/ui/sheet.stories.tsx
@@ -1,0 +1,82 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from './button';
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetFooter,
+  SheetHeader,
+  SheetTitle,
+  SheetTrigger,
+} from './sheet';
+
+const meta: Meta<typeof Sheet> = {
+  title: 'Components/UI/Sheet',
+  component: Sheet,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Sheet>;
+
+// 1. Basic Interactive Demo (Right Side)
+export const Default: Story = {
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">開啟側邊欄 (右側)</Button>
+      </SheetTrigger>
+      <SheetContent side="right" showPrimitiveClose>
+        <SheetHeader>
+          <SheetTitle>導航選單</SheetTitle>
+          <SheetDescription>
+            快速瀏覽本站的所有主要功能與設定。
+          </SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-4 py-4">
+          <div className="flex flex-col gap-2">
+            <Button variant="ghost" className="justify-start">
+              首頁
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              找導師
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              個人檔案
+            </Button>
+            <Button variant="ghost" className="justify-start">
+              預約紀錄
+            </Button>
+          </div>
+        </div>
+        <SheetFooter>
+          <Button variant="outline" className="w-full">
+            登出
+          </Button>
+        </SheetFooter>
+      </SheetContent>
+    </Sheet>
+  ),
+};
+
+// 2. Left Side Sheet
+export const LeftSide: Story = {
+  render: (args) => (
+    <Sheet {...args}>
+      <SheetTrigger asChild>
+        <Button variant="outline">開啟側邊欄 (左側)</Button>
+      </SheetTrigger>
+      <SheetContent side="left" showPrimitiveClose>
+        <SheetHeader>
+          <SheetTitle>篩選條件</SheetTitle>
+          <SheetDescription>依據您的需求過濾搜尋結果。</SheetDescription>
+        </SheetHeader>
+        <div className="grid gap-4 py-4">
+          <p className="text-sm text-muted-foreground">在此放置篩選器元件...</p>
+        </div>
+      </SheetContent>
+    </Sheet>
+  ),
+};

--- a/src/components/ui/skeleton.stories.tsx
+++ b/src/components/ui/skeleton.stories.tsx
@@ -1,0 +1,31 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Skeleton } from './skeleton';
+
+const meta: Meta<typeof Skeleton> = {
+  title: 'Components/UI/Skeleton',
+  component: Skeleton,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Skeleton>;
+
+// 1. Basic Shape
+export const Default: Story = {
+  render: () => <Skeleton className="h-4 w-[250px]" />,
+};
+
+// 2. Profile Card Loading Template
+export const LoadingCard: Story = {
+  render: () => (
+    <div className="flex max-w-sm items-center space-x-4 rounded-lg border bg-card p-4">
+      <Skeleton className="h-12 w-12 rounded-full" />
+      <div className="space-y-2">
+        <Skeleton className="h-4 w-[200px]" />
+        <Skeleton className="h-4 w-[150px]" />
+      </div>
+    </div>
+  ),
+};

--- a/src/components/ui/tabs.stories.tsx
+++ b/src/components/ui/tabs.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
+
+const meta: Meta<typeof Tabs> = {
+  title: 'Components/UI/Tabs',
+  component: Tabs,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Tabs>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  render: (args) => (
+    <Tabs {...args} defaultValue="account" className="w-[400px]">
+      <TabsList className="grid w-full grid-cols-2">
+        <TabsTrigger value="account">帳戶設定</TabsTrigger>
+        <TabsTrigger value="password">密碼安全</TabsTrigger>
+      </TabsList>
+      <TabsContent value="account">
+        <div className="rounded-lg border p-4">
+          <h3 className="text-lg font-medium">帳戶資訊</h3>
+          <p className="mb-4 text-sm text-muted-foreground">
+            在此管理您的帳戶基本設定與偏好。
+          </p>
+          <div className="space-y-2">
+            <span className="text-sm font-medium">使用者名稱</span>
+            <div className="bg-slate-50 rounded border p-2 text-sm text-muted-foreground">
+              alex_chen
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+      <TabsContent value="password">
+        <div className="rounded-lg border p-4">
+          <h3 className="text-lg font-medium">重設密碼</h3>
+          <p className="mb-4 text-sm text-muted-foreground">
+            為了帳戶安全，請定期更新您的密碼。
+          </p>
+          <div className="space-y-2">
+            <span className="text-sm font-medium">新密碼</span>
+            <div className="bg-slate-50 rounded border p-2 text-sm text-muted-foreground">
+              ********
+            </div>
+          </div>
+        </div>
+      </TabsContent>
+    </Tabs>
+  ),
+};

--- a/src/components/ui/textarea.stories.tsx
+++ b/src/components/ui/textarea.stories.tsx
@@ -1,0 +1,41 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { Textarea } from './textarea';
+
+const meta: Meta<typeof Textarea> = {
+  title: 'Components/UI/Textarea',
+  component: Textarea,
+  tags: ['autodocs'],
+  argTypes: {
+    disabled: {
+      control: 'boolean',
+      description: 'Whether the textarea is disabled',
+    },
+    placeholder: {
+      control: 'text',
+      description: 'The placeholder text of the textarea',
+    },
+  },
+  args: {
+    disabled: false,
+    placeholder: '請輸入內容...',
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Textarea>;
+
+// 1. Basic Interactive Demo
+export const Default: Story = {
+  args: {
+    placeholder: '在此輸入您的自傳或專案描述...',
+  },
+};
+
+// 2. Disabled Textarea
+export const Disabled: Story = {
+  args: {
+    disabled: true,
+    defaultValue: '這是已被禁用的文字輸入區域，不可修改。',
+  },
+};

--- a/src/components/ui/toast.stories.tsx
+++ b/src/components/ui/toast.stories.tsx
@@ -1,0 +1,56 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import {
+  Toast,
+  ToastAction,
+  ToastClose,
+  ToastDescription,
+  ToastProvider,
+  ToastTitle,
+  ToastViewport,
+} from './toast';
+
+const meta: Meta<typeof Toast> = {
+  title: 'Components/UI/Toast',
+  component: Toast,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Toast>;
+
+// 1. Default Toast Style
+export const Default: Story = {
+  render: (args) => (
+    <ToastProvider>
+      <Toast {...args}>
+        <div className="grid gap-1">
+          <ToastTitle>系統提示</ToastTitle>
+          <ToastDescription>您的個人資料已成功同步更新！</ToastDescription>
+        </div>
+        <ToastClose />
+      </Toast>
+      <ToastViewport className="relative max-w-sm rounded border p-4" />
+    </ToastProvider>
+  ),
+};
+
+// 2. Destructive Toast Style
+export const Destructive: Story = {
+  render: (args) => (
+    <ToastProvider>
+      <Toast {...args} variant="destructive">
+        <div className="grid gap-1">
+          <ToastTitle>連線錯誤</ToastTitle>
+          <ToastDescription>無法連接至伺服器，請稍後再試。</ToastDescription>
+        </div>
+        <ToastAction altText="Try again" className="border-red-400 text-white">
+          重試
+        </ToastAction>
+        <ToastClose />
+      </Toast>
+      <ToastViewport className="relative max-w-sm rounded border p-4" />
+    </ToastProvider>
+  ),
+};


### PR DESCRIPTION
Implement comprehensive Storybook stories for remaining UI components in src/components/ui/. Covered prioritized components (Card, Dialog, Select, Tabs, Sheet) as well as 16 other supporting components. Each story file covers default states, main visual variants, and size/side configurations.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/390
