### PR TITLE
docs(ui): add JSDoc block comments to overlay and feedback components (X-Tracker #471)

### DIFF
--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -6,14 +6,48 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Dialog 對話框元件的根容器，用於控制對話框的開啟狀態與整體行為。
+ *
+ * 經由 Radix UI 的 Dialog.Root 封裝，支援受控 (controlled) 與非受控 (uncontrolled) 模式。
+ *
+ * @example
+ * <Dialog open={isOpen} onOpenChange={setIsOpen}>
+ *   <DialogTrigger>開啟對話框</DialogTrigger>
+ *   <DialogContent>對話框內容</DialogContent>
+ * </Dialog>
+ */
 const Dialog = DialogPrimitive.Root;
 
+/**
+ * DialogTrigger 用於觸發對話框開啟的按鈕/元件。
+ *
+ * 預設會渲染為一個 button，通常會搭配 `asChild` 屬性將觸發行為套用至子元件（例如 Button）。
+ *
+ * @example
+ * <DialogTrigger asChild>
+ *   <Button>編輯檔案</Button>
+ * </DialogTrigger>
+ */
 const DialogTrigger = DialogPrimitive.Trigger;
 
+/**
+ * DialogPortal 將對話框內容渲染至 React Portal 中，使其脫離常規 DOM 流，通常渲染於 body 底部以避免層級 (z-index) 衝突。
+ */
 const DialogPortal = DialogPrimitive.Portal;
 
+/**
+ * DialogClose 用於關閉對話框的觸發元件。
+ *
+ * 通常置於對話框內容之內，點擊時會將對話框的 open 狀態設為 false。
+ */
 const DialogClose = DialogPrimitive.Close;
 
+/**
+ * DialogOverlay 對話框的背景遮罩。
+ *
+ * 鋪滿整個螢幕，點擊遮罩預設會關閉對話框。支援動畫與透明度設定。
+ */
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
@@ -29,6 +63,14 @@ const DialogOverlay = React.forwardRef<
 ));
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
 
+/**
+ * DialogContent 對話框的主體內容容器。
+ *
+ * 包含對話框的實際內容（如標題、描述、表單、按鈕等），內置預設的置中樣式、響應式設計與關閉按鈕。
+ *
+ * @param className - 額外的自訂樣式類名
+ * @param children - 對話框內部的子元件
+ */
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
@@ -53,6 +95,11 @@ const DialogContent = React.forwardRef<
 ));
 DialogContent.displayName = DialogPrimitive.Content.displayName;
 
+/**
+ * DialogHeader 對話框的頭部區域。
+ *
+ * 用於放置 DialogTitle (標題) 與 DialogDescription (描述文字)，提供標準的垂直間距。
+ */
 const DialogHeader = ({
   className,
   ...props
@@ -67,6 +114,11 @@ const DialogHeader = ({
 );
 DialogHeader.displayName = 'DialogHeader';
 
+/**
+ * DialogFooter 對話框的底部區域。
+ *
+ * 用於放置操作按鈕（例如確認、取消、儲存等），在桌機版預設靠右對齊，手機版垂直排列。
+ */
 const DialogFooter = ({
   className,
   ...props
@@ -81,6 +133,11 @@ const DialogFooter = ({
 );
 DialogFooter.displayName = 'DialogFooter';
 
+/**
+ * DialogTitle 對話框的標題元件。
+ *
+ * 為螢幕閱讀器與無障礙功能 (accessibility) 提供明確的標題定義。
+ */
 const DialogTitle = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
@@ -96,6 +153,11 @@ const DialogTitle = React.forwardRef<
 ));
 DialogTitle.displayName = DialogPrimitive.Title.displayName;
 
+/**
+ * DialogDescription 對話框的描述文字元件。
+ *
+ * 用於提供標題之外的詳細輔助說明資訊。
+ */
 const DialogDescription = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -6,13 +6,51 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * DropdownMenu 下拉選單元件的根容器，用於協調選單的開啟與關閉狀態。
+ *
+ * 經由 Radix UI 的 DropdownMenu.Root 封裝，支援鍵盤導覽、無障礙存取 (a11y) 等完整功能。
+ */
 const DropdownMenu = DropdownMenuPrimitive.Root;
+
+/**
+ * DropdownMenuTrigger 用於觸發下拉選單開啟的按鈕/元件。
+ *
+ * 預設渲染為 button，建議搭配 `asChild` 屬性套用至自訂元件。
+ */
 const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+/**
+ * DropdownMenuGroup 用於將下拉選單中的項目 (Items) 進行邏輯分組。
+ *
+ * 對於螢幕閱讀器非常有用，用來提升無障礙體驗。
+ */
 const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+/**
+ * DropdownMenuPortal 將下拉選單內容渲染至 React Portal 中，以避免層級 (z-index) 遮擋問題。
+ */
 const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+/**
+ * DropdownMenuSub 子下拉選單容器。
+ *
+ * 用於在現有的下拉選單中嵌套另一層選單。
+ */
 const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+/**
+ * DropdownMenuRadioGroup 下拉選單單選組容器。
+ *
+ * 可與 DropdownMenuRadioItem 配合使用，提供在一組選單項目中進行單選的功能。
+ */
 const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
 
+/**
+ * DropdownMenuSeparator 下拉選單分割線。
+ *
+ * 用於分隔選單項目之邏輯區塊。
+ */
 const DropdownMenuSeparator = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Separator>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Separator>
@@ -25,6 +63,13 @@ const DropdownMenuSeparator = React.forwardRef<
 ));
 DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 
+/**
+ * DropdownMenuSubTrigger 用於觸發子選單 (SubMenu) 開啟的選單項目。
+ *
+ * 渲染後右側會帶有箭頭圖示。
+ *
+ * @param inset - 是否向內縮排（留出圖示空間）
+ */
 const DropdownMenuSubTrigger = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubTrigger>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubTrigger> & {
@@ -47,6 +92,11 @@ const DropdownMenuSubTrigger = React.forwardRef<
 DropdownMenuSubTrigger.displayName =
   DropdownMenuPrimitive.SubTrigger.displayName;
 
+/**
+ * DropdownMenuSubContent 子選單的內容容器。
+ *
+ * 在滑鼠懸停或選中子選單觸發器時展開。
+ */
 const DropdownMenuSubContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.SubContent>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.SubContent>
@@ -63,6 +113,14 @@ const DropdownMenuSubContent = React.forwardRef<
 DropdownMenuSubContent.displayName =
   DropdownMenuPrimitive.SubContent.displayName;
 
+/**
+ * DropdownMenuContent 下拉選單的主體內容容器。
+ *
+ * 會自動渲染在 React Portal 中。內置預設的彈出動畫與定位系統。
+ *
+ * @param sideOffset - 選單與觸發按鈕之間的間距（像素數）。預設為 4。
+ * @param className - 額外的自訂樣式類名
+ */
 const DropdownMenuContent = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Content>
@@ -81,6 +139,13 @@ const DropdownMenuContent = React.forwardRef<
 ));
 DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
 
+/**
+ * DropdownMenuItem 下拉選單中的標準可點擊項目。
+ *
+ * 支援選中狀態樣式與鍵盤焦點移動。
+ *
+ * @param inset - 是否向內縮排（留出圖示空間）
+ */
 const DropdownMenuItem = React.forwardRef<
   React.ElementRef<typeof DropdownMenuPrimitive.Item>,
   React.ComponentPropsWithoutRef<typeof DropdownMenuPrimitive.Item> & {

--- a/src/components/ui/loading-spinner.tsx
+++ b/src/components/ui/loading-spinner.tsx
@@ -3,8 +3,22 @@ import { Loader2 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 interface LoadingSpinnerProps {
+  /**
+   * 額外的自訂 CSS 樣式類名。
+   */
   className?: string;
+  /**
+   * 旋轉載入圖示的尺寸大小。
+   * - 'sm': 16px (h-4 w-4)
+   * - 'md': 24px (h-6 w-6)
+   * - 'lg': 32px (h-8 w-8)
+   * @default 'md'
+   */
   size?: 'sm' | 'md' | 'lg';
+  /**
+   * 用於螢幕閱讀器的輔助無障礙說明標籤。
+   * @default '載入中'
+   */
   label?: string;
 }
 
@@ -14,6 +28,14 @@ const sizeClasses = {
   lg: 'h-8 w-8',
 };
 
+/**
+ * LoadingSpinner 旋轉載入指示器。
+ *
+ * 用於展示非同步資料加載或背景處理狀態。內置 `Loader2` (Lucide React) 動畫及無障礙標籤。
+ *
+ * @example
+ * <LoadingSpinner size="lg" label="檔案上傳中..." />
+ */
 export function LoadingSpinner({
   className,
   size = 'md',
@@ -34,6 +56,11 @@ export function LoadingSpinner({
   );
 }
 
+/**
+ * PageLoading 頁面層級的全螢幕載入狀態。
+ *
+ * 預設高度為 50vh，並使 LoadingSpinner (lg) 水平垂直置中，適用於整頁加載或大區塊骨架屏載入。
+ */
 export function PageLoading() {
   return (
     <div className="flex h-[50vh] w-full items-center justify-center">

--- a/src/components/ui/popover.tsx
+++ b/src/components/ui/popover.tsx
@@ -5,10 +5,29 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Popover 氣泡彈窗元件的根容器，用於控制氣泡彈窗的開啟狀態與整體行為。
+ *
+ * 基於 Radix UI 的 Popover.Root 封裝，適合用於展示選單、過濾器、微型表單等。
+ */
 const Popover = PopoverPrimitive.Root;
 
+/**
+ * PopoverTrigger 用於觸發氣泡彈窗開啟的按鈕/元件。
+ *
+ * 通常搭配 `asChild` 屬性將觸發行為套用至子元件（例如 Button）。
+ */
 const PopoverTrigger = PopoverPrimitive.Trigger;
 
+/**
+ * PopoverContent 氣泡彈窗的主體內容容器。
+ *
+ * 會自動渲染在 React Portal 中。具有預設的定位、陰影與開啟/關閉動畫。
+ *
+ * @param align - 對齊方式：'start' | 'center' | 'end'。預設為 'center'。
+ * @param sideOffset - 氣泡與觸發按鈕之間的間距（像素數）。預設為 4。
+ * @param className - 額外的自訂樣式類名
+ */
 const PopoverContent = React.forwardRef<
   React.ElementRef<typeof PopoverPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>

--- a/src/components/ui/sheet.tsx
+++ b/src/components/ui/sheet.tsx
@@ -7,17 +7,40 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * Sheet 側邊抽屜 (Drawer) 元件的根容器，用於控制抽屜的開啟狀態與整體行為。
+ *
+ * 經由 Radix UI 的 Dialog.Root (重新導出為 Sheet) 封裝，支援自訂滑出方向 (top, bottom, left, right)。
+ */
 const Sheet = SheetPrimitive.Root;
 
+/**
+ * SheetTrigger 用於觸發側邊抽屜開啟的按鈕/元件。
+ *
+ * 通常搭配 `asChild` 屬性將觸發行為套用至子元件（例如 Button）。
+ */
 const SheetTrigger = SheetPrimitive.Trigger;
 
+/**
+ * SheetClose 用於關閉側邊抽屜的觸發元件。
+ *
+ * 通常置於側邊抽屜內容之內，點擊時會關閉抽屜。
+ */
 const SheetClose = SheetPrimitive.Close;
 
+/**
+ * SheetPortal 將側邊抽屜內容渲染至 React Portal 中，使其脫離常規 DOM 流，渲染於 body 底部。
+ */
 const SheetPortal = ({ ...props }: SheetPrimitive.DialogPortalProps) => (
   <SheetPrimitive.Portal {...props} />
 );
 SheetPortal.displayName = SheetPrimitive.Portal.displayName;
 
+/**
+ * SheetOverlay 側邊抽屜的背景遮罩。
+ *
+ * 鋪滿整個螢幕，預設具有半透明與模糊效果 (backdrop-blur-sm)。
+ */
 const SheetOverlay = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Overlay>
@@ -56,9 +79,21 @@ interface SheetContentProps
   extends
     React.ComponentPropsWithoutRef<typeof SheetPrimitive.Content>,
     VariantProps<typeof sheetVariants> {
+  /**
+   * 是否顯示預設的關閉按鈕（位於右上角）。
+   * @default false
+   */
   showPrimitiveClose?: boolean;
 }
 
+/**
+ * SheetContent 側邊抽屜的主體內容容器。
+ *
+ * 控制抽屜的滑出方向、寬高、樣式，並決定是否渲染預設關閉按鈕。
+ *
+ * @param side - 抽屜滑出方向：'top' | 'bottom' | 'left' | 'right'。預設為 'right'。
+ * @param showPrimitiveClose - 是否顯示右上角的預設關閉按鈕。預設為 false。
+ */
 const SheetContent = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Content>,
   SheetContentProps
@@ -93,6 +128,11 @@ const SheetContent = React.forwardRef<
 );
 SheetContent.displayName = SheetPrimitive.Content.displayName;
 
+/**
+ * SheetHeader 側邊抽屜的頭部區域。
+ *
+ * 用於放置標題 (SheetTitle) 與描述文字 (SheetDescription)。
+ */
 const SheetHeader = ({
   className,
   ...props
@@ -107,6 +147,11 @@ const SheetHeader = ({
 );
 SheetHeader.displayName = 'SheetHeader';
 
+/**
+ * SheetFooter 側邊抽屜的底部區域。
+ *
+ * 用於放置操作按鈕，預設支援響應式佈局。
+ */
 const SheetFooter = ({
   className,
   ...props
@@ -121,6 +166,11 @@ const SheetFooter = ({
 );
 SheetFooter.displayName = 'SheetFooter';
 
+/**
+ * SheetTitle 側邊抽屜的標題元件。
+ *
+ * 提供側邊抽屜明確的無障礙 (ARIA) 標題。
+ */
 const SheetTitle = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Title>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Title>
@@ -133,6 +183,11 @@ const SheetTitle = React.forwardRef<
 ));
 SheetTitle.displayName = SheetPrimitive.Title.displayName;
 
+/**
+ * SheetDescription 側邊抽屜的描述文字元件。
+ *
+ * 用於提供標題之外的詳細輔助說明資訊。
+ */
 const SheetDescription = React.forwardRef<
   React.ElementRef<typeof SheetPrimitive.Description>,
   React.ComponentPropsWithoutRef<typeof SheetPrimitive.Description>

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,8 +5,18 @@ import * as React from 'react';
 
 import { cn } from '@/lib/utils';
 
+/**
+ * ToastProvider 吐司通知元件的全局提供者 (Provider)。
+ *
+ * 用於管理與調度多個 Toast 吐司通知的渲染。
+ */
 const ToastProvider = ToastPrimitives.Provider;
 
+/**
+ * ToastViewport 吐司通知元件的顯示區域（視窗）。
+ *
+ * 定位在畫面中特定的角落（預設為右下角/右上角），所有 Toast 都會被渲染在此 Viewport 之中。
+ */
 const ToastViewport = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Viewport>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Viewport>
@@ -39,6 +49,13 @@ const toastVariants = cva(
   }
 );
 
+/**
+ * Toast 單個吐司通知元件的主體。
+ *
+ * 支援預設 (default) 與破壞性/錯誤 (destructive) 等多種視覺變體 (variant)。
+ *
+ * @param variant - 吐司通知樣式變體：'default' | 'destructive'。
+ */
 const Toast = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Root>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Root> &
@@ -54,6 +71,11 @@ const Toast = React.forwardRef<
 });
 Toast.displayName = ToastPrimitives.Root.displayName;
 
+/**
+ * ToastAction 吐司通知內的自訂動作按鈕（例如：重試、撤銷等）。
+ *
+ * 會自動繼承 Toast 的變體風格。
+ */
 const ToastAction = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Action>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Action>
@@ -69,6 +91,9 @@ const ToastAction = React.forwardRef<
 ));
 ToastAction.displayName = ToastPrimitives.Action.displayName;
 
+/**
+ * ToastClose 用於關閉個別吐司通知的按鈕（預設顯示為右上角 X 圖標）。
+ */
 const ToastClose = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Close>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Close>
@@ -87,6 +112,9 @@ const ToastClose = React.forwardRef<
 ));
 ToastClose.displayName = ToastPrimitives.Close.displayName;
 
+/**
+ * ToastTitle 吐司通知的標題。
+ */
 const ToastTitle = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Title>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Title>
@@ -99,6 +127,9 @@ const ToastTitle = React.forwardRef<
 ));
 ToastTitle.displayName = ToastPrimitives.Title.displayName;
 
+/**
+ * ToastDescription 吐司通知的詳細描述文字。
+ */
 const ToastDescription = React.forwardRef<
   React.ElementRef<typeof ToastPrimitives.Description>,
   React.ComponentPropsWithoutRef<typeof ToastPrimitives.Description>

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -10,6 +10,26 @@ import {
 } from '@/components/ui/toast';
 import { useToast } from '@/components/ui/use-toast';
 
+/**
+ * Toaster 全局吐司通知渲染器。
+ *
+ * 必須置於應用的 Root layout 中。它會自動訂閱 `useToast` Hook，並將觸發的所有 Toast 吐司通知渲染到畫面上。
+ *
+ * @example
+ * // 於 src/app/layout.tsx 中引入
+ * import { Toaster } from "@/components/ui/toaster"
+ *
+ * export default function RootLayout({ children }) {
+ *   return (
+ *     <html>
+ *       <body>
+ *         {children}
+ *         <Toaster />
+ *       </body>
+ *     </html>
+ *   )
+ * }
+ */
 export function Toaster() {
   const { toasts } = useToast();
 


### PR DESCRIPTION
Enhance popover, overlay, dialog, and loading components with descriptive JSDoc block comments. This populates Storybook's auto-docs with clear explanations of triggers, content alignment, open states, and callbacks.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/471
