### PR TITLE
ci(storybook): add Vercel deploy workflow for Storybook

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -54,11 +54,13 @@ jobs:
 
       - name: Comment on commit with deploy URL
         uses: actions/github-script@v7
+        env:
+          VERCEL_URL: ${{ steps.deploy.outputs.vercel_url }}
         with:
           script: |
             github.rest.repos.createCommitComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
               commit_sha: context.sha,
-              body: `📚 Storybook deployed:\n${{ steps.deploy.outputs.vercel_url }}`
+              body: `📚 Storybook deployed:\n${process.env.VERCEL_URL}`
             })

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,0 +1,64 @@
+name: Deploy Storybook (Vercel)
+
+on:
+  push:
+    branches:
+      - develop
+    paths:
+      - 'src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
+      - 'src/**/*.mdx'
+      - '.storybook/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+  workflow_dispatch:
+
+env:
+  VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID_STORYBOOK }}
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+
+jobs:
+  deploy-storybook:
+    runs-on: ubuntu-latest
+    name: Build & Deploy Storybook
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Set up PNPM
+        uses: pnpm/action-setup@v2
+        with:
+          version: 9
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build Storybook
+        run: pnpm build-storybook
+
+      - name: Install Vercel CLI
+        run: npm install --global vercel@51.2.1
+
+      - name: Deploy Storybook to Vercel
+        id: deploy
+        run: |
+          echo "🚀 Deploying Storybook to Vercel..."
+          url=$(vercel deploy ./storybook-static --prod --yes --token=${{ env.VERCEL_TOKEN }} | tail -n 1)
+          echo "vercel_url=${url}" >> $GITHUB_OUTPUT
+
+      - name: Comment on commit with deploy URL
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: `📚 Storybook deployed:\n${{ steps.deploy.outputs.vercel_url }}`
+            })

--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -49,7 +49,7 @@ jobs:
         id: deploy
         run: |
           echo "🚀 Deploying Storybook to Vercel..."
-          url=$(vercel deploy ./storybook-static --prod --yes --token=${{ env.VERCEL_TOKEN }} | tail -n 1)
+          url=$(vercel deploy ./storybook-static --prod --yes | tail -n 1)
           echo "vercel_url=${url}" >> $GITHUB_OUTPUT
 
       - name: Comment on commit with deploy URL


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/deploy-storybook.yml` to build and deploy Storybook to Vercel on push to `develop` (plus manual `workflow_dispatch`)
- Mirrors the existing `deploy-dev.yml` pattern, but skips `vercel pull`/`vercel build` since Storybook output is a plain static site, not a Next.js app — it deploys `storybook-static/` directly
- Requires `VERCEL_PROJECT_ID_STORYBOOK` secret (already added), reuses existing `VERCEL_TOKEN`/`VERCEL_ORG_ID`

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test` / `tsc --noEmit` pass (via pre-push hook)
- [ ] Merge and confirm the workflow deploys successfully, or trigger manually via `workflow_dispatch` first