### PR TITLE
fix(ui): remove remaining legacy design-token class residue (X-Tracker #404)

### DIFF
--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -59,7 +59,7 @@ const AvatarUpload = <T extends FieldValues>({
     <div className="mb-10 flex flex-col items-center lg:items-start">
       <div
         className={`group relative flex size-36 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 bg-avatar-background lg:h-[150px] lg:w-[150px] ${
-          errorMessage ? 'border-destructive' : 'border-avatar-border'
+          errorMessage ? 'border-status-error-default' : 'border-avatar-border'
         }`}
         onClick={() => document.getElementById('fileInput')?.click()}
       >

--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -49,7 +49,7 @@ export const AllVariants: Story = {
       </Badge>
       <Badge {...args} variant="filter">
         <span>Filter Badge</span>
-        <X className="size-3.5 cursor-pointer text-destructive-foreground hover:text-destructive" />
+        <X className="size-3.5 cursor-pointer text-text-white hover:text-status-error-default" />
       </Badge>
     </div>
   ),

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -61,7 +61,7 @@ const ToastAction = React.forwardRef<
   <ToastPrimitives.Action
     ref={ref}
     className={cn(
-      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background-white transition-colors hover:bg-background-bottom focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-background-bottom/40 group-[.destructive]:hover:border-status-error-default/30 group-[.destructive]:hover:bg-status-error-default group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus:ring-status-error-default',
+      'inline-flex h-8 shrink-0 items-center justify-center rounded-md border bg-transparent px-3 text-sm font-medium ring-offset-background-white transition-colors hover:bg-background-bottom focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 group-[.destructive]:border-background-bottom/40 group-[.destructive]:hover:border-status-error-default/30 group-[.destructive]:hover:bg-status-error-default group-[.destructive]:hover:text-text-white group-[.destructive]:focus:ring-status-error-default',
       className
     )}
     {...props}
@@ -76,7 +76,7 @@ const ToastClose = React.forwardRef<
   <ToastPrimitives.Close
     ref={ref}
     className={cn(
-      'absolute right-2 top-2 rounded-md p-1 text-text-primary/50 opacity-0 transition-opacity hover:text-text-primary focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-destructive-foreground group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
+      'absolute right-2 top-2 rounded-md p-1 text-text-primary/50 opacity-0 transition-opacity hover:text-text-primary focus:opacity-100 focus-visible:outline-none focus-visible:ring-2 group-hover:opacity-100 group-[.destructive]:text-status-error-active group-[.destructive]:hover:text-text-white group-[.destructive]:focus-visible:ring-status-error-active group-[.destructive]:focus-visible:ring-offset-status-error-default',
       className
     )}
     toast-close=""

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,11 +42,11 @@
 
 @layer base {
   * {
-    @apply border-border;
+    @apply border-background-border;
   }
 
   body {
-    @apply bg-background text-foreground;
+    @apply bg-background-white text-text-primary;
   }
 }
 


### PR DESCRIPTION
## Summary
- Base `@layer base` rules in `global.css` (applied to every element and `<body>`) were still on the old shadcn token names (`border-border`, `bg-background`, `text-foreground`) instead of the unified design tokens.
- `toast.tsx` (both `ToastAction` and `ToastClose`), `avatar-upload.tsx`, and `badge.stories.tsx` still referenced `border-destructive` / `text-destructive-foreground`.
- Replaced all of the above per the mapping table in `src/design/MIGRATION.md`, closing out the remaining scope of X-Tracker #404. Token values are unchanged (aliases resolve to the same underlying CSS variables), so there is no visual diff.

## Test plan
- [x] `pnpm lint` - 0 errors (pre-existing warnings unrelated to this change)
- [x] `pnpm type-check` - clean
- [x] `pnpm test` - 643 tests passed
- [x] `pnpm build` - production build succeeds

Generated with Claude Code