### PR TITLE
feat(storybook): add story for RequiredIndicator (X-Tracker #487)

### DIFF
--- a/src/components/profile/edit/RequiredIndicator.stories.tsx
+++ b/src/components/profile/edit/RequiredIndicator.stories.tsx
@@ -1,0 +1,51 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { RequiredIndicator } from './RequiredIndicator';
+
+const meta: Meta<typeof RequiredIndicator> = {
+  title: '業務模組元件/個人檔案(Profile)/Edit/RequiredIndicator',
+  component: RequiredIndicator,
+  tags: ['autodocs'],
+  argTypes: {
+    show: {
+      control: 'boolean',
+      description: '是否顯示必填指示器 (紅色星號)',
+      table: {
+        type: { summary: 'boolean' },
+        defaultValue: { summary: 'true' },
+      },
+    },
+  },
+  args: {
+    show: true,
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof RequiredIndicator>;
+
+export const Default: Story = {
+  args: {
+    show: true,
+  },
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <RequiredIndicator {...args} />
+      <span>必填欄位範例</span>
+    </div>
+  ),
+};
+
+export const Hidden: Story = {
+  args: {
+    show: false,
+  },
+  render: (args) => (
+    <div className="flex items-center gap-2">
+      <RequiredIndicator {...args} />
+      <span>非必填欄位範例</span>
+    </div>
+  ),
+};


### PR DESCRIPTION
- Create `src/components/profile/edit/RequiredIndicator.stories.tsx` to showcase the `RequiredIndicator` component used across profile edit form sections.
- Cover both the default (`show=true`) state and the hidden (`show=false`) state with full Storybook interactive controls.
- Ensure all TypeScript type checks and ESLint linting rules pass.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/487
