### PR TITLE
feat(reservation): resolve counterparty dynamically in mapToReservation (X-Tracker #477)

### DIFF
--- a/src/docs/Introduction.mdx
+++ b/src/docs/Introduction.mdx
@@ -243,6 +243,7 @@ args: {
 disabled: true,
 },
 };`}
+
 </pre>
 </div>
 

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -426,12 +426,16 @@ describe('mapToReservation', () => {
    * myUserId matching (counterparty resolution)
    * ============================ */
 
-  it('myUserId is omitted → counterparty defaults to participant for backward compatibility', () => {
+  it('myUserId is omitted (undefined or null) → counterparty defaults to participant for backward compatibility', () => {
     const reservation = makeReservation();
-    const result = mapToReservation(reservation);
-    // When omitted, should map name/avatar of participant (Bob, user_id: 20)
-    expect(result.name).toBe('Bob');
-    expect(result.participantUserId).toBe(20);
+    const resultUndefined = mapToReservation(reservation);
+    const resultNull = mapToReservation(reservation, null);
+
+    expect(resultUndefined.name).toBe('Bob');
+    expect(resultUndefined.participantUserId).toBe(20);
+
+    expect(resultNull.name).toBe('Bob');
+    expect(resultNull.participantUserId).toBe(20);
   });
 
   it('myUserId matches sender.user_id → counterparty is set to participant', () => {

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -1,3 +1,4 @@
+import { fromAny } from '@total-typescript/shoehorn';
 import { describe, expect, it } from 'vitest';
 
 import {
@@ -457,5 +458,14 @@ describe('mapToReservation', () => {
     const result = mapToReservation(reservation, 20); // myUserId is 20 (participant user_id, not sender)
     // counterparty is sender (Alice, user_id: 10)
     expect(result.name).toBe('Alice');
+  });
+
+  it('myUserId is provided but sender is null/undefined → falls back to participant to prevent crash', () => {
+    const reservation = makeReservation({
+      sender: fromAny(null),
+    });
+    const result = mapToReservation(reservation, 10);
+    expect(result.name).toBe('Bob');
+    expect(result.participantUserId).toBe(20);
   });
 });

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -468,4 +468,13 @@ describe('mapToReservation', () => {
     expect(result.name).toBe('Bob');
     expect(result.participantUserId).toBe(20);
   });
+
+  it('myUserId matches sender.user_id but participant is null/undefined → falls back to sender to prevent crash', () => {
+    const reservation = makeReservation({
+      participant: fromAny(null),
+    });
+    const result = mapToReservation(reservation, 10); // matches sender.user_id, falls back to sender (Alice)
+    expect(result.name).toBe('Alice');
+    expect(result.senderUserId).toBe(10);
+  });
 });

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -421,4 +421,37 @@ describe('mapToReservation', () => {
     const result = mapToReservation(makeReservation());
     expect(result.cancelledBy).toBeUndefined();
   });
+
+  /* ============================
+   * myUserId matching (counterparty resolution)
+   * ============================ */
+
+  it('myUserId is omitted → counterparty defaults to participant for backward compatibility', () => {
+    const reservation = makeReservation();
+    const result = mapToReservation(reservation);
+    // When omitted, should map name/avatar of participant (Bob, user_id: 20)
+    expect(result.name).toBe('Bob');
+    expect(result.participantUserId).toBe(20);
+  });
+
+  it('myUserId matches sender.user_id → counterparty is set to participant', () => {
+    const reservation = makeReservation();
+    const result = mapToReservation(reservation, 10); // sender user_id is 10
+    // counterparty is participant (Bob)
+    expect(result.name).toBe('Bob');
+  });
+
+  it('myUserId matches sender.user_id as string/number mismatch → type-agnostically resolves counterparty to participant', () => {
+    const reservation = makeReservation();
+    const result = mapToReservation(reservation, '10'); // sender user_id is 10 (number)
+    // counterparty is participant (Bob)
+    expect(result.name).toBe('Bob');
+  });
+
+  it('myUserId does NOT match sender.user_id → counterparty is set to sender', () => {
+    const reservation = makeReservation();
+    const result = mapToReservation(reservation, 20); // myUserId is 20 (participant user_id, not sender)
+    // counterparty is sender (Alice, user_id: 10)
+    expect(result.name).toBe('Alice');
+  });
 });

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -79,10 +79,10 @@ export function mapToReservation(
   // If myUserId is omitted (null or undefined), the counterparty defaults to reservation.participant for backward compatibility.
   const counterparty =
     myUserId == null
-      ? reservation.participant
+      ? (reservation.participant ?? reservation.sender)
       : reservation.sender?.user_id != null &&
           String(myUserId) === String(reservation.sender.user_id)
-        ? reservation.participant
+        ? (reservation.participant ?? reservation.sender)
         : (reservation.sender ?? reservation.participant);
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
@@ -128,8 +128,8 @@ export function mapToReservation(
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    counterparty.status === 'REJECT'
-      ? toRole(counterparty.role)
+    reservation.participant?.status === 'REJECT'
+      ? toRole(reservation.participant?.role)
       : reservation.sender?.status === 'REJECT'
         ? toRole(reservation.sender?.role)
         : undefined;

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -71,10 +71,18 @@ function classifyMessageRole(
 }
 
 export function mapToReservation(
-  reservation: components['schemas']['ReservationInfoVO']
+  reservation: components['schemas']['ReservationInfoVO'],
+  myUserId?: string | number
 ): Reservation {
-  // API 固定結構：sender = 當前使用者，participant = 對方
-  const counterparty = reservation.participant;
+  // If myUserId is provided and equals reservation.sender.user_id, the counterparty is set to reservation.participant.
+  // If myUserId is provided and does NOT equal reservation.sender.user_id, the counterparty is set to reservation.sender.
+  // If myUserId is omitted, the counterparty defaults to reservation.participant for backward compatibility.
+  const counterparty =
+    myUserId === undefined
+      ? reservation.participant
+      : String(myUserId) === String(reservation.sender.user_id)
+        ? reservation.participant
+        : reservation.sender;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -168,7 +176,7 @@ export async function fetchReservations(
   if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
-    mapToReservation(reservation)
+    mapToReservation(reservation, userId)
   );
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -72,15 +72,16 @@ function classifyMessageRole(
 
 export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO'],
-  myUserId?: string | number
+  myUserId?: string | number | null
 ): Reservation {
   // If myUserId is provided and equals reservation.sender.user_id, the counterparty is set to reservation.participant.
   // If myUserId is provided and does NOT equal reservation.sender.user_id, the counterparty is set to reservation.sender.
-  // If myUserId is omitted, the counterparty defaults to reservation.participant for backward compatibility.
+  // If myUserId is omitted (null or undefined), the counterparty defaults to reservation.participant for backward compatibility.
   const counterparty =
-    myUserId === undefined
+    myUserId == null
       ? reservation.participant
-      : String(myUserId) === String(reservation.sender.user_id)
+      : reservation.sender?.user_id != null &&
+          String(myUserId) === String(reservation.sender.user_id)
         ? reservation.participant
         : reservation.sender;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -83,7 +83,7 @@ export function mapToReservation(
       : reservation.sender?.user_id != null &&
           String(myUserId) === String(reservation.sender.user_id)
         ? reservation.participant
-        : reservation.sender;
+        : (reservation.sender ?? reservation.participant);
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -97,10 +97,10 @@ export function mapToReservation(
   // card preview (which still wants both the mentee's question and the
   // mentor's reply / cancellation reason at a glance).
   const userIdToRole = new Map<string, string | null | undefined>([
-    [String(reservation.sender.user_id ?? ''), reservation.sender.role],
+    [String(reservation.sender?.user_id ?? ''), reservation.sender?.role],
     [
-      String(reservation.participant.user_id ?? ''),
-      reservation.participant.role,
+      String(reservation.participant?.user_id ?? ''),
+      reservation.participant?.role,
     ],
   ]);
 
@@ -130,8 +130,8 @@ export function mapToReservation(
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
     counterparty.status === 'REJECT'
       ? toRole(counterparty.role)
-      : reservation.sender.status === 'REJECT'
-        ? toRole(reservation.sender.role)
+      : reservation.sender?.status === 'REJECT'
+        ? toRole(reservation.sender?.role)
         : undefined;
 
   return {
@@ -147,8 +147,8 @@ export function mapToReservation(
     scheduleId: reservation.schedule_id,
     dtstart: reservation.dtstart,
     dtend: reservation.dtend,
-    senderUserId: reservation.sender.user_id ?? 0,
-    participantUserId: reservation.participant.user_id ?? 0,
+    senderUserId: reservation.sender?.user_id ?? 0,
+    participantUserId: reservation.participant?.user_id ?? 0,
     cancelledBy,
   };
 }


### PR DESCRIPTION
Refactored the mapToReservation function in reservationService.ts to dynamically resolve the counterparty based on the provided logged-in user ID (myUserId).

- If myUserId is provided and matches reservation.sender.user_id, the counterparty is set to reservation.participant.
- If myUserId is provided and does not match reservation.sender.user_id, the counterparty is set to reservation.sender.
- If myUserId is omitted, it defaults to reservation.participant to ensure full backward compatibility.
- Updated fetchReservations to pass userId to mapToReservation.
- Added unit tests in index.test.ts covering all these scenarios (including string/number mismatches).

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/477
