### PR TITLE
fix(layout): collapse header navigation to hamburger menu at medium widths (X-Tracker #811)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -45,7 +45,7 @@ function HeaderComponent(): JSX.Element {
             <Image src={LogoImgUrl} alt="logo" />
           </Link>
 
-          <nav className="hidden items-center gap-7 md:flex">
+          <nav className="hidden items-center gap-7 lg:flex">
             <Link
               href={findMentorHref}
               className="font-['Open_Sans'] text-base text-text-primary"
@@ -85,8 +85,8 @@ function HeaderComponent(): JSX.Element {
           </nav>
         </div>
 
-        <div className="flex items-center gap-3 md:mr-20">
-          <div className="hidden items-center gap-3 md:flex">
+        <div className="flex items-center gap-3 lg:mr-20">
+          <div className="hidden items-center gap-3 lg:flex">
             {!authKnown ? (
               <Skeleton className="size-9 rounded-full" />
             ) : !isLoggedIn ? (
@@ -113,7 +113,7 @@ function HeaderComponent(): JSX.Element {
             )}
           </div>
 
-          <div className="flex items-center gap-3 md:hidden">
+          <div className="flex items-center gap-3 lg:hidden">
             {hasFullUser ? <MobileUserMenu user={session!.user} /> : null}
             <HamburgerMenu
               isLoggedIn={isLoggedIn}


### PR DESCRIPTION
Change responsive breakpoint classes from md (768px) to lg (1024px) in Header layout.
This ensures the header collapses into HamburgerMenu at middle-width screens (768px~900px, including 789px), preventing horizontal navigation text overflow and layout wrapping.

- Modify <nav> container from md:flex to lg:flex.
- Modify outer navigation content actions from md:mr-20 to lg:mr-20.
- Modify desktop auth action buttons wrapper from md:flex to lg:flex.
- Modify mobile HamburgerMenu container from md:hidden to lg:hidden.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Frontend/issues/811
