### PR TITLE
docs(storybook): add testing, layout, and interaction guide MDX files (X-Tracker #484)

### DIFF
--- a/src/docs/LayoutAndSpacing.mdx
+++ b/src/docs/LayoutAndSpacing.mdx
@@ -14,18 +14,19 @@ X-Talent 平台採用 **行動優先 (Mobile-First)** 的設計理念。為了�
 
 本專案使用 Tailwind CSS 預設的斷點系統，並在 `tailwind.config.js` 中針對最大容器進行了微調：
 
-| 斷點 (Breakpoint) | 寬度閥值 (Width Threshold) | 適用裝置 (Target Devices) | 專案常見開發類別 (Example Utilities) |
-| :--- | :--- | :--- | :--- |
-| **預設 (Mobile)** | `< 640px` | 手機直向 (Mobile Portrait) | 預設樣式 (如 `w-full px-4 text-base`) |
-| **`sm`** | `>= 640px` | 手機橫向 / 迷你平板 (Mobile Landscape / Mini Tablet) | `sm:px-6`, `sm:grid-cols-2` |
-| **`md`** | `>= 768px` | 平板直向 (Tablet Portrait) | `md:px-10`, `md:flex-row`, `md:text-xl` |
-| **`lg`** | `>= 1024px` | 平板橫向 / 筆記型電腦 (Tablet Landscape / Laptop) | `lg:sticky`, `lg:h-screen`, `lg:grid-cols-3` |
-| **`xl`** | `>= 1280px` | 桌上型電腦 (Standard Desktop) | `xl:px-20`, `xl:gap-0` |
-| **`2xl`** | `>= 1400px` | 寬螢幕顯示器 (Large Monitor) | `2xl:max-w-[1400px]` (常用於 Container 限制) |
+| 斷點 (Breakpoint) | 寬度閥值 (Width Threshold) | 適用裝置 (Target Devices)                            | 專案常見開發類別 (Example Utilities)         |
+| :---------------- | :------------------------- | :--------------------------------------------------- | :------------------------------------------- |
+| **預設 (Mobile)** | `< 640px`                  | 手機直向 (Mobile Portrait)                           | 預設樣式 (如 `w-full px-4 text-base`)        |
+| **`sm`**          | `>= 640px`                 | 手機橫向 / 迷你平板 (Mobile Landscape / Mini Tablet) | `sm:px-6`, `sm:grid-cols-2`                  |
+| **`md`**          | `>= 768px`                 | 平板直向 (Tablet Portrait)                           | `md:px-10`, `md:flex-row`, `md:text-xl`      |
+| **`lg`**          | `>= 1024px`                | 平板橫向 / 筆記型電腦 (Tablet Landscape / Laptop)    | `lg:sticky`, `lg:h-screen`, `lg:grid-cols-3` |
+| **`xl`**          | `>= 1280px`                | 桌上型電腦 (Standard Desktop)                        | `xl:px-20`, `xl:gap-0`                       |
+| **`2xl`**         | `>= 1400px`                | 寬螢幕顯示器 (Large Monitor)                         | `2xl:max-w-[1400px]` (常用於 Container 限制) |
 
 ### 💡 開發關鍵原則
-* **Mobile-First**：所有樣式預設均為手機端。僅在需要大螢幕特化時，才向上疊加 `md:`、`lg:` 或 `xl:` 修飾符。
-* **避免過多自定義斷點**：除特殊互動場景外，嚴格禁止在代碼中寫死 `min-width: 800px` 等魔術數字。請一律使用 Tailwind 的語意化斷點。
+
+- **Mobile-First**：所有樣式預設均為手機端。僅在需要大螢幕特化時，才向上疊加 `md:`、`lg:` 或 `xl:` 修飾符。
+- **避免過多自定義斷點**：除特殊互動場景外，嚴格禁止在代碼中寫死 `min-width: 800px` 等魔術數字。請一律使用 Tailwind 的語意化斷點。
 
 ---
 
@@ -34,20 +35,21 @@ X-Talent 平台採用 **行動優先 (Mobile-First)** 的設計理念。為了�
 頁面最外層的水平間距（Page Gutters）應隨著螢幕寬度彈性伸縮，以維持完美的視覺張力：
 
 1. **手機端 (Mobile, < 768px)**：
-   * **標準間距**：`px-4` 或 `px-5` (16px 或 20px)。
-   * **目的**：最大化手機有限螢幕寬度的內容呈現空間，同時防止文字貼邊。
+   - **標準間距**：`px-4` 或 `px-5` (16px 或 20px)。
+   - **目的**：最大化手機有限螢幕寬度的內容呈現空間，同時防止文字貼邊。
 2. **平板端 (Tablet, >= 768px)**：
-   * **標準間距**：`md:px-8` 或 `md:px-10` (32px 或 40px)。
-   * **目的**：提供合適的左右留白，讓眼睛在閱讀時感到舒適。
+   - **標準間距**：`md:px-8` 或 `md:px-10` (32px 或 40px)。
+   - **目的**：提供合適的左右留白，讓眼睛在閱讀時感到舒適。
 3. **桌面端 (Desktop, >= 1280px)**：
-   * **標準間距**：`xl:px-20` (80px) 或者是採用 **中央定寬結構**：`max-w-screen-xl mx-auto xl:px-0`。
-   * **目的**：在大螢幕下限制內容最大寬度，避免行寬過長導致閱讀疲勞，並使頁面兩端完美對齊。
+   - **標準間距**：`xl:px-20` (80px) 或者是採用 **中央定寬結構**：`max-w-screen-xl mx-auto xl:px-0`。
+   - **目的**：在大螢幕下限制內容最大寬度，避免行寬過長導致閱讀疲勞，並使頁面兩端完美對齊。
 
 ---
 
 ## 🛠️ 頁面結構實戰範例
 
 ### 1. 滿版響應式容器 (Full-Width Responsive Container)
+
 適用於具備背景延伸色、但在內容上需要保持標準響應式邊距的區塊（如 Header、Footer、Hero Section）：
 
 ```tsx
@@ -61,6 +63,7 @@ X-Talent 平台採用 **行動優先 (Mobile-First)** 的設計理念。為了�
 ```
 
 ### 2. 響應式卡片網格 (Responsive Grid List)
+
 導師池、推薦列表等卡片式排版，標準間距（Gaps）建議統一為 `gap-6` (24px) 或 `gap-8` (32px)：
 
 ```tsx
@@ -76,6 +79,7 @@ X-Talent 平台採用 **行動優先 (Mobile-First)** 的設計理念。為了�
 ```
 
 ### 3. 表單與細節頁面排版 (Form & Detail Spacing)
+
 在填寫表單或 onboarding 流程中，欄位與欄位之間的垂直間距推薦使用 `space-y-6` (24px) 以維持適當的結構清晰度：
 
 ```tsx

--- a/src/docs/LayoutAndSpacing.mdx
+++ b/src/docs/LayoutAndSpacing.mdx
@@ -1,0 +1,95 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="System/Layout & Spacing" />
+
+# 響應式佈局與間距規範 (Responsive Layout & Spacing Guide)
+
+X-Talent 平台採用 **行動優先 (Mobile-First)** 的設計理念。為了確保平台在手機、平板與桌面端擁有高度一致且具備良好視覺美感的排版結構，我們制定了此套「響應式斷點與頁面邊距（Gutters）規範」。
+
+在進行介面開發與排版時，所有開發人員皆須嚴格遵守以下標準。
+
+---
+
+## 📱 響應式斷點規範 (RWD Breakpoints)
+
+本專案使用 Tailwind CSS 預設的斷點系統，並在 `tailwind.config.js` 中針對最大容器進行了微調：
+
+| 斷點 (Breakpoint) | 寬度閥值 (Width Threshold) | 適用裝置 (Target Devices) | 專案常見開發類別 (Example Utilities) |
+| :--- | :--- | :--- | :--- |
+| **預設 (Mobile)** | `< 640px` | 手機直向 (Mobile Portrait) | 預設樣式 (如 `w-full px-4 text-base`) |
+| **`sm`** | `>= 640px` | 手機橫向 / 迷你平板 (Mobile Landscape / Mini Tablet) | `sm:px-6`, `sm:grid-cols-2` |
+| **`md`** | `>= 768px` | 平板直向 (Tablet Portrait) | `md:px-10`, `md:flex-row`, `md:text-xl` |
+| **`lg`** | `>= 1024px` | 平板橫向 / 筆記型電腦 (Tablet Landscape / Laptop) | `lg:sticky`, `lg:h-screen`, `lg:grid-cols-3` |
+| **`xl`** | `>= 1280px` | 桌上型電腦 (Standard Desktop) | `xl:px-20`, `xl:gap-0` |
+| **`2xl`** | `>= 1400px` | 寬螢幕顯示器 (Large Monitor) | `2xl:max-w-[1400px]` (常用於 Container 限制) |
+
+### 💡 開發關鍵原則
+* **Mobile-First**：所有樣式預設均為手機端。僅在需要大螢幕特化時，才向上疊加 `md:`、`lg:` 或 `xl:` 修飾符。
+* **避免過多自定義斷點**：除特殊互動場景外，嚴格禁止在代碼中寫死 `min-width: 800px` 等魔術數字。請一律使用 Tailwind 的語意化斷點。
+
+---
+
+## 📐 頁面水平邊距規範 (Page Gutters)
+
+頁面最外層的水平間距（Page Gutters）應隨著螢幕寬度彈性伸縮，以維持完美的視覺張力：
+
+1. **手機端 (Mobile, < 768px)**：
+   * **標準間距**：`px-4` 或 `px-5` (16px 或 20px)。
+   * **目的**：最大化手機有限螢幕寬度的內容呈現空間，同時防止文字貼邊。
+2. **平板端 (Tablet, >= 768px)**：
+   * **標準間距**：`md:px-8` 或 `md:px-10` (32px 或 40px)。
+   * **目的**：提供合適的左右留白，讓眼睛在閱讀時感到舒適。
+3. **桌面端 (Desktop, >= 1280px)**：
+   * **標準間距**：`xl:px-20` (80px) 或者是採用 **中央定寬結構**：`max-w-screen-xl mx-auto xl:px-0`。
+   * **目的**：在大螢幕下限制內容最大寬度，避免行寬過長導致閱讀疲勞，並使頁面兩端完美對齊。
+
+---
+
+## 🛠️ 頁面結構實戰範例
+
+### 1. 滿版響應式容器 (Full-Width Responsive Container)
+適用於具備背景延伸色、但在內容上需要保持標準響應式邊距的區塊（如 Header、Footer、Hero Section）：
+
+```tsx
+// 範例來源：src/components/layout/Footer/Footer.tsx
+<footer className="w-full bg-light">
+  {/* 手機端左右 px-5，平板端 md:px-[70px]，桌面端限制最大寬度 */}
+  <div className="mx-auto flex w-full max-w-[1440px] flex-col items-center px-5 pt-[50px] md:flex-row md:items-start md:justify-between md:px-[70px]">
+    {/* Footer 內容 */}
+  </div>
+</footer>
+```
+
+### 2. 響應式卡片網格 (Responsive Grid List)
+導師池、推薦列表等卡片式排版，標準間距（Gaps）建議統一為 `gap-6` (24px) 或 `gap-8` (32px)：
+
+```tsx
+// 範例來源：src/app/mentor-pool/ui.tsx
+<section className="mt-[80px] px-5 pb-10 md:px-10 xl:px-20">
+  {/* 手機單排、平板雙排、大型桌面四排，卡片間距統一為 gap-6 (24px) */}
+  <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+    {mentors.map((mentor) => (
+      <MentorCard key={mentor.id} mentor={mentor} />
+    ))}
+  </div>
+</section>
+```
+
+### 3. 表單與細節頁面排版 (Form & Detail Spacing)
+在填寫表單或 onboarding 流程中，欄位與欄位之間的垂直間距推薦使用 `space-y-6` (24px) 以維持適當的結構清晰度：
+
+```tsx
+// 範例來源：src/app/auth/(sign)/onboarding/ui.tsx
+<div className="mx-auto max-w-[600px] px-5 py-20">
+  <form className="space-y-6">
+    <div>
+      <label className="text-sm font-medium">姓名</label>
+      <input className="mt-1.5 w-full rounded-lg border p-3" />
+    </div>
+    <div>
+      <label className="text-sm font-medium">自我介紹</label>
+      <textarea className="mt-1.5 w-full rounded-lg border p-3" />
+    </div>
+  </form>
+</div>
+```

--- a/src/docs/PlayFunctionsAndA11y.mdx
+++ b/src/docs/PlayFunctionsAndA11y.mdx
@@ -1,0 +1,111 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="System/Play Functions & A11y" />
+
+# 互動式測試與無障礙規範 (Storybook Play Functions & Accessibility Guide)
+
+在 X-Talent 專案中，Storybook 不僅是 UI 元件的靜態目錄，更是元件交互與無障礙（Accessibility）的自動化驗證平台。
+
+本指南詳細說明如何為元件編寫互動式 **Play Functions** 進行端到端模擬測試，以及如何遵循 **WCAG / A11y 規範** 打造人人皆可使用的無障礙平台。
+
+---
+
+## 🎮 Storybook 互動式測試 (Play Functions)
+
+### 什麼是 Play Function？
+`play` 函數是 Storybook 的核心交互測試功能。它允許我們在 Storybook 渲染故事（Story）後，自動化地執行使用者交互（如點擊、輸入、懸停），並透過斷言（Assertion）驗證元件狀態是否符合預期。
+
+### 為什麼使用 Play Function？
+1. **高保真度**：直接在瀏覽器真實的 DOM 環境中執行測試，比虛擬 DOM 測試（如 JSDOM）更貼近真實使用情境。
+2. **視覺與自動化整合**：點開 Storybook 即可動態重播所有交互，便於視覺化除錯；同時支援透過 Storybook Test-Runner 在 CI/CD 流程中進行全自動化測試。
+
+### ✍️ 如何編寫 Play 測試故事
+請一律從 `@storybook/test` 導入交互模組（它整合了 `@testing-library` 與 `jest-mock` 的最優設計）：
+
+```typescript
+import type { Meta, StoryObj } from '@storybook/react';
+import { within, userEvent, expect } from '@storybook/test';
+import { MentorFilterDropdown } from './MentorFilterDropdown';
+
+const meta: Meta<typeof MentorFilterDropdown> = {
+  title: 'Components/Filter/MentorFilterDropdown',
+  component: MentorFilterDropdown,
+};
+export default meta;
+
+type Story = StoryObj<typeof MentorFilterDropdown>;
+
+export const InteractiveSearch: Story = {
+  play: async ({ canvasElement }) => {
+    // 1. 以 canvasElement 為範圍建立查詢對象
+    const canvas = within(canvasElement);
+
+    // 2. 定位「篩選器」按鈕並模擬點擊
+    const filterBtn = canvas.getByRole('button', { name: /篩選/ });
+    await userEvent.click(filterBtn);
+
+    // 3. 驗證下拉選單是否成功開啟
+    const dropdownList = canvas.getByRole('listbox');
+    await expect(dropdownList).toBeInTheDocument();
+
+    // 4. 在搜尋框中模擬輸入文字
+    const searchInput = canvas.getByPlaceholderText(/關鍵字/i);
+    await userEvent.type(searchInput, '設計');
+
+    // 5. 斷言過濾後的選項數量或狀態
+    const matchedOption = canvas.getByRole('option', { name: /UI\/UX 設計/ });
+    await expect(matchedOption).toBeInTheDocument();
+  },
+};
+```
+
+### ⚠️ 撰寫 Play Function 的關鍵準則：
+* **異步交互處理**：所有的 `userEvent` 交互（如 `click`、`type`）皆為非同步，請務必加上 **`await`**，否則測試會提前結束或狀態發生混淆。
+* **無障礙優先查詢**：優先使用符合 A11y 規格的查詢器（如 `getByRole`、`getByLabelText`），這不僅讓測試更穩健，也能順便驗證元件的無障礙結構。
+
+---
+
+## ♿ 無障礙開發規範 (Accessibility / A11y Standards)
+
+本專案已在 `.storybook/main.ts` 中配置了 **`@storybook/addon-a11y`**。當您開啟任何故事時，可以點選底部的 **"Accessibility"** 面板，Storybook 會自動執行 axe-core 無障礙掃描並回報 WCAG (Web Content Accessibility Guidelines) 違規項目。
+
+為了確保平台對輔助設備（如螢幕閱讀器、僅鍵盤使用者）完全友善，開發時必須遵循以下五大規範：
+
+### 1. 語意化 HTML 優先 (Semantic HTML)
+* 嚴格禁止使用 `div` 或 `span` 搭配 `onClick` 來模擬按鈕、連結或導覽。
+* 互動元件必須使用標準的 `<button>`（用於觸發動作）、`<a>`（用於導向路由）、`<input>`（用於輸入）。
+* 若因設計限制必須使用自定義結構，請補齊 `role="button"`、`tabIndex={0}` 以及鍵盤監聽事件（Enter/Space）。
+
+### 2. 色彩對比度標準 (Color Contrast)
+* **標準文字與底色對比**：必須達到 WCAG AA 標準，即 **4.5:1**。
+* **大字型與大型圖示**：必須達到 **3:1**。
+* 建議利用 Chrome DevTools 或者是 Storybook A11y 面板的色彩檢測儀，隨時審核背景色與前景色是否有對比度過低的問題。
+
+### 3. 清晰且無障礙的鍵盤焦點 (Focus States)
+* **嚴格禁止**寫死 `outline: none` 或 `outline-none` 而不提供替代的焦點外框。
+* 行動不便者通常透過 `Tab` 鍵在網頁中移動，清晰的 Focus Ring 對他們至關重要。
+* 本專案統一使用以下 Tailwind 樣式作為標準無障礙焦點框：
+  ```tsx
+  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+  ```
+
+### 4. 圖片替代文字規範 (Image Alternative Text)
+* 所有的圖片元素（原生 `<img>` 或 NextJS `<Image>`）必須設定 `alt` 屬性。
+* **裝飾性圖片**：若圖片僅作為視覺背景或裝飾，應設置 `alt=""` 或者是 `role="presentation"`，讓螢幕閱讀器安全跳過。
+* **具備語意的圖片**：必須填寫清晰的描述：
+  ```tsx
+  // ✅ 好實踐：在頭像中提供清晰的人物名稱描述（如 MobileUserMenu 測試中提及的實踐）
+  <img 
+    src={user.avatar || "/default-avatar.png"} 
+    alt={`${user.name} 的頭像`} 
+    className="rounded-full"
+  />
+  ```
+
+### 5. ARIA 狀態屬性 (ARIA Attributes)
+* **摺疊/展開選單**：點擊展開的按鈕或 DropdownTrigger 必須設定 `aria-expanded={isOpen}`。
+* **關聯輔助說明**：輸入框如果下方有錯誤提示或描述文字，必須使用 `aria-describedby` 進行 ID 關聯，讓視障使用者在輸入時能同步聽到錯誤提示：
+  ```tsx
+  <input id="email" aria-describedby="email-error" />
+  <p id="email-error" role="alert">信箱格式不正確</p>
+  ```

--- a/src/docs/PlayFunctionsAndA11y.mdx
+++ b/src/docs/PlayFunctionsAndA11y.mdx
@@ -13,13 +13,16 @@ import { Meta } from '@storybook/addon-docs/blocks';
 ## 🎮 Storybook 互動式測試 (Play Functions)
 
 ### 什麼是 Play Function？
+
 `play` 函數是 Storybook 的核心交互測試功能。它允許我們在 Storybook 渲染故事（Story）後，自動化地執行使用者交互（如點擊、輸入、懸停），並透過斷言（Assertion）驗證元件狀態是否符合預期。
 
 ### 為什麼使用 Play Function？
+
 1. **高保真度**：直接在瀏覽器真實的 DOM 環境中執行測試，比虛擬 DOM 測試（如 JSDOM）更貼近真實使用情境。
 2. **視覺與自動化整合**：點開 Storybook 即可動態重播所有交互，便於視覺化除錯；同時支援透過 Storybook Test-Runner 在 CI/CD 流程中進行全自動化測試。
 
 ### ✍️ 如何編寫 Play 測試故事
+
 請一律從 `@storybook/test` 導入交互模組（它整合了 `@testing-library` 與 `jest-mock` 的最優設計）：
 
 ```typescript
@@ -60,8 +63,9 @@ export const InteractiveSearch: Story = {
 ```
 
 ### ⚠️ 撰寫 Play Function 的關鍵準則：
-* **異步交互處理**：所有的 `userEvent` 交互（如 `click`、`type`）皆為非同步，請務必加上 **`await`**，否則測試會提前結束或狀態發生混淆。
-* **無障礙優先查詢**：優先使用符合 A11y 規格的查詢器（如 `getByRole`、`getByLabelText`），這不僅讓測試更穩健，也能順便驗證元件的無障礙結構。
+
+- **異步交互處理**：所有的 `userEvent` 交互（如 `click`、`type`）皆為非同步，請務必加上 **`await`**，否則測試會提前結束或狀態發生混淆。
+- **無障礙優先查詢**：優先使用符合 A11y 規格的查詢器（如 `getByRole`、`getByLabelText`），這不僅讓測試更穩健，也能順便驗證元件的無障礙結構。
 
 ---
 
@@ -72,39 +76,45 @@ export const InteractiveSearch: Story = {
 為了確保平台對輔助設備（如螢幕閱讀器、僅鍵盤使用者）完全友善，開發時必須遵循以下五大規範：
 
 ### 1. 語意化 HTML 優先 (Semantic HTML)
-* 嚴格禁止使用 `div` 或 `span` 搭配 `onClick` 來模擬按鈕、連結或導覽。
-* 互動元件必須使用標準的 `<button>`（用於觸發動作）、`<a>`（用於導向路由）、`<input>`（用於輸入）。
-* 若因設計限制必須使用自定義結構，請補齊 `role="button"`、`tabIndex={0}` 以及鍵盤監聽事件（Enter/Space）。
+
+- 嚴格禁止使用 `div` 或 `span` 搭配 `onClick` 來模擬按鈕、連結或導覽。
+- 互動元件必須使用標準的 `<button>`（用於觸發動作）、`<a>`（用於導向路由）、`<input>`（用於輸入）。
+- 若因設計限制必須使用自定義結構，請補齊 `role="button"`、`tabIndex={0}` 以及鍵盤監聽事件（Enter/Space）。
 
 ### 2. 色彩對比度標準 (Color Contrast)
-* **標準文字與底色對比**：必須達到 WCAG AA 標準，即 **4.5:1**。
-* **大字型與大型圖示**：必須達到 **3:1**。
-* 建議利用 Chrome DevTools 或者是 Storybook A11y 面板的色彩檢測儀，隨時審核背景色與前景色是否有對比度過低的問題。
+
+- **標準文字與底色對比**：必須達到 WCAG AA 標準，即 **4.5:1**。
+- **大字型與大型圖示**：必須達到 **3:1**。
+- 建議利用 Chrome DevTools 或者是 Storybook A11y 面板的色彩檢測儀，隨時審核背景色與前景色是否有對比度過低的問題。
 
 ### 3. 清晰且無障礙的鍵盤焦點 (Focus States)
-* **嚴格禁止**寫死 `outline: none` 或 `outline-none` 而不提供替代的焦點外框。
-* 行動不便者通常透過 `Tab` 鍵在網頁中移動，清晰的 Focus Ring 對他們至關重要。
-* 本專案統一使用以下 Tailwind 樣式作為標準無障礙焦點框：
+
+- **嚴格禁止**寫死 `outline: none` 或 `outline-none` 而不提供替代的焦點外框。
+- 行動不便者通常透過 `Tab` 鍵在網頁中移動，清晰的 Focus Ring 對他們至關重要。
+- 本專案統一使用以下 Tailwind 樣式作為標準無障礙焦點框：
   ```tsx
-  className="focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+  className =
+    'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2';
   ```
 
 ### 4. 圖片替代文字規範 (Image Alternative Text)
-* 所有的圖片元素（原生 `<img>` 或 NextJS `<Image>`）必須設定 `alt` 屬性。
-* **裝飾性圖片**：若圖片僅作為視覺背景或裝飾，應設置 `alt=""` 或者是 `role="presentation"`，讓螢幕閱讀器安全跳過。
-* **具備語意的圖片**：必須填寫清晰的描述：
+
+- 所有的圖片元素（原生 `<img>` 或 NextJS `<Image>`）必須設定 `alt` 屬性。
+- **裝飾性圖片**：若圖片僅作為視覺背景或裝飾，應設置 `alt=""` 或者是 `role="presentation"`，讓螢幕閱讀器安全跳過。
+- **具備語意的圖片**：必須填寫清晰的描述：
   ```tsx
   // ✅ 好實踐：在頭像中提供清晰的人物名稱描述（如 MobileUserMenu 測試中提及的實踐）
-  <img 
-    src={user.avatar || "/default-avatar.png"} 
-    alt={`${user.name} 的頭像`} 
+  <img
+    src={user.avatar || '/default-avatar.png'}
+    alt={`${user.name} 的頭像`}
     className="rounded-full"
   />
   ```
 
 ### 5. ARIA 狀態屬性 (ARIA Attributes)
-* **摺疊/展開選單**：點擊展開的按鈕或 DropdownTrigger 必須設定 `aria-expanded={isOpen}`。
-* **關聯輔助說明**：輸入框如果下方有錯誤提示或描述文字，必須使用 `aria-describedby` 進行 ID 關聯，讓視障使用者在輸入時能同步聽到錯誤提示：
+
+- **摺疊/展開選單**：點擊展開的按鈕或 DropdownTrigger 必須設定 `aria-expanded={isOpen}`。
+- **關聯輔助說明**：輸入框如果下方有錯誤提示或描述文字，必須使用 `aria-describedby` 進行 ID 關聯，讓視障使用者在輸入時能同步聽到錯誤提示：
   ```tsx
   <input id="email" aria-describedby="email-error" />
   <p id="email-error" role="alert">信箱格式不正確</p>

--- a/src/docs/TestingAndMocking.mdx
+++ b/src/docs/TestingAndMocking.mdx
@@ -1,0 +1,102 @@
+import { Meta } from '@storybook/addon-docs/blocks';
+
+<Meta title="System/Testing & Mocking" />
+
+# 測試與 Mocking 規範 (Testing & Mocking Standards)
+
+在 X-Talent 專案中，我們使用 **Vitest** 作為單元與整合測試的執行器，並搭配 **React Testing Library** 來測試 UI 元件。
+
+本指南旨在說明專案中的測試與 Mocking 標準，特別是如何利用 **`@total-typescript/shoehorn`** 規避不安全的 `as any` 斷言，確保測試代碼的型別安全性與長期可維護性。
+
+---
+
+## 🚫 為什麼嚴格禁止 `as any` 與 `as ComplexType`？
+
+在撰寫測試時，我們經常需要 Mock 複雜的領域資料模型（例如 `Session`、`User`、`MentorProfileVO` 等）。這些型別通常包含數十個欄位與巢狀結構。
+
+過去開發者為了省事，常使用強行轉型（Type Casting）：
+
+```typescript
+// ❌ 壞實踐：使用不安全的雙重斷言或 as any
+const mockUser = { id: 'user-1', name: 'Ada' } as any;
+const mockProfile = { name: 'Kevin' } as unknown as MentorProfileVO;
+```
+
+### 強行轉型的三大危害：
+1. **失去編譯期型別安全 (Type Safety)**：TypeScript 會完全放棄對該物件的型別檢查。如果您在測試中拼錯了屬性名稱（如 `userName` 拼成 `username`），編譯器不會報錯，直到測試執行失敗或在執行期崩潰。
+2. **掩蓋架構與 Schema 變更**：當後端 API 或資料庫 Schema 變更，修改了 `MentorProfileVO` 的欄位時，強行轉型的測試代碼**不會**拋出 TypeScript 報錯。這會導致測試代碼與真實代碼脫節，失去測試的防禦作用。
+3. **執行期未定義錯誤 (Runtime Undefined)**：如果受測元件內部訪問了被您用 `as any` 忽略的必填欄位，會直接拋出 `TypeError: Cannot read properties of undefined`。
+
+---
+
+## 🛠️ 單一事實來源：`@total-typescript/shoehorn`
+
+為了解決 Mock 複雜型別時「必須補齊幾十個無關欄位」的痛點，本專案已全面啟用 **`@total-typescript/shoehorn`**。
+
+Shoehorn 提供了型別安全的局部 Mock 解決方案，讓您在測試中只宣告「當前測試真正關心的欄位」，其餘欄位會安全地滿足 TypeScript 的編譯要求。
+
+> ⚠️ **重要原則**：`shoehorn` 僅能在測試代碼（`*.test.ts` / `*.spec.ts`）中調用，**嚴格禁止**於任何生產環境代碼中引用。
+
+### 1. `fromPartial()` — 局部型別安全 Mock (最常用)
+
+當您只需要 Mock 複雜型別中的一部分欄位，且希望這些局部欄位**依然受到嚴格的型別檢查**時，請使用 `fromPartial`。
+
+#### 💡 實戰範例：Mock Next-Auth `Session['user']`
+在 `src/components/layout/Header/MobileUserMenu.test.tsx` 中，我們需要測試不同狀態的使用者頭像渲染：
+
+```typescript
+import { fromPartial } from '@total-typescript/shoehorn';
+import type { Session } from 'next-auth';
+import { mockSession } from '@/test/mocks/nextAuth';
+
+// ✅ 好實踐：利用 fromPartial 進行局部型別安全 Mock
+function buildUser(overrides: Partial<Session['user']> = {}): Session['user'] {
+  return fromPartial({
+    ...mockSession.user,
+    id: 'user-1',
+    isMentor: false,
+    ...overrides, // 覆寫的屬性依然會受到嚴格的型別約束
+  });
+}
+```
+
+### 2. `fromAny()` — 強制任意轉型 (特殊場景)
+
+當您需要刻意模擬不合法的 API 回傳、測試錯誤處理邊界，或者在整合測試中快速建構包含自定義嵌套物件的 DTO 時，可以使用 `fromAny`。它類似於 `as any` 的包裝，但語意上更清晰，表明這是測試特意的 Mock。
+
+#### 💡 實戰範例：Mock 複雜 Service DTO
+在 `src/lib/profile/pollUntilSynced.test.ts` 中，建構一個帶有巢狀 `industry` 的 DTO 物件：
+
+```typescript
+import { fromAny } from '@total-typescript/shoehorn';
+import { type MentorProfileVO } from '@/services/profile/user';
+
+// ✅ 好實踐：利用 fromAny 包裝複雜或不完全一致的數據結構
+const makeSyncedDto = (avatar = ''): MentorProfileVO =>
+  fromAny({
+    user_id: 1,
+    name: 'Sync Test',
+    avatar,
+    location: 'Taiwan',
+    about: 'about-me',
+    personal_statement: 'statement',
+    years_of_experience: '1_3',
+    industry: { subject_group: 'tech' }, // 此處型別結構可能與真實完整介面有異，但適用於此測試
+    is_mentor: true,
+    onboarding: true,
+    experiences: [],
+  });
+```
+
+---
+
+## 🚀 一鍵自動遷移工具 (Local Agent Skills)
+
+專案提供了高度自動化的開發工具。如果您在維護舊測試、或撰寫新測試時，遇到型別報錯而想要快速引入 Shoehorn：
+
+1. 開啟 Gemini CLI 的會話。
+2. 直接呼叫內建技能：
+   ```bash
+   /migrate-to-shoehorn
+   ```
+3. Agent 會自動掃描您的測試代碼，尋找不安全的 `as any` 斷言，並一鍵重構為安全的 `fromPartial` 或 `fromAny` 語法！

--- a/src/docs/TestingAndMocking.mdx
+++ b/src/docs/TestingAndMocking.mdx
@@ -23,6 +23,7 @@ const mockProfile = { name: 'Kevin' } as unknown as MentorProfileVO;
 ```
 
 ### 強行轉型的三大危害：
+
 1. **失去編譯期型別安全 (Type Safety)**：TypeScript 會完全放棄對該物件的型別檢查。如果您在測試中拼錯了屬性名稱（如 `userName` 拼成 `username`），編譯器不會報錯，直到測試執行失敗或在執行期崩潰。
 2. **掩蓋架構與 Schema 變更**：當後端 API 或資料庫 Schema 變更，修改了 `MentorProfileVO` 的欄位時，強行轉型的測試代碼**不會**拋出 TypeScript 報錯。這會導致測試代碼與真實代碼脫節，失去測試的防禦作用。
 3. **執行期未定義錯誤 (Runtime Undefined)**：如果受測元件內部訪問了被您用 `as any` 忽略的必填欄位，會直接拋出 `TypeError: Cannot read properties of undefined`。
@@ -42,6 +43,7 @@ Shoehorn 提供了型別安全的局部 Mock 解決方案，讓您在測試中�
 當您只需要 Mock 複雜型別中的一部分欄位，且希望這些局部欄位**依然受到嚴格的型別檢查**時，請使用 `fromPartial`。
 
 #### 💡 實戰範例：Mock Next-Auth `Session['user']`
+
 在 `src/components/layout/Header/MobileUserMenu.test.tsx` 中，我們需要測試不同狀態的使用者頭像渲染：
 
 ```typescript
@@ -65,6 +67,7 @@ function buildUser(overrides: Partial<Session['user']> = {}): Session['user'] {
 當您需要刻意模擬不合法的 API 回傳、測試錯誤處理邊界，或者在整合測試中快速建構包含自定義嵌套物件的 DTO 時，可以使用 `fromAny`。它類似於 `as any` 的包裝，但語意上更清晰，表明這是測試特意的 Mock。
 
 #### 💡 實戰範例：Mock 複雜 Service DTO
+
 在 `src/lib/profile/pollUntilSynced.test.ts` 中，建構一個帶有巢狀 `industry` 的 DTO 物件：
 
 ```typescript


### PR DESCRIPTION
Introduce three high-quality Storybook documentation guide files in Traditional Chinese:
- src/docs/TestingAndMocking.mdx: Details @total-typescript/shoehorn testing and mocking standard to avoid unsafe 'as any' assertions.
- src/docs/LayoutAndSpacing.mdx: Details responsive design (RWD) break points and layout horizontal/vertical spacing and gutters rules.
- src/docs/PlayFunctionsAndA11y.mdx: Details writing interactive 'play' tests and ensuring strict Web Content Accessibility Guidelines (WCAG) and accessibility rules.

All documents have been verified to compile and build correctly in Storybook statically.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/484
