### PR TITLE
ci(storybook): make Storybook deploy workflow manual-only

### DIFF
--- a/.github/workflows/deploy-storybook.yml
+++ b/.github/workflows/deploy-storybook.yml
@@ -1,15 +1,6 @@
 name: Deploy Storybook (Vercel)
 
 on:
-  push:
-    branches:
-      - develop
-    paths:
-      - 'src/**/*.stories.@(js|jsx|mjs|ts|tsx)'
-      - 'src/**/*.mdx'
-      - '.storybook/**'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## Summary
- Remove the push-on-develop trigger from `deploy-storybook.yml` so it only runs via manual `workflow_dispatch`

## Test plan
- [x] `pnpm type-check` and `pnpm test` pass (ran automatically via husky pre-push hook)
- [ ] Manually trigger the workflow from the Actions tab to confirm it still deploys correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)