### PR TITLE
fix(style): remove hardcoded inline color, fix duplicate gray-50 token

### DIFF
--- a/src/components/profile/experience-section/ExperienceSection.tsx
+++ b/src/components/profile/experience-section/ExperienceSection.tsx
@@ -31,14 +31,11 @@ export const ExperienceItemCard = ({
         </span>
       </div>
       <div>
-        <h2
-          className="mb-1 break-words text-base font-bold"
-          style={{ color: '#49454F' }}
-        >
+        <h2 className="mb-1 break-words text-base font-bold text-text-secondary">
           {title}
         </h2>
         {description && (
-          <p className="break-words text-sm" style={{ color: '#49454F' }}>
+          <p className="break-words text-sm text-text-secondary">
             {description}
           </p>
         )}

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -58,7 +58,7 @@
     --color-brand-700: 180 65% 29%; /* #1A7A7A */
     --color-brand-800: 180 64% 19%; /* #125151 */
     --color-brand-900: 180 64% 10%; /* #092929 */
-    --color-gray-50: 0 0% 91%; /* #E9E9E9 */
+    --color-gray-50: 0 0% 97%; /* #F7F7F7 (interpolated, pending Figma confirmation) */
     --color-gray-100: 0 0% 91%; /* #E9E9E9 */
     --color-gray-200: 0 0% 82%; /* #D2D2D2 */
     --color-gray-300: 0 0% 74%; /* #BCBCBC */


### PR DESCRIPTION
## What Does This PR Do?

- Replaces inline `style={{ color: '#49454F' }}` in `ExperienceItemCard`
  with the `text-text-secondary` design token class (nearest match,
  #474D57) so the component no longer bypasses the color token system.
- Fixes `--color-gray-50` in `global.css`, which was accidentally
  defined identically to `--color-gray-100` (both `0 0% 91%`), breaking
  the scale's step progression. Interpolated to `0 0% 97%` following the
  ~8-9% step pattern of the rest of the gray scale; flagged in a comment
  as pending confirmation against the Figma source since gray-50 is not
  currently referenced anywhere in the codebase.

## Demo

http://localhost:3000/profile/[pageUserId]

## Screenshot

N/A

## Anything to Note?

Found while auditing the design system for leftover issues after the
recent color-token convergence work. Two other findings were surfaced
but not fixed here (kept as follow-up scope, not urgent):
- The `no-restricted-syntax` ESLint rule blocking hardcoded colors only
  scans `className`, not `style` props - this is why the inline color
  above wasn't caught by lint. Worth extending the rule.
- `background.DEFAULT` in `src/design/tokens/color.ts` is missing the
  `<alpha-value>` placeholder that every other token has, which is used
  by `bg-background/50` and `bg-background/80` in `sheet.tsx` and
  `ConfirmDialog.tsx`. Tailwind 3.4's color-mix fallback likely keeps it
  working, but it's inconsistent with the rest of the file.
