### PR TITLE
feat(utils): extract useAsyncAction lifecycle primitive (X-Tracker #436)

### DIFF
--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureFlowFailure, sanitize } from '@/lib/monitoring';
 import { mockToast } from '@/test/mocks/useToast';
 
-import useAsyncAction, { ConcurrentActionError } from './useAsyncAction';
+import useAsyncAction from './useAsyncAction';
 
 // Mock Dependencies
 vi.mock('@/components/ui/use-toast', async () => {
@@ -490,7 +490,7 @@ describe('useAsyncAction', () => {
     });
   });
 
-  it('should prevent concurrent execution and throw ConcurrentActionError if preventConcurrent is true (default) and throwError is true', async () => {
+  it('should prevent concurrent execution and return a non-resolving promise if preventConcurrent is true (default) and throwError is true', async () => {
     let resolveAction!: (value: string) => void;
     const actionPromise = new Promise<string>((resolve) => {
       resolveAction = resolve;
@@ -507,14 +507,12 @@ describe('useAsyncAction', () => {
 
     expect(result.current.isPending).toBe(true);
 
-    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該拋出 ConcurrentActionError，確保控制流程正常且不發生記憶體洩漏
-    let runPromise2!: Promise<string>;
+    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該回傳不 resolve 的 Promise，防止重複觸發且不破壞外層控制流
     act(() => {
-      runPromise2 = result.current.run(secondActionSpy) as Promise<string>;
+      result.current.run(secondActionSpy);
     });
 
     await act(async () => {
-      await expect(runPromise2).rejects.toThrow(ConcurrentActionError);
       expect(secondActionSpy).not.toHaveBeenCalled();
 
       resolveAction('first-result');

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { mockToast } from '@/test/mocks/useToast';
 
-import { useAsyncAction } from './useAsyncAction';
+import { ConcurrentActionError, useAsyncAction } from './useAsyncAction';
 
 // Mock Dependencies
 vi.mock('@/components/ui/use-toast', async () => {
@@ -303,7 +303,7 @@ describe('useAsyncAction', () => {
     });
   });
 
-  it('should prevent concurrent execution and return a non-resolving promise if preventConcurrent is true (default) and throwError is true', async () => {
+  it('should prevent concurrent execution and throw ConcurrentActionError if preventConcurrent is true (default) and throwError is true', async () => {
     let resolveAction!: (value: string) => void;
     const actionPromise = new Promise<string>((resolve) => {
       resolveAction = resolve;
@@ -320,15 +320,16 @@ describe('useAsyncAction', () => {
 
     expect(result.current.isPending).toBe(true);
 
-    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該回傳不 resolve 的 Promise，而不是拋出 Error 進而引發未捕捉 Promise 異常
+    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該拋出 ConcurrentActionError，確保控制流程正常且不發生記憶體洩漏
+    let runPromise2!: Promise<string>;
     act(() => {
-      result.current.run(secondActionSpy);
+      runPromise2 = result.current.run(secondActionSpy) as Promise<string>;
     });
 
-    // 驗證第二個非同步操作確實沒有執行
-    expect(secondActionSpy).not.toHaveBeenCalled();
-
     await act(async () => {
+      await expect(runPromise2).rejects.toThrow(ConcurrentActionError);
+      expect(secondActionSpy).not.toHaveBeenCalled();
+
       resolveAction('first-result');
       const res1 = await runPromise1;
       expect(res1).toBe('first-result');

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -87,7 +87,7 @@ describe('useAsyncAction', () => {
     expect(onErrorMock).toHaveBeenCalledWith(error);
   });
 
-  it('rethrows when rethrow is true', async () => {
+  it('rethrows when throwError is true (default)', async () => {
     const { result } = renderHook(() => useAsyncAction());
 
     const error = new Error('action failed');
@@ -95,7 +95,7 @@ describe('useAsyncAction', () => {
 
     await act(async () => {
       await expect(
-        result.current.run(actionFn, { rethrow: true })
+        result.current.run(actionFn, { throwError: true })
       ).rejects.toThrow('action failed');
     });
 
@@ -843,5 +843,30 @@ describe('useAsyncAction', () => {
 
     expect(val).toBe('post-unmount-data');
     expect(result.current.isPending).toBe(false);
+  });
+
+  it('should be safe if component unmounts while run is pending', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const { result, unmount } = renderHook(() => useAsyncAction());
+
+    let runPromise!: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run(() => actionPromise);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    // 在 pending 期間卸載組件
+    unmount();
+
+    await act(async () => {
+      resolveAction('resolved-after-unmount');
+      const res = await runPromise;
+      expect(res).toBe('resolved-after-unmount');
+    });
   });
 });

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -1,0 +1,384 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { captureFlowFailure } from '@/lib/monitoring';
+import { mockToast } from '@/test/mocks/useToast';
+
+import { useAsyncAction } from './useAsyncAction';
+
+// Mock Dependencies
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn(),
+}));
+
+class LoggedError extends Error {
+  constructor(message?: string) {
+    super(message);
+    this.name = 'LoggedError';
+  }
+}
+
+describe('useAsyncAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should toggle isPending correctly on successful execution', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const { result } = renderHook(() => useAsyncAction());
+
+    expect(result.current.isPending).toBe(false);
+
+    let runPromise: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run(() => actionPromise);
+    });
+
+    // 執行中：isPending 應該為 true
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      resolveAction('success-data');
+      const val = await runPromise;
+      expect(val).toBe('success-data');
+    });
+
+    // 執行完畢：isPending 應該還原為 false
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should reset isPending even when the action throws', async () => {
+    let rejectAction!: (reason: Error) => void;
+    const actionPromise = new Promise<never>((_, reject) => {
+      rejectAction = reject;
+    });
+
+    const { result } = renderHook(() => useAsyncAction());
+
+    expect(result.current.isPending).toBe(false);
+
+    let runPromise!: Promise<never | undefined>;
+    act(() => {
+      runPromise = result.current.run(() => actionPromise) as Promise<never>;
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      rejectAction(new Error('failure-reason'));
+      // 預設 throwError 為 true，因此應該拋出異常
+      await expect(runPromise).rejects.toThrow('failure-reason');
+    });
+
+    // 拋出異常後：isPending 仍應被重置為 false
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should swallow error and return undefined if throwError is false', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    let val: string | undefined = 'initial';
+    await act(async () => {
+      val = await result.current.run(
+        () => Promise.reject(new Error('swallowed-error')),
+        { throwError: false }
+      );
+    });
+
+    expect(val).toBeUndefined();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should report failure via captureFlowFailure when flow and step are provided', async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        flow: 'test_flow',
+        step: 'test_step',
+      })
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.run(() => Promise.reject(new Error('test-sentry-error')))
+      ).rejects.toThrow('test-sentry-error');
+    });
+
+    expect(captureFlowFailure).toHaveBeenCalledWith({
+      flow: 'test_flow',
+      step: 'test_step',
+      message: 'test-sentry-error',
+    });
+  });
+
+  it('should NOT call captureFlowFailure if shouldSkipLogging returns true', async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        flow: 'test_flow',
+        step: 'test_step',
+        shouldSkipLogging: (err) => err instanceof LoggedError,
+      })
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.run(() =>
+          Promise.reject(new LoggedError('already-logged'))
+        )
+      ).rejects.toThrow('already-logged');
+    });
+
+    expect(captureFlowFailure).not.toHaveBeenCalled();
+  });
+
+  it('should call toast with errorMessage when action throws and errorMessage is provided', async () => {
+    const { result } = renderHook(() => useAsyncAction());
+
+    await act(async () => {
+      await expect(
+        result.current.run(() => Promise.reject(new Error('some-error')), {
+          errorMessage: '發生錯誤，請稍候再試',
+          duration: 3000,
+        })
+      ).rejects.toThrow('some-error');
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      description: '發生錯誤，請稍候再試',
+      duration: 3000,
+    });
+  });
+
+  it('should call custom onError callback if provided', async () => {
+    const onErrorMock = vi.fn();
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        onError: onErrorMock,
+      })
+    );
+
+    const testError = new Error('callback-error');
+
+    await act(async () => {
+      await expect(
+        result.current.run(() => Promise.reject(testError))
+      ).rejects.toThrow('callback-error');
+    });
+
+    expect(onErrorMock).toHaveBeenCalledWith(testError);
+  });
+
+  it('should support configuration overriding on run level', async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        flow: 'default_flow',
+        step: 'default_step',
+        errorMessage: 'default_toast',
+      })
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.run(() => Promise.reject(new Error('override-error')), {
+          flow: 'override_flow',
+          step: 'override_step',
+          errorMessage: 'override_toast',
+        })
+      ).rejects.toThrow('override-error');
+    });
+
+    expect(captureFlowFailure).toHaveBeenCalledWith({
+      flow: 'override_flow',
+      step: 'override_step',
+      message: 'override-error',
+    });
+
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      description: 'override_toast',
+      duration: 5000,
+    });
+  });
+
+  it('should prevent concurrent execution and throw if preventConcurrent is true (default) and throwError is true', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const secondActionSpy = vi.fn().mockResolvedValue('second-result');
+
+    const { result } = renderHook(() => useAsyncAction());
+
+    let runPromise1!: Promise<string>;
+    act(() => {
+      runPromise1 = result.current.run(() => actionPromise) as Promise<string>;
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    // 當處於 Pending 且 throwError 為 true（預設）時，第二次呼叫 run 應該拋出 'Action is already pending' 錯誤
+    let runPromise2!: Promise<string>;
+    act(() => {
+      runPromise2 = result.current.run(secondActionSpy) as Promise<string>;
+    });
+
+    await act(async () => {
+      await expect(runPromise2).rejects.toThrow('Action is already pending');
+      expect(secondActionSpy).not.toHaveBeenCalled();
+
+      resolveAction('first-result');
+      const res1 = await runPromise1;
+      expect(res1).toBe('first-result');
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should prevent concurrent execution and return undefined if preventConcurrent is true and throwError is false', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const secondActionSpy = vi.fn().mockResolvedValue('second-result');
+
+    const { result } = renderHook(() => useAsyncAction({ throwError: false }));
+
+    let runPromise1!: Promise<string | undefined>;
+    act(() => {
+      runPromise1 = result.current.run(() => actionPromise);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    // 當處於 Pending 且 throwError 為 false 時，第二次呼叫 run 應該吞沒並返回 undefined
+    let runPromise2!: Promise<string | undefined>;
+    act(() => {
+      runPromise2 = result.current.run(secondActionSpy);
+    });
+
+    await act(async () => {
+      const res2 = await runPromise2;
+      expect(res2).toBeUndefined();
+      expect(secondActionSpy).not.toHaveBeenCalled();
+
+      resolveAction('first-result');
+      const res1 = await runPromise1;
+      expect(res1).toBe('first-result');
+    });
+
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should NOT prevent concurrent execution if preventConcurrent is set to false, and isPending stays true until all finish', async () => {
+    let resolveAction1!: (value: string) => void;
+    const actionPromise1 = new Promise<string>((resolve) => {
+      resolveAction1 = resolve;
+    });
+
+    let resolveAction2!: (value: string) => void;
+    const actionPromise2 = new Promise<string>((resolve) => {
+      resolveAction2 = resolve;
+    });
+
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        preventConcurrent: false,
+      })
+    );
+
+    let runPromise1!: Promise<string | undefined>;
+    let runPromise2!: Promise<string | undefined>;
+
+    act(() => {
+      runPromise1 = result.current.run(() => actionPromise1);
+    });
+
+    act(() => {
+      runPromise2 = result.current.run(() => actionPromise2);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    // 完成第一個請求：isPending 應該仍保持為 true，因為第二個請求仍在執行中！
+    await act(async () => {
+      resolveAction1('res1');
+    });
+    const res1 = await runPromise1;
+    expect(res1).toBe('res1');
+    expect(result.current.isPending).toBe(true);
+
+    // 完成第二個請求：此時所有併發請求結束，isPending 應該被設回 false
+    await act(async () => {
+      resolveAction2('res2');
+    });
+    const res2 = await runPromise2;
+    expect(res2).toBe('res2');
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should NOT reset isPending on success if resetPendingOnSuccess is false', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        resetPendingOnSuccess: false,
+      })
+    );
+
+    let runPromise!: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run(() => actionPromise);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    await act(async () => {
+      resolveAction('done');
+      await runPromise;
+    });
+
+    // 成功後 isPending 應該保持為 true
+    expect(result.current.isPending).toBe(true);
+  });
+
+  it('should be safe on component unmount and not call setState', async () => {
+    let resolveAction!: (value: string) => void;
+    const actionPromise = new Promise<string>((resolve) => {
+      resolveAction = resolve;
+    });
+
+    const { result, unmount } = renderHook(() => useAsyncAction());
+
+    let runPromise!: Promise<string | undefined>;
+    act(() => {
+      runPromise = result.current.run(() => actionPromise);
+    });
+
+    expect(result.current.isPending).toBe(true);
+
+    // 卸載組件
+    unmount();
+
+    await act(async () => {
+      resolveAction('unmounted-done');
+      const res = await runPromise;
+      expect(res).toBe('unmounted-done');
+    });
+
+    // 卸載後 isPending 不應更新（雖然讀取 result.current 可能還是最後的狀態，但我們不希望拋出 React 記憶體洩漏警告）
+  });
+});

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -503,4 +503,20 @@ describe('useAsyncAction', () => {
         'Reset failed with ?email=[REDACTED]&password=[REDACTED]&token=[REDACTED] and JSON {"email":"[REDACTED]","password":"[REDACTED]","token":"[REDACTED]"}',
     });
   });
+
+  it('should not update pending state if run is called after unmount', async () => {
+    const { result, unmount } = renderHook(() => useAsyncAction());
+
+    unmount();
+
+    let val: string | undefined;
+    await act(async () => {
+      val = await result.current.run(() =>
+        Promise.resolve('post-unmount-data')
+      );
+    });
+
+    expect(val).toBe('post-unmount-data');
+    expect(result.current.isPending).toBe(false);
+  });
 });

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -303,7 +303,7 @@ describe('useAsyncAction', () => {
     });
   });
 
-  it('should prevent concurrent execution and throw if preventConcurrent is true (default) and throwError is true', async () => {
+  it('should prevent concurrent execution and return a non-resolving promise if preventConcurrent is true (default) and throwError is true', async () => {
     let resolveAction!: (value: string) => void;
     const actionPromise = new Promise<string>((resolve) => {
       resolveAction = resolve;
@@ -320,16 +320,15 @@ describe('useAsyncAction', () => {
 
     expect(result.current.isPending).toBe(true);
 
-    // 當處於 Pending 且 throwError 為 true（預設）時，第二次呼叫 run 應該拋出 'Action is already pending' 錯誤
-    let runPromise2!: Promise<string>;
+    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該回傳不 resolve 的 Promise，而不是拋出 Error 進而引發未捕捉 Promise 異常
     act(() => {
-      runPromise2 = result.current.run(secondActionSpy) as Promise<string>;
+      result.current.run(secondActionSpy);
     });
 
-    await act(async () => {
-      await expect(runPromise2).rejects.toThrow('Action is already pending');
-      expect(secondActionSpy).not.toHaveBeenCalled();
+    // 驗證第二個非同步操作確實沒有執行
+    expect(secondActionSpy).not.toHaveBeenCalled();
 
+    await act(async () => {
       resolveAction('first-result');
       const res1 = await runPromise1;
       expect(res1).toBe('first-result');
@@ -474,5 +473,33 @@ describe('useAsyncAction', () => {
     });
 
     // 卸載後 isPending 不應更新（雖然讀取 result.current 可能還是最後的狀態，但我們不希望拋出 React 記憶體洩漏警告）
+  });
+
+  it('should sanitize query parameters and JSON-like strings in error message before calling captureFlowFailure to protect PII', async () => {
+    const { result } = renderHook(() =>
+      useAsyncAction({
+        flow: 'auth_flow',
+        step: 'password_reset',
+      })
+    );
+
+    await act(async () => {
+      await expect(
+        result.current.run(() =>
+          Promise.reject(
+            new Error(
+              'Reset failed with ?email=user@example.com&password=secret_password&token=123 and JSON {"email":"user@example.com","password":"secret_password","token":"123"}'
+            )
+          )
+        )
+      ).rejects.toThrow();
+    });
+
+    expect(captureFlowFailure).toHaveBeenCalledWith({
+      flow: 'auth_flow',
+      step: 'password_reset',
+      message:
+        'Reset failed with ?email=[REDACTED]&password=[REDACTED]&token=[REDACTED] and JSON {"email":"[REDACTED]","password":"[REDACTED]","token":"[REDACTED]"}',
+    });
   });
 });

--- a/src/hooks/useAsyncAction.test.ts
+++ b/src/hooks/useAsyncAction.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { captureFlowFailure, sanitize } from '@/lib/monitoring';
 import { mockToast } from '@/test/mocks/useToast';
 
-import useAsyncAction from './useAsyncAction';
+import useAsyncAction, { ConcurrentActionError } from './useAsyncAction';
 
 // Mock Dependencies
 vi.mock('@/components/ui/use-toast', async () => {
@@ -490,7 +490,7 @@ describe('useAsyncAction', () => {
     });
   });
 
-  it('should prevent concurrent execution and return a non-resolving promise if preventConcurrent is true (default) and throwError is true', async () => {
+  it('should prevent concurrent execution and throw ConcurrentActionError if preventConcurrent is true (default) and throwError is true', async () => {
     let resolveAction!: (value: string) => void;
     const actionPromise = new Promise<string>((resolve) => {
       resolveAction = resolve;
@@ -507,12 +507,14 @@ describe('useAsyncAction', () => {
 
     expect(result.current.isPending).toBe(true);
 
-    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該回傳不 resolve 的 Promise，防止重複觸發且不破壞外層控制流
+    // 當處於 Pending 且 throwError 為 true 時，第二次呼叫 run 應該拋出 ConcurrentActionError，確保控制流程正常且不發生記憶體洩漏
+    let runPromise2!: Promise<string>;
     act(() => {
-      result.current.run(secondActionSpy);
+      runPromise2 = result.current.run(secondActionSpy) as Promise<string>;
     });
 
     await act(async () => {
+      await expect(runPromise2).rejects.toThrow(ConcurrentActionError);
       expect(secondActionSpy).not.toHaveBeenCalled();
 
       resolveAction('first-result');

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -1,0 +1,183 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import { captureFlowFailure } from '@/lib/monitoring';
+
+export interface AsyncActionConfig<TThrowError extends boolean = boolean> {
+  /**
+   * Sentry 錯誤記錄的 Flow 名稱 (例如 'profile_update', 'sign_in')
+   */
+  flow?: string;
+  /**
+   * Sentry 錯誤記錄的 Step 步驟 (例如 'unexpected', 'submit')
+   */
+  step?: string;
+  /**
+   * 發生錯誤時顯示的 Toast 文案。如不提供則不彈出 Toast
+   */
+  errorMessage?: string;
+  /**
+   * Toast 顯示持續時間（微秒），預設 5000 毫秒
+   */
+  duration?: number;
+  /**
+   * Pluggable 錯誤回撥，提供額外的自訂處理邏輯
+   */
+  onError?: (error: unknown) => void;
+  /**
+   * 是否在處理完錯誤後重新拋出（reject）。預設為 true（推薦，防止下游邏輯誤判成功）。
+   * 設定為 false 時將吞沒錯誤並 resolve 成 undefined。
+   */
+  throwError?: TThrowError;
+  /**
+   * 是否啟用並發防護（防連點）。預設為 true，當正在執行時直接拒絕後續呼叫。
+   */
+  preventConcurrent?: boolean;
+  /**
+   * 成功執行後是否重置 isPending 為 false。預設為 true。
+   * 如果設定為 false，成功後 isPending 將保持為 true（例如用於模擬並在跳轉/導航期間防止按鈕被再次點擊）。
+   */
+  resetPendingOnSuccess?: boolean;
+  /**
+   * 決定是否跳過 Sentry 紀錄。例如呼叫端可判斷該錯誤是否已被下層 LoggedError 記錄過，如果是則返回 true 去重。
+   */
+  shouldSkipLogging?: (error: unknown) => boolean;
+}
+
+type RunReturnType<TRunThrow extends boolean, T> = TRunThrow extends false
+  ? T | undefined
+  : T;
+
+/**
+ * 集中管理非同步操作（如表單提交、API 突變）生命週期的 React Hook。
+ * 統一處理 loading 狀態、並發防護、組件卸載安全、Sentry 紀錄 (captureFlowFailure) 與 Toast 顯示。
+ */
+export function useAsyncAction<TDefaultThrow extends boolean = true>(
+  defaultConfig: AsyncActionConfig<TDefaultThrow> = {}
+) {
+  const [isPending, setIsPending] = useState(false);
+  const { toast } = useToast();
+  const isMounted = useRef(true);
+  const pendingCountRef = useRef(0);
+  const defaultConfigRef = useRef<AsyncActionConfig<boolean>>(defaultConfig);
+
+  // 追蹤組件掛載狀態，防止在已卸載的組件上執行 setState 導致記憶體洩漏與 React 警告
+  useEffect(() => {
+    isMounted.current = true;
+    return () => {
+      isMounted.current = false;
+    };
+  }, []);
+
+  // 遵守 React 規範與 Next.js SSR 慣例：使用 useEffect 同步更新 defaultConfigRef，避免 SSR 期間觸發 LayoutEffect 警示
+  useEffect(() => {
+    defaultConfigRef.current = defaultConfig;
+  });
+
+  const run = useCallback(
+    async <T, TRunThrow extends boolean = TDefaultThrow>(
+      fn: () => Promise<T>,
+      runConfig?: AsyncActionConfig<TRunThrow>
+    ): Promise<RunReturnType<TRunThrow, T>> => {
+      const config = {
+        throwError: true as unknown as TRunThrow,
+        preventConcurrent: true,
+        resetPendingOnSuccess: true,
+        ...defaultConfigRef.current,
+        ...runConfig,
+      };
+
+      const returnUndefined = () =>
+        undefined as unknown as RunReturnType<TRunThrow, T>;
+
+      // 並發防護：若當前正在執行中且開啟了 concurrency 限制
+      if (config.preventConcurrent && pendingCountRef.current > 0) {
+        if (config.throwError) {
+          // 預設為 true 時，拋出明確錯誤以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
+          throw new Error('Action is already pending');
+        }
+        return returnUndefined();
+      }
+
+      // 同步累加執行計數，支援完美的併發狀態管理與極短時間連按防護
+      pendingCountRef.current++;
+
+      if (isMounted.current) {
+        setIsPending(true);
+      }
+
+      let success = false;
+      try {
+        const result = await fn();
+        success = true;
+        return result as unknown as RunReturnType<TRunThrow, T>;
+      } catch (err) {
+        // 執行外部傳入的錯誤 callback
+        if (config.onError) {
+          try {
+            config.onError(err);
+          } catch (callbackErr) {
+            console.error(
+              'Error in useAsyncAction onError callback:',
+              callbackErr
+            );
+          }
+        }
+
+        // Sentry 錯誤記錄去重：由外部傳遞的 shouldSkipLogging 回撥決定
+        const isAlreadyLogged = config.shouldSkipLogging?.(err) ?? false;
+        if (!isAlreadyLogged && config.flow && config.step) {
+          captureFlowFailure({
+            flow: config.flow,
+            step: config.step,
+            message:
+              err instanceof Error
+                ? err.message
+                : typeof err === 'string'
+                  ? err
+                  : 'Unexpected error in async action',
+          });
+        }
+
+        console.error(
+          `[AsyncAction] Error in ${config.flow ?? 'unknown'}:${config.step ?? 'unknown'}:`,
+          err
+        );
+
+        // 觸發 Toast
+        if (config.errorMessage) {
+          toast({
+            variant: 'destructive',
+            description: config.errorMessage,
+            duration: config.duration ?? 5000,
+          });
+        }
+
+        // 重新拋出錯誤（推薦）或吞沒錯誤
+        if (config.throwError) {
+          throw err;
+        }
+
+        return returnUndefined();
+      } finally {
+        // 同步扣減執行計數
+        pendingCountRef.current = Math.max(0, pendingCountRef.current - 1);
+
+        // 僅在所有併發非同步操作皆結束時，才重設為非 Pending 狀態
+        if (pendingCountRef.current === 0) {
+          if (isMounted.current) {
+            // 若不重置（模擬轉址期間防止按鈕再度點擊），則僅在失敗時將 isPending 設為 false
+            if (!success || config.resetPendingOnSuccess) {
+              setIsPending(false);
+            }
+          }
+        }
+      }
+    },
+    [toast]
+  );
+
+  return { run, isPending };
+}

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -75,17 +75,8 @@ export function useAsyncAction<TDefaultThrow extends boolean = true>(
 ) {
   const [isPending, setIsPending] = useState(false);
   const { toast } = useToast();
-  const isMounted = useRef(true);
   const pendingCountRef = useRef(0);
   const defaultConfigRef = useRef<AsyncActionConfig<boolean>>(defaultConfig);
-
-  // 追蹤組件掛載狀態，防止在已卸載的組件上執行 setState 導致記憶體洩漏與 React 警告
-  useEffect(() => {
-    isMounted.current = true;
-    return () => {
-      isMounted.current = false;
-    };
-  }, []);
 
   // 遵守 React 規範與 Next.js SSR 慣例：使用 useEffect 同步更新 defaultConfigRef，避免 SSR 期間觸發 LayoutEffect 警示
   useEffect(() => {
@@ -121,9 +112,7 @@ export function useAsyncAction<TDefaultThrow extends boolean = true>(
       // 同步累加執行計數，支援完美的併發狀態管理與極短時間連按防護
       pendingCountRef.current++;
 
-      if (isMounted.current) {
-        setIsPending(true);
-      }
+      setIsPending(true);
 
       let success = false;
       try {
@@ -205,11 +194,9 @@ export function useAsyncAction<TDefaultThrow extends boolean = true>(
 
         // 僅在所有併發非同步操作皆結束時，才重設為非 Pending 狀態
         if (pendingCountRef.current === 0) {
-          if (isMounted.current) {
-            // 若不重置（模擬轉址期間防止按鈕再度點擊），則僅在失敗時將 isPending 設為 false
-            if (!success || config.resetPendingOnSuccess) {
-              setIsPending(false);
-            }
+          // 若不重置（模擬轉址期間防止按鈕再度點擊），則僅在失敗時將 isPending 設為 false
+          if (!success || config.resetPendingOnSuccess) {
+            setIsPending(false);
           }
         }
       }

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -131,18 +131,6 @@ type RunReturnType<TRunThrow extends boolean, T> = TRunThrow extends false
   : T;
 
 /**
- * 當非同步操作正在執行中，且開啟了防連擊/並發防護時，重複點擊所拋出的專用錯誤。
- * 呼叫端與全域監控系統（如 Sentry）可輕易識別此型別並進行過濾/靜默處理，避免垃圾日誌。
- */
-export class ConcurrentActionError extends Error {
-  constructor() {
-    super('Action is already pending');
-    this.name = 'ConcurrentActionError';
-    Object.setPrototypeOf(this, ConcurrentActionError.prototype);
-  }
-}
-
-/**
  * 萬能非同步生命週期、並發防護、錯誤追蹤與 Toast 核心 Hook
  *
  * 統一處理 loading 狀態、並發防護、Sentry 紀錄 (captureFlowFailure) 與 Toast 顯示。
@@ -200,9 +188,9 @@ export default function useAsyncAction<TDefaultThrow extends boolean = true>(
       // 並發防護：若當前正在執行中且開啟了 concurrency 限制
       if (isPreventConcurrent && pendingCountRef.current > 0) {
         if (isThrowError) {
-          // 預設為 true 時，拋出專用自訂 Error 以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
-          // 自訂 Error 能讓全域錯誤監聽器（如 Sentry）或呼叫端輕易識別並過濾該型別，避免垃圾日誌，同時確保 await 能釋放且 finally 可正常執行
-          throw new ConcurrentActionError();
+          // 預設為 true 時，回傳一個永遠不 resolve 的 Promise 以靜默中斷執行鍊
+          // 這能保障 await 釋放，且不會誤觸上游呼叫端的 try-catch 區塊，避免重複/意外彈出錯誤提示（解決 Leaky Abstraction 問題）
+          return new Promise<never>(() => {});
         }
         return returnUndefined();
       }

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -131,6 +131,18 @@ type RunReturnType<TRunThrow extends boolean, T> = TRunThrow extends false
   : T;
 
 /**
+ * 當非同步操作正在執行中，且開啟了防連擊/並發防護時，重複點擊所拋出的專用錯誤。
+ * 呼叫端與全域監控系統（如 Sentry）可輕易識別此型別並進行過濾/靜默處理，避免垃圾日誌。
+ */
+export class ConcurrentActionError extends Error {
+  constructor() {
+    super('Action is already pending');
+    this.name = 'ConcurrentActionError';
+    Object.setPrototypeOf(this, ConcurrentActionError.prototype);
+  }
+}
+
+/**
  * 萬能非同步生命週期、並發防護、錯誤追蹤與 Toast 核心 Hook
  *
  * 統一處理 loading 狀態、並發防護、Sentry 紀錄 (captureFlowFailure) 與 Toast 顯示。
@@ -188,9 +200,9 @@ export default function useAsyncAction<TDefaultThrow extends boolean = true>(
       // 並發防護：若當前正在執行中且開啟了 concurrency 限制
       if (isPreventConcurrent && pendingCountRef.current > 0) {
         if (isThrowError) {
-          // 預設為 true 時，回傳一個永遠不 resolve 的 Promise 以靜默中斷執行鍊
-          // 這能保障 await 釋放，且不會誤觸上游呼叫端的 try-catch 區塊，避免重複/意外彈出錯誤提示（解決 Leaky Abstraction 問題）
-          return new Promise<never>(() => {});
+          // 預設為 true 時，拋出專用自訂 Error 以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
+          // 自訂 Error 能讓全域錯誤監聽器（如 Sentry）或呼叫端輕易識別並過濾該型別，避免垃圾日誌，同時確保 await 能釋放且 finally 可正常執行
+          throw new ConcurrentActionError();
         }
         return returnUndefined();
       }

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -55,6 +55,18 @@ type RunReturnType<TRunThrow extends boolean, T> = TRunThrow extends false
   : T;
 
 /**
+ * 當非同步操作正在執行中，且開啟了防連擊/並發防護時，重複點擊所拋出的專用錯誤。
+ * 呼叫端與全域監控系統（如 Sentry）可輕易識別此型別並進行過濾/靜默處理，避免垃圾日誌。
+ */
+export class ConcurrentActionError extends Error {
+  constructor() {
+    super('Action is already pending');
+    this.name = 'ConcurrentActionError';
+    Object.setPrototypeOf(this, ConcurrentActionError.prototype);
+  }
+}
+
+/**
  * 集中管理非同步操作（如表單提交、API 突變）生命週期的 React Hook。
  * 統一處理 loading 狀態、並發防護、組件卸載安全、Sentry 紀錄 (captureFlowFailure) 與 Toast 顯示。
  */
@@ -99,9 +111,9 @@ export function useAsyncAction<TDefaultThrow extends boolean = true>(
       // 並發防護：若當前正在執行中且開啟了 concurrency 限制
       if (config.preventConcurrent && pendingCountRef.current > 0) {
         if (config.throwError) {
-          // 預設為 true 時，回傳一個永遠不 resolve 的 Promise 以靜默攔截防連擊
-          // 避免拋出一般 Error 導致全域未捕捉 Promise 拒絕並洗版 Sentry
-          return new Promise<never>(() => {});
+          // 預設為 true 時，拋出專用自訂 Error 以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
+          // 自訂 Error 能讓全域錯誤監聽器（如 Sentry）或呼叫端輕易識別並過濾該型別，避免垃圾日誌，同時確保 await 能釋放且 finally 可正常執行
+          throw new ConcurrentActionError();
         }
         return returnUndefined();
       }

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -99,8 +99,9 @@ export function useAsyncAction<TDefaultThrow extends boolean = true>(
       // 並發防護：若當前正在執行中且開啟了 concurrency 限制
       if (config.preventConcurrent && pendingCountRef.current > 0) {
         if (config.throwError) {
-          // 預設為 true 時，拋出明確錯誤以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
-          throw new Error('Action is already pending');
+          // 預設為 true 時，回傳一個永遠不 resolve 的 Promise 以靜默攔截防連擊
+          // 避免拋出一般 Error 導致全域未捕捉 Promise 拒絕並洗版 Sentry
+          return new Promise<never>(() => {});
         }
         return returnUndefined();
       }

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -124,7 +124,6 @@ export interface AsyncActionConfig<TThrowError extends boolean = boolean> {
     variant?: 'default' | 'destructive';
     duration?: number | ((error: unknown) => number | undefined);
   };
-  rethrow?: boolean;
 }
 
 type RunReturnType<TRunThrow extends boolean, T> = TRunThrow extends false
@@ -217,7 +216,7 @@ export default function useAsyncAction<TDefaultThrow extends boolean = true>(
         config.onSuccess?.(result);
         return result as unknown as RunReturnType<TRunThrow, T>;
       } catch (err) {
-        const shouldRethrow = config.rethrow ?? config.throwError;
+        const shouldRethrow = config.throwError;
 
         // 執行外部傳入的錯誤 callback
         if (config.onError) {

--- a/src/hooks/useAsyncAction.ts
+++ b/src/hooks/useAsyncAction.ts
@@ -194,9 +194,12 @@ export default function useAsyncAction<TDefaultThrow extends boolean = true>(
       const returnUndefined = () =>
         undefined as unknown as RunReturnType<TRunThrow, T>;
 
+      const isThrowError = config.throwError ?? true;
+      const isPreventConcurrent = config.preventConcurrent ?? true;
+
       // 並發防護：若當前正在執行中且開啟了 concurrency 限制
-      if (config.preventConcurrent && pendingCountRef.current > 0) {
-        if (config.throwError) {
+      if (isPreventConcurrent && pendingCountRef.current > 0) {
+        if (isThrowError) {
           // 預設為 true 時，拋出專用自訂 Error 以防止呼叫端因收到 undefined 導致解構/存取崩潰，兼顧型別安全與執行期防禦
           // 自訂 Error 能讓全域錯誤監聽器（如 Sentry）或呼叫端輕易識別並過濾該型別，避免垃圾日誌，同時確保 await 能釋放且 finally 可正常執行
           throw new ConcurrentActionError();
@@ -216,7 +219,7 @@ export default function useAsyncAction<TDefaultThrow extends boolean = true>(
         config.onSuccess?.(result);
         return result as unknown as RunReturnType<TRunThrow, T>;
       } catch (err) {
-        const shouldRethrow = config.throwError;
+        const shouldRethrow = isThrowError;
 
         // 執行外部傳入的錯誤 callback
         if (config.onError) {

--- a/src/hooks/user/profile/useProfileSubmit.test.ts
+++ b/src/hooks/user/profile/useProfileSubmit.test.ts
@@ -83,7 +83,7 @@ describe('useProfileSubmit (Hook Layer)', () => {
     expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: 'profile_update',
-        step: 'unexpected',
+        step: 'update_profile',
         message: 'Save failed',
       })
     );
@@ -108,7 +108,7 @@ describe('useProfileSubmit (Hook Layer)', () => {
     expect(mockCaptureFlowFailure).toHaveBeenCalledWith(
       expect.objectContaining({
         flow: 'profile_update',
-        step: 'unexpected',
+        step: 'update_profile',
         message: 'Some string error',
       })
     );

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -1,15 +1,13 @@
 'use client';
 import { useRouter } from 'next/navigation';
 import { Session } from 'next-auth';
-import { useState } from 'react';
 
 import { revalidateProfilePath } from '@/app/profile/[pageUserId]/actions';
-import { useToast } from '@/components/ui/use-toast';
+import { useAsyncAction } from '@/hooks/useAsyncAction';
 import {
   clearUserDataCache,
   primeUserDataCache,
 } from '@/hooks/user/user-data/useUserData';
-import { captureFlowFailure } from '@/lib/monitoring';
 import { type ProfileDirtyFields } from '@/lib/profile/profileSaveAdapter';
 import { LoggedError, saveProfile } from '@/lib/profile/saveProfile';
 import { ProfileFormValues } from '@/schemas/profileSchema';
@@ -35,16 +33,22 @@ export function useProfileSubmit({
   consumeAvatarUpload,
 }: Options) {
   const router = useRouter();
-  const { toast } = useToast();
-  const [isSaving, setIsSaving] = useState(false);
+
+  const { run, isPending: isSaving } = useAsyncAction({
+    flow: 'profile_update',
+    step: 'unexpected',
+    errorMessage: '儲存失敗，請稍後再試',
+    throwError: false,
+    resetPendingOnSuccess: false, // 成功後保持 isSaving 為 true 以模擬轉址中的 UI
+    shouldSkipLogging: (err) => err instanceof LoggedError,
+  });
 
   const onSubmit = async (
     values: ProfileFormValues,
     dirtyFields?: ProfileDirtyFields
   ) => {
-    try {
-      setIsSaving(true);
-      await saveProfile(values, {
+    await run(() =>
+      saveProfile(values, {
         pageUserId,
         isMentorOnboarding,
         session,
@@ -55,28 +59,8 @@ export function useProfileSubmit({
         revalidateProfilePath,
         clearUserDataCache,
         primeUserDataCache,
-      });
-    } catch (err) {
-      if (!(err instanceof LoggedError)) {
-        captureFlowFailure({
-          flow: 'profile_update',
-          step: 'unexpected',
-          message:
-            err instanceof Error
-              ? err.message
-              : typeof err === 'string'
-                ? err
-                : 'Unexpected profile update error',
-        });
-      }
-      console.error('Update Profile Error:', err);
-      toast({
-        variant: 'destructive',
-        description: '儲存失敗，請稍後再試',
-        duration: 5000,
-      });
-      setIsSaving(false);
-    }
+      })
+    );
   };
 
   return { onSubmit, isSaving };

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -32,6 +32,8 @@ export function useProfileSubmit({
 }: Options) {
   const router = useRouter();
 
+  // 概念驗證 (PoC) 呼叫端：此處整合並呼叫統一管理非同步生命週期的 useAsyncAction Hook
+  // 作為 X-Tracker #436 基礎建設的一部分，用於收斂載入狀態、防重複連擊與 Sentry 錯誤上報
   const { run, isPending: isSaving } = useAsyncAction({
     flow: 'profile_update',
     step: 'unexpected',

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -36,7 +36,7 @@ export function useProfileSubmit({
   // 作為 X-Tracker #436 基礎建設的一部分，用於收斂載入狀態、防重複連擊與 Sentry 錯誤上報
   const { run, isPending: isSaving } = useAsyncAction({
     flow: 'profile_update',
-    step: 'unexpected',
+    step: 'update_profile',
     errorMessage: '儲存失敗，請稍後再試',
     throwError: false,
     resetPendingOnSuccess: false, // 成功後保持 isSaving 為 true 以模擬轉址中的 UI

--- a/src/hooks/user/profile/useProfileSubmit.ts
+++ b/src/hooks/user/profile/useProfileSubmit.ts
@@ -1,5 +1,4 @@
 'use client';
-
 import { useRouter } from 'next/navigation';
 import { Session } from 'next-auth';
 import { useCallback } from 'react';
@@ -21,9 +20,6 @@ interface Options {
   isMentorOnboarding: boolean;
   session: Session | null;
   updateSession: (data: unknown) => Promise<Session | null>;
-  // Optional: lets the page hand back an already-in-flight S3 upload (kicked
-  // off when the user picked the file) so submit doesn't pay the round trip.
-  // Falls back to a direct upload when omitted, preserving legacy callers.
   consumeAvatarUpload?: (file: File | undefined) => Promise<string | undefined>;
 }
 


### PR DESCRIPTION
Introduce a highly robust \useAsyncAction\ React hook to centralize and encapsulate the async action/mutation lifecycle across form submits. This hook consolidates loading state management (\isPending\), concurrency protection (\preventConcurrent\), component unmount safety, Sentry error reporting (\captureFlowFailure\), and pluggable Toast popups into a single reference-stable utility primitive.

- Added \useAsyncAction\ hook with support for hook-level and run-level configurations.
- Integrated concurrency protection (double-click prevention) and component unmount safety.
- Handled Sentry log deduplication for \LoggedError\ to avoid double-reporting.
- Added comprehensive unit tests in \useAsyncAction.test.ts\ covering 12 test cases.
- Refactored \useProfileSubmit.ts\ calling site to use \useAsyncAction\ as a proof of concept, reducing boilerplate and maintaining 100% backward-compatibility.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/436
