### PR TITLE
refactor(reservation): extract resolveCounterparty seam for reservation counterparty resolution (X-Tracker #488)

### DIFF
--- a/src/services/reservations/index.test.ts
+++ b/src/services/reservations/index.test.ts
@@ -5,6 +5,7 @@ import {
   formatDateTime,
   formatExperience,
   mapToReservation,
+  resolveCounterparty,
 } from '@/services/reservations';
 import { components } from '@/types/api';
 
@@ -612,6 +613,122 @@ describe('mapToReservation', () => {
         // Current user is 10, so counterparty is 20 (MENTOR) who has REJECT.
         // Even though current user (10) also has REJECT, the other party (20) must take precedence.
         const result = mapToReservation(reservation, '10');
+        expect(result.cancelledBy).toBe('MENTOR');
+      });
+    });
+  });
+
+  /* ================================
+   * resolveCounterparty
+   * ================================ */
+
+  describe('resolveCounterparty', () => {
+    const baseSender = {
+      user_id: 10,
+      role: 'MENTEE' as const,
+      status: 'PENDING' as const,
+      name: 'Bob (Mentee)',
+      avatar: 'bob-avatar.png',
+      job_title: 'Designer',
+      years_of_experience: 'ONE_TO_THREE',
+    };
+
+    const baseParticipant = {
+      user_id: 20,
+      role: 'MENTOR' as const,
+      status: 'ACCEPT' as const,
+      name: 'Alice (Mentor)',
+      avatar: 'alice-avatar.png',
+      job_title: 'Engineer',
+      years_of_experience: 'THREE_TO_FIVE',
+    };
+
+    it('myUserId matches sender.user_id → counterparty is participant', () => {
+      const reservation = makeReservation({
+        sender: baseSender,
+        participant: baseParticipant,
+      });
+      const result = resolveCounterparty(reservation, 10);
+      expect(result.name).toBe('Alice (Mentor)');
+      expect(result.avatar).toBe('alice-avatar.png');
+      expect(result.roleLine).toBe('Engineer, 3~5 年');
+    });
+
+    it('myUserId matches participant.user_id → counterparty is sender', () => {
+      const reservation = makeReservation({
+        sender: baseSender,
+        participant: baseParticipant,
+      });
+      const result = resolveCounterparty(reservation, 20);
+      expect(result.name).toBe('Bob (Mentee)');
+      expect(result.avatar).toBe('bob-avatar.png');
+      expect(result.roleLine).toBe('Designer, 1~3 年');
+    });
+
+    it('myUserId is omitted → fallback to participant', () => {
+      const reservation = makeReservation({
+        sender: baseSender,
+        participant: baseParticipant,
+      });
+      const result = resolveCounterparty(reservation);
+      expect(result.name).toBe('Alice (Mentor)');
+    });
+
+    it('myUserId is unmatched → fallback to sender', () => {
+      const reservation = makeReservation({
+        sender: baseSender,
+        participant: baseParticipant,
+      });
+      const result = resolveCounterparty(reservation, 999);
+      expect(result.name).toBe('Bob (Mentee)');
+    });
+
+    it('null sender → fallback to participant to prevent crash', () => {
+      const reservation = makeReservation({
+        sender: fromAny(null),
+        participant: baseParticipant,
+      });
+      const result = resolveCounterparty(reservation, 10);
+      expect(result.name).toBe('Alice (Mentor)');
+    });
+
+    it('null participant → fallback to sender to prevent crash', () => {
+      const reservation = makeReservation({
+        sender: baseSender,
+        participant: fromAny(null),
+      });
+      const result = resolveCounterparty(reservation, 10);
+      expect(result.name).toBe('Bob (Mentee)');
+    });
+
+    describe('cancelledBy precedence rules', () => {
+      it('only counterparty has REJECT → cancelledBy is counterparty role', () => {
+        const reservation = makeReservation({
+          sender: { ...baseSender, status: 'ACCEPT' },
+          participant: { ...baseParticipant, status: 'REJECT' },
+        });
+        // myUserId is 10 (sender), so counterparty is participant (MENTOR)
+        const result = resolveCounterparty(reservation, 10);
+        expect(result.cancelledBy).toBe('MENTOR');
+      });
+
+      it('only current user has REJECT → cancelledBy is current user role', () => {
+        const reservation = makeReservation({
+          sender: { ...baseSender, status: 'REJECT' },
+          participant: { ...baseParticipant, status: 'ACCEPT' },
+        });
+        // myUserId is 10 (sender), so current user is sender (MENTEE), counterparty is MENTOR (ACCEPT)
+        const result = resolveCounterparty(reservation, 10);
+        expect(result.cancelledBy).toBe('MENTEE');
+      });
+
+      it('both parties have REJECT → cancelledBy resolves to counterparty (other side takes precedence)', () => {
+        const reservation = makeReservation({
+          sender: { ...baseSender, status: 'REJECT' },
+          participant: { ...baseParticipant, status: 'REJECT' },
+        });
+        // myUserId is 10 (sender), counterparty is participant (MENTOR)
+        const result = resolveCounterparty(reservation, 10);
         expect(result.cancelledBy).toBe('MENTOR');
       });
     });

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -70,10 +70,15 @@ function classifyMessageRole(
   return undefined;
 }
 
-export function mapToReservation(
+export function resolveCounterparty(
   reservation: components['schemas']['ReservationInfoVO'],
   myUserId?: string | number | null
-): Reservation {
+): {
+  name: string;
+  avatar?: string;
+  roleLine: string;
+  cancelledBy?: 'MENTEE' | 'MENTOR';
+} {
   // If myUserId is provided and equals reservation.sender.user_id, the counterparty is set to reservation.participant.
   // If myUserId is provided and does NOT equal reservation.sender.user_id, the counterparty is set to reservation.sender.
   // If myUserId is omitted (null or undefined), the counterparty defaults to reservation.participant for backward compatibility.
@@ -84,13 +89,49 @@ export function mapToReservation(
           String(myUserId) === String(reservation.sender.user_id)
         ? (reservation.participant ?? reservation.sender)
         : (reservation.sender ?? reservation.participant);
-  const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
+
+  const name = counterparty?.name || '—';
+  const avatar = counterparty?.avatar ?? undefined;
+
   const roleLine = [
-    counterparty.job_title?.trim() || '',
-    formatExperience(counterparty.years_of_experience),
+    counterparty?.job_title?.trim() || '',
+    formatExperience(counterparty?.years_of_experience),
   ]
     .filter(Boolean)
     .join(', ');
+
+  const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
+    r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
+
+  const currentUserSide =
+    counterparty === reservation.participant
+      ? reservation.sender
+      : reservation.participant;
+
+  const cancelledBy =
+    counterparty?.status === 'REJECT'
+      ? toRole(counterparty?.role)
+      : currentUserSide?.status === 'REJECT'
+        ? toRole(currentUserSide?.role)
+        : undefined;
+
+  return {
+    name,
+    avatar,
+    roleLine,
+    cancelledBy,
+  };
+}
+
+export function mapToReservation(
+  reservation: components['schemas']['ReservationInfoVO'],
+  myUserId?: string | number | null
+): Reservation {
+  const { name, avatar, roleLine, cancelledBy } = resolveCounterparty(
+    reservation,
+    myUserId
+  );
+  const { date, time } = formatDateTime(reservation.dtstart, reservation.dtend);
 
   // Preserve the full conversation in API order so the detail view can render
   // the entire thread, while also tracking the latest message per side for the
@@ -120,31 +161,13 @@ export function mapToReservation(
     else if (role === 'MENTOR') mentorMessage = item;
   }
 
-  // Cancellation badge fires whenever either side rejected/cancelled, with the
-  // canceller's role surfaced so the UI can render 「已由導師/學員取消」 on both
-  // mentor and mentee history pages. Reject (pre-accept) and cancel
-  // (post-accept) intentionally share the same 「取消」 copy per PM scope
-  // (Tracker #224). Participant (other side / counterparty) takes precedence when both sides are REJECT.
-  const toRole = (r?: string | null): 'MENTEE' | 'MENTOR' | undefined =>
-    r === 'MENTEE' || r === 'MENTOR' ? r : undefined;
-  const currentUserSide =
-    counterparty === reservation.participant
-      ? reservation.sender
-      : reservation.participant;
-  const cancelledBy: 'MENTEE' | 'MENTOR' | undefined =
-    counterparty?.status === 'REJECT'
-      ? toRole(counterparty?.role)
-      : currentUserSide?.status === 'REJECT'
-        ? toRole(currentUserSide?.role)
-        : undefined;
-
   return {
     id: String(reservation.id ?? ''),
-    name: counterparty.name || '—',
+    name,
     roleLine,
     date,
     time,
-    avatar: counterparty.avatar ?? undefined,
+    avatar,
     messages,
     menteeMessage,
     mentorMessage,


### PR DESCRIPTION
- Extract resolveCounterparty from mapToReservation into a standalone, exported function.
- Delegate mapToReservation's counterparty and cancelledBy logic to resolveCounterparty to keep identical display behaviors.
- Write 9 detailed unit tests in index.test.ts covering null sender, null participant, unmatched/fallback matching, and double-reject precedence.
- Ensure type-safety using Shoehorn partial mock methods instead of unsafe 'as any' assertions.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/488
