### PR TITLE
refactor(style): clean up and modularize status design tokens (X-Tracker #392)

### DIFF
--- a/src/app/auth/password-forgot/page.tsx
+++ b/src/app/auth/password-forgot/page.tsx
@@ -35,7 +35,7 @@ export default function Page() {
                 {...register('email')}
               />
               {errors.email && (
-                <p className="text-sm text-status-200">
+                <p className="text-sm text-status-error-default">
                   {errors.email.message}
                 </p>
               )}

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -108,13 +108,20 @@ vi.mock('@/components/profile/edit/Section', () => ({
     id,
     title,
     children,
+    required = false,
   }: {
     id?: string;
     title?: React.ReactNode;
     children: React.ReactNode;
+    required?: boolean;
   }) => (
     <div id={id} data-testid={`section-${id}`}>
-      {title && <span data-testid={`section-${id}-title`}>{title}</span>}
+      {title && (
+        <span data-testid={`section-${id}-title`}>
+          {required && '* '}
+          {title}
+        </span>
+      )}
       {children}
     </div>
   ),

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -210,7 +210,7 @@ export default function EditProfileContainer({
             id="name"
             title={
               <>
-                <span className="text-status-200">* </span>姓名
+                <span className="text-status-error-default">* </span>姓名
               </>
             }
           >
@@ -221,7 +221,9 @@ export default function EditProfileContainer({
             id="about"
             title={
               <>
-                {isMentorRole && <span className="text-status-200">* </span>}
+                {isMentorRole && (
+                  <span className="text-status-error-default">* </span>
+                )}
                 關於我
               </>
             }
@@ -234,7 +236,8 @@ export default function EditProfileContainer({
               id="have_topic"
               title={
                 <>
-                  <span className="text-status-200">* </span>我能提供的服務
+                  <span className="text-status-error-default">* </span>
+                  我能提供的服務
                 </>
               }
             >
@@ -253,7 +256,7 @@ export default function EditProfileContainer({
               id="have_skill"
               title={
                 <>
-                  <span className="text-status-200">* </span>專業能力
+                  <span className="text-status-error-default">* </span>專業能力
                 </>
               }
             >
@@ -271,7 +274,7 @@ export default function EditProfileContainer({
             id="location"
             title={
               <>
-                <span className="text-status-200">* </span>地區
+                <span className="text-status-error-default">* </span>地區
               </>
             }
           >
@@ -290,7 +293,7 @@ export default function EditProfileContainer({
             id="years_of_experience"
             title={
               <>
-                <span className="text-status-200">* </span>經驗
+                <span className="text-status-error-default">* </span>經驗
               </>
             }
           >
@@ -306,7 +309,9 @@ export default function EditProfileContainer({
             id="industry"
             title={
               <>
-                {isMentorRole && <span className="text-status-200">* </span>}
+                {isMentorRole && (
+                  <span className="text-status-error-default">* </span>
+                )}
                 產業
               </>
             }
@@ -326,7 +331,8 @@ export default function EditProfileContainer({
             id="want_position"
             title={
               <>
-                <span className="text-status-200">* </span>有興趣多了解的職位
+                <span className="text-status-error-default">* </span>
+                有興趣多了解的職位
               </>
             }
           >
@@ -343,7 +349,8 @@ export default function EditProfileContainer({
             id="want_skill"
             title={
               <>
-                <span className="text-status-200">* </span>想多了解、加強的技能
+                <span className="text-status-error-default">* </span>
+                想多了解、加強的技能
               </>
             }
           >
@@ -360,7 +367,8 @@ export default function EditProfileContainer({
             id="want_topic"
             title={
               <>
-                <span className="text-status-200">* </span>想多了解的主題
+                <span className="text-status-error-default">* </span>
+                想多了解的主題
               </>
             }
           >

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -206,41 +206,16 @@ export default function EditProfileContainer({
             }
           />
 
-          <Section
-            id="name"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>姓名
-              </>
-            }
-          >
+          <Section id="name" title="姓名" required>
             <TextField form={form} name="name" placeholder="請填入您的姓名" />
           </Section>
 
-          <Section
-            id="about"
-            title={
-              <>
-                {isMentorRole && (
-                  <span className="text-status-error-default">* </span>
-                )}
-                關於我
-              </>
-            }
-          >
+          <Section id="about" title="關於我" required={isMentorRole}>
             <TextareaField form={form} name="about" rows={10} />
           </Section>
 
           {isMentorRole && (
-            <Section
-              id="have_topic"
-              title={
-                <>
-                  <span className="text-status-error-default">* </span>
-                  我能提供的服務
-                </>
-              }
-            >
+            <Section id="have_topic" title="我能提供的服務" required>
               <CategoryMultiSelectField
                 form={form}
                 name="have_topic"
@@ -252,14 +227,7 @@ export default function EditProfileContainer({
           )}
 
           {isMentorRole && (
-            <Section
-              id="have_skill"
-              title={
-                <>
-                  <span className="text-status-error-default">* </span>專業能力
-                </>
-              }
-            >
+            <Section id="have_skill" title="專業能力" required>
               <CategoryMultiSelectField
                 form={form}
                 name="have_skill"
@@ -270,14 +238,7 @@ export default function EditProfileContainer({
             </Section>
           )}
 
-          <Section
-            id="location"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>地區
-              </>
-            }
-          >
+          <Section id="location" title="地區" required>
             <SelectField
               form={form}
               name="location"
@@ -289,14 +250,7 @@ export default function EditProfileContainer({
             />
           </Section>
 
-          <Section
-            id="years_of_experience"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>經驗
-              </>
-            }
-          >
+          <Section id="years_of_experience" title="經驗" required>
             <SelectField
               form={form}
               name="years_of_experience"
@@ -305,17 +259,7 @@ export default function EditProfileContainer({
             />
           </Section>
 
-          <Section
-            id="industry"
-            title={
-              <>
-                {isMentorRole && (
-                  <span className="text-status-error-default">* </span>
-                )}
-                產業
-              </>
-            }
-          >
+          <Section id="industry" title="產業" required={isMentorRole}>
             <SelectField
               form={form}
               name="industry"
@@ -327,15 +271,7 @@ export default function EditProfileContainer({
             />
           </Section>
 
-          <Section
-            id="want_position"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>
-                有興趣多了解的職位
-              </>
-            }
-          >
+          <Section id="want_position" title="有興趣多了解的職位" required>
             <CategoryMultiSelectField
               form={form}
               name="want_position"
@@ -345,15 +281,7 @@ export default function EditProfileContainer({
             />
           </Section>
 
-          <Section
-            id="want_skill"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>
-                想多了解、加強的技能
-              </>
-            }
-          >
+          <Section id="want_skill" title="想多了解、加強的技能" required>
             <CategoryMultiSelectField
               form={form}
               name="want_skill"
@@ -363,15 +291,7 @@ export default function EditProfileContainer({
             />
           </Section>
 
-          <Section
-            id="want_topic"
-            title={
-              <>
-                <span className="text-status-error-default">* </span>
-                想多了解的主題
-              </>
-            }
-          >
+          <Section id="want_topic" title="想多了解的主題" required>
             <CategoryMultiSelectField
               form={form}
               name="want_topic"

--- a/src/components/onboarding/steps/GroupedSelections.tsx
+++ b/src/components/onboarding/steps/GroupedSelections.tsx
@@ -67,7 +67,7 @@ export const GroupedSelections: React.FC<GroupedSelectionsProps> = ({
       <p
         className={cn(
           'text-sm tabular-nums',
-          limitReached ? 'text-status-200' : 'text-text-tertiary'
+          limitReached ? 'text-status-error-default' : 'text-text-tertiary'
         )}
         aria-live="polite"
       >

--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -33,7 +33,7 @@ export const AvatarSection = <T extends FieldValues>({
       id={id}
       title={
         <>
-          {isMentor && <span className="text-status-200">* </span>}
+          {isMentor && <span className="text-status-error-default">* </span>}
           個人頭像
         </>
       }

--- a/src/components/profile/edit/AvatarSection.tsx
+++ b/src/components/profile/edit/AvatarSection.tsx
@@ -29,15 +29,7 @@ export const AvatarSection = <T extends FieldValues>({
   const avatarUrl = session?.user?.avatar ?? '';
 
   return (
-    <Section
-      id={id}
-      title={
-        <>
-          {isMentor && <span className="text-status-error-default">* </span>}
-          個人頭像
-        </>
-      }
-    >
+    <Section id={id} title="個人頭像" required={isMentor}>
       <AvatarUpload
         control={control}
         name={name}

--- a/src/components/profile/edit/JobExperienceSection.tsx
+++ b/src/components/profile/edit/JobExperienceSection.tsx
@@ -122,7 +122,7 @@ export const JobExperienceSection = ({
     <Section
       title={
         <>
-          {isMentor && <span className="text-status-200">* </span>}
+          {isMentor && <span className="text-status-error-default">* </span>}
           工作經驗
         </>
       }
@@ -252,7 +252,7 @@ export const JobExperienceSection = ({
             </div>
 
             {invalidPeriod && (
-              <p className="mb-4 text-sm font-medium text-status-200">
+              <p className="mb-4 text-sm font-medium text-status-error-default">
                 開始年份不可大於結束年份
               </p>
             )}

--- a/src/components/profile/edit/JobExperienceSection.tsx
+++ b/src/components/profile/edit/JobExperienceSection.tsx
@@ -119,14 +119,7 @@ export const JobExperienceSection = ({
   };
 
   return (
-    <Section
-      title={
-        <>
-          {isMentor && <span className="text-status-error-default">* </span>}
-          工作經驗
-        </>
-      }
-    >
+    <Section title="工作經驗" required={isMentor}>
       {fields.map((field, index) => {
         const invalidPeriod = isInvalidPeriod(index);
 

--- a/src/components/profile/edit/RequiredIndicator.tsx
+++ b/src/components/profile/edit/RequiredIndicator.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import React from 'react';
+
+interface RequiredIndicatorProps {
+  show?: boolean;
+}
+
+export const RequiredIndicator = ({ show = true }: RequiredIndicatorProps) => {
+  if (!show) return null;
+  return (
+    <span className="text-status-error-default" aria-hidden="true">
+      *{' '}
+    </span>
+  );
+};

--- a/src/components/profile/edit/RequiredIndicator.tsx
+++ b/src/components/profile/edit/RequiredIndicator.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 
 interface RequiredIndicatorProps {

--- a/src/components/profile/edit/Section.tsx
+++ b/src/components/profile/edit/Section.tsx
@@ -1,5 +1,3 @@
-'use client';
-
 import React from 'react';
 
 import { RequiredIndicator } from './RequiredIndicator';

--- a/src/components/profile/edit/Section.tsx
+++ b/src/components/profile/edit/Section.tsx
@@ -2,6 +2,8 @@
 
 import React from 'react';
 
+import { RequiredIndicator } from './RequiredIndicator';
+
 //--------------------------------------------------
 // 🧩 Two‑column Section Wrapper
 //--------------------------------------------------
@@ -10,15 +12,24 @@ interface SectionProps {
   title: string | React.ReactNode;
   children: React.ReactNode;
   id?: string;
+  required?: boolean;
 }
 
-export const Section = ({ title, children, id }: SectionProps) => (
+export const Section = ({
+  title,
+  children,
+  id,
+  required = false,
+}: SectionProps) => (
   <div
     id={id}
     className="flex flex-col border-t-2 border-solid border-background-border pt-10 lg:flex-row"
   >
     <div className="max-w-80 grow">
-      <p className="mb-4 text-xl font-bold">{title}</p>
+      <p className="mb-4 text-xl font-bold">
+        <RequiredIndicator show={required} />
+        {title}
+      </p>
     </div>
     <div className="grow">{children}</div>
   </div>

--- a/src/components/profile/edit/educationSection/educationSection.tsx
+++ b/src/components/profile/edit/educationSection/educationSection.tsx
@@ -156,7 +156,7 @@ export const EducationSection = ({
     <Section
       title={
         <>
-          {isMentor && <span className="text-status-200">* </span>}
+          {isMentor && <span className="text-status-error-default">* </span>}
           教育經歷
         </>
       }
@@ -276,7 +276,7 @@ export const EducationSection = ({
             </div>
 
             {invalidPeriod && (
-              <p className="mb-4 text-sm font-medium text-status-200">
+              <p className="mb-4 text-sm font-medium text-status-error-default">
                 開始年份不可大於結束年份
               </p>
             )}

--- a/src/components/profile/edit/educationSection/educationSection.tsx
+++ b/src/components/profile/edit/educationSection/educationSection.tsx
@@ -153,14 +153,7 @@ export const EducationSection = ({
   };
 
   return (
-    <Section
-      title={
-        <>
-          {isMentor && <span className="text-status-error-default">* </span>}
-          教育經歷
-        </>
-      }
-    >
+    <Section title="教育經歷" required={isMentor}>
       {fields.map((field, index) => {
         const invalidPeriod = isInvalidPeriod(index);
 

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -93,7 +93,7 @@ export function MenteeBookingForm({
           {...register('bookingQuestion')}
         />
         {errors.bookingQuestion && (
-          <p className="mt-1 text-sm text-status-200">
+          <p className="mt-1 text-sm text-status-error-default">
             {errors.bookingQuestion.message}
           </p>
         )}

--- a/src/components/reservation/ReservationStatusBadge.tsx
+++ b/src/components/reservation/ReservationStatusBadge.tsx
@@ -12,9 +12,9 @@ const statusBadgeVariants = cva(
     variants: {
       status: {
         far: 'bg-muted text-muted-foreground',
-        soon: 'bg-status-500/20 text-status-400',
-        imminent: 'bg-status-300/20 text-status-200',
-        live: 'bg-status-100/20 text-status-50',
+        soon: 'bg-status-warning-active/20 text-status-warning-default',
+        imminent: 'bg-status-error-active/20 text-status-error-default',
+        live: 'bg-status-success-active/20 text-status-success-default',
         ended: 'bg-muted text-muted-foreground/70',
       },
     },
@@ -43,7 +43,7 @@ export function ReservationStatusBadge({
     >
       {status === 'live' ? (
         <span
-          className="h-1.5 w-1.5 rounded-full bg-status-50 motion-safe:animate-pulse"
+          className="h-1.5 w-1.5 rounded-full bg-status-success-default motion-safe:animate-pulse"
           aria-hidden
         />
       ) : null}

--- a/src/components/ui/category-multi-select.tsx
+++ b/src/components/ui/category-multi-select.tsx
@@ -258,7 +258,7 @@ export function CategoryMultiSelect({
       <div
         className={cn(
           'border-t border-background-border px-4 py-2 text-sm tabular-nums',
-          limitReached ? 'text-status-200' : 'text-text-tertiary'
+          limitReached ? 'text-status-error-default' : 'text-text-tertiary'
         )}
         aria-live="polite"
       >

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -41,14 +41,22 @@ module.exports = {
     900: 'hsl(var(--color-gray-900) / <alpha-value>)',
   },
   status: {
-    50: 'hsl(var(--color-status-50) / <alpha-value>)',
-    100: 'hsl(var(--color-status-100) / <alpha-value>)',
-    200: 'hsl(var(--color-status-200) / <alpha-value>)',
-    300: 'hsl(var(--color-status-300) / <alpha-value>)',
-    400: 'hsl(var(--color-status-400) / <alpha-value>)',
-    500: 'hsl(var(--color-status-500) / <alpha-value>)',
-    600: 'hsl(var(--color-status-600) / <alpha-value>)',
-    700: 'hsl(var(--color-status-700) / <alpha-value>)',
+    success: {
+      default: 'hsl(var(--color-status-success-default) / <alpha-value>)',
+      active: 'hsl(var(--color-status-success-active) / <alpha-value>)',
+    },
+    error: {
+      default: 'hsl(var(--color-status-error-default) / <alpha-value>)',
+      active: 'hsl(var(--color-status-error-active) / <alpha-value>)',
+    },
+    warning: {
+      default: 'hsl(var(--color-status-warning-default) / <alpha-value>)',
+      active: 'hsl(var(--color-status-warning-active) / <alpha-value>)',
+    },
+    info: {
+      default: 'hsl(var(--color-status-info-default) / <alpha-value>)',
+      active: 'hsl(var(--color-status-info-active) / <alpha-value>)',
+    },
   },
   blue: {
     default: 'hsl(var(--color-blue-default) / <alpha-value>)',
@@ -81,7 +89,8 @@ module.exports = {
     border: 'hsl(var(--color-avatar-border) / <alpha-value>)',
     overlay: 'hsl(var(--color-avatar-overlay) / <alpha-value>)',
   },
-  // Legacy / Landing page specific tokens to be reviewed by Design
+  // [Item 3: Legacy landing-only tokens]
+  // 經過全面代碼檢索（grep），以下 5 個 Token 仍被 (landing)/about、(landing)/page、(landing)/terms、(landing)/privacy、mentor-pool/PopularPositionChips 以及 components/landing/HomePageSlider 廣泛調用，為防樣式損壞，依據工程規範維持保留。
   navy: 'hsl(var(--color-navy) / <alpha-value>)',
   logoBlue: 'hsl(var(--color-logo-blue) / <alpha-value>)',
   bdBlue: 'hsl(var(--color-bd-blue) / <alpha-value>)',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -68,14 +68,14 @@
     --color-gray-700: 0 0% 34%; /* #565656 */
     --color-gray-800: 0 0% 22%; /* #393939 */
     --color-gray-900: 0 0% 11%; /* #1D1D1D */
-    --color-status-50: 137 100% 36%; /* #00BA34 */
-    --color-status-100: 137 62% 48%; /* #2EC659 */
-    --color-status-200: 11 87% 50%; /* #EE3911 */
-    --color-status-300: 11 87% 59%; /* #F15D3C */
-    --color-status-400: 47 87% 50%; /* #EEBE11 */
-    --color-status-500: 47 87% 59%; /* #F1CA3C */
-    --color-status-600: 29 87% 50%; /* #EE7C11 */
-    --color-status-700: 29 87% 59%; /* #F1943C */
+    --color-status-success-default: 137 100% 36%; /* #00BA34 */
+    --color-status-success-active: 137 62% 48%; /* #2EC659 */
+    --color-status-error-default: 11 87% 50%; /* #EE3911 */
+    --color-status-error-active: 11 87% 59%; /* #F15D3C */
+    --color-status-warning-default: 47 87% 50%; /* #EEBE11 */
+    --color-status-warning-active: 47 87% 59%; /* #F1CA3C */
+    --color-status-info-default: 29 87% 50%; /* #EE7C11 */
+    --color-status-info-active: 29 87% 59%; /* #F1943C */
     --color-blue-default: 190 100% 68%; /* #5DE5FF */
     --color-blue-active: 190 100% 80%; /* #97EEFF */
     --color-pink-default: 340 100% 69%; /* #FF6397 */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,6 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const colors = require('./src/design/tokens/color');
 
-export const darkMode = ['class'];
-
 export const content = ['./src/**/*.{js,jsx,ts,tsx}'];
 
 export const theme = {


### PR DESCRIPTION
- Refactored numeric status tokens (status-50~700) to semantic success/error/warning/info categories in global.css and color.ts to improve type-safety and alignment with Design System guidelines.
- Cleaned up legacy unused darkMode config in tailwind.config.js.
- Documented and retained legacy landing-only tokens (navy, logoBlue, bdBlue, marketingOrange, landingPurpleLight) that are actively used.
- Replaced references to old status classes with new semantic classes across 9 UI components.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/392
