### PR TITLE
feat(reservation): dynamically resolve counterparty name and avatar on reservation cards (X-Tracker #478)

### DIFF
--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -423,26 +423,30 @@ describe('mapToReservation', () => {
   });
 
   describe('dynamic counterparty resolution using currentUserId', () => {
+    const baseSender = {
+      user_id: 10,
+      role: 'MENTEE' as const,
+      status: 'PENDING' as const,
+      name: 'Bob (Mentee)',
+      avatar: 'bob-avatar.png',
+      job_title: 'Designer',
+      years_of_experience: 'ONE_TO_THREE',
+    };
+
+    const baseParticipant = {
+      user_id: 20,
+      role: 'MENTOR' as const,
+      status: 'ACCEPT' as const,
+      name: 'Alice (Mentor)',
+      avatar: 'alice-avatar.png',
+      job_title: 'Engineer',
+      years_of_experience: 'THREE_TO_FIVE',
+    };
+
     it('currentUserId matches sender.user_id → counterparty should be participant', () => {
       const reservation = makeReservation({
-        sender: {
-          user_id: 10,
-          role: 'MENTEE',
-          status: 'PENDING',
-          name: 'Bob (Mentee)',
-          avatar: 'bob-avatar.png',
-          job_title: 'Designer',
-          years_of_experience: 'ONE_TO_THREE',
-        },
-        participant: {
-          user_id: 20,
-          role: 'MENTOR',
-          status: 'ACCEPT',
-          name: 'Alice (Mentor)',
-          avatar: 'alice-avatar.png',
-          job_title: 'Engineer',
-          years_of_experience: 'THREE_TO_FIVE',
-        },
+        sender: baseSender,
+        participant: baseParticipant,
       });
 
       // currentUserId is 10, which matches sender.user_id
@@ -455,24 +459,8 @@ describe('mapToReservation', () => {
 
     it('currentUserId matches participant.user_id → counterparty should be sender', () => {
       const reservation = makeReservation({
-        sender: {
-          user_id: 10,
-          role: 'MENTEE',
-          status: 'PENDING',
-          name: 'Bob (Mentee)',
-          avatar: 'bob-avatar.png',
-          job_title: 'Designer',
-          years_of_experience: 'ONE_TO_THREE',
-        },
-        participant: {
-          user_id: 20,
-          role: 'MENTOR',
-          status: 'ACCEPT',
-          name: 'Alice (Mentor)',
-          avatar: 'alice-avatar.png',
-          job_title: 'Engineer',
-          years_of_experience: 'THREE_TO_FIVE',
-        },
+        sender: baseSender,
+        participant: baseParticipant,
       });
 
       // currentUserId is 20, which matches participant.user_id
@@ -485,24 +473,8 @@ describe('mapToReservation', () => {
 
     it('currentUserId is not provided → fallback to participant as counterparty', () => {
       const reservation = makeReservation({
-        sender: {
-          user_id: 10,
-          role: 'MENTEE',
-          status: 'PENDING',
-          name: 'Bob (Mentee)',
-          avatar: 'bob-avatar.png',
-          job_title: 'Designer',
-          years_of_experience: 'ONE_TO_THREE',
-        },
-        participant: {
-          user_id: 20,
-          role: 'MENTOR',
-          status: 'ACCEPT',
-          name: 'Alice (Mentor)',
-          avatar: 'alice-avatar.png',
-          job_title: 'Engineer',
-          years_of_experience: 'THREE_TO_FIVE',
-        },
+        sender: baseSender,
+        participant: baseParticipant,
       });
 
       // currentUserId is omitted
@@ -515,24 +487,8 @@ describe('mapToReservation', () => {
 
     it('currentUserId is provided but unmatched → fallback to participant as counterparty (isSenderCurrentUser = true)', () => {
       const reservation = makeReservation({
-        sender: {
-          user_id: 10,
-          role: 'MENTEE',
-          status: 'PENDING',
-          name: 'Bob (Mentee)',
-          avatar: 'bob-avatar.png',
-          job_title: 'Designer',
-          years_of_experience: 'ONE_TO_THREE',
-        },
-        participant: {
-          user_id: 20,
-          role: 'MENTOR',
-          status: 'ACCEPT',
-          name: 'Alice (Mentor)',
-          avatar: 'alice-avatar.png',
-          job_title: 'Engineer',
-          years_of_experience: 'THREE_TO_FIVE',
-        },
+        sender: baseSender,
+        participant: baseParticipant,
       });
 
       // currentUserId is unmatched (e.g. '999')
@@ -546,24 +502,8 @@ describe('mapToReservation', () => {
     describe('cancelledBy precedence rules with dynamic counterparty', () => {
       it('currentUserId is sender (MENTEE) and participant (MENTOR) is REJECT → cancelledBy is MENTOR (other party takes precedence)', () => {
         const reservation = makeReservation({
-          sender: {
-            user_id: 10,
-            role: 'MENTEE',
-            status: 'ACCEPT',
-            name: 'Alice',
-            avatar: '',
-            job_title: 'Designer',
-            years_of_experience: 'ONE_TO_THREE',
-          },
-          participant: {
-            user_id: 20,
-            role: 'MENTOR',
-            status: 'REJECT',
-            name: 'Bob',
-            avatar: '',
-            job_title: 'Engineer',
-            years_of_experience: 'THREE_TO_FIVE',
-          },
+          sender: { ...baseSender, status: 'ACCEPT' },
+          participant: { ...baseParticipant, status: 'REJECT' },
         });
 
         // Current user is 10, so counterparty is 20 (MENTOR) who has REJECT
@@ -573,24 +513,8 @@ describe('mapToReservation', () => {
 
       it('currentUserId is participant (MENTOR) and sender (MENTEE) is REJECT → cancelledBy is MENTEE (other party takes precedence)', () => {
         const reservation = makeReservation({
-          sender: {
-            user_id: 10,
-            role: 'MENTEE',
-            status: 'REJECT',
-            name: 'Alice',
-            avatar: '',
-            job_title: 'Designer',
-            years_of_experience: 'ONE_TO_THREE',
-          },
-          participant: {
-            user_id: 20,
-            role: 'MENTOR',
-            status: 'ACCEPT',
-            name: 'Bob',
-            avatar: '',
-            job_title: 'Engineer',
-            years_of_experience: 'THREE_TO_FIVE',
-          },
+          sender: { ...baseSender, status: 'REJECT' },
+          participant: { ...baseParticipant, status: 'ACCEPT' },
         });
 
         // Current user is 20, so counterparty is 10 (MENTEE) who has REJECT
@@ -600,24 +524,8 @@ describe('mapToReservation', () => {
 
       it('both parties are REJECT and currentUserId is participant (MENTOR) → cancelledBy is MENTEE (other party takes precedence when both are REJECT)', () => {
         const reservation = makeReservation({
-          sender: {
-            user_id: 10,
-            role: 'MENTEE',
-            status: 'REJECT',
-            name: 'Alice',
-            avatar: '',
-            job_title: 'Designer',
-            years_of_experience: 'ONE_TO_THREE',
-          },
-          participant: {
-            user_id: 20,
-            role: 'MENTOR',
-            status: 'REJECT',
-            name: 'Bob',
-            avatar: '',
-            job_title: 'Engineer',
-            years_of_experience: 'THREE_TO_FIVE',
-          },
+          sender: { ...baseSender, status: 'REJECT' },
+          participant: { ...baseParticipant, status: 'REJECT' },
         });
 
         // Current user is 20, so counterparty is 10 (MENTEE) who has REJECT.
@@ -628,24 +536,8 @@ describe('mapToReservation', () => {
 
       it('both parties are REJECT and currentUserId is sender (MENTEE) → cancelledBy is MENTOR (other party takes precedence when both are REJECT)', () => {
         const reservation = makeReservation({
-          sender: {
-            user_id: 10,
-            role: 'MENTEE',
-            status: 'REJECT',
-            name: 'Alice',
-            avatar: '',
-            job_title: 'Designer',
-            years_of_experience: 'ONE_TO_THREE',
-          },
-          participant: {
-            user_id: 20,
-            role: 'MENTOR',
-            status: 'REJECT',
-            name: 'Bob',
-            avatar: '',
-            job_title: 'Engineer',
-            years_of_experience: 'THREE_TO_FIVE',
-          },
+          sender: { ...baseSender, status: 'REJECT' },
+          participant: { ...baseParticipant, status: 'REJECT' },
         });
 
         // Current user is 10, so counterparty is 20 (MENTOR) who has REJECT.

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -512,5 +512,147 @@ describe('mapToReservation', () => {
       expect(result.avatar).toBe('alice-avatar.png');
       expect(result.roleLine).toBe('Engineer, 3~5 年');
     });
+
+    it('currentUserId is provided but unmatched → fallback to participant as counterparty (isSenderCurrentUser = false but defaults gracefully)', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob (Mentee)',
+          avatar: 'bob-avatar.png',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice (Mentor)',
+          avatar: 'alice-avatar.png',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+
+      // currentUserId is unmatched (e.g. '999')
+      const result = mapToReservation(reservation, '999');
+
+      expect(result.name).toBe('Bob (Mentee)');
+      expect(result.avatar).toBe('bob-avatar.png');
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    describe('cancelledBy precedence rules with dynamic counterparty', () => {
+      it('currentUserId is sender (MENTEE) and participant (MENTOR) is REJECT → cancelledBy is MENTOR (other party takes precedence)', () => {
+        const reservation = makeReservation({
+          sender: {
+            user_id: 10,
+            role: 'MENTEE',
+            status: 'ACCEPT',
+            name: 'Alice',
+            avatar: '',
+            job_title: 'Designer',
+            years_of_experience: 'ONE_TO_THREE',
+          },
+          participant: {
+            user_id: 20,
+            role: 'MENTOR',
+            status: 'REJECT',
+            name: 'Bob',
+            avatar: '',
+            job_title: 'Engineer',
+            years_of_experience: 'THREE_TO_FIVE',
+          },
+        });
+
+        // Current user is 10, so counterparty is 20 (MENTOR) who has REJECT
+        const result = mapToReservation(reservation, '10');
+        expect(result.cancelledBy).toBe('MENTOR');
+      });
+
+      it('currentUserId is participant (MENTOR) and sender (MENTEE) is REJECT → cancelledBy is MENTEE (other party takes precedence)', () => {
+        const reservation = makeReservation({
+          sender: {
+            user_id: 10,
+            role: 'MENTEE',
+            status: 'REJECT',
+            name: 'Alice',
+            avatar: '',
+            job_title: 'Designer',
+            years_of_experience: 'ONE_TO_THREE',
+          },
+          participant: {
+            user_id: 20,
+            role: 'MENTOR',
+            status: 'ACCEPT',
+            name: 'Bob',
+            avatar: '',
+            job_title: 'Engineer',
+            years_of_experience: 'THREE_TO_FIVE',
+          },
+        });
+
+        // Current user is 20, so counterparty is 10 (MENTEE) who has REJECT
+        const result = mapToReservation(reservation, '20');
+        expect(result.cancelledBy).toBe('MENTEE');
+      });
+
+      it('both parties are REJECT and currentUserId is participant (MENTOR) → cancelledBy is MENTEE (other party takes precedence when both are REJECT)', () => {
+        const reservation = makeReservation({
+          sender: {
+            user_id: 10,
+            role: 'MENTEE',
+            status: 'REJECT',
+            name: 'Alice',
+            avatar: '',
+            job_title: 'Designer',
+            years_of_experience: 'ONE_TO_THREE',
+          },
+          participant: {
+            user_id: 20,
+            role: 'MENTOR',
+            status: 'REJECT',
+            name: 'Bob',
+            avatar: '',
+            job_title: 'Engineer',
+            years_of_experience: 'THREE_TO_FIVE',
+          },
+        });
+
+        // Current user is 20, so counterparty is 10 (MENTEE) who has REJECT.
+        // Even though current user (20) also has REJECT, the other party (10) must take precedence.
+        const result = mapToReservation(reservation, '20');
+        expect(result.cancelledBy).toBe('MENTEE');
+      });
+
+      it('both parties are REJECT and currentUserId is sender (MENTEE) → cancelledBy is MENTOR (other party takes precedence when both are REJECT)', () => {
+        const reservation = makeReservation({
+          sender: {
+            user_id: 10,
+            role: 'MENTEE',
+            status: 'REJECT',
+            name: 'Alice',
+            avatar: '',
+            job_title: 'Designer',
+            years_of_experience: 'ONE_TO_THREE',
+          },
+          participant: {
+            user_id: 20,
+            role: 'MENTOR',
+            status: 'REJECT',
+            name: 'Bob',
+            avatar: '',
+            job_title: 'Engineer',
+            years_of_experience: 'THREE_TO_FIVE',
+          },
+        });
+
+        // Current user is 10, so counterparty is 20 (MENTOR) who has REJECT.
+        // Even though current user (10) also has REJECT, the other party (20) must take precedence.
+        const result = mapToReservation(reservation, '10');
+        expect(result.cancelledBy).toBe('MENTOR');
+      });
+    });
   });
 });

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -513,7 +513,7 @@ describe('mapToReservation', () => {
       expect(result.roleLine).toBe('Engineer, 3~5 年');
     });
 
-    it('currentUserId is provided but unmatched → fallback to participant as counterparty (isSenderCurrentUser = false but defaults gracefully)', () => {
+    it('currentUserId is provided but unmatched → fallback to participant as counterparty (isSenderCurrentUser = true)', () => {
       const reservation = makeReservation({
         sender: {
           user_id: 10,
@@ -538,9 +538,9 @@ describe('mapToReservation', () => {
       // currentUserId is unmatched (e.g. '999')
       const result = mapToReservation(reservation, '999');
 
-      expect(result.name).toBe('Bob (Mentee)');
-      expect(result.avatar).toBe('bob-avatar.png');
-      expect(result.roleLine).toBe('Designer, 1~3 年');
+      expect(result.name).toBe('Alice (Mentor)');
+      expect(result.avatar).toBe('alice-avatar.png');
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
     });
 
     describe('cancelledBy precedence rules with dynamic counterparty', () => {

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -421,4 +421,96 @@ describe('mapToReservation', () => {
     const result = mapToReservation(makeReservation());
     expect(result.cancelledBy).toBeUndefined();
   });
+
+  describe('dynamic counterparty resolution using currentUserId', () => {
+    it('currentUserId matches sender.user_id → counterparty should be participant', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob (Mentee)',
+          avatar: 'bob-avatar.png',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice (Mentor)',
+          avatar: 'alice-avatar.png',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+
+      // currentUserId is 10, which matches sender.user_id
+      const result = mapToReservation(reservation, '10');
+
+      expect(result.name).toBe('Alice (Mentor)');
+      expect(result.avatar).toBe('alice-avatar.png');
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
+    });
+
+    it('currentUserId matches participant.user_id → counterparty should be sender', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob (Mentee)',
+          avatar: 'bob-avatar.png',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice (Mentor)',
+          avatar: 'alice-avatar.png',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+
+      // currentUserId is 20, which matches participant.user_id
+      const result = mapToReservation(reservation, '20');
+
+      expect(result.name).toBe('Bob (Mentee)');
+      expect(result.avatar).toBe('bob-avatar.png');
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    it('currentUserId is not provided → fallback to participant as counterparty', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob (Mentee)',
+          avatar: 'bob-avatar.png',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice (Mentor)',
+          avatar: 'alice-avatar.png',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+
+      // currentUserId is omitted
+      const result = mapToReservation(reservation);
+
+      expect(result.name).toBe('Alice (Mentor)');
+      expect(result.avatar).toBe('alice-avatar.png');
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
+    });
+  });
 });

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -74,11 +74,14 @@ export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO'],
   currentUserId?: string
 ): Reservation {
-  // If currentUserId is passed, resolve counterparty by checking who is NOT the current user.
-  // Otherwise fallback to the previous behaviour (reservation.participant).
-  const isSenderCurrentUser = currentUserId
-    ? String(reservation.sender.user_id) === String(currentUserId)
-    : true;
+  // If currentUserId is passed and matches participant, the current user is participant,
+  // so the counterparty is sender (isSenderCurrentUser = false).
+  // Otherwise, fallback to the previous behaviour where counterparty is participant (isSenderCurrentUser = true).
+  const isSenderCurrentUser =
+    currentUserId &&
+    String(reservation.participant.user_id) === String(currentUserId)
+      ? false
+      : true;
   const counterparty = isSenderCurrentUser
     ? reservation.participant
     : reservation.sender;

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -71,10 +71,18 @@ function classifyMessageRole(
 }
 
 export function mapToReservation(
-  reservation: components['schemas']['ReservationInfoVO']
+  reservation: components['schemas']['ReservationInfoVO'],
+  currentUserId?: string
 ): Reservation {
-  // API 固定結構：sender = 當前使用者，participant = 對方
-  const counterparty = reservation.participant;
+  // If currentUserId is passed, resolve counterparty by checking who is NOT the current user.
+  // Otherwise fallback to the previous behaviour (reservation.participant).
+  const isSenderCurrentUser = currentUserId
+    ? String(reservation.sender.user_id) === String(currentUserId)
+    : true;
+  const counterparty = isSenderCurrentUser
+    ? reservation.participant
+    : reservation.sender;
+
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -119,8 +127,8 @@ export function mapToReservation(
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    counterparty.status === 'REJECT'
-      ? toRole(counterparty.role)
+    reservation.participant.status === 'REJECT'
+      ? toRole(reservation.participant.role)
       : reservation.sender.status === 'REJECT'
         ? toRole(reservation.sender.role)
         : undefined;
@@ -168,7 +176,7 @@ export async function fetchReservations(
   if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
-    mapToReservation(reservation)
+    mapToReservation(reservation, String(userId))
   );
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -123,14 +123,17 @@ export function mapToReservation(
   // canceller's role surfaced so the UI can render 「已由導師/學員取消」 on both
   // mentor and mentee history pages. Reject (pre-accept) and cancel
   // (post-accept) intentionally share the same 「取消」 copy per PM scope
-  // (Tracker #224). Participant takes precedence when both sides are REJECT.
+  // (Tracker #224). Participant (other side / counterparty) takes precedence when both sides are REJECT.
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
+  const currentUser = isSenderCurrentUser
+    ? reservation.sender
+    : reservation.participant;
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    reservation.participant.status === 'REJECT'
-      ? toRole(reservation.participant.role)
-      : reservation.sender.status === 'REJECT'
-        ? toRole(reservation.sender.role)
+    counterparty.status === 'REJECT'
+      ? toRole(counterparty.role)
+      : currentUser.status === 'REJECT'
+        ? toRole(currentUser.role)
         : undefined;
 
   return {
@@ -176,7 +179,7 @@ export async function fetchReservations(
   if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
-    mapToReservation(reservation, String(userId))
+    mapToReservation(reservation, userId != null ? String(userId) : undefined)
   );
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }


### PR DESCRIPTION
Update mapToReservation inside reservationService.ts to accept an optional currentUserId argument. When currentUserId is provided, dynamically resolve the counterparty based on who is NOT the logged-in user, rather than always assuming participant is the other party.

- Pass String(userId) to mapToReservation from fetchReservations queries.
- Explicitly reference reservation.participant and reservation.sender in cancelledBy status evaluation to preserve original precedence logic (Tracker #224).
- Add detailed unit tests in src/services/reservations/index.test.ts to cover different dynamic resolution scenarios and verify backward compatibility when currentUserId is omitted.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/478
