### PR TITLE
fix(design): restore white text token and black active-tab colors

### DIFF
--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -47,7 +47,7 @@ export function ReservationDashboard({ role }: ReservationDashboardProps) {
   const triggerClass =
     'group shrink-0 rounded-full border border-background-border px-3 py-1.5 text-sm ' +
     'bg-transparent text-text-primary ' +
-    'data-[state=active]:bg-black data-[state=active]:text-text-white data-[state=active]:border-black';
+    'data-[state=active]:bg-dark data-[state=active]:text-text-white data-[state=active]:border-dark';
 
   const countClass =
     'ml-1 text-xs text-text-tertiary group-data-[state=active]:text-text-white/80';

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -6,7 +6,7 @@ module.exports = {
     secondary: 'hsl(var(--color-text-secondary) / <alpha-value>)',
     tertiary: 'hsl(var(--color-text-tertiary) / <alpha-value>)',
     disable: 'hsl(var(--color-text-disable) / <alpha-value>)',
-    white: 'hsl(var(--color-text-text-white) / <alpha-value>)',
+    white: 'hsl(var(--color-text-white) / <alpha-value>)',
   },
   background: {
     DEFAULT: 'hsl(var(--background))',


### PR DESCRIPTION
## Summary
- `src/design/tokens/color.ts` mapped the `text-white` Tailwind color to a nonexistent CSS variable, `--color-text-text-white` (typo introduced in 4b8b2a9). Since `var()` references with no fallback are invalid at computed-value time, every `text-text-white` usage silently fell back to the inherited text color instead of rendering white -- affecting the Footer, destructive buttons/badges, the reservation tab active-state text, and more.
- `ReservationDashboard`'s active-tab classes used `bg-black`/`border-black`, which generate no CSS because `tailwind.config.js` fully replaces the default Tailwind color palette (rather than extending it) -- so the active tab never actually turned black. Switched to `bg-dark`/`border-dark`, the token already used elsewhere (Footer, mentor card badge) as this app's black equivalent.

## Test plan
- [x] `pnpm lint` -- 0 errors (6 pre-existing unrelated warnings)
- [x] `pnpm type-check` -- clean
- [x] `pnpm build` -- succeeds
- [x] `pnpm vitest run` -- 643 tests passed
- [ ] Manual check: Footer text renders white, Reservation tab turns black (`bg-dark`) when active

Generated with Claude Code