### PR TITLE
feat(storybook): build shared context decorator for nextauth session and nextjs navigation (X-Tracker #435)

### DIFF
--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -1,7 +1,7 @@
 import type { Preview } from '@storybook/nextjs';
 import React from 'react';
-import '../src/styles/global.css';
 import { withAppContext } from './withAppContext';
+import '../src/styles/global.css';
 
 const preview: Preview = {
   parameters: {

--- a/.storybook/preview.tsx
+++ b/.storybook/preview.tsx
@@ -5,6 +5,9 @@ import '../src/styles/global.css';
 
 const preview: Preview = {
   parameters: {
+    // Enable out-of-the-box App Router mocking via the official @storybook/nextjs framework.
+    // To override the router behavior in individual stories, use parameters.nextjs.router:
+    //   `parameters: { nextjs: { router: { pathname: '/profile', query: { id: '123' } } } }`
     nextjs: {
       appDirectory: true,
     },

--- a/.storybook/withAppContext.test.ts
+++ b/.storybook/withAppContext.test.ts
@@ -106,13 +106,58 @@ describe('resolveMockSession', () => {
       expires: '2026-12-31T23:59:59.000Z',
     };
 
-    const result = resolveMockSession(undefined, {
-      session: customSession,
-      user: { name: 'User Arg' },
-    });
+    const result = resolveMockSession(
+      undefined,
+      {
+        session: customSession,
+        user: { name: 'User Arg' },
+      }
+    );
     expect(result).toEqual({
       session: customSession,
       status: 'authenticated',
+    });
+  });
+
+  it('should resolve session and status from parameters.auth nested structure', () => {
+    const customSession: Session = {
+      user: {
+        id: 'auth-param-id',
+        email: 'auth@example.com',
+        name: 'Auth Param User',
+        onBoarding: true,
+        isMentor: false,
+      },
+      accessToken: 'auth-token',
+      expires: '2099-01-01T00:00:00.000Z',
+    };
+
+    const params = {
+      auth: {
+        session: customSession,
+        status: 'authenticated' as const,
+      },
+    };
+
+    const result = resolveMockSession(params);
+    expect(result).toEqual({
+      session: customSession,
+      status: 'authenticated',
+    });
+  });
+
+  it('should support loading status from parameters.auth', () => {
+    const params = {
+      auth: {
+        session: null,
+        status: 'loading' as const,
+      },
+    };
+
+    const result = resolveMockSession(params);
+    expect(result).toEqual({
+      session: null,
+      status: 'loading',
     });
   });
 });

--- a/.storybook/withAppContext.test.ts
+++ b/.storybook/withAppContext.test.ts
@@ -106,13 +106,10 @@ describe('resolveMockSession', () => {
       expires: '2026-12-31T23:59:59.000Z',
     };
 
-    const result = resolveMockSession(
-      undefined,
-      {
-        session: customSession,
-        user: { name: 'User Arg' },
-      }
-    );
+    const result = resolveMockSession(undefined, {
+      session: customSession,
+      user: { name: 'User Arg' },
+    });
     expect(result).toEqual({
       session: customSession,
       status: 'authenticated',

--- a/.storybook/withAppContext.test.ts
+++ b/.storybook/withAppContext.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { resolveMockSession, defaultMockSession } from './withAppContext';
+import {
+  resolveMockSession,
+  defaultMockSession,
+  syncSessionHintCookie,
+} from './withAppContext';
 import type { Session } from 'next-auth';
 
 describe('resolveMockSession', () => {
@@ -156,5 +160,18 @@ describe('resolveMockSession', () => {
       session: null,
       status: 'loading',
     });
+  });
+});
+
+describe('syncSessionHintCookie', () => {
+  it('should set the session-hint cookie when sessionHint is provided', () => {
+    syncSessionHintCookie('test-hint');
+    expect(document.cookie).toContain('session-hint=test-hint');
+  });
+
+  it('should clear the session-hint cookie when sessionHint is undefined', () => {
+    document.cookie = 'session-hint=old-hint';
+    syncSessionHintCookie(undefined);
+    expect(document.cookie).not.toContain('session-hint=old-hint');
   });
 });

--- a/.storybook/withAppContext.test.ts
+++ b/.storybook/withAppContext.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+import { resolveMockSession, defaultMockSession } from './withAppContext';
+import type { Session } from 'next-auth';
+
+describe('resolveMockSession', () => {
+  it('should return defaultMockSession and status authenticated when no args are provided', () => {
+    const result = resolveMockSession({});
+    expect(result).toEqual({
+      session: defaultMockSession,
+      status: 'authenticated',
+    });
+  });
+
+  it('should return defaultMockSession and status authenticated when args is undefined', () => {
+    const result = resolveMockSession(undefined);
+    expect(result).toEqual({
+      session: defaultMockSession,
+      status: 'authenticated',
+    });
+  });
+
+  it('should prioritize and return the session arg and status when provided', () => {
+    const customSession: Session = {
+      user: {
+        id: 'custom-id',
+        email: 'custom@example.com',
+        name: 'Custom User',
+        onBoarding: false,
+        isMentor: true,
+      },
+      accessToken: 'custom-token',
+      expires: '2026-12-31T23:59:59.000Z',
+    };
+
+    const result = resolveMockSession(undefined, { session: customSession });
+    expect(result).toEqual({
+      session: customSession,
+      status: 'authenticated',
+    });
+  });
+
+  it('should return null session and unauthenticated status if the session arg is null', () => {
+    const result = resolveMockSession(undefined, { session: null });
+    expect(result).toEqual({
+      session: null,
+      status: 'unauthenticated',
+    });
+  });
+
+  it('should merge user fields with defaultMockSession when user arg is provided', () => {
+    const partialUser = {
+      name: 'Jane Doe',
+      isMentor: true,
+    };
+
+    const result = resolveMockSession(undefined, { user: partialUser });
+    expect(result).toEqual({
+      session: {
+        ...defaultMockSession,
+        user: {
+          ...defaultMockSession.user,
+          name: 'Jane Doe',
+          isMentor: true,
+        },
+      },
+      status: 'authenticated',
+    });
+  });
+
+  it('should resolve session correctly from parameters configuration object', () => {
+    const nextAuthParams = {
+      user: { name: 'Parameter User', isMentor: true },
+    };
+    const result = resolveMockSession(nextAuthParams);
+    expect(result).toEqual({
+      session: {
+        ...defaultMockSession,
+        user: {
+          ...defaultMockSession.user,
+          name: 'Parameter User',
+          isMentor: true,
+        },
+      },
+      status: 'authenticated',
+    });
+  });
+
+  it('should return null session and unauthenticated status if the user arg is null and session is not provided', () => {
+    const result = resolveMockSession(undefined, { user: null });
+    expect(result).toEqual({
+      session: null,
+      status: 'unauthenticated',
+    });
+  });
+
+  it('should prioritize session over user when both are provided', () => {
+    const customSession: Session = {
+      user: {
+        id: 'custom-id',
+        email: 'custom@example.com',
+        name: 'Session User',
+        onBoarding: false,
+        isMentor: true,
+      },
+      accessToken: 'custom-token',
+      expires: '2026-12-31T23:59:59.000Z',
+    };
+
+    const result = resolveMockSession(
+      undefined,
+      {
+        session: customSession,
+        user: { name: 'User Arg' },
+      }
+    );
+    expect(result).toEqual({
+      session: customSession,
+      status: 'authenticated',
+    });
+  });
+});

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -22,25 +22,25 @@ export interface ResolveMockSessionResult {
   status: 'authenticated' | 'unauthenticated' | 'loading';
 }
 
+/** Shared configuration options for mocking NextAuth session and status in Storybook. */
+export interface MockSessionOptions {
+  user?: Partial<Session['user']> | null;
+  session?: Session | null;
+  status?: 'authenticated' | 'unauthenticated' | 'loading';
+}
+
+/** Complete parameters input type for resolveMockSession including optional legacy auth structure. */
+export type ResolveMockSessionParams = MockSessionOptions & {
+  auth?: (MockSessionOptions & { sessionHint?: string }) | null;
+};
+
 /**
  * Pure function to resolve the mock session and status from Storybook parameters and args,
  * fully preserving all flexible configurations and maintaining 100% strict type safety.
  */
 export function resolveMockSession(
-  params?: {
-    auth?: {
-      session?: Session | null;
-      status?: 'authenticated' | 'unauthenticated' | 'loading';
-    } | null;
-    user?: Partial<Session['user']> | null;
-    session?: Session | null;
-    status?: 'authenticated' | 'unauthenticated' | 'loading';
-  },
-  args?: {
-    user?: Partial<Session['user']> | null;
-    session?: Session | null;
-    status?: 'authenticated' | 'unauthenticated' | 'loading';
-  }
+  params?: ResolveMockSessionParams | null,
+  args?: MockSessionOptions | null
 ): ResolveMockSessionResult {
   const authParams = params?.auth || {};
 
@@ -83,9 +83,7 @@ export function resolveMockSession(
   }
 
   // 4. Determine session status
-  let status: 'authenticated' | 'unauthenticated' | 'loading' = session
-    ? 'authenticated'
-    : 'unauthenticated';
+  let status: 'authenticated' | 'unauthenticated' | 'loading' = session ? 'authenticated' : 'unauthenticated';
   if (authParams.status !== undefined) {
     status = authParams.status;
   } else if (params?.status !== undefined) {
@@ -99,13 +97,13 @@ export function resolveMockSession(
 
 /**
  * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
- * By default, stories are authenticated with a standard test session.
- *
+ * By default, stories are authenticated with a standard test session (defaultMockSession).
+ * 
  * To override the default user or session:
  * 1. Via parameters (Recommended for components without user/session Props to avoid TypeScript strict compile errors):
  *    - `parameters: { nextAuth: { user: { name: 'Custom PM', isMentor: true } } }`
  *    - `parameters: { nextAuth: { session: null } }` (unauthenticated guest states)
- *
+ * 
  * 2. Via args (Best for components like UserDropdown that accept user/session as direct Props):
  *    - `args: { user: { name: 'Custom Name' } }`
  *    - `args: { user: null }`
@@ -123,11 +121,9 @@ export const withAppContext: Decorator = (Story, context) => {
     }
   }
 
-  // Resolve mock session and status from parameters or args
-  const { session, status } = resolveMockSession(
-    context.parameters,
-    context.args
-  );
+  // Resolve mock session and status from parameters (prioritizing nextAuth namespace) or args
+  const nextAuthParams = context.parameters?.nextAuth || context.parameters;
+  const { session, status } = resolveMockSession(nextAuthParams, context.args);
 
   const contextValue: SessionContextValue = {
     data: session,

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -2,10 +2,6 @@ import React from 'react';
 import type { Decorator } from '@storybook/react';
 import { SessionContext, SessionContextValue } from 'next-auth/react';
 import type { Session } from 'next-auth';
-import {
-  AppRouterContext,
-  AppRouterInstance,
-} from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 export const defaultMockUser = {
   id: 'test-user-id',
@@ -19,15 +15,6 @@ export const defaultMockSession: Session = {
   user: defaultMockUser,
   accessToken: 'mock-access-token',
   expires: '2099-01-01T00:00:00.000Z',
-};
-
-export const defaultMockRouter: AppRouterInstance = {
-  back: () => {},
-  forward: () => {},
-  refresh: () => {},
-  push: () => {},
-  replace: () => {},
-  prefetch: () => {},
 };
 
 export interface ResolveMockSessionResult {
@@ -125,8 +112,7 @@ export function resolveMockSession(
 }
 
 /**
- * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) and
- * Next.js App Router context (via AppRouterContext.Provider) with configurable mocks.
+ * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
  * By default, stories are authenticated with a standard test session (defaultMockSession).
  *
  * To override the default user or session:
@@ -157,9 +143,7 @@ export const withAppContext: Decorator = (Story, context) => {
 
   return (
     <SessionContext.Provider value={contextValue}>
-      <AppRouterContext.Provider value={defaultMockRouter}>
-        <Story />
-      </AppRouterContext.Provider>
+      <Story />
     </SessionContext.Provider>
   );
 };

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -1,19 +1,115 @@
-import { Decorator } from '@storybook/react';
-import { SessionContext, SessionContextValue } from 'next-auth/react';
 import React from 'react';
+import type { Decorator } from '@storybook/react';
+import { SessionContext, SessionContextValue } from 'next-auth/react';
+import type { Session } from 'next-auth';
 
+export const defaultMockUser = {
+  id: 'test-user-id',
+  email: 'test@example.com',
+  name: 'Test User',
+  onBoarding: true,
+  isMentor: false,
+};
+
+export const defaultMockSession: Session = {
+  user: defaultMockUser,
+  accessToken: 'mock-access-token',
+  expires: '2099-01-01T00:00:00.000Z',
+};
+
+export interface ResolveMockSessionResult {
+  session: Session | null;
+  status: 'authenticated' | 'unauthenticated' | 'loading';
+}
+
+/**
+ * Pure function to resolve the mock session and status from Storybook parameters and args,
+ * fully preserving all flexible configurations and maintaining 100% strict type safety.
+ */
+export function resolveMockSession(
+  params?: {
+    auth?: {
+      session?: Session | null;
+      status?: 'authenticated' | 'unauthenticated' | 'loading';
+    } | null;
+    user?: Partial<Session['user']> | null;
+    session?: Session | null;
+    status?: 'authenticated' | 'unauthenticated' | 'loading';
+  },
+  args?: {
+    user?: Partial<Session['user']> | null;
+    session?: Session | null;
+    status?: 'authenticated' | 'unauthenticated' | 'loading';
+  }
+): ResolveMockSessionResult {
+  const authParams = params?.auth || {};
+
+  // 1. Resolve user
+  const userFromParam =
+    authParams.session?.user !== undefined
+      ? authParams.session.user
+      : params?.user !== undefined
+        ? params?.user
+        : params?.session?.user !== undefined
+          ? params?.session?.user
+          : undefined;
+
+  const user =
+    userFromParam !== undefined
+      ? userFromParam
+      : args?.user !== undefined
+        ? args?.user
+        : defaultMockUser;
+
+  // 2. Resolve default session from user
+  let session: Session | null = null;
+  if (user !== null) {
+    session = {
+      ...defaultMockSession,
+      user: {
+        ...defaultMockSession.user,
+        ...user,
+      },
+    } as Session;
+  }
+
+  // 3. Override session if directly provided
+  if (authParams.session !== undefined) {
+    session = authParams.session;
+  } else if (params?.session !== undefined) {
+    session = params?.session;
+  } else if (args?.session !== undefined) {
+    session = args?.session;
+  }
+
+  // 4. Determine session status
+  let status: 'authenticated' | 'unauthenticated' | 'loading' = session ? 'authenticated' : 'unauthenticated';
+  if (authParams.status !== undefined) {
+    status = authParams.status;
+  } else if (params?.status !== undefined) {
+    status = params?.status;
+  } else if (args?.status !== undefined) {
+    status = args?.status;
+  }
+
+  return { session, status };
+}
+
+/**
+ * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
+ * By default, stories are authenticated with a standard test session.
+ * 
+ * To override the default user or session:
+ * 1. Via parameters (Recommended for components without user/session Props to avoid TypeScript strict compile errors):
+ *    - `parameters: { nextAuth: { user: { name: 'Custom PM', isMentor: true } } }`
+ *    - `parameters: { nextAuth: { session: null } }` (unauthenticated guest states)
+ * 
+ * 2. Via args (Best for components like UserDropdown that accept user/session as direct Props):
+ *    - `args: { user: { name: 'Custom Name' } }`
+ *    - `args: { user: null }`
+ */
 export const withAppContext: Decorator = (Story, context) => {
-  // Standard default user shape from src/test/mocks/nextAuth.ts
-  const defaultUser = {
-    id: 'test-user-id',
-    email: 'test@example.com',
-    name: 'Test User',
-    onBoarding: true,
-    isMentor: false,
-  };
-
-  // 1. Support parameter configurations from auth (used in Header.stories.tsx)
-  const authParams = context.parameters.auth || {};
+  const authParams = context.parameters?.auth || {};
   const sessionHint = authParams.sessionHint;
 
   // Handle cookie sync if auth parameters are explicitly provided
@@ -21,57 +117,12 @@ export const withAppContext: Decorator = (Story, context) => {
     if (sessionHint !== undefined) {
       document.cookie = `session-hint=${sessionHint}; path=/; max-age=3600`;
     } else {
-      // Unconditionally clear the cookie when sessionHint is undefined
-      // to avoid environment pollution across story switches
       document.cookie = 'session-hint=; path=/; max-age=0';
     }
   }
 
-  // 2. Determine user: check auth parameters, standard parameters, then args
-  const userFromParam =
-    authParams.session?.user !== undefined
-      ? authParams.session.user
-      : context.parameters.user !== undefined
-        ? context.parameters.user
-        : context.parameters.session?.user !== undefined
-          ? context.parameters.session.user
-          : undefined;
-
-  const user =
-    userFromParam !== undefined
-      ? userFromParam
-      : context.args.user !== undefined
-        ? context.args.user
-        : defaultUser;
-
-  // 3. Determine session
-  let session = null;
-  if (user !== null) {
-    session = {
-      user,
-      accessToken: 'mock-access-token',
-      expires: '2099-01-01T00:00:00.000Z',
-    };
-  }
-
-  // Override session if directly provided in parameters or args
-  if (authParams.session !== undefined) {
-    session = authParams.session;
-  } else if (context.parameters.session !== undefined) {
-    session = context.parameters.session;
-  } else if (context.args.session !== undefined) {
-    session = context.args.session;
-  }
-
-  // 4. Determine session status
-  let status = session ? 'authenticated' : 'unauthenticated';
-  if (authParams.status !== undefined) {
-    status = authParams.status;
-  } else if (context.parameters.status !== undefined) {
-    status = context.parameters.status;
-  } else if (context.args.status !== undefined) {
-    status = context.args.status;
-  }
+  // Resolve mock session and status from parameters or args
+  const { session, status } = resolveMockSession(context.parameters, context.args);
 
   const contextValue: SessionContextValue = {
     data: session,
@@ -85,3 +136,4 @@ export const withAppContext: Decorator = (Story, context) => {
     </SessionContext.Provider>
   );
 };
+export default withAppContext;

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -1,3 +1,4 @@
+// Shared Storybook decorator for NextAuth session and next/navigation App Router mocking.
 import React from 'react';
 import type { Decorator } from '@storybook/react';
 import { SessionContext, SessionContextValue } from 'next-auth/react';

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -83,7 +83,9 @@ export function resolveMockSession(
   }
 
   // 4. Determine session status
-  let status: 'authenticated' | 'unauthenticated' | 'loading' = session ? 'authenticated' : 'unauthenticated';
+  let status: 'authenticated' | 'unauthenticated' | 'loading' = session
+    ? 'authenticated'
+    : 'unauthenticated';
   if (authParams.status !== undefined) {
     status = authParams.status;
   } else if (params?.status !== undefined) {
@@ -98,12 +100,12 @@ export function resolveMockSession(
 /**
  * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
  * By default, stories are authenticated with a standard test session.
- * 
+ *
  * To override the default user or session:
  * 1. Via parameters (Recommended for components without user/session Props to avoid TypeScript strict compile errors):
  *    - `parameters: { nextAuth: { user: { name: 'Custom PM', isMentor: true } } }`
  *    - `parameters: { nextAuth: { session: null } }` (unauthenticated guest states)
- * 
+ *
  * 2. Via args (Best for components like UserDropdown that accept user/session as direct Props):
  *    - `args: { user: { name: 'Custom Name' } }`
  *    - `args: { user: null }`
@@ -122,7 +124,10 @@ export const withAppContext: Decorator = (Story, context) => {
   }
 
   // Resolve mock session and status from parameters or args
-  const { session, status } = resolveMockSession(context.parameters, context.args);
+  const { session, status } = resolveMockSession(
+    context.parameters,
+    context.args
+  );
 
   const contextValue: SessionContextValue = {
     data: session,

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -1,8 +1,11 @@
-// Shared Storybook decorator for NextAuth session and next/navigation App Router mocking.
 import React from 'react';
 import type { Decorator } from '@storybook/react';
 import { SessionContext, SessionContextValue } from 'next-auth/react';
 import type { Session } from 'next-auth';
+import {
+  AppRouterContext,
+  AppRouterInstance,
+} from 'next/dist/shared/lib/app-router-context.shared-runtime';
 
 export const defaultMockUser = {
   id: 'test-user-id',
@@ -16,6 +19,15 @@ export const defaultMockSession: Session = {
   user: defaultMockUser,
   accessToken: 'mock-access-token',
   expires: '2099-01-01T00:00:00.000Z',
+};
+
+export const defaultMockRouter: AppRouterInstance = {
+  back: () => {},
+  forward: () => {},
+  refresh: () => {},
+  push: () => {},
+  replace: () => {},
+  prefetch: () => {},
 };
 
 export interface ResolveMockSessionResult {
@@ -34,6 +46,20 @@ export interface MockSessionOptions {
 export type ResolveMockSessionParams = MockSessionOptions & {
   auth?: (MockSessionOptions & { sessionHint?: string }) | null;
 };
+
+/**
+ * Syncs the session-hint cookie based on the explicit auth parameters.
+ * Clears the cookie if undefined to prevent environment pollution.
+ */
+export function syncSessionHintCookie(sessionHint: string | undefined): void {
+  if (typeof document !== 'undefined') {
+    if (sessionHint !== undefined) {
+      document.cookie = `session-hint=${sessionHint}; path=/; max-age=3600`;
+    } else {
+      document.cookie = 'session-hint=; path=/; max-age=0';
+    }
+  }
+}
 
 /**
  * Pure function to resolve the mock session and status from Storybook parameters and args,
@@ -99,7 +125,8 @@ export function resolveMockSession(
 }
 
 /**
- * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
+ * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) and
+ * Next.js App Router context (via AppRouterContext.Provider) with configurable mocks.
  * By default, stories are authenticated with a standard test session (defaultMockSession).
  *
  * To override the default user or session:
@@ -116,13 +143,7 @@ export const withAppContext: Decorator = (Story, context) => {
   const sessionHint = authParams.sessionHint;
 
   // Handle cookie sync if auth parameters are explicitly provided
-  if (typeof window !== 'undefined') {
-    if (sessionHint !== undefined) {
-      document.cookie = `session-hint=${sessionHint}; path=/; max-age=3600`;
-    } else {
-      document.cookie = 'session-hint=; path=/; max-age=0';
-    }
-  }
+  syncSessionHintCookie(sessionHint);
 
   // Resolve mock session and status from parameters (prioritizing nextAuth namespace) or args
   const nextAuthParams = context.parameters?.nextAuth || context.parameters;
@@ -136,7 +157,9 @@ export const withAppContext: Decorator = (Story, context) => {
 
   return (
     <SessionContext.Provider value={contextValue}>
-      <Story />
+      <AppRouterContext.Provider value={defaultMockRouter}>
+        <Story />
+      </AppRouterContext.Provider>
     </SessionContext.Provider>
   );
 };

--- a/.storybook/withAppContext.tsx
+++ b/.storybook/withAppContext.tsx
@@ -83,7 +83,9 @@ export function resolveMockSession(
   }
 
   // 4. Determine session status
-  let status: 'authenticated' | 'unauthenticated' | 'loading' = session ? 'authenticated' : 'unauthenticated';
+  let status: 'authenticated' | 'unauthenticated' | 'loading' = session
+    ? 'authenticated'
+    : 'unauthenticated';
   if (authParams.status !== undefined) {
     status = authParams.status;
   } else if (params?.status !== undefined) {
@@ -98,12 +100,12 @@ export function resolveMockSession(
 /**
  * Shared Storybook decorator to provide NextAuth `SessionProvider` (via SessionContext.Provider) with configurable mocks.
  * By default, stories are authenticated with a standard test session (defaultMockSession).
- * 
+ *
  * To override the default user or session:
  * 1. Via parameters (Recommended for components without user/session Props to avoid TypeScript strict compile errors):
  *    - `parameters: { nextAuth: { user: { name: 'Custom PM', isMentor: true } } }`
  *    - `parameters: { nextAuth: { session: null } }` (unauthenticated guest states)
- * 
+ *
  * 2. Via args (Best for components like UserDropdown that accept user/session as direct Props):
  *    - `args: { user: { name: 'Custom Name' } }`
  *    - `args: { user: null }`

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,7 +20,7 @@ export default defineConfig({
       NEXT_PUBLIC_API_URL: '',
     },
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs'],
+    include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs', '.storybook/**/*.{test,spec}.{ts,tsx}'],
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,7 +20,11 @@ export default defineConfig({
       NEXT_PUBLIC_API_URL: '',
     },
     setupFiles: ['./src/test/setup.ts'],
-    include: ['src/**/*.{test,spec}.{ts,tsx}', 'scripts/**/*.{test,spec}.mjs', '.storybook/**/*.{test,spec}.{ts,tsx}'],
+    include: [
+      'src/**/*.{test,spec}.{ts,tsx}',
+      'scripts/**/*.{test,spec}.mjs',
+      '.storybook/**/*.{test,spec}.{ts,tsx}',
+    ],
     typecheck: {
       tsconfig: './tsconfig.test.json',
     },


### PR DESCRIPTION
Introduce withAppContext global Storybook decorator to wrap stories with standard NextAuth SessionProvider containing default mock session.
Enable global nextjs appDirectory parameter to allow stories to use App Router hooks without crashing.
Refactor existing stories to use the global decorators and parameters, removing redundant local setup.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/435
