### PR TITLE
chore(mcp): add local gemini mcp configuration for genable

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "genable": {
+      "command": "npx",
+      "args": ["-y", "genable-mcp"],
+      "env": {}
+    }
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,8 @@ next-env.d.ts
 CLAUDE.md
 
 # Gemini CLI local caches and logs
-/.gemini/
+/.gemini/*
+!/.gemini/settings.json
 /gemini.log
 
 # Test reports and screenshots


### PR DESCRIPTION
- Register genable-mcp inside .gemini/settings.json for Gemini CLI auto-connection
- Update .gitignore to safely track settings.json while ignoring other transient cache and log files
