### PR TITLE
chore(skills): retry /ai-review up to 20 times in /implement before halting

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -20,11 +20,12 @@ If the workspace is an `X-Frontend` project (e.g., `X-Talent-Frontend` or simila
 3. **Run AI Review Locally:**
    - Once implementation is complete, call the `/ai-review` skill to launch parallel sub-agents (Security, Correctness, Business Logic, Performance, Testing, Architecture, and Review Guide).
    - These agents will review your changes locally against the actual X-Tracker ticket requirements.
-   - Address any critical issues, security warnings, or logic bugs highlighted in the review.
+   - **Pass/Blocked criterion**: `/ai-review`'s summary stage returns `overallRisk.level` (`low` / `medium` / `high`), not a literal status line — derive the verdict yourself:
+     - `overallRisk.level == "low"` → **PASS**.
+     - `overallRisk.level == "medium"` or `"high"` → **BLOCKED**.
    - **Automated Handoff Contract**:
-     - Locate the generated review report and parse the `Review Status` line.
-     - **If the output contains `Review Status: PASS`**: You MUST automatically transition to **Step 4 (`/submit-pr`)** in the exact same turn without stopping, asking the user, or halting the workflow.
-     - **If the output contains `Review Status: BLOCKED`** (or if the status line is missing): You MUST halt immediately, output the findings clearly to the user, and wait for manual intervention or fix instructions. Do not proceed to `/submit-pr`.
+     - **If PASS**: You MUST automatically transition to **Step 4 (`/submit-pr`)** in the exact same turn without stopping, asking the user, or halting the workflow.
+     - **If BLOCKED**: Directly address the findings yourself (critical issues, security warnings, logic bugs, anything driving the risk level), then re-run `/ai-review` and re-evaluate. Repeat this fix-and-re-review cycle up to a maximum of **20 attempts**. If it is still BLOCKED after 20 attempts, you MUST halt, output the accumulated findings clearly to the user, and wait for manual intervention. Do not proceed to `/submit-pr` until it passes.
 
 4. **Complete & Submit PR:**
    - Once implementation is done, verified, and reviewed, call the `/submit-pr` skill to run final tests, commit, push, create a PR, and move the ticket to `PR Review` status.


### PR DESCRIPTION
## What Does This PR Do?

Updates **`.agents/skills/implement/SKILL.md`** — Step 3 ("Run AI Review Locally").

### Problem

The automated handoff contract checked for a literal `Review Status: PASS/BLOCKED` line, but `/ai-review`'s summary stage (`scripts/ai-review/prompts/summary.md`, `scripts/ai-review/lib/format-comment.mjs`) never emits that line — it returns `overallRisk.level` (`low` / `medium` / `high`) plus a `mergeRecommendation`. In practice the "status line missing" branch always fired, so the workflow never had a working self-correction loop and always fell through to a hard halt.

### Change

- PASS/BLOCKED is now derived from `overallRisk.level`:
  - `low` → **PASS** → auto-continue to `/submit-pr`.
  - `medium` / `high` → **BLOCKED** → fix the findings directly, re-run `/ai-review`, and re-evaluate.
- The fix-and-re-review cycle is capped at **20 attempts**; if still `BLOCKED` after 20, halt and hand off to the user with the accumulated findings instead of looping forever.

## Test Plan

- [x] `pnpm type-check`
- [x] `pnpm test` (671 tests passed)
- This is a workflow/skill doc change (no application code touched), so no UI verification needed.