### PR TITLE
refactor(ui): migrate 10 storybook stories to unified design color tokens (X-Tracker #398)

### DIFF
--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -18,7 +18,7 @@ const CalendarDemo = (args: React.ComponentProps<typeof Calendar>) => {
     <div className="w-fit rounded-lg border bg-card p-4 shadow">
       <Calendar {...args} mode="single" selected={date} onSelect={setDate} />
       {date && (
-        <p className="mt-4 text-center text-sm text-muted-foreground">
+        <p className="mt-4 text-center text-sm text-text-tertiary">
           您選取的日期是: {date.toLocaleDateString()}
         </p>
       )}

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -38,7 +38,7 @@ export const Default: Story = {
         <div className="grid w-full items-center gap-4">
           <div className="flex flex-col space-y-1.5">
             <span className="text-sm font-medium">專案名稱</span>
-            <div className="rounded border bg-background-bottom p-2 text-sm text-muted-foreground">
+            <div className="rounded border bg-background-bottom p-2 text-sm text-text-tertiary">
               My New Awesome Project
             </div>
           </div>
@@ -57,7 +57,7 @@ export const ContentOnly: Story = {
   render: (args) => (
     <Card {...args} className="w-[350px]">
       <CardContent className="pt-6">
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-text-tertiary">
           這是一個極簡卡片，只包含內容區塊，適合用在格狀版面 (Grid)
           中展示簡單的統計數據或資訊卡片。
         </p>

--- a/src/components/ui/category-multi-select.stories.tsx
+++ b/src/components/ui/category-multi-select.stories.tsx
@@ -44,7 +44,7 @@ const CategoryMultiSelectDemo = (
         value={selected}
         onChange={setSelected}
       />
-      <div className="mt-4 text-sm text-muted-foreground">
+      <div className="mt-4 text-sm text-text-tertiary">
         已選取: {selected.join(', ') || '無'}
       </div>
     </div>

--- a/src/components/ui/loading-spinner.stories.tsx
+++ b/src/components/ui/loading-spinner.stories.tsx
@@ -38,15 +38,15 @@ export const AllSizes: Story = {
     <div className="flex items-center gap-6">
       <div className="flex flex-col items-center gap-1.5">
         <LoadingSpinner {...args} size="sm" />
-        <span className="text-xs text-muted-foreground">小 (sm)</span>
+        <span className="text-xs text-text-tertiary">小 (sm)</span>
       </div>
       <div className="flex flex-col items-center gap-1.5">
         <LoadingSpinner {...args} size="md" />
-        <span className="text-xs text-muted-foreground">中 (md)</span>
+        <span className="text-xs text-text-tertiary">中 (md)</span>
       </div>
       <div className="flex flex-col items-center gap-1.5">
         <LoadingSpinner {...args} size="lg" />
-        <span className="text-xs text-muted-foreground">大 (lg)</span>
+        <span className="text-xs text-text-tertiary">大 (lg)</span>
       </div>
     </div>
   ),

--- a/src/components/ui/multi-select.stories.tsx
+++ b/src/components/ui/multi-select.stories.tsx
@@ -32,7 +32,7 @@ const MultiSelectDemo = (args: React.ComponentProps<typeof MultiSelect>) => {
         onValueChange={setSelected}
         placeholder="請選擇您的興趣愛好..."
       />
-      <div className="mt-4 text-sm text-muted-foreground">
+      <div className="mt-4 text-sm text-text-tertiary">
         目前選取值: {selected.join(', ') || '無'}
       </div>
     </div>

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -24,7 +24,7 @@ export const Default: Story = {
         <div className="grid gap-4">
           <div className="space-y-2">
             <h4 className="font-medium leading-none">Alex Chen</h4>
-            <p className="font-mono text-xs text-muted-foreground">
+            <p className="font-mono text-xs text-text-tertiary">
               alex@example.com
             </p>
           </div>

--- a/src/components/ui/progress.stories.tsx
+++ b/src/components/ui/progress.stories.tsx
@@ -33,15 +33,15 @@ export const Comparisons: Story = {
   render: () => (
     <div className="flex max-w-md flex-col gap-4">
       <div className="space-y-1.5">
-        <span className="text-xs text-muted-foreground">進度：0%</span>
+        <span className="text-xs text-text-tertiary">進度：0%</span>
         <Progress value={0} />
       </div>
       <div className="space-y-1.5">
-        <span className="text-xs text-muted-foreground">進度：50%</span>
+        <span className="text-xs text-text-tertiary">進度：50%</span>
         <Progress value={50} />
       </div>
       <div className="space-y-1.5">
-        <span className="text-xs text-muted-foreground">進度：100%</span>
+        <span className="text-xs text-text-tertiary">進度：100%</span>
         <Progress value={100} />
       </div>
     </div>

--- a/src/components/ui/separator.stories.tsx
+++ b/src/components/ui/separator.stories.tsx
@@ -25,7 +25,7 @@ export const Horizontal: Story = {
     <div className="max-w-md">
       <div className="space-y-1">
         <h4 className="text-sm font-medium leading-none">X-Talent UI</h4>
-        <p className="text-sm text-muted-foreground">
+        <p className="text-sm text-text-tertiary">
           為 Xchange 建立的高品質前端元件庫。
         </p>
       </div>

--- a/src/components/ui/sheet.stories.tsx
+++ b/src/components/ui/sheet.stories.tsx
@@ -74,7 +74,7 @@ export const LeftSide: Story = {
           <SheetDescription>依據您的需求過濾搜尋結果。</SheetDescription>
         </SheetHeader>
         <div className="grid gap-4 py-4">
-          <p className="text-sm text-muted-foreground">在此放置篩選器元件...</p>
+          <p className="text-sm text-text-tertiary">在此放置篩選器元件...</p>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/ui/tabs.stories.tsx
+++ b/src/components/ui/tabs.stories.tsx
@@ -23,12 +23,12 @@ export const Default: Story = {
       <TabsContent value="account">
         <div className="rounded-lg border p-4">
           <h3 className="text-lg font-medium">帳戶資訊</h3>
-          <p className="mb-4 text-sm text-muted-foreground">
+          <p className="mb-4 text-sm text-text-tertiary">
             在此管理您的帳戶基本設定與偏好。
           </p>
           <div className="space-y-2">
             <span className="text-sm font-medium">使用者名稱</span>
-            <div className="rounded border bg-background-bottom p-2 text-sm text-muted-foreground">
+            <div className="rounded border bg-background-bottom p-2 text-sm text-text-tertiary">
               alex_chen
             </div>
           </div>
@@ -37,12 +37,12 @@ export const Default: Story = {
       <TabsContent value="password">
         <div className="rounded-lg border p-4">
           <h3 className="text-lg font-medium">重設密碼</h3>
-          <p className="mb-4 text-sm text-muted-foreground">
+          <p className="mb-4 text-sm text-text-tertiary">
             為了帳戶安全，請定期更新您的密碼。
           </p>
           <div className="space-y-2">
             <span className="text-sm font-medium">新密碼</span>
-            <div className="rounded border bg-background-bottom p-2 text-sm text-muted-foreground">
+            <div className="rounded border bg-background-bottom p-2 text-sm text-text-tertiary">
               ********
             </div>
           </div>


### PR DESCRIPTION
Migrated 10 Storybook story files away from legacy shadcn semantic classes (such as text-muted-foreground) to the newly consolidated unified design token (text-text-tertiary), complying with the design token convergence policy in src/design/MIGRATION.md and X-Tracker #396.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/398
