### PR TITLE
docs(ui): add JSDoc comments to foundation UI components (X-Tracker #470)

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -25,11 +25,31 @@ const badgeVariants = cva(
   }
 );
 
+/**
+ * Properties for the Badge component. Inherits all standard HTML div element attributes
+ * and variant configuration properties from the CVA configuration.
+ */
 export interface BadgeProps
   extends
     React.HTMLAttributes<HTMLDivElement>,
-    VariantProps<typeof badgeVariants> {}
+    VariantProps<typeof badgeVariants> {
+  /**
+   * The visual style variant of the badge.
+   * @default 'default'
+   */
+  variant?:
+    | 'default'
+    | 'secondary'
+    | 'destructive'
+    | 'outline'
+    | 'filter'
+    | null;
+}
 
+/**
+ * A Badge component used to display tags, status highlights, or category labels,
+ * with various styling variants defined by class-variance-authority (CVA).
+ */
 function Badge({ className, variant, ...props }: BadgeProps) {
   return (
     <div className={cn(badgeVariants({ variant }), className)} {...props} />

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -38,13 +38,52 @@ const buttonVariants = cva(
   }
 );
 
+/**
+ * Properties for the Button component. Inherits all standard HTML button attributes
+ * and variant configuration properties from the CVA (class-variance-authority) configuration.
+ */
 export interface ButtonProps
   extends
     React.ButtonHTMLAttributes<HTMLButtonElement>,
     VariantProps<typeof buttonVariants> {
+  /**
+   * The visual style variant of the button.
+   * @default 'default'
+   */
+  variant?:
+    | 'default'
+    | 'destructive'
+    | 'outline'
+    | 'secondary'
+    | 'ghost'
+    | 'link'
+    | null;
+
+  /**
+   * The size of the button, controlling height and padding.
+   * @default 'default'
+   */
+  size?: 'default' | 'sm' | 'lg' | 'icon' | null;
+
+  /**
+   * The shape / border-radius configuration of the button.
+   * @default 'default'
+   */
+  shape?: 'default' | 'pill' | null;
+
+  /**
+   * If true, the button will render as its child component instead of a native button element.
+   * This is useful when you want to use custom elements (like Next.js Link) but keep button styling.
+   * @default false
+   */
   asChild?: boolean;
 }
 
+/**
+ * A highly customizable and reusable Button component that supports various visual styles,
+ * sizes, and shapes based on the class-variance-authority (CVA) design token mappings.
+ * It also supports custom elements via Radix UI's Slot wrapper using the `asChild` property.
+ */
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   ({ className, variant, size, shape, asChild = false, ...props }, ref) => {
     const Comp = asChild ? Slot : 'button';

--- a/src/components/ui/checkbox.tsx
+++ b/src/components/ui/checkbox.tsx
@@ -6,9 +6,57 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Properties for the Checkbox component. Inherits standard Radix UI Checkbox Primitive Root properties.
+ */
+export interface CheckboxProps extends React.ComponentPropsWithoutRef<
+  typeof CheckboxPrimitive.Root
+> {
+  /**
+   * The controlled checked state of the checkbox.
+   */
+  checked?: boolean | 'indeterminate';
+
+  /**
+   * The default checked state when first rendered.
+   */
+  defaultChecked?: boolean;
+
+  /**
+   * Event handler called when the checked state changes.
+   */
+  onCheckedChange?: (checked: boolean | 'indeterminate') => void;
+
+  /**
+   * Whether the checkbox is disabled.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Whether the checkbox is required for form submission.
+   */
+  required?: boolean;
+
+  /**
+   * The name of the checkbox (for form submission).
+   */
+  name?: string;
+
+  /**
+   * The value of the checkbox (for form submission).
+   * @default "on"
+   */
+  value?: string;
+}
+
+/**
+ * A custom checkbox component built on top of Radix UI's Checkbox primitive,
+ * with customizable styling and accessibility features built-in.
+ */
 const Checkbox = React.forwardRef<
   React.ElementRef<typeof CheckboxPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof CheckboxPrimitive.Root>
+  CheckboxProps
 >(({ className, ...props }, ref) => (
   <CheckboxPrimitive.Root
     ref={ref}

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -2,8 +2,42 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
-export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {}
+/**
+ * Properties for the Input component. Inherits all standard HTML input element attributes.
+ */
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
+  /**
+   * The type of input to render (e.g., 'text', 'email', 'password', 'number', 'file', etc.).
+   * @default 'text'
+   */
+  type?: string;
 
+  /**
+   * Whether the input is disabled and cannot be interacted with.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Short hint that describes the expected value of the input field.
+   */
+  placeholder?: string;
+
+  /**
+   * The controlled value of the input field.
+   */
+  value?: string | number | readonly string[];
+
+  /**
+   * Event handler triggered when the input value changes.
+   */
+  onChange?: React.ChangeEventHandler<HTMLInputElement>;
+}
+
+/**
+ * A standard, stylized Input component for user text, email, password, and file entries.
+ * Seamlessly integrates with focus states, disabled states, and responsive styling.
+ */
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
   ({ className, type, ...props }, ref) => {
     return (

--- a/src/components/ui/label.tsx
+++ b/src/components/ui/label.tsx
@@ -10,10 +10,22 @@ const labelVariants = cva(
   'text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70'
 );
 
+/**
+ * Properties for the Label component. Inherits all standard Radix UI Label Primitive Root properties
+ * and CVA label configuration properties.
+ */
+export interface LabelProps
+  extends
+    React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>,
+    VariantProps<typeof labelVariants> {}
+
+/**
+ * An accessible label component built on top of Radix UI's Label primitive,
+ * configured with standard font styling and disabled states.
+ */
 const Label = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
-    VariantProps<typeof labelVariants>
+  LabelProps
 >(({ className, ...props }, ref) => (
   <LabelPrimitive.Root
     ref={ref}

--- a/src/components/ui/separator.tsx
+++ b/src/components/ui/separator.tsx
@@ -5,9 +5,32 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Properties for the Separator component. Inherits standard Radix UI Separator properties.
+ */
+export interface SeparatorProps extends React.ComponentPropsWithoutRef<
+  typeof SeparatorPrimitive.Root
+> {
+  /**
+   * The orientation of the separator line.
+   * @default 'horizontal'
+   */
+  orientation?: 'horizontal' | 'vertical';
+
+  /**
+   * Whether the separator is purely decorative. If true, it is excluded from the accessibility tree.
+   * @default true
+   */
+  decorative?: boolean;
+}
+
+/**
+ * A Separator component used to visually divide content, supporting both horizontal
+ * and vertical orientations, built on top of Radix UI's Separator primitive.
+ */
 const Separator = React.forwardRef<
   React.ElementRef<typeof SeparatorPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof SeparatorPrimitive.Root>
+  SeparatorProps
 >(
   (
     { className, orientation = 'horizontal', decorative = true, ...props },


### PR DESCRIPTION
Add comprehensive JSDoc block comments and explicit prop descriptions
for Button, Input, Checkbox, Badge, Label, and Separator components.
This allows Storybook's Autodocs automatic document generator to
extract and display clean, complete API tables and descriptions on
the Docs tab.

Also resolved TypeScript compatibility issues with CVA's VariantProps
by including 'null' in union types of variant / size / shape properties.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/470
