### PR TITLE
fix(reservation): resolve router context and layout issues in MentorScheduleDialog story (X-Tracker #427)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
@@ -12,6 +12,19 @@ const meta: Meta<typeof MentorScheduleDialog> = {
   title: 'Components/Profile/Reservation/MentorScheduleDialog',
   component: MentorScheduleDialog,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+    layout: 'fullscreen',
+  },
+  decorators: [
+    (Story) => (
+      <div className="min-h-[600px] p-6">
+        <Story />
+      </div>
+    ),
+  ],
 };
 
 export default meta;


### PR DESCRIPTION
Configure Next.js App Router simulation context and set layout to fullscreen with a min-height decorator wrapper for the MentorScheduleDialog Storybook story. This resolves the useRouter crash and layout measurement warnings when mounting.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/427
