### PR TITLE
fix(schedule): include required UTC month fields

### DIFF
--- a/src/services/mentor-schedule/schedule.test.ts
+++ b/src/services/mentor-schedule/schedule.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient } from '@/lib/apiClient';
+
+import { saveMentorSchedule } from './schedule';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiClient: {
+    put: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {},
+}));
+
+describe('saveMentorSchedule', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(apiClient.put).mockResolvedValue({ code: '0', msg: 'ok' });
+  });
+
+  it('includes the UTC year and month required by the schedule API', async () => {
+    await saveMentorSchedule({
+      userId: '42',
+      timeslots: [
+        {
+          dt_type: 'ALLOW',
+          dtstart: 1767226200, // 2026-01-01T00:10:00Z
+          dtend: 1767229800,
+          exdate: [],
+          timezone: 'UTC',
+          user_id: 42,
+        },
+      ],
+    });
+
+    expect(apiClient.put).toHaveBeenCalledWith('/v1/mentors/42/schedule', {
+      timeslots: [
+        {
+          user_id: 42,
+          dt_type: 'ALLOW',
+          dt_year: 2026,
+          dt_month: 1,
+          dtstart: 1767226200,
+          dtend: 1767229800,
+          timezone: 'UTC',
+          exdate: [],
+        },
+      ],
+    });
+  });
+});

--- a/src/services/mentor-schedule/schedule.ts
+++ b/src/services/mentor-schedule/schedule.ts
@@ -40,6 +40,11 @@ interface SaveScheduleResponse {
 
 type CleanObject = Record<string, unknown>;
 
+function utcYearMonth(unixSeconds: number): { year: number; month: number } {
+  const date = new Date(unixSeconds * 1000);
+  return { year: date.getUTCFullYear(), month: date.getUTCMonth() + 1 };
+}
+
 /**
  * PUT /v1/mentors/:userId/schedule
  *
@@ -62,18 +67,23 @@ export async function saveMentorSchedule(params: {
 
   const body = cleanOptional({
     until: params.until,
-    timeslots: params.timeslots.map((t) =>
-      cleanOptional({
+    timeslots: params.timeslots.map((t) => {
+      const { year, month } = utcYearMonth(t.dtstart);
+      return cleanOptional({
         id: t.id,
         user_id: Number(params.userId),
         dt_type: t.dt_type,
+        // The schedule API requires the UTC month bucket for every slot.
+        // Derive it from dtstart so callers cannot omit stale generated DTO fields.
+        dt_year: year,
+        dt_month: month,
         dtstart: t.dtstart,
         dtend: t.dtend,
         rrule: t.rrule,
         timezone: 'UTC',
         exdate: t.exdate,
-      })
-    ),
+      });
+    }),
   });
 
   const result = await apiClient.put<SaveScheduleResponse>(


### PR DESCRIPTION
## Summary
- derive UTC dt_year and dt_month from every slot's dtstart before PUT
- include a unit test for the required schedule payload fields

## Validation
- npm test -- --run src/services/mentor-schedule/schedule.test.ts
- npm run type-check (blocked by pre-existing missing @storybook/nextjs and @total-typescript/shoehorn dependencies)
- eslint / git hooks are blocked by pre-existing missing eslint-plugin-storybook dependency