### PR TITLE
feat(profile): add stories for profile edit sub-components (X-Tracker #482)

### DIFF
--- a/src/components/profile/edit/AvatarSection.stories.tsx
+++ b/src/components/profile/edit/AvatarSection.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { AvatarSection } from './AvatarSection';
+import { ProfileStoryWrapper } from './ProfileStoryWrapper';
+
+const meta: Meta<typeof AvatarSection> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/AvatarSection',
+  component: AvatarSection,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof AvatarSection>;
+
+export const Default: Story = {
+  parameters: {
+    nextAuth: {
+      user: {
+        avatar: '',
+      },
+    },
+  },
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ avatar: null }}>
+      {(form) => (
+        <AvatarSection control={form.control} name="avatar" isMentor={false} />
+      )}
+    </ProfileStoryWrapper>
+  ),
+};
+
+export const WithInitialAvatar: Story = {
+  parameters: {
+    nextAuth: {
+      user: {
+        avatar:
+          'https://images.unsplash.com/photo-1472099645785-5658abf4ff4e?auto=format&fit=crop&w=150&h=150&q=80',
+      },
+    },
+  },
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ avatar: null }}>
+      {(form) => (
+        <AvatarSection control={form.control} name="avatar" isMentor={false} />
+      )}
+    </ProfileStoryWrapper>
+  ),
+};
+
+export const MentorRequiredState: Story = {
+  name: '導師必填狀態 (IsMentor)',
+  parameters: {
+    nextAuth: {
+      user: {
+        avatar: '',
+      },
+    },
+  },
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ avatar: null }}>
+      {(form) => (
+        <AvatarSection control={form.control} name="avatar" isMentor={true} />
+      )}
+    </ProfileStoryWrapper>
+  ),
+};

--- a/src/components/profile/edit/CategoryMultiSelectField.stories.tsx
+++ b/src/components/profile/edit/CategoryMultiSelectField.stories.tsx
@@ -1,0 +1,137 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { CategoryMultiSelectField } from './CategoryMultiSelectField';
+import { ProfileStoryWrapper } from './ProfileStoryWrapper';
+
+const meta: Meta<typeof CategoryMultiSelectField> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/CategoryMultiSelectField',
+  component: CategoryMultiSelectField,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CategoryMultiSelectField>;
+
+const CATEGORIES = [
+  {
+    key: 'position',
+    label: '專業角色 (Positions)',
+    options: [
+      { value: 'frontend', label: '前端工程師 (Frontend)' },
+      { value: 'backend', label: '後端工程師 (Backend)' },
+      { value: 'pm', label: '產品經理 (Product Manager)' },
+      { value: 'designer', label: 'UI/UX 設計師 (Designer)' },
+    ],
+  },
+  {
+    key: 'skill',
+    label: '專業技能 (Skills)',
+    options: [
+      { value: 'react', label: 'React' },
+      { value: 'typescript', label: 'TypeScript' },
+      { value: 'node', label: 'Node.js' },
+      { value: 'tailwind', label: 'Tailwind CSS' },
+    ],
+  },
+  {
+    key: 'topic',
+    label: '諮詢主題 (Topics)',
+    options: [
+      { value: 'career', label: '職涯規劃 (Career Planning)' },
+      { value: 'resume', label: '履歷健檢 (Resume Review)' },
+      { value: 'mock-interview', label: '模擬面試 (Mock Interview)' },
+    ],
+  },
+];
+
+export const TreeStructure: Story = {
+  name: '分組樹狀結構 (預設)',
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ selected_skills: [] }}>
+      {(form) => (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            展示完整的類別樹狀結構，使用者可以展開/收合各個大類，並選取其中的子項目。
+          </p>
+          <CategoryMultiSelectField
+            form={form}
+            name="selected_skills"
+            categories={CATEGORIES}
+            searchPlaceholder="搜尋技能、主題或角色..."
+          />
+        </div>
+      )}
+    </ProfileStoryWrapper>
+  ),
+};
+
+export const FlatList: Story = {
+  name: '扁平化標籤列表 (Flat Mode)',
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ selected_skills: [] }}>
+      {(form) => (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            當 <code>flat=true</code>{' '}
+            時，所有的子選項會被拉平直接顯示為標籤列表，適用於選項總量較少或不需分組的場景。
+          </p>
+          <CategoryMultiSelectField
+            form={form}
+            name="selected_skills"
+            categories={CATEGORIES}
+            flat={true}
+            searchPlaceholder="在扁平列表中搜尋..."
+          />
+        </div>
+      )}
+    </ProfileStoryWrapper>
+  ),
+};
+
+export const LimitSelection: Story = {
+  name: '設定選取數量限制 (Limit: 2)',
+  render: () => (
+    <ProfileStoryWrapper defaultValues={{ selected_skills: ['frontend'] }}>
+      {(form) => (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            當設定 <code>maxSelected=2</code> 時，若使用者企圖選取第 3
+            個選項，系統將限制其選取，並在畫面上顯示限制提示。
+          </p>
+          <CategoryMultiSelectField
+            form={form}
+            name="selected_skills"
+            categories={CATEGORIES}
+            maxSelected={2}
+            searchPlaceholder="搜尋 (最多選取兩個)..."
+          />
+        </div>
+      )}
+    </ProfileStoryWrapper>
+  ),
+};
+
+export const SearchAndFilterShowcase: Story = {
+  name: '搜尋與過濾功能展示',
+  render: () => (
+    <ProfileStoryWrapper
+      defaultValues={{ selected_skills: ['react', 'typescript'] }}
+    >
+      {(form) => (
+        <div className="space-y-4">
+          <p className="text-sm text-text-secondary">
+            使用者可以點擊輸入框進行即時輸入搜尋。系統會自動篩選符合輸入字串的選項，並高亮或保留符合條件的群組結構。
+          </p>
+          <CategoryMultiSelectField
+            form={form}
+            name="selected_skills"
+            categories={CATEGORIES}
+            searchPlaceholder="輸入 'react' 或 'career' 測試即時過濾..."
+          />
+        </div>
+      )}
+    </ProfileStoryWrapper>
+  ),
+};

--- a/src/components/profile/edit/EditPageHeader.stories.tsx
+++ b/src/components/profile/edit/EditPageHeader.stories.tsx
@@ -1,0 +1,42 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+
+import { EditPageHeader } from './EditPageHeader';
+
+const meta: Meta<typeof EditPageHeader> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/EditPageHeader',
+  component: EditPageHeader,
+  tags: ['autodocs'],
+  args: {
+    isSaving: false,
+    isMentorOnboarding: false,
+    onBack: () => console.log('Back button clicked'),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof EditPageHeader>;
+
+export const EditProfile: Story = {
+  name: '編輯個人頁面',
+  args: {
+    isMentorOnboarding: false,
+    isSaving: false,
+  },
+};
+
+export const MentorOnboarding: Story = {
+  name: '導師完成個人資料',
+  args: {
+    isMentorOnboarding: true,
+    isSaving: false,
+  },
+};
+
+export const Saving: Story = {
+  name: '儲存中狀態',
+  args: {
+    isMentorOnboarding: false,
+    isSaving: true,
+  },
+};

--- a/src/components/profile/edit/LinkSection.stories.tsx
+++ b/src/components/profile/edit/LinkSection.stories.tsx
@@ -1,0 +1,97 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import {
+  createProfileFormSchema,
+  defaultValues,
+} from '@/schemas/profileSchema';
+
+import { LinksSection } from './LinkSection';
+import { ProfileStoryWrapper } from './ProfileStoryWrapper';
+
+const meta: Meta<typeof LinksSection> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/LinksSection',
+  component: LinksSection,
+  tags: ['autodocs'],
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LinksSection>;
+
+export const Default: Story = {
+  name: '空白連結區塊',
+  render: () => {
+    const schema = createProfileFormSchema(false);
+    return (
+      <ProfileStoryWrapper schema={schema} defaultValues={defaultValues}>
+        {(form) => <LinksSection form={form} />}
+      </ProfileStoryWrapper>
+    );
+  },
+};
+
+export const Filled: Story = {
+  name: '已填寫連結區塊',
+  render: () => {
+    const schema = createProfileFormSchema(false);
+    const filledValues = {
+      ...defaultValues,
+      linkedin: {
+        id: 1,
+        url: 'https://www.linkedin.com/in/testuser',
+        platform: 'linkedin',
+      },
+      facebook: {
+        id: 2,
+        url: 'https://www.facebook.com/testuser',
+        platform: 'facebook',
+      },
+      instagram: {
+        id: 3,
+        url: 'https://www.instagram.com/testuser',
+        platform: 'instagram',
+      },
+      twitter: { id: 4, url: 'https://x.com/testuser', platform: 'twitter' },
+      youtube: {
+        id: 5,
+        url: 'https://www.youtube.com/@testuser',
+        platform: 'youtube',
+      },
+      website: { id: 6, url: 'https://mywebsite.com', platform: 'website' },
+    };
+    return (
+      <ProfileStoryWrapper schema={schema} defaultValues={filledValues}>
+        {(form) => <LinksSection form={form} />}
+      </ProfileStoryWrapper>
+    );
+  },
+};
+
+export const WithValidationErrors: Story = {
+  name: '有格式錯誤狀態',
+  render: () => {
+    const schema = createProfileFormSchema(false);
+    const invalidValues = {
+      ...defaultValues,
+      linkedin: {
+        id: 1,
+        url: 'https://www.invalid-linkedin.com',
+        platform: 'linkedin',
+      },
+      twitter: { id: 4, url: 'not-a-valid-url', platform: 'twitter' },
+    };
+    return (
+      <ProfileStoryWrapper schema={schema} defaultValues={invalidValues}>
+        {(form) => {
+          // Trigger validation on mount to display errors immediately
+          React.useEffect(() => {
+            form.trigger();
+          }, [form]);
+
+          return <LinksSection form={form} />;
+        }}
+      </ProfileStoryWrapper>
+    );
+  },
+};

--- a/src/components/profile/edit/Section.stories.tsx
+++ b/src/components/profile/edit/Section.stories.tsx
@@ -1,0 +1,88 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { RequiredIndicator } from './RequiredIndicator';
+import { Section } from './Section';
+
+const meta: Meta<typeof Section> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/Section',
+  component: Section,
+  tags: ['autodocs'],
+  args: {
+    title: '個人基本資料',
+    required: false,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Section>;
+
+export const Default: Story = {
+  render: (args) => (
+    <Section {...args}>
+      <div className="space-y-4 rounded-lg border border-background-border p-4">
+        <p className="text-sm text-text-secondary">
+          這是 Section 元件的內容區域。你可以在這裡放置各種表單欄位或區塊元件。
+        </p>
+      </div>
+    </Section>
+  ),
+};
+
+export const Required: Story = {
+  args: {
+    title: '必填區塊 (例如：姓名、信箱)',
+    required: true,
+  },
+  render: (args) => (
+    <Section {...args}>
+      <div className="space-y-4 rounded-lg border border-background-border p-4">
+        <p className="text-sm text-text-secondary">
+          當 <code>required=true</code> 時，標題左側會自動顯示由{' '}
+          <code>RequiredIndicator</code> 渲染的紅色星號 <code>*</code>。
+        </p>
+      </div>
+    </Section>
+  ),
+};
+
+export const RequiredIndicatorDemo: Story = {
+  name: 'RequiredIndicator 獨立展示',
+  render: () => (
+    <div className="space-y-6 rounded-lg border border-background-border bg-background-white p-6">
+      <h3 className="border-b pb-2 text-lg font-bold">
+        RequiredIndicator 元件功能示範
+      </h3>
+      <div className="space-y-4">
+        <div className="flex items-center gap-4">
+          <span className="w-48 text-sm font-semibold">
+            顯示必填指示器 (show=true):
+          </span>
+          <span className="text-lg">
+            <RequiredIndicator show={true} />
+            必填欄位
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="w-48 text-sm font-semibold">
+            隱藏必填指示器 (show=false):
+          </span>
+          <span className="text-lg">
+            <RequiredIndicator show={false} />
+            非必填欄位
+          </span>
+        </div>
+        <div className="flex items-center gap-4">
+          <span className="w-48 text-sm font-semibold">
+            預設狀態 (不帶參數):
+          </span>
+          <span className="text-lg">
+            <RequiredIndicator />
+            預設必填
+          </span>
+        </div>
+      </div>
+    </div>
+  ),
+};


### PR DESCRIPTION
Add isolated Storybook previews for personal profile edit form sub-components in src/components/profile/edit/. Covers Section with RequiredIndicator demonstration, AvatarSection with upload/modal trigger modeling, EditPageHeader with loading states, LinksSection with field error validation, and CategoryMultiSelectField demonstrating tree/flat layouts, limiting constraints, and search filtering.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/482
