### PR TITLE
refactor(ui): migrate 22 UI primitives to unified color token naming (X-Tracker #397)

### DIFF
--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -39,7 +39,7 @@ const AvatarFallback = React.forwardRef<
   <AvatarPrimitive.Fallback
     ref={ref}
     className={cn(
-      'flex h-full w-full items-center justify-center rounded-full bg-muted',
+      'flex h-full w-full items-center justify-center rounded-full bg-background-bottom',
       className
     )}
     {...props}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -5,7 +5,7 @@ import * as React from 'react';
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  'inline-flex items-center justify-center text-sm font-medium ring-offset-background-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
   {
     variants: {
       variant: {

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -9,15 +9,15 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+        default: 'bg-brand-500 text-text-primary hover:bg-brand-500/90',
         destructive:
-          'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+          'bg-status-error-default text-text-white hover:bg-status-error-default/90',
         outline:
-          'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          'border border-background-border bg-background-white hover:bg-background-bottom hover:text-text-primary',
         secondary:
-          'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
-        link: 'text-primary underline-offset-4 hover:underline',
+          'bg-background-bottom text-text-primary hover:bg-background-bottom/80',
+        ghost: 'hover:bg-background-bottom hover:text-text-primary',
+        link: 'text-brand-500 underline-offset-4 hover:underline',
       },
       size: {
         default: 'h-10 px-4 py-2',

--- a/src/components/ui/calendar.tsx
+++ b/src/components/ui/calendar.tsx
@@ -45,7 +45,7 @@ function Calendar({
           'max-w-full',
           'mx-auto',
 
-          'bg-background',
+          'bg-background-white',
           'p-3',
 
           // Fallback values.
@@ -121,7 +121,7 @@ function Calendar({
         dropdown_root: cn(
           isProfile
             ? 'relative inline-flex items-center gap-0.5 rounded-md px-1 py-0.5 text-sm font-semibold text-text-primary hover:bg-background-bottom-secondary'
-            : 'has-focus:border-ring border-input shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] relative rounded-md border',
+            : 'has-focus:border-ring border-background-border shadow-xs has-focus:ring-ring/50 has-focus:ring-[3px] relative rounded-md border',
           defaultClassNames.dropdown_root
         ),
 
@@ -137,8 +137,8 @@ function Calendar({
           captionLayout === 'label'
             ? 'text-[length:var(--calendar-caption-font-size)]'
             : isProfile
-              ? '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md text-[length:var(--calendar-caption-font-size)] [&>svg]:size-3.5'
-              : '[&>svg]:text-muted-foreground flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-[length:var(--calendar-caption-font-size)] [&>svg]:size-3.5',
+              ? '[&>svg]:text-text-tertiary flex h-8 items-center gap-1 rounded-md text-[length:var(--calendar-caption-font-size)] [&>svg]:size-3.5'
+              : '[&>svg]:text-text-tertiary flex h-8 items-center gap-1 rounded-md pl-2 pr-1 text-[length:var(--calendar-caption-font-size)] [&>svg]:size-3.5',
           defaultClassNames.caption_label
         ),
 
@@ -150,7 +150,7 @@ function Calendar({
         weekday: cn(
           isProfile
             ? 'text-black font-semibold flex h-[var(--cell-size)] select-none items-center justify-center rounded-md text-[length:var(--calendar-weekday-font-size)]'
-            : 'text-muted-foreground font-normal flex h-[var(--cell-size)] select-none items-center justify-center rounded-md text-[length:var(--calendar-weekday-font-size)]',
+            : 'text-text-tertiary font-normal flex h-[var(--cell-size)] select-none items-center justify-center rounded-md text-[length:var(--calendar-weekday-font-size)]',
           defaultClassNames.weekday
         ),
 
@@ -162,7 +162,7 @@ function Calendar({
         ),
 
         week_number: cn(
-          'text-muted-foreground select-none text-[length:var(--calendar-weekday-font-size)]',
+          'text-text-tertiary select-none text-[length:var(--calendar-weekday-font-size)]',
           defaultClassNames.week_number
         ),
 
@@ -172,13 +172,16 @@ function Calendar({
         ),
 
         range_start: cn(
-          'bg-accent rounded-l-md',
+          'bg-background-bottom rounded-l-md',
           defaultClassNames.range_start
         ),
 
         range_middle: cn('rounded-none', defaultClassNames.range_middle),
 
-        range_end: cn('bg-accent rounded-r-md', defaultClassNames.range_end),
+        range_end: cn(
+          'bg-background-bottom rounded-r-md',
+          defaultClassNames.range_end
+        ),
 
         today: cn(
           showTodayStyle
@@ -188,12 +191,12 @@ function Calendar({
         ),
 
         outside: cn(
-          'text-muted-foreground aria-selected:text-muted-foreground',
+          'text-text-tertiary aria-selected:text-text-tertiary',
           defaultClassNames.outside
         ),
 
         disabled: cn(
-          'text-muted-foreground opacity-50',
+          'text-text-tertiary opacity-50',
           defaultClassNames.disabled
         ),
 
@@ -315,19 +318,19 @@ function CalendarDayButton({
           'data-[range-end=true]:rounded-md',
           'data-[range-middle=true]:rounded-none',
           'data-[range-start=true]:rounded-md',
-          'data-[range-end=true]:bg-primary',
-          'data-[range-middle=true]:bg-accent',
-          'data-[range-start=true]:bg-primary',
-          'data-[selected-single=true]:bg-primary',
-          'data-[selected-single=true]:text-primary-foreground',
+          'data-[range-end=true]:bg-brand-500',
+          'data-[range-middle=true]:bg-background-bottom',
+          'data-[range-start=true]:bg-brand-500',
+          'data-[selected-single=true]:bg-brand-500',
+          'data-[selected-single=true]:text-text-primary',
           'group-data-[variant=profile]/calendar:data-[selected-single=true]:bg-brand-100',
           'group-data-[variant=profile]/calendar:data-[selected-single=true]:text-text-primary',
           'group-data-[variant=profile]/calendar:data-[selected-single=true]:font-medium',
           'group-data-[variant=profile]/calendar:data-[selected-single=true]:border',
           'group-data-[variant=profile]/calendar:data-[selected-single=true]:border-brand-300',
-          'data-[range-end=true]:text-primary-foreground',
-          'data-[range-middle=true]:text-accent-foreground',
-          'data-[range-start=true]:text-primary-foreground',
+          'data-[range-end=true]:text-text-primary',
+          'data-[range-middle=true]:text-text-primary',
+          'data-[range-start=true]:text-text-primary',
 
           // Focus state.
           'group-data-[focused=true]/day:relative',
@@ -343,7 +346,7 @@ function CalendarDayButton({
         isAvailable &&
           !modifiers.selected &&
           !modifiers.disabled &&
-          'bg-primary/20 hover:bg-primary/30',
+          'bg-brand-500/20 hover:bg-brand-500/30',
 
         !modifiers.disabled &&
           'group-data-[variant=profile]/calendar:text-black group-data-[variant=profile]/calendar:font-medium'

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ const Card = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      'rounded-lg border bg-card text-card-foreground shadow-sm',
+      'rounded-lg border bg-background-white text-text-primary shadow-sm',
       className
     )}
     {...props}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -50,7 +50,7 @@ const CardDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-text-tertiary', className)}
     {...props}
   />
 ));

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-primary ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-brand-500 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-500 data-[state=checked]:text-text-primary',
       className
     )}
     {...props}

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -13,7 +13,7 @@ const Checkbox = React.forwardRef<
   <CheckboxPrimitive.Root
     ref={ref}
     className={cn(
-      'peer h-4 w-4 shrink-0 rounded-sm border border-brand-500 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-500 data-[state=checked]:text-text-primary',
+      'peer h-4 w-4 shrink-0 rounded-sm border border-brand-500 ring-offset-background-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-brand-500 data-[state=checked]:text-text-primary',
       className
     )}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -89,7 +89,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-text-tertiary',
+      'overflow-hidden p-1 text-text-primary [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-text-tertiary',
       className
     )}
     {...props}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -29,7 +29,7 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-text-tertiary [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
           {children}
         </Command>
       </DialogContent>
@@ -46,7 +46,7 @@ const CommandInput = React.forwardRef<
     <CommandPrimitive.Input
       ref={ref}
       className={cn(
-        'bg-transparent flex h-11 w-full rounded-md py-3 text-base outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+        'bg-transparent flex h-11 w-full rounded-md py-3 text-base outline-none placeholder:text-text-tertiary disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
         className
       )}
       {...props}
@@ -89,7 +89,7 @@ const CommandGroup = React.forwardRef<
   <CommandPrimitive.Group
     ref={ref}
     className={cn(
-      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground',
+      'overflow-hidden p-1 text-foreground [&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:py-1.5 [&_[cmdk-group-heading]]:text-xs [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-text-tertiary',
       className
     )}
     {...props}
@@ -117,7 +117,7 @@ const CommandItem = React.forwardRef<
   <CommandPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground data-[disabled=true]:opacity-50',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none data-[disabled=true]:pointer-events-none data-[selected=true]:bg-background-bottom data-[selected=true]:text-text-primary data-[disabled=true]:opacity-50',
       className
     )}
     {...props}
@@ -133,7 +133,7 @@ const CommandShortcut = ({
   return (
     <span
       className={cn(
-        'ml-auto text-xs tracking-widest text-muted-foreground',
+        'ml-auto text-xs tracking-widest text-text-tertiary',
         className
       )}
       {...props}

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom data-[state=open]:text-text-tertiary">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background-white transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom data-[state=open]:text-text-tertiary">
         <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">關閉</span>
       </DialogPrimitive.Close>

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,13 +38,13 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background-white p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom data-[state=open]:text-text-tertiary">
         <X className="h-4 w-4" aria-hidden="true" />
         <span className="sr-only">關閉</span>
       </DialogPrimitive.Close>
@@ -102,7 +102,7 @@ const DialogDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DialogPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-text-tertiary', className)}
     {...props}
   />
 ));

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -19,7 +19,7 @@ const DropdownMenuSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <DropdownMenuPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-background-bottom', className)}
     {...props}
   />
 ));
@@ -34,7 +34,7 @@ const DropdownMenuSubTrigger = React.forwardRef<
   <DropdownMenuPrimitive.SubTrigger
     ref={ref}
     className={cn(
-      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-accent hover:text-accent-foreground',
+      'flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none hover:bg-background-bottom hover:text-text-primary',
       inset && 'pl-8',
       className
     )}
@@ -90,7 +90,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground',
+      'relative flex cursor-default select-none items-center rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-background-bottom focus:text-text-primary',
       inset && 'pl-8',
       className
     )}

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -96,7 +96,10 @@ const FormLabel = React.forwardRef<
   return (
     <Label
       ref={ref}
-      className={cn(showErrorStyle && error && 'text-destructive', className)}
+      className={cn(
+        showErrorStyle && error && 'text-status-error-default',
+        className
+      )}
       htmlFor={formItemId}
       {...props}
     />
@@ -137,7 +140,7 @@ const FormDescription = React.forwardRef<
     <p
       ref={ref}
       id={formDescriptionId}
-      className={cn('text-sm text-muted-foreground', className)}
+      className={cn('text-sm text-text-tertiary', className)}
       {...props}
     />
   );
@@ -159,7 +162,7 @@ const FormMessage = React.forwardRef<
     <p
       ref={ref}
       id={formMessageId}
-      className={cn('text-sm font-medium text-destructive', className)}
+      className={cn('text-sm font-medium text-status-error-default', className)}
       {...props}
     >
       {body}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'file:bg-transparent flex h-10 w-full rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'file:bg-transparent flex h-10 w-full rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background-white file:border-0 file:text-sm file:font-medium placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       <input
         type={type}
         className={cn(
-          'file:bg-transparent flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'file:bg-transparent flex h-10 w-full rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background file:border-0 file:text-sm file:font-medium placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring focus-visible:ring-offset-0 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -24,7 +24,7 @@ export function LoadingSpinner({
       <Loader2
         aria-hidden="true"
         className={cn(
-          'animate-spin text-muted-foreground',
+          'animate-spin text-text-tertiary',
           sizeClasses[size],
           className
         )}

--- a/src/components/ui/multi-select-dropdown.tsx
+++ b/src/components/ui/multi-select-dropdown.tsx
@@ -60,9 +60,9 @@ export default function MultiSelectDropdown({
           >
             <div
               className={cn(
-                'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-brand-500',
                 selectedValues.length === options.length
-                  ? 'bg-primary text-primary-foreground'
+                  ? 'bg-brand-500 text-text-primary'
                   : 'opacity-50 [&_svg]:invisible'
               )}
             >
@@ -80,16 +80,16 @@ export default function MultiSelectDropdown({
               >
                 <div
                   className={cn(
-                    'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-primary',
+                    'mr-2 flex h-4 w-4 items-center justify-center rounded-sm border border-brand-500',
                     isSelected
-                      ? 'bg-primary text-primary-foreground'
+                      ? 'bg-brand-500 text-text-primary'
                       : 'opacity-50 [&_svg]:invisible'
                   )}
                 >
                   <CheckIcon className="h-4 w-4" />
                 </div>
                 {option.icon && (
-                  <option.icon className="mr-2 h-4 w-4 text-muted-foreground" />
+                  <option.icon className="mr-2 h-4 w-4 text-text-tertiary" />
                 )}
                 <span>{option.label}</span>
               </CommandItem>

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -33,9 +33,9 @@ const multiSelectVariants = cva(
         default:
           'border-foreground/10 text-foreground bg-card hover:bg-card/80',
         secondary:
-          'border-foreground/10 bg-secondary text-secondary-foreground hover:bg-secondary/80',
+          'border-foreground/10 bg-background-bottom text-text-primary hover:bg-background-bottom/80',
         destructive:
-          'border-transparent bg-destructive text-destructive-foreground hover:bg-destructive/80',
+          'border-transparent bg-status-error-default text-text-white hover:bg-status-error-default/80',
       },
     },
     defaultVariants: {
@@ -204,7 +204,7 @@ export const MultiSelect = React.forwardRef<
                 </div>
                 <div className="flex items-center justify-between">
                   <XIcon
-                    className="mx-2 h-4 cursor-pointer text-muted-foreground"
+                    className="mx-2 h-4 cursor-pointer text-text-tertiary"
                     onClick={(event) => {
                       event.stopPropagation();
                       handleClear();
@@ -214,15 +214,15 @@ export const MultiSelect = React.forwardRef<
                     orientation="vertical"
                     className="flex h-full min-h-6"
                   />
-                  <ChevronDown className="mx-2 h-4 cursor-pointer text-muted-foreground" />
+                  <ChevronDown className="mx-2 h-4 cursor-pointer text-text-tertiary" />
                 </div>
               </div>
             ) : (
               <div className="mx-auto flex w-full items-center justify-between">
-                <span className="mx-3 text-sm text-muted-foreground">
+                <span className="mx-3 text-sm text-text-tertiary">
                   {placeholder}
                 </span>
-                <ChevronDown className="mx-2 h-4 cursor-pointer text-muted-foreground" />
+                <ChevronDown className="mx-2 h-4 cursor-pointer text-text-tertiary" />
               </div>
             )}
           </Button>

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -31,9 +31,9 @@ const multiSelectVariants = cva(
     variants: {
       variant: {
         default:
-          'border-foreground/10 text-foreground bg-card hover:bg-card/80',
+          'border-text-primary/10 text-text-primary bg-background-white hover:bg-background-white/80',
         secondary:
-          'border-foreground/10 bg-background-bottom text-text-primary hover:bg-background-bottom/80',
+          'border-text-primary/10 bg-background-bottom text-text-primary hover:bg-background-bottom/80',
         destructive:
           'border-transparent bg-status-error-default text-text-white hover:bg-status-error-default/80',
       },
@@ -186,7 +186,7 @@ export const MultiSelect = React.forwardRef<
                   {selectedValues.length > maxCount && (
                     <Badge
                       className={cn(
-                        'bg-transparent border-foreground/1 hover:bg-transparent text-foreground',
+                        'bg-transparent border-text-primary/1 hover:bg-transparent text-text-primary',
                         multiSelectVariants({ variant })
                       )}
                       style={{ animationDuration: `${animation}s` }}

--- a/src/components/ui/progress.tsx
+++ b/src/components/ui/progress.tsx
@@ -12,13 +12,13 @@ const Progress = React.forwardRef<
   <ProgressPrimitive.Root
     ref={ref}
     className={cn(
-      'relative h-4 w-full overflow-hidden rounded-full bg-secondary',
+      'relative h-4 w-full overflow-hidden rounded-full bg-background-bottom',
       className
     )}
     {...props}
   >
     <ProgressPrimitive.Indicator
-      className="h-full w-full flex-1 bg-primary transition-all"
+      className="h-full w-full flex-1 bg-brand-500 transition-all"
       style={{ transform: `translateX(-${100 - (value || 0)}%)` }}
     />
   </ProgressPrimitive.Root>

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -81,7 +81,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
         onClick={handleSearch}
         disabled={isLoading}
         aria-label="搜尋"
-        className="ml-2 h-10 w-10 shrink-0 cursor-pointer rounded-full border-none bg-primary p-0 leading-5 md:h-auto md:w-auto md:rounded-[24px] md:px-6 md:py-2.5"
+        className="ml-2 h-10 w-10 shrink-0 cursor-pointer rounded-full border-none bg-brand-500 p-0 leading-5 md:h-auto md:w-auto md:rounded-[24px] md:px-6 md:py-2.5"
       >
         {isLoading ? (
           <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />

--- a/src/components/ui/select-options.tsx
+++ b/src/components/ui/select-options.tsx
@@ -29,7 +29,7 @@ const SelectItem = React.forwardRef<HTMLDivElement, SelectItemProps>(
     return (
       <Select.Item
         className={cn(
-          'data-[disabled]:text-mauve8 text-black data-[highlighted]:text-white relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-base leading-none data-[disabled]:pointer-events-none data-[highlighted]:bg-primary data-[highlighted]:outline-none md:text-13',
+          'data-[disabled]:text-mauve8 text-black data-[highlighted]:text-white relative flex h-[25px] select-none items-center rounded-[3px] pl-[25px] pr-[35px] text-base leading-none data-[disabled]:pointer-events-none data-[highlighted]:bg-brand-500 data-[highlighted]:outline-none md:text-13',
           className
         )}
         {...props}
@@ -50,7 +50,7 @@ const SelectOptions = React.forwardRef<HTMLDivElement, SelectOptionsProps>(
     return (
       <Select.Root>
         <Select.Trigger
-          className="text-violet11 inline-flex h-10 items-center gap-[5px] rounded border border-input px-3 py-2 text-base leading-none outline-none data-[placeholder]:text-muted-foreground md:text-sm"
+          className="text-violet11 inline-flex h-10 items-center gap-[5px] rounded border border-background-border px-3 py-2 text-base leading-none outline-none data-[placeholder]:text-text-tertiary md:text-sm"
           aria-label="Food"
         >
           <Select.Value placeholder={selectItemData.placeholder} />
@@ -65,7 +65,7 @@ const SelectOptions = React.forwardRef<HTMLDivElement, SelectOptionsProps>(
             </Select.ScrollUpButton>
             <Select.Viewport className="p-[5px]">
               <Select.Group>
-                <Select.Label className="px-[25px] text-base leading-[25px] text-muted-foreground md:text-xs">
+                <Select.Label className="px-[25px] text-base leading-[25px] text-text-tertiary md:text-xs">
                   {selectItemData.label}
                 </Select.Label>
                 {selectItemData.options.map((option) => {

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background-white placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1',
       className
     )}
     {...props}

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -19,7 +19,7 @@ const SelectTrigger = React.forwardRef<
   <SelectPrimitive.Trigger
     ref={ref}
     className={cn(
-      'flex h-10 w-full items-center justify-between rounded-md border border-input bg-background px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1',
+      'flex h-10 w-full items-center justify-between rounded-md border border-background-border bg-background-white px-3 py-2 text-base ring-offset-background placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50 md:text-sm [&>span]:line-clamp-1',
       className
     )}
     {...props}
@@ -120,7 +120,7 @@ const SelectItem = React.forwardRef<
   <SelectPrimitive.Item
     ref={ref}
     className={cn(
-      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+      'relative flex w-full cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none focus:bg-background-bottom focus:text-text-primary data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
       className
     )}
     {...props}
@@ -142,7 +142,7 @@ const SelectSeparator = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SelectPrimitive.Separator
     ref={ref}
-    className={cn('-mx-1 my-1 h-px bg-muted', className)}
+    className={cn('-mx-1 my-1 h-px bg-background-bottom', className)}
     {...props}
   />
 ));

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -24,7 +24,7 @@ const SheetOverlay = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Overlay
     className={cn(
-      'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-background-white/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
@@ -34,7 +34,7 @@ const SheetOverlay = React.forwardRef<
 SheetOverlay.displayName = SheetPrimitive.Overlay.displayName;
 
 const sheetVariants = cva(
-  'fixed z-50 gap-4 bg-background p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
+  'fixed z-50 gap-4 bg-background-white p-6 shadow-lg transition ease-in-out data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:duration-500',
   {
     variants: {
       side: {
@@ -82,7 +82,7 @@ const SheetContent = React.forwardRef<
       >
         {children}
         {showPrimitiveClose && (
-          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom">
             <X className="h-4 w-4" aria-hidden="true" />
             <span className="sr-only">關閉</span>
           </SheetPrimitive.Close>
@@ -139,7 +139,7 @@ const SheetDescription = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Description
     ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
+    className={cn('text-sm text-text-tertiary', className)}
     {...props}
   />
 ));

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -82,7 +82,7 @@ const SheetContent = React.forwardRef<
       >
         {children}
         {showPrimitiveClose && (
-          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom">
+          <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background-white transition-opacity hover:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-background-bottom">
             <X className="h-4 w-4" aria-hidden="true" />
             <span className="sr-only">關閉</span>
           </SheetPrimitive.Close>
@@ -127,7 +127,7 @@ const SheetTitle = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <SheetPrimitive.Title
     ref={ref}
-    className={cn('text-lg font-semibold text-foreground', className)}
+    className={cn('text-lg font-semibold text-text-primary', className)}
     {...props}
   />
 ));

--- a/src/components/ui/skeleton.tsx
+++ b/src/components/ui/skeleton.tsx
@@ -6,7 +6,7 @@ export function Skeleton({
 }: React.HTMLAttributes<HTMLDivElement>) {
   return (
     <div
-      className={cn('animate-pulse rounded-md bg-muted', className)}
+      className={cn('animate-pulse rounded-md bg-background-bottom', className)}
       {...props}
     />
   );

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -14,7 +14,7 @@ const TabsList = React.forwardRef<
   <TabsPrimitive.List
     ref={ref}
     className={cn(
-      'inline-flex h-10 items-center justify-center rounded-md bg-muted p-1 text-muted-foreground',
+      'inline-flex h-10 items-center justify-center rounded-md bg-background-bottom p-1 text-text-tertiary',
       className
     )}
     {...props}
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background-white data-[state=active]:text-foreground data-[state=active]:shadow-sm',
       className
     )}
     {...props}

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -29,7 +29,7 @@ const TabsTrigger = React.forwardRef<
   <TabsPrimitive.Trigger
     ref={ref}
     className={cn(
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background-white data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background-white transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background-white data-[state=active]:text-text-primary data-[state=active]:shadow-sm',
       className
     )}
     {...props}
@@ -44,7 +44,7 @@ const TabsContent = React.forwardRef<
   <TabsPrimitive.Content
     ref={ref}
     className={cn(
-      'mt-2 ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      'mt-2 ring-offset-background-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
       className
     )}
     {...props}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'bg-transparent block w-full rounded-md border border-background-border px-3 py-2 text-base ring-offset-background placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'bg-transparent block w-full rounded-md border border-background-border px-3 py-2 text-base ring-offset-background-white placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -9,7 +9,7 @@ const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <textarea
         className={cn(
-          'bg-transparent block w-full rounded-md border border-input px-3 py-2 text-base ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
+          'bg-transparent block w-full rounded-md border border-background-border px-3 py-2 text-base ring-offset-background placeholder:text-text-tertiary focus-visible:outline-none focus-visible:ring focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm',
           className
         )}
         ref={ref}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -27,9 +27,9 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border bg-background text-foreground',
+        default: 'border bg-background-white text-foreground',
         destructive:
-          'destructive group border-destructive bg-destructive text-destructive-foreground',
+          'destructive group border-status-error-default bg-status-error-default text-text-white',
       },
     },
     defaultVariants: {
@@ -60,7 +60,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'bg-transparent inline-flex h-8 shrink-0 items-center justify-center rounded-md border px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-secondary focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-muted/40 group-[.destructive]:hover:border-destructive/30 group-[.destructive]:hover:bg-destructive group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-destructive',
+      'bg-transparent inline-flex h-8 shrink-0 items-center justify-center rounded-md border px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-background-bottom focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-background-bottom/40 group-[.destructive]:hover:border-status-error-default/30 group-[.destructive]:hover:bg-status-error-default group-[.destructive]:hover:text-text-white group-[.destructive]:focus:ring-status-error-default',
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
+      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-text-white group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
       className
     )}
     toast-close=""

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -27,7 +27,7 @@ const toastVariants = cva(
   {
     variants: {
       variant: {
-        default: 'border bg-background-white text-foreground',
+        default: 'border bg-background-white text-text-primary',
         destructive:
           'destructive group border-status-error-default bg-status-error-default text-text-white',
       },
@@ -60,7 +60,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'bg-transparent inline-flex h-8 shrink-0 items-center justify-center rounded-md border px-3 text-sm font-medium ring-offset-background transition-colors hover:bg-background-bottom focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-background-bottom/40 group-[.destructive]:hover:border-status-error-default/30 group-[.destructive]:hover:bg-status-error-default group-[.destructive]:hover:text-text-white group-[.destructive]:focus:ring-status-error-default',
+      'bg-transparent inline-flex h-8 shrink-0 items-center justify-center rounded-md border px-3 text-sm font-medium ring-offset-background-white transition-colors hover:bg-background-bottom focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-background-bottom/40 group-[.destructive]:hover:border-status-error-default/30 group-[.destructive]:hover:bg-status-error-default group-[.destructive]:hover:text-text-white group-[.destructive]:focus:ring-status-error-default',
       className
     )}
     {...props}
@@ -75,7 +75,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-foreground/50 opacity-0 transition-opacity hover:text-foreground focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-text-white group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
+      'absolute right-2 top-2 rounded-md p-1 text-text-primary/50 opacity-0 transition-opacity hover:text-text-primary focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-text-white group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
       className
     )}
     toast-close=""


### PR DESCRIPTION
Migrate 22 UI primitive components in `src/components/ui/` from the legacy shadcn semantic classes (e.g. `bg-primary`, `bg-secondary`, `bg-muted`, `bg-accent`, `bg-destructive`, `border-border`, `border-input`, `bg-background` and their `-foreground` variants) to the new unified color tokens defined in `src/design/MIGRATION.md` (e.g. `bg-brand-500`, `bg-background-bottom`, `text-text-tertiary`, `bg-status-error-default`, `text-text-white`, `border-background-border`, and `bg-background-white`).

- Replaced old styles while keeping pseudo-classes (like `:hover`, `:focus`, `:focus-visible`) intact.
- Verified visual and style consistency across all states.
- Audited with scanning scripts to ensure 100% removal of target legacy color classes across all 22 files.
- Verified that `tsc --noEmit`, ESLint rules, and all 636 vitest tests pass successfully.
- Successfully compiled the Next.js production build with zero errors.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/397
