### PR TITLE
docs(storybook): translate storybook docs and components to Traditional Chinese (X-Tracker #480)

### DIFF
--- a/src/components/auth/AuthButton.stories.tsx
+++ b/src/components/auth/AuthButton.stories.tsx
@@ -3,13 +3,13 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import AuthButton from './AuthButton';
 
 const meta: Meta<typeof AuthButton> = {
-  title: 'Components/Auth/AuthButton',
+  title: '業務模組元件/會員驗證(Auth)/AuthButton',
   component: AuthButton,
   tags: ['autodocs'],
   argTypes: {
     isSubmitting: {
       control: 'boolean',
-      description: 'Whether the form is currently submitting',
+      description: '表單是否正在提交中',
     },
   },
 };

--- a/src/components/auth/AuthLink.stories.tsx
+++ b/src/components/auth/AuthLink.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import AuthLink from './AuthLink';
 
 const meta: Meta<typeof AuthLink> = {
-  title: 'Components/Auth/AuthLink',
+  title: '業務模組元件/會員驗證(Auth)/AuthLink',
   component: AuthLink,
   tags: ['autodocs'],
 };

--- a/src/components/auth/AuthMessageCard.stories.tsx
+++ b/src/components/auth/AuthMessageCard.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import AuthMessageCard from './AuthMessageCard';
 
 const meta: Meta<typeof AuthMessageCard> = {
-  title: 'Components/Auth/AuthMessageCard',
+  title: '業務模組元件/會員驗證(Auth)/AuthMessageCard',
   component: AuthMessageCard,
   tags: ['autodocs'],
 };

--- a/src/components/auth/AuthTitle.stories.tsx
+++ b/src/components/auth/AuthTitle.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import AuthTitle from './AuthTitle';
 
 const meta: Meta<typeof AuthTitle> = {
-  title: 'Components/Auth/AuthTitle',
+  title: '業務模組元件/會員驗證(Auth)/AuthTitle',
   component: AuthTitle,
   tags: ['autodocs'],
 };

--- a/src/components/auth/DeleteAccountDialog.stories.tsx
+++ b/src/components/auth/DeleteAccountDialog.stories.tsx
@@ -10,7 +10,7 @@ import { DeleteAccountXCSchema } from '@/schemas/auth';
 import { DeleteAccountDialogView } from './DeleteAccountDialog';
 
 const meta: Meta<typeof DeleteAccountDialogView> = {
-  title: 'Components/Auth/DeleteAccountDialog',
+  title: '業務模組元件/會員驗證(Auth)/DeleteAccountDialog',
   component: DeleteAccountDialogView,
   tags: ['autodocs'],
 };

--- a/src/components/auth/Divider.stories.tsx
+++ b/src/components/auth/Divider.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import Divider from './Divider';
 
 const meta: Meta<typeof Divider> = {
-  title: 'Components/Auth/Divider',
+  title: '業務模組元件/會員驗證(Auth)/Divider',
   component: Divider,
   tags: ['autodocs'],
 };

--- a/src/components/auth/GoogleButton.stories.tsx
+++ b/src/components/auth/GoogleButton.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import GoogleSignUpButton from './GoogleButton';
 
 const meta: Meta<typeof GoogleSignUpButton> = {
-  title: 'Components/Auth/GoogleButton',
+  title: '業務模組元件/會員驗證(Auth)/GoogleButton',
   component: GoogleSignUpButton,
   tags: ['autodocs'],
 };

--- a/src/components/auth/signin/ForgotPasswordLink.stories.tsx
+++ b/src/components/auth/signin/ForgotPasswordLink.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import ForgotPasswordLink from './ForgotPasswordLink';
 
 const meta: Meta<typeof ForgotPasswordLink> = {
-  title: 'Components/Auth/ForgotPasswordLink',
+  title: '業務模組元件/會員驗證(Auth)/ForgotPasswordLink',
   component: ForgotPasswordLink,
   tags: ['autodocs'],
 };

--- a/src/components/auth/signin/SignInForm.stories.tsx
+++ b/src/components/auth/signin/SignInForm.stories.tsx
@@ -9,7 +9,7 @@ import { SignInSchema } from '@/schemas/auth';
 import SignInForm from './SignInForm';
 
 const meta: Meta<typeof SignInForm> = {
-  title: 'Components/Auth/SignInForm',
+  title: '業務模組元件/會員驗證(Auth)/SignInForm',
   component: SignInForm,
   tags: ['autodocs'],
 };

--- a/src/components/auth/signup/SignUpForm.stories.tsx
+++ b/src/components/auth/signup/SignUpForm.stories.tsx
@@ -9,7 +9,7 @@ import { SignUpSchema } from '@/schemas/auth';
 import SignUpForm from './SignUpForm';
 
 const meta: Meta<typeof SignUpForm> = {
-  title: 'Components/Auth/SignUpForm',
+  title: '業務模組元件/會員驗證(Auth)/SignUpForm',
   component: SignUpForm,
   tags: ['autodocs'],
 };

--- a/src/components/auth/signup/TermsOfServiceCheckbox.stories.tsx
+++ b/src/components/auth/signup/TermsOfServiceCheckbox.stories.tsx
@@ -9,7 +9,7 @@ import { SignUpSchema } from '@/schemas/auth';
 import TermsOfServiceCheckbox from './TermsOfServiceCheckbox';
 
 const meta: Meta<typeof TermsOfServiceCheckbox> = {
-  title: 'Components/Auth/TermsOfServiceCheckbox',
+  title: '業務模組元件/會員驗證(Auth)/TermsOfServiceCheckbox',
   component: TermsOfServiceCheckbox,
   tags: ['autodocs'],
 };

--- a/src/components/filter/FilterSelect.stories.tsx
+++ b/src/components/filter/FilterSelect.stories.tsx
@@ -5,7 +5,7 @@ import { REAL_FILTER_OPTIONS } from './__mocks__/filterMockData';
 import FilterSelect from './FilterSelect';
 
 const meta: Meta<typeof FilterSelect> = {
-  title: 'Components/Filter/FilterSelect',
+  title: '業務模組元件/篩選器(Filter)/FilterSelect',
   component: FilterSelect,
   tags: ['autodocs'],
 };

--- a/src/components/filter/MentorFilterDropdown.stories.tsx
+++ b/src/components/filter/MentorFilterDropdown.stories.tsx
@@ -5,7 +5,7 @@ import { REAL_FILTER_OPTIONS } from './__mocks__/filterMockData';
 import MentorFilterDropdown, { SelectFilters } from './MentorFilterDropdown';
 
 const meta: Meta<typeof MentorFilterDropdown> = {
-  title: 'Components/Filter/MentorFilterDropdown',
+  title: '業務模組元件/篩選器(Filter)/MentorFilterDropdown',
   component: MentorFilterDropdown,
   tags: ['autodocs'],
 };

--- a/src/components/landing/HomePageSlider.stories.tsx
+++ b/src/components/landing/HomePageSlider.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { HomePageSlider } from './HomePageSlider';
 
 const meta: Meta<typeof HomePageSlider> = {
-  title: 'Components/Landing/HomePageSlider',
+  title: '業務模組元件/首頁(Landing)/HomePageSlider',
   component: HomePageSlider,
   tags: ['autodocs'],
 };

--- a/src/components/landing/HomePageSliderClient.stories.tsx
+++ b/src/components/landing/HomePageSliderClient.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { HomePageSliderClient } from './HomePageSliderClient';
 
 const meta: Meta<typeof HomePageSliderClient> = {
-  title: 'Components/Landing/HomePageSliderClient',
+  title: '業務模組元件/首頁(Landing)/HomePageSliderClient',
   component: HomePageSliderClient,
   tags: ['autodocs'],
 };

--- a/src/components/layout/Footer/Footer.stories.tsx
+++ b/src/components/layout/Footer/Footer.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Footer } from './Footer';
 
 const meta: Meta<typeof Footer> = {
-  title: 'Components/Layout/Footer',
+  title: '佈局元件/Footer',
   component: Footer,
   tags: ['autodocs'],
 };

--- a/src/components/layout/Header/DisabledAwareLink.stories.tsx
+++ b/src/components/layout/Header/DisabledAwareLink.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { DisabledAwareLink } from './DisabledAwareLink';
 
 const meta: Meta<typeof DisabledAwareLink> = {
-  title: 'Layout/Header/DisabledAwareLink',
+  title: '佈局元件/Header/DisabledAwareLink',
   component: DisabledAwareLink,
   tags: ['autodocs'],
   parameters: {
@@ -15,11 +15,11 @@ const meta: Meta<typeof DisabledAwareLink> = {
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the link is disabled',
+      description: '連結是否已被禁用',
     },
     href: {
       control: 'text',
-      description: 'The destination URL',
+      description: '目標連結的 URL',
     },
   },
   args: {

--- a/src/components/layout/Header/HamburgerMenu.stories.tsx
+++ b/src/components/layout/Header/HamburgerMenu.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { HamburgerMenu } from './HamburgerMenu';
 
 const meta: Meta<typeof HamburgerMenu> = {
-  title: 'Layout/Header/HamburgerMenu',
+  title: '佈局元件/Header/HamburgerMenu',
   component: HamburgerMenu,
   tags: ['autodocs'],
   parameters: {

--- a/src/components/layout/Header/Header.stories.tsx
+++ b/src/components/layout/Header/Header.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Header } from './Header';
 
 const meta: Meta<typeof Header> = {
-  title: 'Layout/Header/Header',
+  title: '佈局元件/Header/Header',
   component: Header,
   tags: ['autodocs'],
   parameters: {

--- a/src/components/layout/Header/MobileUserMenu.stories.tsx
+++ b/src/components/layout/Header/MobileUserMenu.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { MobileUserMenu } from './MobileUserMenu';
 
 const meta: Meta<typeof MobileUserMenu> = {
-  title: 'Layout/Header/MobileUserMenu',
+  title: '佈局元件/Header/MobileUserMenu',
   component: MobileUserMenu,
   tags: ['autodocs'],
   parameters: {

--- a/src/components/layout/Header/ShareProfileDialog.stories.tsx
+++ b/src/components/layout/Header/ShareProfileDialog.stories.tsx
@@ -6,7 +6,7 @@ import { Button } from '@/components/ui/button';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 const meta: Meta<typeof ShareProfileDialog> = {
-  title: 'Layout/Header/ShareProfileDialog',
+  title: '佈局元件/Header/ShareProfileDialog',
   component: ShareProfileDialog,
   tags: ['autodocs'],
   args: {

--- a/src/components/layout/Header/UserDropdown.stories.tsx
+++ b/src/components/layout/Header/UserDropdown.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { UserDropdown } from './UserDropdown';
 
 const meta: Meta<typeof UserDropdown> = {
-  title: 'Layout/Header/UserDropdown',
+  title: '佈局元件/Header/UserDropdown',
   component: UserDropdown,
   tags: ['autodocs'],
   parameters: {

--- a/src/components/mentor-pool/mentor-card-list/index.stories.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.stories.tsx
@@ -4,7 +4,7 @@ import { mockMentors } from '../__mocks__/mentors.mock';
 import { MentorCardList } from './index';
 
 const meta: Meta<typeof MentorCardList> = {
-  title: 'Components/MentorPool/MentorCardList',
+  title: '業務模組元件/導師池(MentorPool)/MentorCardList',
   component: MentorCardList,
   tags: ['autodocs'],
   args: {

--- a/src/components/mentor-pool/mentor-card/AvatarWithBadge.stories.tsx
+++ b/src/components/mentor-pool/mentor-card/AvatarWithBadge.stories.tsx
@@ -5,7 +5,7 @@ import { mockMentors } from '../__mocks__/mentors.mock';
 import { AvatarWithBadge } from './AvatarWithBadge';
 
 const meta: Meta<typeof AvatarWithBadge> = {
-  title: 'Components/MentorPool/AvatarWithBadge',
+  title: '業務模組元件/導師池(MentorPool)/AvatarWithBadge',
   component: AvatarWithBadge,
   tags: ['autodocs'],
   decorators: [

--- a/src/components/mentor-pool/mentor-card/Information.stories.tsx
+++ b/src/components/mentor-pool/mentor-card/Information.stories.tsx
@@ -5,7 +5,7 @@ import { mockMentors } from '../__mocks__/mentors.mock';
 import { Information } from './Information';
 
 const meta: Meta<typeof Information> = {
-  title: 'Components/MentorPool/Information',
+  title: '業務模組元件/導師池(MentorPool)/Information',
   component: Information,
   tags: ['autodocs'],
   decorators: [

--- a/src/components/mentor-pool/mentor-card/Tag.stories.tsx
+++ b/src/components/mentor-pool/mentor-card/Tag.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { Tag } from './Tag';
 
 const meta: Meta<typeof Tag> = {
-  title: 'Components/MentorPool/Tag',
+  title: '業務模組元件/導師池(MentorPool)/Tag',
   component: Tag,
   tags: ['autodocs'],
   args: {

--- a/src/components/mentor-pool/mentor-card/index.stories.tsx
+++ b/src/components/mentor-pool/mentor-card/index.stories.tsx
@@ -4,7 +4,7 @@ import { mockMentors } from '../__mocks__/mentors.mock';
 import { MentorCard } from './index';
 
 const meta: Meta<typeof MentorCard> = {
-  title: 'Components/MentorPool/MentorCard',
+  title: '業務模組元件/導師池(MentorPool)/MentorCard',
   component: MentorCard,
   tags: ['autodocs'],
   args: {

--- a/src/components/onboarding/steps/GroupedSelections.stories.tsx
+++ b/src/components/onboarding/steps/GroupedSelections.stories.tsx
@@ -10,7 +10,7 @@ import { mockPositionGroups } from '@/test/fixtures/tagCatalog';
 import { GroupedSelections } from './GroupedSelections';
 
 const meta: Meta<typeof GroupedSelections> = {
-  title: 'Components/Onboarding/Steps/GroupedSelections',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/GroupedSelections',
   component: GroupedSelections,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/InterestedPosition.stories.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.stories.tsx
@@ -8,7 +8,7 @@ import { InterestedPosition } from './InterestedPosition';
 import { OnboardingStepDemoWrapper } from './OnboardingStoryWrapper';
 
 const meta: Meta<typeof InterestedPosition> = {
-  title: 'Components/Onboarding/Steps/InterestedPosition',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/InterestedPosition',
   component: InterestedPosition,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/PersonalInfo.stories.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.stories.tsx
@@ -23,7 +23,7 @@ const mockIndustries: IndustryOption[] = [
 ];
 
 const meta: Meta<typeof PersonalInfo> = {
-  title: 'Onboarding/Steps/PersonalInfo',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/PersonalInfo',
   component: PersonalInfo,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/SkillsToImprove.stories.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.stories.tsx
@@ -8,7 +8,7 @@ import { OnboardingStepDemoWrapper } from './OnboardingStoryWrapper';
 import { SkillsToImprove } from './SkillsToImprove';
 
 const meta: Meta<typeof SkillsToImprove> = {
-  title: 'Components/Onboarding/Steps/SkillsToImprove',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/SkillsToImprove',
   component: SkillsToImprove,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/TagMultiSelect.stories.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.stories.tsx
@@ -10,7 +10,7 @@ import { mockSkillGroups } from '@/test/fixtures/tagCatalog';
 import { TagMultiSelect } from './TagMultiSelect';
 
 const meta: Meta<typeof TagMultiSelect> = {
-  title: 'Components/Onboarding/Steps/TagMultiSelect',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/TagMultiSelect',
   component: TagMultiSelect,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/TopicsToDiscuss.stories.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.stories.tsx
@@ -8,7 +8,7 @@ import { OnboardingStepDemoWrapper } from './OnboardingStoryWrapper';
 import { TopicsToDiscuss } from './TopicsToDiscuss';
 
 const meta: Meta<typeof TopicsToDiscuss> = {
-  title: 'Components/Onboarding/Steps/TopicsToDiscuss',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/TopicsToDiscuss',
   component: TopicsToDiscuss,
   tags: ['autodocs'],
 };

--- a/src/components/onboarding/steps/WhoAreYou.stories.tsx
+++ b/src/components/onboarding/steps/WhoAreYou.stories.tsx
@@ -6,7 +6,7 @@ import { OnboardingStoryWrapper } from './OnboardingStoryWrapper';
 import { WhoAreYou } from './WhoAreYou';
 
 const meta: Meta<typeof WhoAreYou> = {
-  title: 'Onboarding/Steps/WhoAreYou',
+  title: '業務模組元件/新手引導(Onboarding)/Steps/WhoAreYou',
   component: WhoAreYou,
   tags: ['autodocs'],
 };

--- a/src/components/profile/edit/JobExperienceSection.stories.tsx
+++ b/src/components/profile/edit/JobExperienceSection.stories.tsx
@@ -24,7 +24,7 @@ const industriesMock = [
 ];
 
 const meta: Meta<typeof JobExperienceSection> = {
-  title: 'Components/Profile/Edit/JobExperienceSection',
+  title: '業務模組元件/個人檔案(Profile)/Edit/JobExperienceSection',
   component: JobExperienceSection,
   tags: ['autodocs'],
   args: {

--- a/src/components/profile/edit/educationSection/educationSection.stories.tsx
+++ b/src/components/profile/edit/educationSection/educationSection.stories.tsx
@@ -11,7 +11,7 @@ import { ProfileStoryWrapper } from '../ProfileStoryWrapper';
 import { EducationSection } from './educationSection';
 
 const meta: Meta<typeof EducationSection> = {
-  title: 'Components/Profile/Edit/EducationSection',
+  title: '業務模組元件/個人檔案(Profile)/Edit/EducationSection',
   component: EducationSection,
   tags: ['autodocs'],
   args: {

--- a/src/components/profile/experience-section/ExperienceSection.stories.tsx
+++ b/src/components/profile/experience-section/ExperienceSection.stories.tsx
@@ -8,7 +8,7 @@ import {
 } from './ExperienceSection';
 
 const meta: Meta<typeof ExperienceSection> = {
-  title: 'Components/Profile/ExperienceSection/ExperienceSection',
+  title: '業務模組元件/個人檔案(Profile)/ExperienceSection/ExperienceSection',
   component: ExperienceSection,
   tags: ['autodocs'],
   args: {

--- a/src/components/profile/expertise-select-item/ExpertiseSelectItem.stories.tsx
+++ b/src/components/profile/expertise-select-item/ExpertiseSelectItem.stories.tsx
@@ -5,7 +5,7 @@ import { ProfileStoryWrapper } from '../edit/ProfileStoryWrapper';
 import { ExpertiseSelectItem, formSchema } from './ExpertiseSelectItem';
 
 const meta: Meta<typeof ExpertiseSelectItem> = {
-  title: 'Components/Profile/ExpertiseSelectItem',
+  title: '業務模組元件/個人檔案(Profile)/ExpertiseSelectItem',
   component: ExpertiseSelectItem,
   tags: ['autodocs'],
   args: {

--- a/src/components/profile/profile-banner/ProfileBanner.stories.tsx
+++ b/src/components/profile/profile-banner/ProfileBanner.stories.tsx
@@ -5,7 +5,7 @@ import { AvatarCard } from '../avatar-card';
 import { ProfileBanner } from './ProfileBanner';
 
 const meta: Meta<typeof ProfileBanner> = {
-  title: 'Components/Profile/ProfileBanner',
+  title: '業務模組元件/個人檔案(Profile)/ProfileBanner',
   component: ProfileBanner,
   tags: ['autodocs'],
   decorators: [

--- a/src/components/profile/profile-card/ProfileCard.stories.tsx
+++ b/src/components/profile/profile-card/ProfileCard.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { ProfileCard } from './ProfileCard';
 
 const meta: Meta<typeof ProfileCard> = {
-  title: 'Components/Profile/ProfileCard',
+  title: '業務模組元件/個人檔案(Profile)/ProfileCard',
   component: ProfileCard,
   tags: ['autodocs'],
 };

--- a/src/components/profile/reservation/BookingForm.stories.tsx
+++ b/src/components/profile/reservation/BookingForm.stories.tsx
@@ -4,7 +4,7 @@ import { mockBookingSlots } from './__mocks__/reservationStories.mock';
 import { BookingForm } from './BookingForm';
 
 const meta: Meta<typeof BookingForm> = {
-  title: 'Components/Profile/Reservation/BookingForm',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/BookingForm',
   component: BookingForm,
   tags: ['autodocs'],
 };

--- a/src/components/profile/reservation/MenteeBookingForm.stories.tsx
+++ b/src/components/profile/reservation/MenteeBookingForm.stories.tsx
@@ -4,7 +4,7 @@ import { mockBookingSlots } from './__mocks__/reservationStories.mock';
 import { MenteeBookingForm } from './MenteeBookingForm';
 
 const meta: Meta<typeof MenteeBookingForm> = {
-  title: 'Components/Profile/Reservation/MenteeBookingForm',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/MenteeBookingForm',
   component: MenteeBookingForm,
   tags: ['autodocs'],
 };

--- a/src/components/profile/reservation/MentorScheduleConfig.stories.tsx
+++ b/src/components/profile/reservation/MentorScheduleConfig.stories.tsx
@@ -4,7 +4,7 @@ import { mockBookingSlots } from './__mocks__/reservationStories.mock';
 import { MentorScheduleConfig } from './MentorScheduleConfig';
 
 const meta: Meta<typeof MentorScheduleConfig> = {
-  title: 'Components/Profile/Reservation/MentorScheduleConfig',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/MentorScheduleConfig',
   component: MentorScheduleConfig,
   tags: ['autodocs'],
 };

--- a/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
@@ -9,7 +9,7 @@ import type {
 import MentorScheduleDialog from './MentorScheduleDialog';
 
 const meta: Meta<typeof MentorScheduleDialog> = {
-  title: 'Components/Profile/Reservation/MentorScheduleDialog',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/MentorScheduleDialog',
   component: MentorScheduleDialog,
   tags: ['autodocs'],
   parameters: {

--- a/src/components/profile/reservation/ScheduleCalendar.stories.tsx
+++ b/src/components/profile/reservation/ScheduleCalendar.stories.tsx
@@ -4,7 +4,7 @@ import dayjs from 'dayjs';
 import { ScheduleCalendar } from './ScheduleCalendar';
 
 const meta: Meta<typeof ScheduleCalendar> = {
-  title: 'Components/Profile/Reservation/ScheduleCalendar',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/ScheduleCalendar',
   component: ScheduleCalendar,
   tags: ['autodocs'],
 };

--- a/src/components/profile/reservation/ScheduleSlotList.stories.tsx
+++ b/src/components/profile/reservation/ScheduleSlotList.stories.tsx
@@ -9,7 +9,7 @@ import { mockBookingSlots } from './__mocks__/reservationStories.mock';
 import { BOOKED_SLOT_CLASSES, ScheduleSlotList } from './ScheduleSlotList';
 
 const meta: Meta<typeof ScheduleSlotList> = {
-  title: 'Components/Profile/Reservation/ScheduleSlotList',
+  title: '業務模組元件/個人檔案(Profile)/Reservation/ScheduleSlotList',
   component: ScheduleSlotList,
   tags: ['autodocs'],
 };

--- a/src/components/profile/view/ProfileBadgeSection.stories.tsx
+++ b/src/components/profile/view/ProfileBadgeSection.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { ProfileBadgeSection } from './ProfileBadgeSection';
 
 const meta: Meta<typeof ProfileBadgeSection> = {
-  title: 'Components/Profile/ProfileBadgeSection',
+  title: '業務模組元件/個人檔案(Profile)/ProfileBadgeSection',
   component: ProfileBadgeSection,
   tags: ['autodocs'],
 };

--- a/src/components/reservation/AcceptReservationDialog.stories.tsx
+++ b/src/components/reservation/AcceptReservationDialog.stories.tsx
@@ -4,13 +4,13 @@ import AcceptReservationDialog from './AcceptReservationDialog';
 import { mockReservation } from './mocks';
 
 const meta: Meta<typeof AcceptReservationDialog> = {
-  title: 'Components/Reservation/AcceptReservationDialog',
+  title: '業務模組元件/預約管理(Reservation)/AcceptReservationDialog',
   component: AcceptReservationDialog,
   tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the dialog trigger and action buttons are disabled',
+      description: '對話框的觸發器與操作按鈕是否已被禁用',
     },
   },
 };

--- a/src/components/reservation/CancelReservationDialog.stories.tsx
+++ b/src/components/reservation/CancelReservationDialog.stories.tsx
@@ -4,13 +4,13 @@ import CancelReservationDialog from './CancelReservationDialog';
 import { mockReservation } from './mocks';
 
 const meta: Meta<typeof CancelReservationDialog> = {
-  title: 'Components/Reservation/CancelReservationDialog',
+  title: '業務模組元件/預約管理(Reservation)/CancelReservationDialog',
   component: CancelReservationDialog,
   tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the dialog trigger and action buttons are disabled',
+      description: '對話框的觸發器與操作按鈕是否已被禁用',
     },
   },
 };

--- a/src/components/reservation/RejectReservationDialog.stories.tsx
+++ b/src/components/reservation/RejectReservationDialog.stories.tsx
@@ -4,13 +4,13 @@ import { mockReservation } from './mocks';
 import RejectReservationDialog from './RejectReservationDialog';
 
 const meta: Meta<typeof RejectReservationDialog> = {
-  title: 'Components/Reservation/RejectReservationDialog',
+  title: '業務模組元件/預約管理(Reservation)/RejectReservationDialog',
   component: RejectReservationDialog,
   tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the dialog trigger and action buttons are disabled',
+      description: '對話框的觸發器與操作按鈕是否已被禁用',
     },
   },
 };

--- a/src/components/reservation/ReservationCard.stories.tsx
+++ b/src/components/reservation/ReservationCard.stories.tsx
@@ -8,14 +8,14 @@ import { mockReservation } from './mocks';
 import { ReservationCard } from './ReservationCard';
 
 const meta: Meta<typeof ReservationCard> = {
-  title: 'Components/Reservation/ReservationCard',
+  title: '業務模組元件/預約管理(Reservation)/ReservationCard',
   component: ReservationCard,
   tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',
       options: ['pending', 'upcoming', 'history'],
-      description: 'The status tab category variant of the card',
+      description: '卡片的狀態標籤類別變體',
     },
   },
 };

--- a/src/components/reservation/ReservationConversationDialog.stories.tsx
+++ b/src/components/reservation/ReservationConversationDialog.stories.tsx
@@ -5,7 +5,7 @@ import ReservationConversationDialog from './ReservationConversationDialog';
 import type { Reservation } from './types';
 
 const meta: Meta<typeof ReservationConversationDialog> = {
-  title: 'Components/Reservation/ReservationConversationDialog',
+  title: '業務模組元件/預約管理(Reservation)/ReservationConversationDialog',
   component: ReservationConversationDialog,
   tags: ['autodocs'],
   argTypes: {

--- a/src/components/reservation/ReservationDashboard.stories.tsx
+++ b/src/components/reservation/ReservationDashboard.stories.tsx
@@ -5,7 +5,7 @@ import { mockReservations } from './__mocks__/reservations.mock';
 import { ReservationDashboardView } from './ReservationDashboard';
 
 const meta: Meta<typeof ReservationDashboardView> = {
-  title: 'Components/Reservation/ReservationDashboard',
+  title: '業務模組元件/預約管理(Reservation)/ReservationDashboard',
   component: ReservationDashboardView,
   tags: ['autodocs'],
   decorators: [

--- a/src/components/reservation/ReservationList.stories.tsx
+++ b/src/components/reservation/ReservationList.stories.tsx
@@ -7,7 +7,7 @@ import { mockReservations } from './__mocks__/reservations.mock';
 import { ReservationList } from './ReservationList';
 
 const meta: Meta<typeof ReservationList> = {
-  title: 'Components/Reservation/ReservationList',
+  title: '業務模組元件/預約管理(Reservation)/ReservationList',
   component: ReservationList,
   tags: ['autodocs'],
   decorators: [

--- a/src/components/reservation/ReservationStatusBadge.stories.tsx
+++ b/src/components/reservation/ReservationStatusBadge.stories.tsx
@@ -3,17 +3,17 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { ReservationStatusBadge } from './ReservationStatusBadge';
 
 const meta: Meta<typeof ReservationStatusBadge> = {
-  title: 'Components/Reservation/ReservationStatusBadge',
+  title: '業務模組元件/預約管理(Reservation)/ReservationStatusBadge',
   component: ReservationStatusBadge,
   tags: ['autodocs'],
   argTypes: {
     dtstart: {
       control: 'number',
-      description: 'Reservation start time (Unix epoch seconds)',
+      description: '預約開始時間 (Unix 紀元秒數)',
     },
     dtend: {
       control: 'number',
-      description: 'Reservation end time (Unix epoch seconds)',
+      description: '預約結束時間 (Unix 紀元秒數)',
     },
   },
 };

--- a/src/components/ui/avatar-crop-modal.stories.tsx
+++ b/src/components/ui/avatar-crop-modal.stories.tsx
@@ -5,7 +5,7 @@ import AvatarCropModal from './avatar-crop-modal';
 import { Button } from './button';
 
 const meta: Meta<typeof AvatarCropModal> = {
-  title: 'Components/UI/AvatarCropModal',
+  title: '基礎/原子元件/AvatarCropModal',
   component: AvatarCropModal,
   tags: ['autodocs'],
 };

--- a/src/components/ui/avatar-upload.stories.tsx
+++ b/src/components/ui/avatar-upload.stories.tsx
@@ -5,7 +5,7 @@ import { useForm } from 'react-hook-form';
 import AvatarUpload from './avatar-upload';
 
 const meta: Meta<typeof AvatarUpload> = {
-  title: 'Components/UI/AvatarUpload',
+  title: '基礎/原子元件/AvatarUpload',
   component: AvatarUpload,
   tags: ['autodocs'],
 };

--- a/src/components/ui/avatar.stories.tsx
+++ b/src/components/ui/avatar.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Avatar, AvatarFallback, AvatarImage } from './avatar';
 
 const meta: Meta<typeof Avatar> = {
-  title: 'Components/UI/Avatar',
+  title: '基礎/原子元件/Avatar',
   component: Avatar,
   tags: ['autodocs'],
 };

--- a/src/components/ui/badge.stories.tsx
+++ b/src/components/ui/badge.stories.tsx
@@ -5,14 +5,14 @@ import React from 'react';
 import { Badge } from './badge';
 
 const meta: Meta<typeof Badge> = {
-  title: 'Components/UI/Badge',
+  title: '基礎/原子元件/Badge',
   component: Badge,
   tags: ['autodocs'],
   argTypes: {
     variant: {
       control: 'select',
       options: ['default', 'secondary', 'destructive', 'outline', 'filter'],
-      description: 'The visual style variant of the badge',
+      description: '徽章的視覺樣式變體',
     },
   },
   args: {

--- a/src/components/ui/button.stories.tsx
+++ b/src/components/ui/button.stories.tsx
@@ -5,7 +5,7 @@ import React from 'react';
 import { Button } from './button';
 
 const meta: Meta<typeof Button> = {
-  title: 'Components/UI/Button',
+  title: '基礎/原子元件/Button',
   component: Button,
   tags: ['autodocs'],
   argTypes: {
@@ -19,26 +19,25 @@ const meta: Meta<typeof Button> = {
         'ghost',
         'link',
       ],
-      description: 'The visual style variant of the button',
+      description: '按鈕的視覺樣式變體',
     },
     size: {
       control: 'select',
       options: ['default', 'sm', 'lg', 'icon'],
-      description: 'The size of the button',
+      description: '按鈕的大小',
     },
     shape: {
       control: 'select',
       options: ['default', 'pill'],
-      description: 'The shape / border-radius of the button',
+      description: '按鈕的形狀/邊角半徑',
     },
     disabled: {
       control: 'boolean',
-      description: 'Whether the button is disabled',
+      description: '按鈕是否已被禁用',
     },
     asChild: {
       control: 'boolean',
-      description:
-        'Change the default rendered element to the one passed as a child',
+      description: '將預設渲染的元素變更為作為子元件傳遞的元素',
     },
   },
   args: {

--- a/src/components/ui/calendar.stories.tsx
+++ b/src/components/ui/calendar.stories.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { Calendar } from './calendar';
 
 const meta: Meta<typeof Calendar> = {
-  title: 'Components/UI/Calendar',
+  title: '基礎/原子元件/Calendar',
   component: Calendar,
   tags: ['autodocs'],
 };

--- a/src/components/ui/card.stories.tsx
+++ b/src/components/ui/card.stories.tsx
@@ -12,13 +12,13 @@ import {
 } from './card';
 
 const meta: Meta<typeof Card> = {
-  title: 'Components/UI/Card',
+  title: '基礎/原子元件/Card',
   component: Card,
   tags: ['autodocs'],
   argTypes: {
     className: {
       control: 'text',
-      description: 'Custom CSS classes for styling the card',
+      description: '自定義的 CSS class 名稱以設定卡片樣式',
     },
   },
 };

--- a/src/components/ui/category-multi-select.stories.tsx
+++ b/src/components/ui/category-multi-select.stories.tsx
@@ -4,7 +4,7 @@ import React, { useState } from 'react';
 import { CategoryMultiSelect } from './category-multi-select';
 
 const meta: Meta<typeof CategoryMultiSelect> = {
-  title: 'Components/UI/CategoryMultiSelect',
+  title: '基礎/原子元件/CategoryMultiSelect',
   component: CategoryMultiSelect,
   tags: ['autodocs'],
 };

--- a/src/components/ui/checkbox.stories.tsx
+++ b/src/components/ui/checkbox.stories.tsx
@@ -5,17 +5,17 @@ import { Checkbox } from './checkbox';
 import { Label } from './label';
 
 const meta: Meta<typeof Checkbox> = {
-  title: 'Components/UI/Checkbox',
+  title: '基礎/原子元件/Checkbox',
   component: Checkbox,
   tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the checkbox is disabled',
+      description: '核取方塊是否已被禁用',
     },
     checked: {
       control: 'boolean',
-      description: 'Whether the checkbox is checked',
+      description: '核取方塊是否已被勾選',
     },
   },
 };

--- a/src/components/ui/command.stories.tsx
+++ b/src/components/ui/command.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from './command';
 
 const meta: Meta<typeof Command> = {
-  title: 'Components/UI/Command',
+  title: '基礎/原子元件/Command',
   component: Command,
   tags: ['autodocs'],
 };

--- a/src/components/ui/dialog.stories.tsx
+++ b/src/components/ui/dialog.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from './dialog';
 
 const meta: Meta<typeof Dialog> = {
-  title: 'Components/UI/Dialog',
+  title: '基礎/原子元件/Dialog',
   component: Dialog,
   tags: ['autodocs'],
 };

--- a/src/components/ui/dropdown-menu.stories.tsx
+++ b/src/components/ui/dropdown-menu.stories.tsx
@@ -15,7 +15,7 @@ import {
 } from './dropdown-menu';
 
 const meta: Meta<typeof DropdownMenu> = {
-  title: 'Components/UI/DropdownMenu',
+  title: '基礎/原子元件/DropdownMenu',
   component: DropdownMenu,
   tags: ['autodocs'],
 };

--- a/src/components/ui/form.stories.tsx
+++ b/src/components/ui/form.stories.tsx
@@ -15,7 +15,7 @@ import {
 import { Input } from './input';
 
 const meta: Meta<typeof Form> = {
-  title: 'Components/UI/Form',
+  title: '基礎/原子元件/Form',
   component: Form,
   tags: ['autodocs'],
 };

--- a/src/components/ui/input.stories.tsx
+++ b/src/components/ui/input.stories.tsx
@@ -4,26 +4,26 @@ import React from 'react';
 import { Input } from './input';
 
 const meta: Meta<typeof Input> = {
-  title: 'Components/UI/Input',
+  title: '基礎/原子元件/Input',
   component: Input,
   tags: ['autodocs'],
   argTypes: {
     type: {
       control: 'select',
       options: ['text', 'password', 'email', 'number', 'file'],
-      description: 'The native input type',
+      description: '原生輸入框的 type 屬性',
     },
     disabled: {
       control: 'boolean',
-      description: 'Whether the input is disabled',
+      description: '輸入框是否已被禁用',
     },
     readOnly: {
       control: 'boolean',
-      description: 'Whether the input is read-only',
+      description: '輸入框是否為唯讀',
     },
     placeholder: {
       control: 'text',
-      description: 'The placeholder text of the input',
+      description: '輸入框的預設提示文字 (placeholder)',
     },
   },
   args: {

--- a/src/components/ui/label.stories.tsx
+++ b/src/components/ui/label.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Label } from './label';
 
 const meta: Meta<typeof Label> = {
-  title: 'Components/UI/Label',
+  title: '基礎/原子元件/Label',
   component: Label,
   tags: ['autodocs'],
 };

--- a/src/components/ui/loading-spinner.stories.tsx
+++ b/src/components/ui/loading-spinner.stories.tsx
@@ -4,18 +4,18 @@ import React from 'react';
 import { LoadingSpinner, PageLoading } from './loading-spinner';
 
 const meta: Meta<typeof LoadingSpinner> = {
-  title: 'Components/UI/LoadingSpinner',
+  title: '基礎/原子元件/LoadingSpinner',
   component: LoadingSpinner,
   tags: ['autodocs'],
   argTypes: {
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
-      description: 'The size of the loading spinner',
+      description: '載入中旋轉圖示的大小',
     },
     label: {
       control: 'text',
-      description: 'The accessibility label for screen readers',
+      description: '螢幕閱讀器的無障礙標籤 (aria-label)',
     },
   },
   args: {

--- a/src/components/ui/multi-select-dropdown.stories.tsx
+++ b/src/components/ui/multi-select-dropdown.stories.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import MultiSelectDropdown from './multi-select-dropdown';
 
 const meta: Meta<typeof MultiSelectDropdown> = {
-  title: 'Components/UI/MultiSelectDropdown',
+  title: '基礎/原子元件/MultiSelectDropdown',
   component: MultiSelectDropdown,
   tags: ['autodocs'],
 };

--- a/src/components/ui/multi-select.stories.tsx
+++ b/src/components/ui/multi-select.stories.tsx
@@ -5,7 +5,7 @@ import React, { useState } from 'react';
 import { MultiSelect } from './multi-select';
 
 const meta: Meta<typeof MultiSelect> = {
-  title: 'Components/UI/MultiSelect',
+  title: '基礎/原子元件/MultiSelect',
   component: MultiSelect,
   tags: ['autodocs'],
 };

--- a/src/components/ui/popover.stories.tsx
+++ b/src/components/ui/popover.stories.tsx
@@ -5,7 +5,7 @@ import { Button } from './button';
 import { Popover, PopoverContent, PopoverTrigger } from './popover';
 
 const meta: Meta<typeof Popover> = {
-  title: 'Components/UI/Popover',
+  title: '基礎/原子元件/Popover',
   component: Popover,
   tags: ['autodocs'],
 };

--- a/src/components/ui/search-bar.stories.tsx
+++ b/src/components/ui/search-bar.stories.tsx
@@ -3,13 +3,13 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import SearchBar from './search-bar';
 
 const meta: Meta<typeof SearchBar> = {
-  title: 'Components/UI/SearchBar',
+  title: '基礎/原子元件/SearchBar',
   component: SearchBar,
   tags: ['autodocs'],
   argTypes: {
     placeholder: {
       control: 'text',
-      description: 'The placeholder text of the search bar',
+      description: '搜尋列的預設提示文字 (placeholder)',
     },
   },
 };

--- a/src/components/ui/select.stories.tsx
+++ b/src/components/ui/select.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from './select';
 
 const meta: Meta<typeof Select> = {
-  title: 'Components/UI/Select',
+  title: '基礎/原子元件/Select',
   component: Select,
   tags: ['autodocs'],
 };

--- a/src/components/ui/separator.stories.tsx
+++ b/src/components/ui/separator.stories.tsx
@@ -4,14 +4,14 @@ import React from 'react';
 import { Separator } from './separator';
 
 const meta: Meta<typeof Separator> = {
-  title: 'Components/UI/Separator',
+  title: '基礎/原子元件/Separator',
   component: Separator,
   tags: ['autodocs'],
   argTypes: {
     orientation: {
       control: 'select',
       options: ['horizontal', 'vertical'],
-      description: 'The orientation of the separator',
+      description: '分隔線的方向',
     },
   },
 };

--- a/src/components/ui/sheet.stories.tsx
+++ b/src/components/ui/sheet.stories.tsx
@@ -13,7 +13,7 @@ import {
 } from './sheet';
 
 const meta: Meta<typeof Sheet> = {
-  title: 'Components/UI/Sheet',
+  title: '基礎/原子元件/Sheet',
   component: Sheet,
   tags: ['autodocs'],
 };

--- a/src/components/ui/skeleton.stories.tsx
+++ b/src/components/ui/skeleton.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Skeleton } from './skeleton';
 
 const meta: Meta<typeof Skeleton> = {
-  title: 'Components/UI/Skeleton',
+  title: '基礎/原子元件/Skeleton',
   component: Skeleton,
   tags: ['autodocs'],
 };

--- a/src/components/ui/tabs.stories.tsx
+++ b/src/components/ui/tabs.stories.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './tabs';
 
 const meta: Meta<typeof Tabs> = {
-  title: 'Components/UI/Tabs',
+  title: '基礎/原子元件/Tabs',
   component: Tabs,
   tags: ['autodocs'],
 };

--- a/src/components/ui/textarea.stories.tsx
+++ b/src/components/ui/textarea.stories.tsx
@@ -3,17 +3,17 @@ import type { Meta, StoryObj } from '@storybook/nextjs';
 import { Textarea } from './textarea';
 
 const meta: Meta<typeof Textarea> = {
-  title: 'Components/UI/Textarea',
+  title: '基礎/原子元件/Textarea',
   component: Textarea,
   tags: ['autodocs'],
   argTypes: {
     disabled: {
       control: 'boolean',
-      description: 'Whether the textarea is disabled',
+      description: '文字輸入區域是否已被禁用',
     },
     placeholder: {
       control: 'text',
-      description: 'The placeholder text of the textarea',
+      description: '文字輸入區域的預設提示文字 (placeholder)',
     },
   },
   args: {

--- a/src/components/ui/toast.stories.tsx
+++ b/src/components/ui/toast.stories.tsx
@@ -12,7 +12,7 @@ import {
 } from './toast';
 
 const meta: Meta<typeof Toast> = {
-  title: 'Components/UI/Toast',
+  title: '基礎/原子元件/Toast',
   component: Toast,
   tags: ['autodocs'],
 };

--- a/src/components/ui/toaster.stories.tsx
+++ b/src/components/ui/toaster.stories.tsx
@@ -6,7 +6,7 @@ import { Toaster } from './toaster';
 import { useToast } from './use-toast';
 
 const meta: Meta<typeof Toaster> = {
-  title: 'Components/UI/Toaster',
+  title: '基礎/原子元件/Toaster',
   component: Toaster,
   tags: ['autodocs'],
 };

--- a/src/docs/DesignTokens.mdx
+++ b/src/docs/DesignTokens.mdx
@@ -1,4 +1,4 @@
-import { Meta } from '@storybook/blocks';
+import { Meta } from '@storybook/addon-docs/blocks';
 import { ColorPalette } from './ColorPalette';
 
 <Meta title="System/Design Tokens & Colors" />

--- a/src/docs/Introduction.mdx
+++ b/src/docs/Introduction.mdx
@@ -208,20 +208,20 @@ import { Meta } from '@storybook/addon-docs/blocks';
 import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
-  title: 'UI/MyComponent', // 類別/元件名稱
-  component: MyComponent,
-  tags: ['autodocs'], // 自動生成 Docs 頁籤
-  argTypes: {
-    variant: {
-      control: 'select',
-      options: ['default', 'outline', 'ghost'],
-      description: '元件的視覺樣式',
-    },
-    disabled: {
-      control: 'boolean',
-      description: '切換互動行為',
-    },
-  },
+title: 'UI/MyComponent', // 類別/元件名稱
+component: MyComponent,
+tags: ['autodocs'], // 自動生成 Docs 頁籤
+argTypes: {
+variant: {
+control: 'select',
+options: ['default', 'outline', 'ghost'],
+description: '元件的視覺樣式',
+},
+disabled: {
+control: 'boolean',
+description: '切換互動行為',
+},
+},
 };
 
 export default meta;
@@ -229,19 +229,19 @@ type Story = StoryObj<typeof MyComponent>;
 
 // 1. 主要預設狀態
 export const Default: Story = {
-  args: {
-    variant: 'default',
-    children: '互動式元件',
-    disabled: false,
-  },
+args: {
+variant: 'default',
+children: '互動式元件',
+disabled: false,
+},
 };
 
 // 2. 禁用狀態變體
 export const Disabled: Story = {
-  args: {
-    ...Default.args,
-    disabled: true,
-  },
+args: {
+...Default.args,
+disabled: true,
+},
 };`}
 
 </pre>

--- a/src/docs/Introduction.mdx
+++ b/src/docs/Introduction.mdx
@@ -9,13 +9,13 @@ import { Meta } from '@storybook/addon-docs/blocks';
     <div className="flex-1">
       <div className="flex items-center gap-3 mb-4">
         <img src="/logo.svg" alt="X-Talent Logo" className="h-10 w-auto" />
-        <span className="text-2xl font-bold tracking-tight text-indigo-600">Storybook Portal</span>
+        <span className="text-2xl font-bold tracking-tight text-indigo-600">Storybook 入口網站</span>
       </div>
       <h1 className="text-4xl font-extrabold tracking-tight text-slate-900 sm:text-5xl mb-4">
-        Welcome to X-Talent Component Library
+        歡迎來到 X-Talent 元件庫
       </h1>
       <p className="text-lg text-slate-600 leading-relaxed max-w-2xl">
-        X-Talent is a platform connecting mentors and mentees. This Storybook environment serves as our single source of truth for UI components, helping developers build, test, and document user interfaces in isolation.
+        X-Talent 是一個連結導師與學員的平台。本 Storybook 環境是我們 UI 元件的單一事實來源（Single Source of Truth），能協助開發人員在隔離環境中建構、測試與編寫使用者介面文件。
       </p>
     </div>
     <div className="w-full md:w-1/3 flex justify-center">
@@ -28,36 +28,36 @@ import { Meta } from '@storybook/addon-docs/blocks';
   <div className="mb-12">
     <h2 className="text-2xl font-bold text-slate-900 mb-6 flex items-center gap-2">
       <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-50 text-indigo-600 text-sm font-bold">1</span>
-      Getting Started
+      快速上手
     </h2>
     <p className="text-slate-600 mb-6 leading-relaxed">
-      You can develop UI components in isolation without launching the full Next.js development server.
+      您可以在不啟動完整 Next.js 開發伺服器的情況下，獨立開發與測試 UI 元件。
     </p>
     
     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
       <div className="p-6 bg-slate-50 rounded-xl border border-slate-200 hover:border-indigo-200 transition-all duration-200 shadow-sm">
-        <h3 className="text-lg font-semibold text-slate-900 mb-2">Run Storybook locally</h3>
+        <h3 className="text-lg font-semibold text-slate-900 mb-2">在本地執行 Storybook</h3>
         <p className="text-sm text-slate-600 mb-4">
-          Starts a local development server with live-reloading.
+          啟動具有即時重載（live-reloading）功能的本地開發伺服器。
         </p>
         <div className="bg-slate-900 text-slate-100 font-mono text-sm p-3 rounded-lg flex justify-between items-center">
           <code>pnpm storybook</code>
         </div>
         <p className="text-xs text-slate-500 mt-2">
-          Runs on <a href="http://localhost:6006" target="_blank" className="text-indigo-600 hover:underline">localhost:6006</a> by default.
+          預設於 <a href="http://localhost:6006" target="_blank" className="text-indigo-600 hover:underline">localhost:6006</a> 執行。
         </p>
       </div>
 
       <div className="p-6 bg-slate-50 rounded-xl border border-slate-200 hover:border-indigo-200 transition-all duration-200 shadow-sm">
-        <h3 className="text-lg font-semibold text-slate-900 mb-2">Build static Storybook</h3>
+        <h3 className="text-lg font-semibold text-slate-900 mb-2">建構靜態 Storybook</h3>
         <p className="text-sm text-slate-600 mb-4">
-          Compiles Storybook into a static website for deployment.
+          將 Storybook 編譯成靜態網站以便部署。
         </p>
         <div className="bg-slate-900 text-slate-100 font-mono text-sm p-3 rounded-lg flex justify-between items-center">
           <code>pnpm build-storybook</code>
         </div>
         <p className="text-xs text-slate-500 mt-2">
-          Outputs to the <code>storybook-static/</code> directory.
+          輸出至 <code>storybook-static/</code> 目錄。
         </p>
       </div>
     </div>
@@ -69,10 +69,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
   <div className="mb-12">
     <h2 className="text-2xl font-bold text-slate-900 mb-6 flex items-center gap-2">
       <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-50 text-indigo-600 text-sm font-bold">2</span>
-      Component Organization
+      元件組織結構
     </h2>
     <p className="text-slate-600 mb-6 leading-relaxed">
-      To maintain a clean and scalable codebase, components are categorized into three distinct layers. Every component should be accompanied by a <code>*.stories.tsx</code> file located in the same directory.
+      為了維護乾淨且具擴充性的代碼庫，元件被劃分為三個不同的層級。每個元件都應在相同目錄下附帶一個 <code>*.stories.tsx</code> 檔案。
     </p>
 
     <div className="space-y-4">
@@ -83,15 +83,15 @@ import { Meta } from '@storybook/addon-docs/blocks';
           </svg>
         </div>
         <div className="flex-1">
-          <h3 className="text-lg font-semibold text-slate-900 mb-1">Foundational UI (Atoms)</h3>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1">基礎/原子元件 (Atoms)</h3>
           <p className="text-sm text-slate-600 mb-2">
-            Low-level, style-pure, and highly reusable building blocks. They manage their own internal states (if any) but have absolutely no awareness of domain logic.
+            底層、純樣式且高度可重用的建構基礎。它們管理自己的內部狀態（若有），但完全不涉及任何業務領域邏輯。
           </p>
           <div className="text-xs text-indigo-600 font-mono bg-indigo-50/50 inline-block px-2 py-1 rounded">
-            Location: src/components/ui/
+            位置：src/components/ui/
           </div>
           <p className="text-xs text-slate-500 mt-1">
-            Examples: <code>Button</code>, <code>Input</code>, <code>Badge</code>, <code>Dialog</code>, <code>DropdownMenu</code>
+            範例：<code>Button</code>、<code>Input</code>、<code>Badge</code>、<code>Dialog</code>、<code>DropdownMenu</code>
           </p>
         </div>
       </div>
@@ -103,15 +103,15 @@ import { Meta } from '@storybook/addon-docs/blocks';
           </svg>
         </div>
         <div className="flex-1">
-          <h3 className="text-lg font-semibold text-slate-900 mb-1">Layout Components (Molecules/Organisms)</h3>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1">佈局元件 (Molecules/Organisms)</h3>
           <p className="text-sm text-slate-600 mb-2">
-            Structure-defining components that establish page framework, scaffolding, and responsive content spacing.
+            定義結構的元件，用於建立頁面框架、架構與響應式內容間距。
           </p>
           <div className="text-xs text-emerald-600 font-mono bg-emerald-50/50 inline-block px-2 py-1 rounded">
-            Location: src/components/layout/
+            位置：src/components/layout/
           </div>
           <p className="text-xs text-slate-500 mt-1">
-            Examples: <code>Header</code>, <code>Footer</code>, <code>HamburgerMenu</code>
+            範例：<code>Header</code>、<code>Footer</code>、<code>HamburgerMenu</code>
           </p>
         </div>
       </div>
@@ -123,15 +123,15 @@ import { Meta } from '@storybook/addon-docs/blocks';
           </svg>
         </div>
         <div className="flex-1">
-          <h3 className="text-lg font-semibold text-slate-900 mb-1">Modules (Feature-Specific)</h3>
+          <h3 className="text-lg font-semibold text-slate-900 mb-1">業務模組元件 (Modules)</h3>
           <p className="text-sm text-slate-600 mb-2">
-            Business-logic aware composite components mapped to specific system features and domains.
+            具備業務邏輯感知能力的複合元件，對應到特定的系統功能與領域。
           </p>
           <div className="text-xs text-amber-600 font-mono bg-amber-50/50 inline-block px-2 py-1 rounded">
-            Location: src/components/[module-name]/
+            位置：src/components/[module-name]/
           </div>
           <p className="text-xs text-slate-500 mt-1">
-            Examples: <code>SignInForm</code> (auth), <code>MentorFilterDropdown</code> (filter), <code>ProfileBanner</code> (profile), <code>BookingForm</code> (reservation)
+            範例：<code>SignInForm</code> (auth)、<code>MentorFilterDropdown</code> (filter)、<code>ProfileBanner</code> (profile)、<code>BookingForm</code> (reservation)
           </p>
         </div>
       </div>
@@ -144,10 +144,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
   <div className="mb-12">
     <h2 className="text-2xl font-bold text-slate-900 mb-6 flex items-center gap-2">
       <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-50 text-indigo-600 text-sm font-bold">3</span>
-      Storybook Best Practices
+      Storybook 最佳實踐
     </h2>
     <p className="text-slate-600 mb-6 leading-relaxed">
-      Follow these standards to ensure components remain modular, well-documented, and easily testable.
+      請遵循以下標準，以確保元件保持模組化、文件完整且易於測試。
     </p>
 
     <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
@@ -156,10 +156,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
           <svg className="w-5 h-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
           </svg>
-          JSDoc & Type Safety
+          JSDoc 與型別安全
         </h3>
         <p className="text-sm text-slate-600 leading-relaxed">
-          Document your TypeScript interfaces using JSDoc comments. Storybook automatically parses these to generate precise property descriptions and default value fields in the interactive controls panel.
+          使用 JSDoc 註解來編寫您的 TypeScript 介面文件。Storybook 會自動解析這些註解，以在互動式控制面板中生成精確的屬性說明與預設值欄位。
         </p>
       </div>
 
@@ -168,10 +168,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
           <svg className="w-5 h-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M13 10V3L4 14h7v7l9-11h-7z" />
           </svg>
-          Auto-docs Feature
+          自動文件功能 (Auto-docs)
         </h3>
         <p className="text-sm text-slate-600 leading-relaxed">
-          Always include <code>tags: ['autodocs']</code> in your default Meta export. This builds an automatic documentation panel for your component displaying primary usage, code examples, and live sandbox properties.
+          請務必在預設的 <code>Meta</code> 導出中包含 <code>tags: ['autodocs']</code>。這會為您的元件建立一個自動文件面板，展示主要用法、程式碼範例與即時沙盒屬性。
         </p>
       </div>
 
@@ -180,10 +180,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
           <svg className="w-5 h-5 text-indigo-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
             <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M15 15l-2 5L9 9l11 4-5 2zm0 0l5 5M7.188 2.239l.777 2.897M5.136 7.965l-2.898-.777M13.95 4.05l-2.122 2.122m-5.657 5.656l-2.12 2.122" />
           </svg>
-          Interactive States
+          互動狀態
         </h3>
         <p className="text-sm text-slate-600 leading-relaxed">
-          Provide stories for every visual permutation (e.g., Default, Active, Disabled, Error, Loading). Use Storybook's interactions and mock contexts to demonstrate asynchronous workflows and dialog triggers.
+          為每種視覺排列組合（例如：Default、Active、Disabled、Error、Loading）提供 story。使用 Storybook 的互動功能與模擬內容（mock contexts）來演示非同步工作流程與對話框觸發器。
         </p>
       </div>
     </div>
@@ -195,10 +195,10 @@ import { Meta } from '@storybook/addon-docs/blocks';
   <div className="mb-8">
     <h2 className="text-2xl font-bold text-slate-900 mb-6 flex items-center gap-2">
       <span className="flex items-center justify-center w-8 h-8 rounded-lg bg-indigo-50 text-indigo-600 text-sm font-bold">4</span>
-      Story Code Blueprint
+      Story 程式碼藍圖
     </h2>
     <p className="text-slate-600 mb-4 leading-relaxed">
-      Below is a standard template for creating a component story (e.g., <code>MyComponent.stories.tsx</code>):
+      以下是建立元件 story 的標準範本（例如：<code>MyComponent.stories.tsx</code>）：
     </p>
 
     <div className="bg-slate-900 text-slate-100 font-mono text-sm p-6 rounded-xl overflow-x-auto shadow-md">
@@ -208,40 +208,40 @@ import { Meta } from '@storybook/addon-docs/blocks';
 import { MyComponent } from './MyComponent';
 
 const meta: Meta<typeof MyComponent> = {
-title: 'UI/MyComponent', // Category/Component Name
-component: MyComponent,
-tags: ['autodocs'], // Generates the Docs tab automatically
-argTypes: {
-variant: {
-control: 'select',
-options: ['default', 'outline', 'ghost'],
-description: 'The visual style of the component',
-},
-disabled: {
-control: 'boolean',
-description: 'Toggles interactive behavior',
-},
-},
+  title: 'UI/MyComponent', // 類別/元件名稱
+  component: MyComponent,
+  tags: ['autodocs'], // 自動生成 Docs 頁籤
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'outline', 'ghost'],
+      description: '元件的視覺樣式',
+    },
+    disabled: {
+      control: 'boolean',
+      description: '切換互動行為',
+    },
+  },
 };
 
 export default meta;
 type Story = StoryObj<typeof MyComponent>;
 
-// 1. Primary Default State
+// 1. 主要預設狀態
 export const Default: Story = {
-args: {
-variant: 'default',
-children: 'Interactive Component',
-disabled: false,
-},
+  args: {
+    variant: 'default',
+    children: '互動式元件',
+    disabled: false,
+  },
 };
 
-// 2. Disabled State Variant
+// 2. 禁用狀態變體
 export const Disabled: Story = {
-args: {
-...Default.args,
-disabled: true,
-},
+  args: {
+    ...Default.args,
+    disabled: true,
+  },
 };`}
 
 </pre>


### PR DESCRIPTION
在本次開發中，我們成功將 Storybook 所有的說明文件與元件 Story 故事設定完整翻譯為繁體中文（zh-TW）：
- **Portal 說明文件 (Introduction.mdx)**：完美翻譯，並將 Atoms/Molecules/Modules 正確對齊為「基礎/原子元件」、「佈局元件」與「業務模組元件」。
- **設計標記 (DesignTokens.mdx)**：完成審查與導入，修正 Meta 導入路徑。
- **全站 83 個元件 Story (src/components/**/*.stories.tsx)**：將 Sidebar 結構（`title:` 屬性）與控制面板說明（`description:` 屬性）全部中文化，確保開發者體驗一致。
- **編譯驗證**：完成本地並行編譯與測試自檢，全數 757 個單元測試均 100% 通過，且 Storybook 編譯綠燈。

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/480
