### PR TITLE
chore(skills): chain /fix-pr into /implement's post-PR workflow

### DIFF
--- a/.agents/skills/implement/SKILL.md
+++ b/.agents/skills/implement/SKILL.md
@@ -30,6 +30,12 @@ If the workspace is an `X-Frontend` project (e.g., `X-Talent-Frontend` or simila
 4. **Complete & Submit PR:**
    - Once implementation is done, verified, and reviewed, call the `/submit-pr` skill to run final tests, commit, push, create a PR, and move the ticket to `PR Review` status.
 
+5. **Post-PR Fix Loop:**
+   - Unless the user has explicitly indicated they only want the PR opened and nothing further (e.g. "just open the PR", "stop once it's submitted"), automatically continue into the `/fix-pr` skill immediately after Step 4 succeeds — do not stop to ask first.
+   - `/fix-pr` runs under its own existing rules unchanged (up to 20 rounds, Vercel daily-limit failures excluded from the retry budget and reported instead of retried). Do not alter or share its retry budget with Step 3's local `/ai-review` loop.
+   - `/implement` is only considered fully complete when `/fix-pr` converges (all watched checks green) or its only remaining blocker is the Vercel daily deployment limit. Any other non-converged outcome (including hitting the 20-round cap) means `/implement` is **not** complete — report `/fix-pr`'s final findings to the user as-is and wait for manual intervention.
+   - Never auto-merge the PR (`gh pr merge`) and never advance the X-Talent-Tracker board status past `PR Review` — both remain manual actions for the user, even when `/fix-pr` fully converges.
+
 ---
 
 ## General Guidelines (All Repositories)


### PR DESCRIPTION
## What Does This PR Do?

Adds a **Step 5** to `/implement`'s X-Frontend Repositories Workflow: once `/submit-pr` (Step 4) opens a PR, `/implement` now automatically continues into `/fix-pr` to close the loop between "PR is open" and "PR is mergeable" — instead of stopping the moment the PR exists.

**Modified:**
- **`.agents/skills/implement/SKILL.md`** — new Step 5 ("Post-PR Fix Loop")

## Design Decisions

Agreed via an interactive `/grilling` session before implementation:

- **Full auto-chain by default**, with a natural-language opt-out (e.g. "just open the PR") rather than a flag/config option.
- **Retry budgets left untouched** — `/fix-pr`'s existing 20-round outer loop (and its own inner `/ai-review` sub-loop) is not shared with or reduced relative to Step 3's pre-PR `/ai-review` loop.
- **"Complete" is redefined for the chained flow**: `/implement` is only fully complete when `/fix-pr` converges (all watched checks green) or its only remaining blocker is Vercel's free-tier daily deploy quota. Any other non-convergence (e.g. hitting the 20-round cap) is reported to the user as incomplete rather than silently accepted.
- **No auto-merge** — `gh pr merge` is never invoked automatically; merging stays a human decision.
- **No automatic board advancement** — the X-Talent-Tracker board stays at `PR Review` (set by `/submit-pr`); it is not auto-advanced further once `/fix-pr` converges.

This is a skills/process change only — no application code is touched.

## Test Plan

- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (683 tests, 90 files)
- [ ] Exercise `/implement` end-to-end on a real ticket to confirm the Step 5 handoff triggers correctly and respects the opt-out phrase