### PR TITLE
feat(storybook): add stories for AvatarCard, AuthFormInput, and ConfirmDialog (X-Tracker #481)

### DIFF
--- a/src/components/auth/AuthFormInput.stories.tsx
+++ b/src/components/auth/AuthFormInput.stories.tsx
@@ -1,0 +1,124 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+import { useForm } from 'react-hook-form';
+
+import { Form } from '@/components/ui/form';
+
+import AuthFormInput from './AuthFormInput';
+
+const meta: Meta<typeof AuthFormInput> = {
+  title: '業務模組元件/會員驗證(Auth)/AuthFormInput',
+  component: AuthFormInput,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AuthFormInput>;
+
+interface FormValues {
+  email: string;
+  password?: string;
+  verificationCode?: string;
+}
+
+interface WrapperProps {
+  name: keyof FormValues;
+  label: string;
+  placeholder: string;
+  type?: string;
+  autocomplete?: string;
+  triggerError?: boolean;
+  forgotPasswordLink?: React.ReactNode;
+}
+
+const FormInputWrapper = ({
+  name,
+  label,
+  placeholder,
+  type = 'text',
+  autocomplete = 'off',
+  triggerError = false,
+  forgotPasswordLink,
+}: WrapperProps) => {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      email: '',
+      password: '',
+      verificationCode: '',
+    },
+  });
+
+  React.useEffect(() => {
+    if (triggerError) {
+      form.setError(name, {
+        type: 'manual',
+        message: '輸入格式不正確，請確認後再試一次',
+      });
+    } else {
+      form.clearErrors(name);
+    }
+  }, [form, name, triggerError]);
+
+  return (
+    <Form {...form}>
+      <form
+        className="max-w-md space-y-4 p-4"
+        onSubmit={(e) => e.preventDefault()}
+      >
+        <AuthFormInput
+          name={name}
+          label={label}
+          placeholder={placeholder}
+          type={type}
+          control={form.control}
+          autocomplete={autocomplete}
+          forgotPasswordLink={forgotPasswordLink}
+        />
+      </form>
+    </Form>
+  );
+};
+
+export const Normal: Story = {
+  render: () => (
+    <FormInputWrapper
+      name="email"
+      label="電子信箱"
+      placeholder="例如：talent@xchange.tw"
+      type="text"
+      autocomplete="email"
+    />
+  ),
+};
+
+export const Password: Story = {
+  render: () => (
+    <FormInputWrapper
+      name="password"
+      label="密碼"
+      placeholder="請輸入密碼"
+      type="password"
+      autocomplete="current-password"
+      forgotPasswordLink={
+        <div className="text-right text-xs">
+          <a href="#" className="text-text-tertiary hover:underline">
+            忘記密碼？
+          </a>
+        </div>
+      }
+    />
+  ),
+};
+
+export const ValidationError: Story = {
+  render: () => (
+    <FormInputWrapper
+      name="verificationCode"
+      label="驗證碼"
+      placeholder="請輸入 6 位數驗證碼"
+      type="text"
+      autocomplete="one-time-code"
+      triggerError={true}
+    />
+  ),
+};

--- a/src/components/profile/avatar-card/AvatarCard.stories.tsx
+++ b/src/components/profile/avatar-card/AvatarCard.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { AvatarCard } from './AvatarCard';
+
+const meta: Meta<typeof AvatarCard> = {
+  title: '業務模組元件/個人檔案(Profile)/AvatarCard',
+  component: AvatarCard,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof AvatarCard>;
+
+export const Default: Story = {
+  args: {
+    name: '林小華 Hana Lin',
+    avatarImgUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=hana',
+    linkedinUrl: 'https://www.linkedin.com/in/hana-lin',
+    jobTitle: 'Senior Frontend Engineer',
+    companyName: 'Google',
+  },
+};
+
+export const NoLinkedIn: Story = {
+  args: {
+    name: '林小華 Hana Lin',
+    avatarImgUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=hana',
+    jobTitle: 'Senior Frontend Engineer',
+    companyName: 'Google',
+  },
+};
+
+export const NoCompanyJob: Story = {
+  args: {
+    name: '林小華 Hana Lin',
+    avatarImgUrl: 'https://api.dicebear.com/7.x/adventurer/svg?seed=hana',
+    linkedinUrl: 'https://www.linkedin.com/in/hana-lin',
+  },
+};
+
+export const DefaultAvatar: Story = {
+  args: {
+    name: '林小華 Hana Lin',
+    linkedinUrl: 'https://www.linkedin.com/in/hana-lin',
+    jobTitle: 'Senior Frontend Engineer',
+    companyName: 'Google',
+  },
+};

--- a/src/components/profile/edit/ConfirmDialog.stories.tsx
+++ b/src/components/profile/edit/ConfirmDialog.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { Button } from '@/components/ui/button';
+
+import { ConfirmDialog } from './ConfirmDialog';
+
+const meta: Meta<typeof ConfirmDialog> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/ConfirmDialog',
+  component: ConfirmDialog,
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof ConfirmDialog>;
+
+export const DeleteEducation: Story = {
+  args: {
+    title: '確認刪除學歷資訊？',
+    description: '刪除後將無法復原，您確定要刪除這筆學歷記錄嗎？',
+    onConfirm: () => alert('學歷已刪除！'),
+    trigger: <Button variant="destructive">刪除學歷</Button>,
+  },
+};
+
+export const Logout: Story = {
+  args: {
+    title: '確認要登出嗎？',
+    description: '登出後需要重新登入才能使用平台完整功能。',
+    onConfirm: () => alert('帳號已登出！'),
+    trigger: <Button variant="outline">帳號登出</Button>,
+  },
+};


### PR DESCRIPTION
Introduce high-fidelity Storybook stories to showcase key components in isolation:
- **AvatarCard.stories.tsx**: Demonstrates the Default, No LinkedIn, No company/job, and default avatar fallback states.
- **AuthFormInput.stories.tsx**: Wraps component in react-hook-form using a custom FormInputWrapper, showcasing Normal input, Password input (with hide/show functionality), and ValidationError validation states.
- **ConfirmDialog.stories.tsx**: Illustrates the Radix UI overlay dialog with DeleteEducation and Logout usage examples.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/481
