### PR TITLE
test(layout): harden App Router configuration for Layout Header stories (X-Tracker #474)

### DIFF
--- a/src/components/layout/Header/DisabledAwareLink.stories.tsx
+++ b/src/components/layout/Header/DisabledAwareLink.stories.tsx
@@ -7,6 +7,11 @@ const meta: Meta<typeof DisabledAwareLink> = {
   title: 'Layout/Header/DisabledAwareLink',
   component: DisabledAwareLink,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   argTypes: {
     disabled: {
       control: 'boolean',

--- a/src/components/layout/Header/HamburgerMenu.stories.tsx
+++ b/src/components/layout/Header/HamburgerMenu.stories.tsx
@@ -6,6 +6,11 @@ const meta: Meta<typeof HamburgerMenu> = {
   title: 'Layout/Header/HamburgerMenu',
   component: HamburgerMenu,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   args: {
     isLoggedIn: false,
     isMentor: false,

--- a/src/components/layout/Header/Header.stories.tsx
+++ b/src/components/layout/Header/Header.stories.tsx
@@ -7,6 +7,11 @@ const meta: Meta<typeof Header> = {
   title: 'Layout/Header/Header',
   component: Header,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   decorators: [
     (Story) => (
       <div className="min-h-[120px] bg-background-bottom">

--- a/src/components/layout/Header/MobileUserMenu.stories.tsx
+++ b/src/components/layout/Header/MobileUserMenu.stories.tsx
@@ -7,6 +7,11 @@ const meta: Meta<typeof MobileUserMenu> = {
   title: 'Layout/Header/MobileUserMenu',
   component: MobileUserMenu,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   decorators: [
     (Story) => (
       <div className="flex min-h-[300px] justify-end bg-background-bottom p-8">

--- a/src/components/layout/Header/UserDropdown.stories.tsx
+++ b/src/components/layout/Header/UserDropdown.stories.tsx
@@ -7,6 +7,11 @@ const meta: Meta<typeof UserDropdown> = {
   title: 'Layout/Header/UserDropdown',
   component: UserDropdown,
   tags: ['autodocs'],
+  parameters: {
+    nextjs: {
+      appDirectory: true,
+    },
+  },
   decorators: [
     (Story) => (
       <div className="flex min-h-[300px] justify-end bg-background-bottom p-8">


### PR DESCRIPTION
Explicitly configure parameters.nextjs.appDirectory = true in the Storybook files for Layout Header and its sub-components:
- Header.stories.tsx
- UserDropdown.stories.tsx
- MobileUserMenu.stories.tsx
- HamburgerMenu.stories.tsx
- DisabledAwareLink.stories.tsx

This ensures that the Next.js App Router context is properly mocked and isolated for all Header component stories, preventing Storybook mock clashing and resolving the SB_FRAMEWORK_NEXTJS_0002 router mock exception.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/474
