### PR TITLE
chore(storybook): standardize framework config to use object format (X-Tracker #473)

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -7,7 +7,10 @@ const config: StorybookConfig = {
     '@storybook/addon-docs',
     '@storybook/addon-onboarding',
   ],
-  framework: '@storybook/nextjs',
+  framework: {
+    name: '@storybook/nextjs',
+    options: {},
+  },
   staticDirs: ['../public'],
 };
 export default config;


### PR DESCRIPTION
Update the Storybook framework configuration in .storybook/main.ts from a simple string to the advanced object format: framework: { name: '@storybook/nextjs', options: {} }. This ensures that the @storybook/nextjs framework and its associated Webpack/Babel and Next.js routing integrations are fully and correctly initialized.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/473
