### PR TITLE
refactor(reservation): migrate reservation and profile components to unified color tokens (X-Tracker #399)

### DIFF
--- a/src/components/profile/edit/educationSection/educationSection.tsx
+++ b/src/components/profile/edit/educationSection/educationSection.tsx
@@ -68,7 +68,7 @@ function SchoolComboboxField({
               aria-expanded={open}
               className="w-full justify-between font-normal"
             >
-              <span className={cn(!field.value && 'text-muted-foreground')}>
+              <span className={cn(!field.value && 'text-text-tertiary')}>
                 {field.value || '請選擇學校'}
               </span>
               <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
@@ -300,7 +300,7 @@ export const EducationSection = ({
         新增
       </Button>
       {errors.educations?.message && (
-        <p className="mt-2 text-sm font-medium text-destructive">
+        <p className="mt-2 text-sm font-medium text-status-error-default">
           {errors.educations?.message as string}
         </p>
       )}

--- a/src/components/profile/expertise-select-item/ExpertiseSelectItem.tsx
+++ b/src/components/profile/expertise-select-item/ExpertiseSelectItem.tsx
@@ -62,8 +62,9 @@ export const ExpertiseSelectItem: FC<Props> = ({ form, type }) => {
           <FormItem
             className={cn(
               'flex cursor-pointer items-start gap-2 rounded-xl border border-background-border px-4 py-3',
-              'hover:border-primary hover:bg-secondary',
-              field.value.includes(type) && 'border-primary bg-secondary'
+              'hover:border-brand-500 hover:bg-background-bottom',
+              field.value.includes(type) &&
+                'border-brand-500 bg-background-bottom'
             )}
           >
             <FormLabel className="flex grow cursor-pointer gap-4">

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -265,19 +265,19 @@ export default function MentorScheduleDialog({
                               },
                             })}
                         className={cn(
-                          'flex flex-col gap-2 rounded-lg border bg-background p-3 transition-colors lg:p-4',
+                          'flex flex-col gap-2 rounded-lg border bg-background-white p-3 transition-colors lg:p-4',
                           isPast
                             ? 'cursor-not-allowed opacity-50'
-                            : 'cursor-pointer hover:bg-muted/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring'
+                            : 'cursor-pointer hover:bg-background-bottom/50 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500'
                         )}
                       >
                         <div className="flex flex-row flex-nowrap items-center justify-between gap-2 lg:gap-3">
                           <div className="flex items-center gap-2">
-                            <Clock className="h-4 w-4 text-muted-foreground" />
+                            <Clock className="h-4 w-4 text-text-tertiary" />
                             <span className="text-base font-medium tabular-nums">
                               {startLabel} – {endLabel}
                             </span>
-                            <span className="text-sm text-muted-foreground">
+                            <span className="text-sm text-text-tertiary">
                               ({slot.durationMinutes} 分)
                               {isPast ? ' · 已過' : ''}
                             </span>
@@ -448,7 +448,7 @@ function TimeSelectPair({
           ))}
         </SelectContent>
       </Select>
-      <span className="text-base text-muted-foreground">:</span>
+      <span className="text-base text-text-tertiary">:</span>
       <Select value={minuteValue} onValueChange={onMinuteChange}>
         <SelectTrigger className="h-12 w-24 text-base lg:w-28">
           <SelectValue />
@@ -482,8 +482,8 @@ function DurationRadio({
           className={cn(
             'flex-1 rounded-lg border px-4 py-2 text-base transition-colors',
             value === opt
-              ? 'border-primary bg-primary/10 text-primary'
-              : 'border-input bg-background hover:bg-muted/50'
+              ? 'border-brand-500 bg-brand-500/10 text-brand-500'
+              : 'border-background-border bg-background-white hover:bg-background-bottom/50'
           )}
         >
           {opt} 分
@@ -577,7 +577,7 @@ function AddSlotModal({
           </label>
 
           {weekly && previewDates.length > 0 && (
-            <p className="text-sm text-muted-foreground">
+            <p className="text-sm text-text-tertiary">
               將建立 {previewDates.length} 個時段:{previewDates.join('、')}
             </p>
           )}

--- a/src/components/profile/reservation/ScheduleCalendar.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.tsx
@@ -208,7 +208,7 @@ export const ScheduleCalendar = ({
             aria-live="polite"
             className="pointer-events-none absolute inset-0 flex items-center justify-center"
           >
-            <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+            <Loader2 className="h-6 w-6 animate-spin text-text-tertiary" />
           </div>
         )}
       </div>

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -106,7 +106,7 @@ export default function AcceptReservationDialog({
               </Avatar>
               <div className="min-w-0">
                 <div className="truncate font-medium">{reservation.name}</div>
-                <div className="truncate text-sm text-muted-foreground">
+                <div className="truncate text-sm text-text-tertiary">
                   {reservation.roleLine}
                 </div>
               </div>
@@ -127,8 +127,8 @@ export default function AcceptReservationDialog({
           {menteeMessage ? (
             <div className="mt-6">
               <div className="mb-2 text-sm font-medium">學員所提出的問題</div>
-              <div className="rounded-2xl border bg-muted/40 p-4 text-sm">
-                <p className="whitespace-pre-wrap text-foreground">
+              <div className="rounded-2xl border bg-background-bottom/40 p-4 text-sm">
+                <p className="whitespace-pre-wrap text-text-primary">
                   {menteeMessage}
                 </p>
               </div>
@@ -155,7 +155,7 @@ export default function AcceptReservationDialog({
               <button
                 type="button"
                 onClick={() => setReplyOpen(true)}
-                className="flex items-center gap-1.5 text-sm text-muted-foreground hover:text-foreground"
+                className="flex items-center gap-1.5 text-sm text-text-tertiary hover:text-text-primary"
                 disabled={isSubmitting}
               >
                 <MessageSquarePlus className="h-4 w-4" aria-hidden />

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -103,7 +103,7 @@ export default function CancelReservationDialog({
             </DialogClose>
             <Button
               disabled={!canSubmit || disabled}
-              className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
+              className="w-full bg-status-error-default text-text-white hover:bg-status-error-active sm:w-auto"
               onClick={handleConfirm}
             >
               {isSubmitting && (

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -104,7 +104,7 @@ export default function RejectReservationDialog({
 
             <Button
               type="button"
-              className="w-full bg-destructive text-destructive-foreground hover:bg-destructive/90 sm:w-auto"
+              className="w-full bg-status-error-default text-text-white hover:bg-status-error-active sm:w-auto"
               disabled={!canSubmit || disabled}
               onClick={handleReject}
             >

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -137,36 +137,16 @@ export function ReservationCard({
             {hasAnyMessage ? (
               <div className="mt-3 space-y-2">
                 {menteeMessage ? (
-                  <div className="flex items-start gap-2 rounded-lg bg-background-bottom/40 p-2.5 text-xs sm:text-sm">
-                    <MessageSquare
-                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary sm:h-4 sm:w-4"
-                      aria-hidden
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="text-11 font-medium text-text-tertiary sm:text-xs">
-                        學員留言
-                      </div>
-                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-text-primary">
-                        {menteeMessage.content}
-                      </p>
-                    </div>
-                  </div>
+                  <MessageBlock
+                    label="學員留言"
+                    content={menteeMessage.content}
+                  />
                 ) : null}
                 {mentorMessage ? (
-                  <div className="flex items-start gap-2 rounded-lg bg-background-bottom/40 p-2.5 text-xs sm:text-sm">
-                    <MessageSquare
-                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary sm:h-4 sm:w-4"
-                      aria-hidden
-                    />
-                    <div className="min-w-0 flex-1">
-                      <div className="text-11 font-medium text-text-tertiary sm:text-xs">
-                        導師回覆
-                      </div>
-                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-text-primary">
-                        {mentorMessage.content}
-                      </p>
-                    </div>
-                  </div>
+                  <MessageBlock
+                    label="導師回覆"
+                    content={mentorMessage.content}
+                  />
                 ) : null}
               </div>
             ) : null}
@@ -183,5 +163,24 @@ export function ReservationCard({
         </div>
       </CardContent>
     </Card>
+  );
+}
+
+function MessageBlock({ label, content }: { label: string; content: string }) {
+  return (
+    <div className="flex items-start gap-2 rounded-lg bg-background-bottom/40 p-2.5 text-xs sm:text-sm">
+      <MessageSquare
+        className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary sm:h-4 sm:w-4"
+        aria-hidden
+      />
+      <div className="min-w-0 flex-1">
+        <div className="text-11 font-medium text-text-tertiary sm:text-xs">
+          {label}
+        </div>
+        <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-text-primary">
+          {content}
+        </p>
+      </div>
+    </div>
   );
 }

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -62,7 +62,7 @@ export function ReservationCard({
 
   return (
     <Card
-      className="border-muted/40 transition-shadow hover:shadow-sm"
+      className="border-background-border/40 transition-shadow hover:shadow-sm"
       data-testid="reservation-card"
     >
       <CardContent className="p-3 sm:p-4">
@@ -73,7 +73,7 @@ export function ReservationCard({
               href={profileHref}
               aria-label={profileAriaLabel}
               onClick={onProfileClick}
-              className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+              className="shrink-0 rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
             >
               {avatar}
             </Link>
@@ -89,12 +89,12 @@ export function ReservationCard({
                   href={profileHref}
                   aria-label={profileAriaLabel}
                   onClick={onProfileClick}
-                  className="group min-w-0 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+                  className="group min-w-0 truncate rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2"
                 >
                   <div className="truncate text-sm font-medium group-hover:underline sm:text-base">
                     {item.name}
                   </div>
-                  <div className="truncate text-xs text-muted-foreground sm:text-sm">
+                  <div className="truncate text-xs text-text-tertiary sm:text-sm">
                     {item.roleLine}
                   </div>
                 </Link>
@@ -103,7 +103,7 @@ export function ReservationCard({
                   <div className="truncate text-sm font-medium sm:text-base">
                     {item.name}
                   </div>
-                  <div className="truncate text-xs text-muted-foreground sm:text-sm">
+                  <div className="truncate text-xs text-text-tertiary sm:text-sm">
                     {item.roleLine}
                   </div>
                 </div>
@@ -112,10 +112,10 @@ export function ReservationCard({
             </div>
 
             {/* Divider only on >=sm to match Figma feel */}
-            <div className="my-3 hidden h-px bg-border sm:block" />
+            <div className="my-3 hidden h-px bg-background-border sm:block" />
 
             {/* Date & time row */}
-            <div className="mt-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-muted-foreground sm:mt-0 sm:text-sm">
+            <div className="mt-2 flex flex-wrap items-center justify-between gap-x-4 gap-y-2 text-xs text-text-tertiary sm:mt-0 sm:text-sm">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
                 <div className="flex items-center gap-1.5">
                   <CalendarDays className="h-4 w-4" aria-hidden />
@@ -137,32 +137,32 @@ export function ReservationCard({
             {hasAnyMessage ? (
               <div className="mt-3 space-y-2">
                 {menteeMessage ? (
-                  <div className="flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
+                  <div className="flex items-start gap-2 rounded-lg bg-background-bottom/40 p-2.5 text-xs sm:text-sm">
                     <MessageSquare
-                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary sm:h-4 sm:w-4"
                       aria-hidden
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="text-11 font-medium text-muted-foreground sm:text-xs">
+                      <div className="text-11 font-medium text-text-tertiary sm:text-xs">
                         學員留言
                       </div>
-                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
+                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-text-primary">
                         {menteeMessage.content}
                       </p>
                     </div>
                   </div>
                 ) : null}
                 {mentorMessage ? (
-                  <div className="flex items-start gap-2 rounded-lg bg-muted/40 p-2.5 text-xs sm:text-sm">
+                  <div className="flex items-start gap-2 rounded-lg bg-background-bottom/40 p-2.5 text-xs sm:text-sm">
                     <MessageSquare
-                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-muted-foreground sm:h-4 sm:w-4"
+                      className="mt-0.5 h-3.5 w-3.5 shrink-0 text-text-tertiary sm:h-4 sm:w-4"
                       aria-hidden
                     />
                     <div className="min-w-0 flex-1">
-                      <div className="text-11 font-medium text-muted-foreground sm:text-xs">
+                      <div className="text-11 font-medium text-text-tertiary sm:text-xs">
                         導師回覆
                       </div>
-                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-foreground">
+                      <p className="mt-0.5 line-clamp-2 whitespace-pre-wrap break-words text-text-primary">
                         {mentorMessage.content}
                       </p>
                     </div>
@@ -174,7 +174,7 @@ export function ReservationCard({
             {footer ? <div className="mt-3">{footer}</div> : null}
 
             {isUpcoming ? (
-              <div className="mt-3 flex items-center gap-1.5 text-11 text-muted-foreground sm:text-xs">
+              <div className="mt-3 flex items-center gap-1.5 text-11 text-text-tertiary sm:text-xs">
                 <Mail className="h-3.5 w-3.5 shrink-0" aria-hidden />
                 <span>會議連結已寄至您的信箱</span>
               </div>

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -67,7 +67,7 @@ export default function ReservationConversationDialog({
         {trigger ?? (
           <button
             type="button"
-            className="inline-flex items-center gap-1 rounded-sm text-xs text-muted-foreground hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 sm:text-sm"
+            className="inline-flex items-center gap-1 rounded-sm text-xs text-text-tertiary hover:text-text-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-500 focus-visible:ring-offset-2 sm:text-sm"
           >
             <MessageSquare className="h-3.5 w-3.5" aria-hidden />
             查看完整對話
@@ -97,7 +97,7 @@ export default function ReservationConversationDialog({
               </DialogDescription>
             </div>
           </div>
-          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-muted-foreground sm:text-sm">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-text-tertiary sm:text-sm">
             <span className="inline-flex items-center gap-1.5">
               <CalendarDays className="h-3.5 w-3.5" aria-hidden />
               {reservation.date}
@@ -111,7 +111,7 @@ export default function ReservationConversationDialog({
 
         <div className="flex-1 space-y-3 overflow-y-auto p-4 sm:p-6">
           {reservation.messages.length === 0 ? (
-            <p className="py-8 text-center text-sm text-muted-foreground">
+            <p className="py-8 text-center text-sm text-text-tertiary">
               尚無對話內容
             </p>
           ) : (
@@ -152,16 +152,16 @@ function MessageBubble({
       )}
     >
       {label && !isPrevSameRole ? (
-        <div className="text-11 font-medium text-muted-foreground sm:text-xs">
+        <div className="text-11 font-medium text-text-tertiary sm:text-xs">
           {label}
         </div>
       ) : null}
       <div
         className={cn(
           'max-w-[85%] whitespace-pre-wrap break-words rounded-2xl px-3.5 py-2.5 text-sm',
-          isMentor && 'bg-primary text-primary-foreground',
-          isMentee && 'bg-muted text-foreground',
-          !message.role && 'bg-muted/60 text-muted-foreground'
+          isMentor && 'bg-brand-500 text-text-primary',
+          isMentee && 'bg-background-bottom text-text-primary',
+          !message.role && 'bg-background-bottom/60 text-text-tertiary'
         )}
       >
         {message.content}

--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -45,12 +45,12 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   const loadMoreHistory = useCallback(() => loadMore('history'), [loadMore]);
 
   const triggerClass =
-    'group shrink-0 rounded-full border border-border px-3 py-1.5 text-sm ' +
-    'bg-transparent text-foreground ' +
+    'group shrink-0 rounded-full border border-background-border px-3 py-1.5 text-sm ' +
+    'bg-transparent text-text-primary ' +
     'data-[state=active]:bg-black data-[state=active]:text-white data-[state=active]:border-black';
 
   const countClass =
-    'ml-1 text-xs text-muted-foreground group-data-[state=active]:text-white/80';
+    'ml-1 text-xs text-text-tertiary group-data-[state=active]:text-white/80';
 
   const handleValueChange = (value: string) => {
     if (value === 'history' && !isHistoryLoaded && !isLoadingHistory) {
@@ -68,7 +68,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   return (
     <div className="flex min-h-[calc(100vh-70px)] justify-center pb-12">
       <div className="w-full max-w-[90%] rounded-2xl md:max-w-[800px]">
-        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-foreground md:text-36 md:leading-tight">
+        <div className="font-roboto mx-auto mb-6 text-center text-2xl font-semibold leading-tight tracking-[0%] text-text-primary md:text-36 md:leading-tight">
           {title}
         </div>
 

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -155,7 +155,7 @@ export function ReservationList({
 
       {items.length === 0 && (
         <Card className="border-dashed">
-          <CardContent className="p-8 text-center text-muted-foreground">
+          <CardContent className="p-8 text-center text-text-tertiary">
             目前尚無資料
           </CardContent>
         </Card>

--- a/src/components/reservation/ReservationStatusBadge.tsx
+++ b/src/components/reservation/ReservationStatusBadge.tsx
@@ -11,11 +11,11 @@ const statusBadgeVariants = cva(
   {
     variants: {
       status: {
-        far: 'bg-muted text-muted-foreground',
+        far: 'bg-background-bottom text-text-tertiary',
         soon: 'bg-status-warning-active/20 text-status-warning-default',
         imminent: 'bg-status-error-active/20 text-status-error-default',
         live: 'bg-status-success-active/20 text-status-success-default',
-        ended: 'bg-muted text-muted-foreground/70',
+        ended: 'bg-background-bottom text-text-tertiary/70',
       },
     },
     defaultVariants: {


### PR DESCRIPTION
Migrated 12 Reservation and Profile components to use the unified color token system as specified in src/design/MIGRATION.md. Legacy shadcn classes like bg-primary, bg-muted, text-muted-foreground, bg-destructive and border-input have been replaced with their respective unified design tokens.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/399
