### PR TITLE
refactor(profile): replace useLocations hand-rolled cache with createKeyedCache (X-Tracker #437)

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -85,6 +85,7 @@
     "out/",
     "build/",
     "dist/",
+    "storybook-static/",
     "*.config.js",
     "*.config.ts"
   ]

--- a/src/hooks/user/country/useLocations.test.tsx
+++ b/src/hooks/user/country/useLocations.test.tsx
@@ -195,4 +195,76 @@ describe('useLocations', () => {
 
     // The test should pass without any React warnings or errors
   });
+
+  it('correctly shifts state synchronously and triggers a new fetch when language prop changes', async () => {
+    const zhData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+    const enData = [
+      fromPartial<LocationType>({ value: 'USA', text: 'United States' }),
+    ];
+
+    vi.mocked(getCountries)
+      .mockResolvedValueOnce(zhData)
+      .mockResolvedValueOnce(enData);
+
+    const { result, rerender } = renderHook((lang) => useLocations(lang), {
+      initialProps: 'zh_TW',
+    });
+
+    // Initial load for zh_TW
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.locations).toEqual(zhData);
+    expect(getCountries).toHaveBeenCalledTimes(1);
+    expect(getCountries).toHaveBeenLastCalledWith('zh_TW');
+
+    // Change language dynamically to en_US
+    rerender('en_US');
+
+    // Due to derived state, isLoading must shift to true immediately synchronously during render
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.locations).toEqual([]);
+    expect(result.current.error).toBeNull();
+
+    // Wait for the new fetch to resolve
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.locations).toEqual(enData);
+    expect(getCountries).toHaveBeenCalledTimes(2);
+    expect(getCountries).toHaveBeenLastCalledWith('en_US');
+  });
+
+  it('clears the previous error state immediately when shifting to a cached language', async () => {
+    // 1. Warm cache for 'en_US'
+    const enData = [
+      fromPartial<LocationType>({ value: 'USA', text: 'United States' }),
+    ];
+    locationsCache.set('en_US', enData);
+
+    // 2. Set up getCountries to fail for 'zh_TW'
+    vi.mocked(getCountries).mockRejectedValueOnce(new Error('Fetch failed'));
+
+    const { result, rerender } = renderHook((lang) => useLocations(lang), {
+      initialProps: 'zh_TW',
+    });
+
+    // Initial load for zh_TW fails
+    expect(result.current.isLoading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.error).toBe('Failed to load location options');
+
+    // 3. Shift language to 'en_US' which is in cache
+    rerender('en_US');
+
+    // It should immediately synchronously clear the error and load cached locations
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.error).toBeNull();
+    expect(result.current.locations).toEqual(enData);
+  });
 });

--- a/src/hooks/user/country/useLocations.test.tsx
+++ b/src/hooks/user/country/useLocations.test.tsx
@@ -122,4 +122,77 @@ describe('useLocations', () => {
     expect(retryResult.current.locations).toEqual(mockData);
     expect(getCountries).toHaveBeenCalledTimes(2);
   });
+
+  it('correctly expires the cache after TTL and triggers a new fetch', async () => {
+    vi.useFakeTimers();
+
+    const mockData1 = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+    const mockData2 = [
+      fromPartial<LocationType>({ value: 'USA', text: 'United States' }),
+    ];
+
+    vi.mocked(getCountries)
+      .mockResolvedValueOnce(mockData1)
+      .mockResolvedValueOnce(mockData2);
+
+    // Initial render and fetch
+    const { result, unmount } = renderHook(() => useLocations('zh_TW'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+    expect(result.current.locations).toEqual(mockData1);
+    expect(getCountries).toHaveBeenCalledTimes(1);
+
+    // Unmount so we can test next mounting
+    unmount();
+
+    // Fast-forward time past 24 hours (24 * 60 * 60 * 1000)
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+
+    // Remount the hook for the same language
+    const { result: retryResult } = renderHook(() => useLocations('zh_TW'));
+
+    // Cache should be expired, so it should load and fetch again
+    expect(retryResult.current.isLoading).toBe(true);
+
+    await vi.waitFor(() => {
+      expect(retryResult.current.isLoading).toBe(false);
+    });
+
+    expect(retryResult.current.locations).toEqual(mockData2);
+    expect(getCountries).toHaveBeenCalledTimes(2);
+
+    vi.useRealTimers();
+  });
+
+  it('handles unmounting while a fetch is pending and prevents state updates', async () => {
+    let resolveFetch: (value: LocationType[]) => void = () => {};
+    const delayPromise = new Promise<LocationType[]>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.mocked(getCountries).mockReturnValueOnce(delayPromise);
+
+    const { result, unmount } = renderHook(() => useLocations('zh_TW'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    // Unmount while the promise is still pending
+    unmount();
+
+    // Resolve the promise now that the hook is unmounted
+    const mockData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+    resolveFetch(mockData);
+
+    // Give microtasks a chance to run
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // The test should pass without any React warnings or errors
+  });
 });

--- a/src/hooks/user/country/useLocations.test.tsx
+++ b/src/hooks/user/country/useLocations.test.tsx
@@ -1,0 +1,125 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { getCountries, LocationType } from '@/services/profile/countries';
+
+import useLocations, { locationsCache } from './useLocations';
+
+vi.mock('@/services/profile/countries', async () => {
+  const actual = await vi.importActual<
+    typeof import('@/services/profile/countries')
+  >('@/services/profile/countries');
+  return {
+    ...actual,
+    getCountries: vi.fn(),
+  };
+});
+
+describe('useLocations', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    locationsCache.clear();
+  });
+
+  it('fetches location data on mount and updates state', async () => {
+    const mockData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+      fromPartial<LocationType>({ value: 'USA', text: 'United States' }),
+    ];
+    vi.mocked(getCountries).mockResolvedValueOnce(mockData);
+
+    const { result } = renderHook(() => useLocations('zh_TW'));
+
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.locations).toEqual([]);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.locations).toEqual(mockData);
+    expect(getCountries).toHaveBeenCalledTimes(1);
+    expect(getCountries).toHaveBeenCalledWith('zh_TW');
+  });
+
+  it('uses cached data synchronously on subsequent renders', async () => {
+    const mockData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+    vi.mocked(getCountries).mockResolvedValueOnce(mockData);
+
+    // Warm the cache
+    await locationsCache.fetch('zh_TW', () => getCountries('zh_TW'));
+
+    const { result } = renderHook(() => useLocations('zh_TW'));
+
+    // Should load synchronously from cache (isLoading = false initially)
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.locations).toEqual(mockData);
+    expect(getCountries).toHaveBeenCalledTimes(1);
+  });
+
+  it('deduplicates concurrent calls for the same language key', async () => {
+    const mockData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+
+    // Controlled unresolved promise to mimic concurrent requests
+    let resolveFetch: (value: LocationType[]) => void = () => {};
+    const delayPromise = new Promise<LocationType[]>((resolve) => {
+      resolveFetch = resolve;
+    });
+    vi.mocked(getCountries).mockReturnValueOnce(delayPromise);
+
+    // Render hook multiple times concurrently
+    const { result: r1 } = renderHook(() => useLocations('zh_TW'));
+    const { result: r2 } = renderHook(() => useLocations('zh_TW'));
+
+    expect(r1.current.isLoading).toBe(true);
+    expect(r2.current.isLoading).toBe(true);
+
+    // Resolve the single promise
+    resolveFetch(mockData);
+
+    await waitFor(() => {
+      expect(r1.current.isLoading).toBe(false);
+      expect(r2.current.isLoading).toBe(false);
+    });
+
+    expect(r1.current.locations).toEqual(mockData);
+    expect(r2.current.locations).toEqual(mockData);
+    expect(getCountries).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles fetch failures and allows subsequent retries', async () => {
+    vi.mocked(getCountries).mockRejectedValueOnce(new Error('Fetch failed'));
+
+    const { result, unmount } = renderHook(() => useLocations('zh_TW'));
+
+    expect(result.current.isLoading).toBe(true);
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to load location options');
+
+    // Unmount so we can remount and trigger a fresh fetch
+    unmount();
+
+    const mockData = [
+      fromPartial<LocationType>({ value: 'TWN', text: 'Taiwan' }),
+    ];
+    vi.mocked(getCountries).mockResolvedValueOnce(mockData);
+
+    const { result: retryResult } = renderHook(() => useLocations('zh_TW'));
+
+    await waitFor(() => {
+      expect(retryResult.current.isLoading).toBe(false);
+    });
+
+    expect(retryResult.current.locations).toEqual(mockData);
+    expect(getCountries).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/hooks/user/country/useLocations.ts
+++ b/src/hooks/user/country/useLocations.ts
@@ -24,6 +24,15 @@ export default function useLocations(language: string): UseLocationsResult {
   );
   const [error, setError] = useState<string | null>(null);
 
+  // Synchronously update state on language prop change during render (Derived State pattern)
+  const [prevLang, setPrevLang] = useState(language);
+  if (prevLang !== language) {
+    setPrevLang(language);
+    setLocations(locationsCache.get(language) ?? []);
+    setIsLoading(!locationsCache.has(language));
+    setError(null);
+  }
+
   useEffect(() => {
     let cancelled = false;
 

--- a/src/hooks/user/country/useLocations.ts
+++ b/src/hooks/user/country/useLocations.ts
@@ -1,9 +1,13 @@
 import { useEffect, useState } from 'react';
 
+import { createKeyedCache } from '@/lib/createKeyedCache';
 import { getCountries, LocationType } from '@/services/profile/countries';
 
-const cache = new Map<string, LocationType[]>();
-const inflight = new Map<string, Promise<LocationType[]>>();
+export const LOCATIONS_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+export const locationsCache = createKeyedCache<string, LocationType[]>({
+  ttlMs: LOCATIONS_CACHE_TTL_MS,
+});
 
 interface UseLocationsResult {
   locations: LocationType[];
@@ -13,15 +17,17 @@ interface UseLocationsResult {
 
 export default function useLocations(language: string): UseLocationsResult {
   const [locations, setLocations] = useState<LocationType[]>(
-    () => cache.get(language) ?? []
+    () => locationsCache.get(language) ?? []
   );
-  const [isLoading, setIsLoading] = useState(!cache.has(language));
+  const [isLoading, setIsLoading] = useState(
+    () => !locationsCache.has(language)
+  );
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     let cancelled = false;
 
-    const cached = cache.get(language);
+    const cached = locationsCache.get(language);
     if (cached) {
       setLocations(cached);
       setIsLoading(false);
@@ -32,19 +38,8 @@ export default function useLocations(language: string): UseLocationsResult {
     setIsLoading(true);
     setError(null);
 
-    const promise =
-      inflight.get(language) ??
-      (() => {
-        const p = getCountries(language).then((data) => {
-          cache.set(language, data);
-          inflight.delete(language);
-          return data;
-        });
-        inflight.set(language, p);
-        return p;
-      })();
-
-    promise
+    locationsCache
+      .fetch(language, () => getCountries(language))
       .then((data) => {
         if (!cancelled) {
           setLocations(data);


### PR DESCRIPTION
Motivation & Key Changes:
- Replaced the hand-rolled Map-based cache and in-flight promise de-dup logic in useLocations.ts with the shared createKeyedCache primitive.
- Configured the cache with a 24-hour TTL expiration.
- Added a full unit test suite in useLocations.test.tsx using @total-typescript/shoehorn's fromPartial for maximum type safety.
- Handled error retry and unmounted component state updates safely to improve strict correctness.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/437
