### PR TITLE
test(setup): configure global router and navigation mocks in test setup (X-Tracker #475)

### DIFF
--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,7 @@
 import '@testing-library/jest-dom';
+
+import { createNavigation } from '@storybook/nextjs/navigation.mock';
+import { createRouter } from '@storybook/nextjs/router.mock';
+
+createRouter({});
+createNavigation({});

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -20,6 +20,11 @@ export default defineConfig({
       NEXT_PUBLIC_API_URL: '',
     },
     setupFiles: ['./src/test/setup.ts'],
+    server: {
+      deps: {
+        inline: [/@storybook\/nextjs/],
+      },
+    },
     include: [
       'src/**/*.{test,spec}.{ts,tsx}',
       'scripts/**/*.{test,spec}.mjs',


### PR DESCRIPTION
Initialize global router and navigation mocks in src/test/setup.ts to avoid any uninitialized mock exceptions (such as SB_FRAMEWORK_NEXTJS_0002) when importing or composing Storybook stories inside unit tests.

Also added @storybook/nextjs to server.deps.inline in vitest.config.mts to bypass a CommonJS transpilation issue where the mock router was being overwritten by Next's original router during execution.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/475
