### PR TITLE
docs(ui): add comprehensive jsdoc descriptions to structure and selection components (X-Tracker #472)

### DIFF
--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -2,6 +2,9 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Card 卡片元件：提供一個帶有圓角、邊框與陰影的容器外框，常用於承載、區隔及展示具備獨立主題的區塊內容。
+ */
 const Card = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -17,6 +20,9 @@ const Card = React.forwardRef<
 ));
 Card.displayName = 'Card';
 
+/**
+ * CardHeader 卡片頂部欄：用於容納卡片的標題（CardTitle）及描述（CardDescription），提供合適的垂直邊距與間距。
+ */
 const CardHeader = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -29,6 +35,9 @@ const CardHeader = React.forwardRef<
 ));
 CardHeader.displayName = 'CardHeader';
 
+/**
+ * CardTitle 卡片標題：顯示於卡片頂部的主要醒目標題，預設套用粗體與合適的字型大小（2xl）。
+ */
 const CardTitle = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -44,6 +53,9 @@ const CardTitle = React.forwardRef<
 ));
 CardTitle.displayName = 'CardTitle';
 
+/**
+ * CardDescription 卡片描述：緊鄰於標題下方的副標題或說明性文字，字型顏色預設較淡。
+ */
 const CardDescription = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -56,6 +68,9 @@ const CardDescription = React.forwardRef<
 ));
 CardDescription.displayName = 'CardDescription';
 
+/**
+ * CardContent 卡片主體內容區：放置卡片核心資訊與互動元件的區塊，內建與外框對齊的內邊距（padding）。
+ */
 const CardContent = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -64,6 +79,9 @@ const CardContent = React.forwardRef<
 ));
 CardContent.displayName = 'CardContent';
 
+/**
+ * CardFooter 卡片底部欄：常用於放置按鈕、操作項、連結或狀態提示等，並與卡片內容維持一致的對齊與間距。
+ */
 const CardFooter = React.forwardRef<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>

--- a/src/components/ui/multi-select-dropdown.tsx
+++ b/src/components/ui/multi-select-dropdown.tsx
@@ -24,20 +24,64 @@ import {
 import { Separator } from '@/components/ui/separator';
 import { cn } from '@/lib/utils';
 
+/**
+ * MultiSelectDropdown 元件屬性介面
+ */
 export interface MultiSelectDropdownProps {
+  /**
+   * 可供選擇的下拉選項清單。
+   */
   options: Array<{
+    /**
+     * 選項顯示的標籤文字。
+     */
     label: string;
+    /**
+     * 選項對應的實際數值。
+     */
     value: string;
+    /**
+     * 選項前方可選的圖示元件。
+     */
     icon?: React.ComponentType<{ className?: string }>;
   }>;
+
+  /**
+   * 當前已被選中的值陣列。
+   */
   selectedValues: string[];
+
+  /**
+   * 搜尋框輸入時的鍵盤事件回呼函式（例如偵測 Enter 或 Backspace）。
+   */
   onInputKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+
+  /**
+   * 切換特定選項選取狀態的回呼函式。
+   */
   onToggleOption: (value: string) => void;
+
+  /**
+   * 全選或取消全選時觸發的回呼函式。
+   */
   onToggleAll: () => void;
+
+  /**
+   * 清除所有選中項目的回呼函式。
+   */
   onClear: () => void;
+
+  /**
+   * 關閉下拉彈出視窗的回呼函式。
+   */
   onClose: () => void;
 }
 
+/**
+ * MultiSelectDropdown 多選下拉選單內容元件：
+ * 作為 MultiSelect 的彈出層內容，內含過濾搜尋框、選項清單（含全選選項）、清除與關閉按鈕。
+ * 本元件採用延遲加載（Lazy-load），僅在選單展開時進行 chunk 的 fetch，以縮小 initial bundle size。
+ */
 export default function MultiSelectDropdown({
   options,
   selectedValues,

--- a/src/components/ui/multi-select.tsx
+++ b/src/components/ui/multi-select.tsx
@@ -45,29 +45,88 @@ const multiSelectVariants = cva(
 );
 
 /**
- * Props for MultiSelect component
+ * MultiSelect 元件屬性介面
  */
 interface MultiSelectProps
   extends
     Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, 'onChange'>,
     VariantProps<typeof multiSelectVariants> {
+  /**
+   * 可供選擇的下拉選項清單。
+   */
   options: {
+    /**
+     * 選項顯示的標籤文字。
+     */
     label: string;
+    /**
+     * 選項對應的實際數值。
+     */
     value: string;
+    /**
+     * 選項前方可選的圖示元件。
+     */
     icon?: React.ComponentType<{ className?: string }>;
   }[];
+
+  /**
+   * 當選取的值發生變化時觸發的回呼函式。
+   * @param value 已選取的 value 陣列
+   */
   onValueChange?: (value: string[]) => void;
+
+  /**
+   * 與 React Hook Form 或舊版 Form 相容的變動回呼函式。
+   * @param value 已選取的 value 陣列
+   */
   onChange?: (value: string[]) => void;
+
+  /**
+   * 非受控模式下的預設選取值陣列。
+   */
   defaultValue?: string[];
+
+  /**
+   * 尚未選取任何項目時顯示的提示預設文字。
+   */
   placeholder?: string;
+
+  /**
+   * 選取項目徽章的動畫持續秒數，設為 0 代表無動畫。
+   */
   animation?: number;
+
+  /**
+   * 展開收納時，按鈕內最多同時顯示的選取項目徽章個數。超出部分會顯示為 "+ X more" 的縮略標記。
+   */
   maxCount?: number;
+
+  /**
+   * 是否將彈出視窗（Popover）作為模態框（Modal）對齊，這會阻止與頁面其餘部分的互動。
+   */
   modalPopover?: boolean;
+
+  /**
+   * 是否將按鈕渲染為其唯一的子元素（用於 Radix Slot 轉譯）。
+   */
   asChild?: boolean;
+
+  /**
+   * 容器的自訂 CSS 樣式類別名稱。
+   */
   className?: string;
+
+  /**
+   * 受控模式下當前選中的值陣列。
+   */
   value?: string[];
 }
 
+/**
+ * MultiSelect 多選下拉選單元件：
+ * 提供搜尋過濾、全選、一鍵清除以及多個選中項目徽章（Badge）展示的功能。
+ * 內建性能優化，CMDK 下拉內容元件（MultiSelectDropdown）採用 Client-side 延遲載入（Lazy-load）。
+ */
 export const MultiSelect = React.forwardRef<
   HTMLButtonElement,
   MultiSelectProps

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -4,16 +4,44 @@ import React, { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
 
+/**
+ * SearchBar 元件屬性介面
+ */
 interface SearchBarProps {
+  /**
+   * 點擊搜尋按鈕或按下 Enter 鍵時觸發的搜尋非同步回呼函式。
+   * @param query 使用者輸入並去除了首尾空格的搜尋關鍵字
+   */
   onSearch: (query: string) => Promise<void>;
+
+  /**
+   * 預設（如桌機版螢幕寬度）顯示的搜尋輸入框提示預設文字。
+   */
   placeholder?: string;
+
+  /**
+   * 手機版（窄螢幕）下顯示的自訂搜尋輸入框提示預設文字。若未傳入，將回退至 mobilePlaceholder / placeholder。
+   */
   mobilePlaceholder?: string;
+
+  /**
+   * 平板版（中等螢幕）下顯示的自訂搜尋輸入框提示預設文字。若未傳入，將回退至 tabletPlaceholder / placeholder。
+   */
   tabletPlaceholder?: string;
+
+  /**
+   * 搜尋框的預設初始輸入值，預設為空字串。
+   */
   defaultValue?: string;
 }
 
 const DEFAULT_PLACEHOLDER = '搜尋有興趣職位、公司或是想精進的領域';
 
+/**
+ * SearchBar 搜尋欄元件：
+ * 支援響應式設計（針對手機、平板、桌機寬度提供不同的 Placeholder）、防重覆提交的非同步 Loading 載入狀態，
+ * 以及按下 Enter 鍵快速搜尋等功能，常置於首頁或導師列表頂部。
+ */
 const SearchBar: React.FC<SearchBarProps> = ({
   onSearch,
   placeholder = DEFAULT_PLACEHOLDER,

--- a/src/components/ui/select.tsx
+++ b/src/components/ui/select.tsx
@@ -6,12 +6,24 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Select 單選下拉選單根容器：負責控制下拉選單的開啟與關閉狀態、管理選中的值。
+ */
 const Select = SelectPrimitive.Root;
 
+/**
+ * SelectGroup 下拉選單分組：將相關的選項（SelectItem）封裝在一起，便於在視覺和語意上進行分組。
+ */
 const SelectGroup = SelectPrimitive.Group;
 
+/**
+ * SelectValue 下拉選單顯示值：渲染當前已被選中選項的文字內容，若尚未選中則會顯示設定的 Placeholder 佔位文字。
+ */
 const SelectValue = SelectPrimitive.Value;
 
+/**
+ * SelectTrigger 下拉選單觸發按鈕：使用者點擊時會展開下拉選單內容。通常內含 SelectValue。
+ */
 const SelectTrigger = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
@@ -32,6 +44,9 @@ const SelectTrigger = React.forwardRef<
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;
 
+/**
+ * SelectScrollUpButton 向上滾動按鈕：當選單內容溢出時，提供觸控或點擊以向上滾動選單的功能。
+ */
 const SelectScrollUpButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollUpButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollUpButton>
@@ -49,6 +64,9 @@ const SelectScrollUpButton = React.forwardRef<
 ));
 SelectScrollUpButton.displayName = SelectPrimitive.ScrollUpButton.displayName;
 
+/**
+ * SelectScrollDownButton 向下滾動按鈕：當選單內容溢出時，提供觸控或點擊以向下滾動選單的功能。
+ */
 const SelectScrollDownButton = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.ScrollDownButton>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.ScrollDownButton>
@@ -67,6 +85,9 @@ const SelectScrollDownButton = React.forwardRef<
 SelectScrollDownButton.displayName =
   SelectPrimitive.ScrollDownButton.displayName;
 
+/**
+ * SelectContent 下拉選單彈出框內容容器：包含所有可選項目（SelectItem），並支援動畫、彈出位置定位等設定。
+ */
 const SelectContent = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Content>
@@ -101,6 +122,9 @@ const SelectContent = React.forwardRef<
 ));
 SelectContent.displayName = SelectPrimitive.Content.displayName;
 
+/**
+ * SelectLabel 下拉選單標題：在選單分組（SelectGroup）中顯示唯讀的群組描述或類別文字。
+ */
 const SelectLabel = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Label>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Label>
@@ -113,6 +137,9 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
+/**
+ * SelectItem 下拉選單選項：下拉選單中的具體可選項。當前被選中時會顯示勾選符號，且支援鍵盤導覽和滑鼠懸停效果。
+ */
 const SelectItem = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
@@ -136,6 +163,9 @@ const SelectItem = React.forwardRef<
 ));
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
+/**
+ * SelectSeparator 分隔線：在下拉選單選項之間繪製一條細水平線，通常用於邏輯分組的視覺區隔。
+ */
 const SelectSeparator = React.forwardRef<
   React.ElementRef<typeof SelectPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof SelectPrimitive.Separator>

--- a/src/components/ui/tabs.tsx
+++ b/src/components/ui/tabs.tsx
@@ -5,8 +5,14 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Tabs 頁籤容器：作為整個分頁標籤系統的根容器，用於協調分頁狀態（如當前選中的分頁值等）。
+ */
 const Tabs = TabsPrimitive.Root;
 
+/**
+ * TabsList 頁籤清單：包裹所有分頁標籤按鈕（TabsTrigger）的水平列容器，提供了底色及內距。
+ */
 const TabsList = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.List>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.List>
@@ -22,6 +28,9 @@ const TabsList = React.forwardRef<
 ));
 TabsList.displayName = TabsPrimitive.List.displayName;
 
+/**
+ * TabsTrigger 頁籤觸發器：代表各個分頁標籤的按鈕。當點擊或選中時，會切換至對應 value 的內容區塊。
+ */
 const TabsTrigger = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Trigger>
@@ -37,6 +46,9 @@ const TabsTrigger = React.forwardRef<
 ));
 TabsTrigger.displayName = TabsPrimitive.Trigger.displayName;
 
+/**
+ * TabsContent 頁籤內容區塊：對應特定 value 的分頁內容區，僅在對應的分頁觸發器被選中時顯示。
+ */
 const TabsContent = React.forwardRef<
   React.ElementRef<typeof TabsPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TabsPrimitive.Content>

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,15 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Textarea 元件屬性介面：繼承所有原生 HTML textarea 的屬性。
+ */
 export interface TextareaProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
 
+/**
+ * Textarea 多行輸入框元件：
+ * 提供自適應寬度的多行文字輸入區域，內建流暢的 Focus 外框動畫、Disabled 禁用狀態樣式，並支援與 React Hook Form 雙向綁定。
+ */
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {
     return (


### PR DESCRIPTION
Introduce detailed, professional Traditional Chinese JSDoc comments to major structural, dropdown, tab, selection, and search components. This enhances inline developer readability, provides clear API specs, and guarantees no empty/blank description fields in Storybook Docs.

Key changes:
- **Card**: Add JSDoc comments to `Card`, `CardHeader`, `CardTitle`, `CardDescription`, `CardContent`, and `CardFooter`.
- **Tabs**: Add JSDoc comments to `Tabs`, `TabsList`, `TabsTrigger`, and `TabsContent`.
- **Select**: Add JSDoc comments to `Select` root and sub-components (`SelectTrigger`, `SelectContent`, `SelectItem`, etc.).
- **MultiSelect**: Add detailed prop-by-prop JSDoc to `MultiSelectProps` and describe the component.
- **MultiSelectDropdown**: Add JSDoc definitions to all properties of `MultiSelectDropdownProps` and the component.
- **Textarea**: Add JSDoc comments to `Textarea` and `TextareaProps`.
- **SearchBar**: Document `SearchBarProps` and responsive input layout.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/472
