### PR TITLE
chore(mcp): add project-level genable MCP server config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "genable": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "genable-mcp"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
Registers genable-mcp as a project-scoped MCP server in .mcp.json so
the whole team gets the same Figma design-generation tooling on pull,
instead of relying on individual user-level ~/.claude.json setups.
Removes the penpot entry, which is no longer used.
