### PR TITLE
refactor(style): merge duplicate-value tokens and remove unused gray-50 (X-Tracker #396)

### DIFF
--- a/src/components/profile/reservation/BookingForm.test.tsx
+++ b/src/components/profile/reservation/BookingForm.test.tsx
@@ -93,7 +93,7 @@ describe('BookingForm', () => {
     // Scenario 1: selectedSlot=null, bookingQuestion=""
     const submitBtn = screen.getByRole('button', { name: '預約時間' });
     expect(submitBtn).toBeDisabled();
-    expect(submitBtn).toHaveClass('disabled:bg-background-top-active');
+    expect(submitBtn).toHaveClass('disabled:bg-background-border');
     expect(submitBtn).toHaveClass('disabled:text-text-disable');
 
     // Scenario 2: Select slot, and question is empty (now allowed)

--- a/src/components/profile/reservation/MenteeBookingForm.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.tsx
@@ -102,7 +102,7 @@ export function MenteeBookingForm({
       <Button
         type="submit"
         variant="default"
-        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
+        className="w-full rounded-full px-6 py-3 disabled:bg-background-border disabled:text-text-disable disabled:opacity-100"
         disabled={isButtonDisabled}
       >
         {isSubmitting ? (

--- a/src/components/profile/reservation/MentorScheduleConfig.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.tsx
@@ -35,7 +35,7 @@ export function MentorScheduleConfig({
 
       <Button
         variant="default"
-        className="w-full rounded-full px-6 py-3 disabled:bg-background-top-active disabled:text-text-disable disabled:opacity-100"
+        className="w-full rounded-full px-6 py-3 disabled:bg-background-border disabled:text-text-disable disabled:opacity-100"
         onClick={onReservation}
       >
         預約設定

--- a/src/components/ui/category-multi-select.tsx
+++ b/src/components/ui/category-multi-select.tsx
@@ -71,7 +71,7 @@ function FlatList({
               className={cn(
                 'flex cursor-pointer items-center gap-3 px-4 py-2',
                 disabled && 'cursor-not-allowed opacity-50',
-                !disabled && 'hover:bg-background-top'
+                !disabled && 'hover:bg-background-bottom'
               )}
             >
               <Checkbox
@@ -197,7 +197,7 @@ export function CategoryMultiSelect({
                   disabled={isSearching}
                   className={cn(
                     'flex w-full items-center justify-between px-4 py-3 text-left',
-                    !isSearching && 'hover:bg-background-top'
+                    !isSearching && 'hover:bg-background-bottom'
                   )}
                 >
                   <span className="flex items-center gap-2">
@@ -233,7 +233,7 @@ export function CategoryMultiSelect({
                             className={cn(
                               'flex cursor-pointer items-center gap-3 px-4 py-2 pl-11',
                               disabled && 'cursor-not-allowed opacity-50',
-                              !disabled && 'hover:bg-background-top'
+                              !disabled && 'hover:bg-background-bottom'
                             )}
                           >
                             <Checkbox

--- a/src/design/MIGRATION.md
+++ b/src/design/MIGRATION.md
@@ -106,12 +106,3 @@ const badgeVariants = cva(
 1. **嚴禁新增硬編碼數值**：任何色彩設定，不論是在 `.css` 還是 Tailwind class 中，均不得使用自訂的十六進位（Hex）或 RGB 數值。
 2. **優先使用系統類名**：新開發之業務元件（如：profile, reservation, mentor-pool）與自訂元件，請一律優先採用 `text-text-primary`, `bg-brand-500`, `border-background-border` 等命名。
 3. **逐步完成 `src/components/ui` 遷移**：當前基礎元件在映射後雖然視覺表現已對齊，但在下一次對該元件進行修改/重構時，請順手將其 Tailwind 類名改寫為新統一系統命名。
-
----
-
-## 5. 待 Design 確認事項 (Pending Design Confirmation)
-
-以下項目數值/決策尚未經 Design 正式確認，追蹤於 [X-Tracker #396](https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/396)，請勿在確認前逕自合併或修改：
-
-- `--color-background-top` 與 `--color-background-bottom` 目前數值相同（`0 0% 96%`），`--color-background-top-active` 與 `--color-background-border` 也相同（`210 9% 91%`）。待確認是否為刻意共用（可合併）或巧合（應保留獨立 token）。
-- `--color-gray-50`（`global.css`）目前為內插推算值（`0 0% 97%` / #F7F7F7），非 Figma 正式數值，待 Design 提供確認值。

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -12,8 +12,6 @@ module.exports = {
     'bottom-secondary':
       'hsl(var(--color-background-bottom-secondary) / <alpha-value>)',
     white: 'hsl(var(--color-background-white) / <alpha-value>)',
-    top: 'hsl(var(--color-background-top) / <alpha-value>)',
-    'top-active': 'hsl(var(--color-background-top-active) / <alpha-value>)',
     border: 'hsl(var(--color-background-border) / <alpha-value>)',
   },
   brand: {
@@ -29,7 +27,6 @@ module.exports = {
     900: 'hsl(var(--color-brand-900) / <alpha-value>)',
   },
   gray: {
-    50: 'hsl(var(--color-gray-50) / <alpha-value>)',
     100: 'hsl(var(--color-gray-100) / <alpha-value>)',
     200: 'hsl(var(--color-gray-200) / <alpha-value>)',
     300: 'hsl(var(--color-gray-300) / <alpha-value>)',

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -45,8 +45,6 @@
     --color-background-bottom: 0 0% 96%; /* #F5F5F5 */
     --color-background-bottom-secondary: 0 0% 98%; /* #FAFAFA */
     --color-background-white: 0 0% 100%; /* #FFFFFF */
-    --color-background-top: 0 0% 96%; /* #F5F5F5 */
-    --color-background-top-active: 210 9% 91%; /* #E6E8EA */
     --color-background-border: 210 9% 91%; /* #E6E8EA */
     --color-brand-50: 180 62% 95%; /* #EAFAFA */
     --color-brand-100: 180 62% 90%; /* #D5F5F5 */
@@ -58,7 +56,6 @@
     --color-brand-700: 180 65% 29%; /* #1A7A7A */
     --color-brand-800: 180 64% 19%; /* #125151 */
     --color-brand-900: 180 64% 10%; /* #092929 */
-    --color-gray-50: 0 0% 97%; /* #F7F7F7 (interpolated, pending Figma confirmation) */
     --color-gray-100: 0 0% 91%; /* #E9E9E9 */
     --color-gray-200: 0 0% 82%; /* #D2D2D2 */
     --color-gray-300: 0 0% 74%; /* #BCBCBC */


### PR DESCRIPTION
## What Does This PR Do?

Fixes #396 (Xchange-Taiwan/X-Talent-Tracker).

Re-does work that was supposed to land via PR #748 but didn't: #748 auto-merged right after its first commit landed, so three follow-up commits pushed to that same branch afterward (gray-50 removal, background-top/top-active token merge) were pushed to an already-merged PR and never actually reached `develop`, even though the linked issue's checklist said they were done. Verified against current `develop` before starting this branch — `gray-50` and `background-top`/`background-top-active` were still present.

This PR contains the actual changes:

1. **Duplicate-value tokens, merged** — `--color-background-top`/`--color-background-bottom` and `--color-background-top-active`/`--color-background-border` shared identical HSL values. Design confirmed this was intentional, so removed `background.top` / `background.top-active` from `color.ts` and `global.css` and repointed all 3 call sites (`category-multi-select.tsx` hover state, `MentorScheduleConfig.tsx`/`MenteeBookingForm.tsx` disabled state, plus the matching test assertion) to `bg-background-bottom` / `bg-background-border`.
2. **Unused `gray-50` token, removed** — interpolated placeholder from #746, zero references anywhere in the codebase per grep. Removed from `color.ts` and `global.css`.
3. Dropped the now-resolved "Pending Design Confirmation" section from `MIGRATION.md`.

## Test Plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — clean
- [x] `pnpm test` — 636/636 passing
- [x] grep-confirmed no remaining `gray-50` or `background-top`/`background-top-active` references anywhere in `src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
