### PR TITLE
fix(reservation): resolve card counterparty dynamically based on user session (X-Tracker #478)

### DIFF
--- a/src/docs/Introduction.mdx
+++ b/src/docs/Introduction.mdx
@@ -243,6 +243,7 @@ args: {
 disabled: true,
 },
 };`}
+
 </pre>
 </div>
 

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -555,7 +555,7 @@ describe('mapToReservation', () => {
       expect(result.roleLine).toBe('Designer, 1~3 年');
     });
 
-    it('when reservation.sender.user_id is null → does not crash and falls back to participant', () => {
+    it('when reservation.sender.user_id is null → does not crash and correctly identifies sender as counterparty', () => {
       const reservation = makeReservation({
         sender: {
           ...baseSender,

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -507,5 +507,57 @@ describe('mapToReservation', () => {
       expect(result.name).toBe('Bob'); // counterparty is Bob (sender)
       expect(result.cancelledBy).toBe('MENTOR'); // should correctly identify mentor as the canceller
     });
+
+    it('when reservation.sender.user_id is null → does not crash and maps to sender as counterparty', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: null as any,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const result = mapToReservation(reservation, 20); // current user is Alice (participant)
+      expect(result.name).toBe('Bob'); // counterparty is Bob (sender with null id)
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    it('when myUserId is an unrelated third-party ID → maps to sender as counterparty', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const result = mapToReservation(reservation, 999); // unrelated user
+      expect(result.name).toBe('Bob'); // counterparty falls back to Bob (sender)
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
   });
 });

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -508,6 +508,34 @@ describe('mapToReservation', () => {
       expect(result.cancelledBy).toBe('MENTOR'); // should correctly identify mentor as the canceller
     });
 
+    it('when both sides rejected → cancelledBy resolves correctly to MENTOR (participant) regardless of myUserId', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'REJECT',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'REJECT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const resultSender = mapToReservation(reservation, 10);
+      expect(resultSender.cancelledBy).toBe('MENTOR');
+
+      const resultParticipant = mapToReservation(reservation, 20);
+      expect(resultParticipant.cancelledBy).toBe('MENTOR');
+    });
+
     it('when reservation.sender.user_id is null → does not crash and maps to sender as counterparty', () => {
       const reservation = makeReservation({
         sender: {

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -536,6 +536,34 @@ describe('mapToReservation', () => {
       expect(resultParticipant.cancelledBy).toBe('MENTOR');
     });
 
+    it('when only sender rejected → cancelledBy resolves correctly to MENTEE regardless of myUserId', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'REJECT',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const resultSender = mapToReservation(reservation, 10);
+      expect(resultSender.cancelledBy).toBe('MENTEE');
+
+      const resultParticipant = mapToReservation(reservation, 20);
+      expect(resultParticipant.cancelledBy).toBe('MENTEE');
+    });
+
     it('when reservation.sender.user_id is null → does not crash and maps to sender as counterparty', () => {
       const reservation = makeReservation({
         sender: {

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -511,7 +511,7 @@ describe('mapToReservation', () => {
     it('when reservation.sender.user_id is null → does not crash and maps to sender as counterparty', () => {
       const reservation = makeReservation({
         sender: {
-          user_id: null as any,
+          user_id: null as unknown as number,
           role: 'MENTEE',
           status: 'PENDING',
           name: 'Bob',
@@ -534,7 +534,7 @@ describe('mapToReservation', () => {
       expect(result.roleLine).toBe('Designer, 1~3 年');
     });
 
-    it('when myUserId is an unrelated third-party ID → maps to sender as counterparty', () => {
+    it('when myUserId is an unrelated third-party ID → maps to participant as counterparty', () => {
       const reservation = makeReservation({
         sender: {
           user_id: 10,
@@ -556,8 +556,8 @@ describe('mapToReservation', () => {
         },
       });
       const result = mapToReservation(reservation, 999); // unrelated user
-      expect(result.name).toBe('Bob'); // counterparty falls back to Bob (sender)
-      expect(result.roleLine).toBe('Designer, 1~3 年');
+      expect(result.name).toBe('Alice'); // counterparty falls back to Alice (participant)
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
     });
   });
 });

--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -421,4 +421,91 @@ describe('mapToReservation', () => {
     const result = mapToReservation(makeReservation());
     expect(result.cancelledBy).toBeUndefined();
   });
+
+  describe('dynamic counterparty resolution based on myUserId', () => {
+    it('when myUserId is undefined → falls back to participant as counterparty (original behavior)', () => {
+      const reservation = makeReservation();
+      const result = mapToReservation(reservation);
+      expect(result.name).toBe('Bob'); // participant name
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    it('when myUserId matches sender.user_id (me) → maps participant as counterparty', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const result = mapToReservation(reservation, 10); // current user is Bob (sender)
+      expect(result.name).toBe('Alice'); // counterparty is Alice (participant)
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
+    });
+
+    it('when myUserId matches participant.user_id (me) → maps sender as counterparty', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'PENDING',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'ACCEPT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const result = mapToReservation(reservation, 20); // current user is Alice (participant)
+      expect(result.name).toBe('Bob'); // counterparty is Bob (sender)
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    it('when myUserId matches participant.user_id (me) and participant rejected → cancelledBy resolves correctly to MENTOR', () => {
+      const reservation = makeReservation({
+        sender: {
+          user_id: 10,
+          role: 'MENTEE',
+          status: 'ACCEPT',
+          name: 'Bob',
+          avatar: '',
+          job_title: 'Designer',
+          years_of_experience: 'ONE_TO_THREE',
+        },
+        participant: {
+          user_id: 20,
+          role: 'MENTOR',
+          status: 'REJECT',
+          name: 'Alice',
+          avatar: '',
+          job_title: 'Engineer',
+          years_of_experience: 'THREE_TO_FIVE',
+        },
+      });
+      const result = mapToReservation(reservation, 20); // current user is Alice (participant)
+      expect(result.name).toBe('Bob'); // counterparty is Bob (sender)
+      expect(result.cancelledBy).toBe('MENTOR'); // should correctly identify mentor as the canceller
+    });
+  });
 });

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -131,20 +131,14 @@ export function mapToReservation(
   // canceller's role surfaced so the UI can render 「已由導師/學員取消」 on both
   // mentor and mentee history pages. Reject (pre-accept) and cancel
   // (post-accept) intentionally share the same 「取消」 copy per PM scope
-  // (Tracker #224). Participant (other side) takes precedence when both sides are REJECT.
+  // (Tracker #224). Participant takes precedence when both sides are REJECT.
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
-
-  const me =
-    counterparty === reservation.participant
-      ? reservation.sender
-      : reservation.participant;
-
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    counterparty.status === 'REJECT'
-      ? toRole(counterparty.role)
-      : me.status === 'REJECT'
-        ? toRole(me.role)
+    reservation.participant.status === 'REJECT'
+      ? toRole(reservation.participant.role)
+      : reservation.sender.status === 'REJECT'
+        ? toRole(reservation.sender.role)
         : undefined;
 
   return {

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -74,14 +74,22 @@ export function mapToReservation(
   reservation: components['schemas']['ReservationInfoVO'],
   myUserId?: string | number
 ): Reservation {
-  // If myUserId is provided, we resolve the counterparty dynamically based on who is logged in.
-  // Otherwise, fallback to reservation.participant.
-  const counterparty =
-    myUserId !== undefined
-      ? reservation.sender.user_id != null &&
-        String(reservation.sender.user_id) === String(myUserId)
-        ? reservation.participant
-        : reservation.sender
+  // If myUserId is provided, we resolve the counterparty dynamically based on who is logged in:
+  // - If myUserId matches the sender, the counterparty is the participant.
+  // - If myUserId matches the participant, the counterparty is the sender.
+  // - Otherwise (or if myUserId is undefined/unrelated), fallback to the original default reservation.participant.
+  const isSender =
+    myUserId !== undefined &&
+    reservation.sender.user_id != null &&
+    String(reservation.sender.user_id) === String(myUserId);
+  const isParticipant =
+    myUserId !== undefined &&
+    reservation.participant.user_id != null &&
+    String(reservation.participant.user_id) === String(myUserId);
+  const counterparty = isSender
+    ? reservation.participant
+    : isParticipant
+      ? reservation.sender
       : reservation.participant;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
@@ -123,14 +131,20 @@ export function mapToReservation(
   // canceller's role surfaced so the UI can render 「已由導師/學員取消」 on both
   // mentor and mentee history pages. Reject (pre-accept) and cancel
   // (post-accept) intentionally share the same 「取消」 copy per PM scope
-  // (Tracker #224). Participant takes precedence when both sides are REJECT.
+  // (Tracker #224). Participant (other side) takes precedence when both sides are REJECT.
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
+
+  const me =
+    counterparty === reservation.participant
+      ? reservation.sender
+      : reservation.participant;
+
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    reservation.participant.status === 'REJECT'
-      ? toRole(reservation.participant.role)
-      : reservation.sender.status === 'REJECT'
-        ? toRole(reservation.sender.role)
+    counterparty.status === 'REJECT'
+      ? toRole(counterparty.role)
+      : me.status === 'REJECT'
+        ? toRole(me.role)
         : undefined;
 
   return {

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -71,10 +71,18 @@ function classifyMessageRole(
 }
 
 export function mapToReservation(
-  reservation: components['schemas']['ReservationInfoVO']
+  reservation: components['schemas']['ReservationInfoVO'],
+  myUserId?: string | number
 ): Reservation {
-  // API 固定結構：sender = 當前使用者，participant = 對方
-  const counterparty = reservation.participant;
+  // If myUserId is provided, we resolve the counterparty dynamically based on who is logged in.
+  // Otherwise, fallback to reservation.participant.
+  const counterparty =
+    myUserId !== undefined
+      ? reservation.sender.user_id != null &&
+        String(reservation.sender.user_id) === String(myUserId)
+        ? reservation.participant
+        : reservation.sender
+      : reservation.participant;
   const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
   const roleLine = [
     counterparty.job_title?.trim() || '',
@@ -119,8 +127,8 @@ export function mapToReservation(
   const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
     r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
   const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    counterparty.status === 'REJECT'
-      ? toRole(counterparty.role)
+    reservation.participant.status === 'REJECT'
+      ? toRole(reservation.participant.role)
       : reservation.sender.status === 'REJECT'
         ? toRole(reservation.sender.role)
         : undefined;
@@ -168,7 +176,7 @@ export async function fetchReservations(
   if (json.code !== '0') throw new FetchApiError(json.code, json.msg, path);
 
   const items = (json.data?.reservations ?? []).map((reservation) =>
-    mapToReservation(reservation)
+    mapToReservation(reservation, userId)
   );
   return { items, next_dtend: json.data?.next_dtend ?? 0 };
 }


### PR DESCRIPTION
- Update mapToReservation to dynamically resolve the counterparty name, avatar, and role details based on the logged-in user's ID if provided.
- Pass the logged-in user's ID from fetchReservations to the mapping helper.
- Ensure the cancelledBy logic is correctly decoupled from the dynamic counterparty mapping to prevent cancellation badge regression.
- Add robust unit tests covering fallback behavior, different user perspectives, and the cancellation badge regression scenario.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/478
