### PR TITLE
feat(analytics): report core web vitals to ga4 (X-Tracker #490)

### DIFF
--- a/src/components/Providers.tsx
+++ b/src/components/Providers.tsx
@@ -6,12 +6,14 @@ import ErrorBoundary from '@/components/ErrorBoundary';
 import GlobalErrorMonitor from '@/components/GlobalErrorMonitor';
 import PageViewTracker from '@/components/PageViewTracker';
 import SessionErrorWatcher from '@/components/SessionErrorWatcher';
+import WebVitalsReporter from '@/components/WebVitalsReporter';
 
 export default function Providers({ children }: { children: React.ReactNode }) {
   return (
     <SessionProvider>
       <GlobalErrorMonitor />
       <PageViewTracker />
+      <WebVitalsReporter />
       <SessionErrorWatcher />
       <ErrorBoundary>{children}</ErrorBoundary>
     </SessionProvider>

--- a/src/components/WebVitalsReporter.test.tsx
+++ b/src/components/WebVitalsReporter.test.tsx
@@ -1,0 +1,74 @@
+import { render } from '@testing-library/react';
+import { fromPartial } from '@total-typescript/shoehorn';
+import { useReportWebVitals } from 'next/web-vitals';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { trackEvent } from '@/lib/analytics';
+
+import WebVitalsReporter from './WebVitalsReporter';
+
+// Mock next/web-vitals
+vi.mock('next/web-vitals', () => ({
+  useReportWebVitals: vi.fn(),
+}));
+
+// Mock @/lib/analytics
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+describe('WebVitalsReporter', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('registers the web vitals reporter callback', () => {
+    render(<WebVitalsReporter />);
+    expect(useReportWebVitals).toHaveBeenCalledTimes(1);
+    expect(useReportWebVitals).toHaveBeenCalledWith(expect.any(Function));
+  });
+
+  it('tracks supported metrics (LCP, CLS, INP, FCP, TTFB) with correct parameters', () => {
+    let callback: Exclude<Parameters<typeof useReportWebVitals>[0], undefined>;
+
+    vi.mocked(useReportWebVitals).mockImplementation((cb) => {
+      callback = cb;
+    });
+
+    render(<WebVitalsReporter />);
+
+    const metrics = [
+      { name: 'LCP', value: 2500, rating: 'needs-improvement' },
+      { name: 'CLS', value: 0.1, rating: 'good' },
+      { name: 'INP', value: 150, rating: 'good' },
+      { name: 'FCP', value: 1200, rating: 'good' },
+      { name: 'TTFB', value: 600, rating: 'poor' },
+    ] as const;
+
+    metrics.forEach((metric) => {
+      callback!(fromPartial(metric));
+
+      expect(trackEvent).toHaveBeenCalledWith({
+        name: `performance_${metric.name.toLowerCase()}_measured`,
+        feature: 'performance',
+        metadata: {
+          raw_value: metric.value,
+          rating: metric.rating,
+        },
+      });
+    });
+  });
+
+  it('ignores unsupported metrics', () => {
+    let callback: Exclude<Parameters<typeof useReportWebVitals>[0], undefined>;
+
+    vi.mocked(useReportWebVitals).mockImplementation((cb) => {
+      callback = cb;
+    });
+
+    render(<WebVitalsReporter />);
+
+    callback!(fromPartial({ name: 'FID', value: 50, rating: 'good' }));
+    expect(trackEvent).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/WebVitalsReporter.test.tsx
+++ b/src/components/WebVitalsReporter.test.tsx
@@ -48,15 +48,17 @@ describe('WebVitalsReporter', () => {
     metrics.forEach((metric) => {
       callback!(fromPartial(metric));
 
-      expect(trackEvent).toHaveBeenCalledWith({
-        name: `performance_${metric.name.toLowerCase()}_measured`,
-        feature: 'performance',
-        metadata: {
-          raw_value: metric.value,
-          rating: metric.rating,
+      expect(trackEvent).toHaveBeenCalledWith(
+        {
+          name: `performance_${metric.name.toLowerCase()}_measured`,
+          feature: 'performance',
+          metadata: {
+            raw_value: metric.value,
+            rating: metric.rating,
+          },
         },
-        skipClarity: true,
-      });
+        { skipClarity: true }
+      );
     });
   });
 

--- a/src/components/WebVitalsReporter.test.tsx
+++ b/src/components/WebVitalsReporter.test.tsx
@@ -55,6 +55,7 @@ describe('WebVitalsReporter', () => {
           raw_value: metric.value,
           rating: metric.rating,
         },
+        skipClarity: true,
       });
     });
   });

--- a/src/components/WebVitalsReporter.tsx
+++ b/src/components/WebVitalsReporter.tsx
@@ -1,0 +1,23 @@
+'use client';
+
+import { useReportWebVitals } from 'next/web-vitals';
+
+import { trackEvent } from '@/lib/analytics';
+
+export default function WebVitalsReporter() {
+  useReportWebVitals((metric) => {
+    const name = metric.name.toUpperCase();
+    if (['LCP', 'CLS', 'INP', 'FCP', 'TTFB'].includes(name)) {
+      trackEvent({
+        name: `performance_${metric.name.toLowerCase()}_measured`,
+        feature: 'performance',
+        metadata: {
+          raw_value: metric.value,
+          rating: metric.rating,
+        },
+      });
+    }
+  });
+
+  return null;
+}

--- a/src/components/WebVitalsReporter.tsx
+++ b/src/components/WebVitalsReporter.tsx
@@ -4,20 +4,31 @@ import { useReportWebVitals } from 'next/web-vitals';
 
 import { trackEvent } from '@/lib/analytics';
 
+const SUPPORTED_METRICS = ['LCP', 'CLS', 'INP', 'FCP', 'TTFB'];
+
+interface WebVitalsMetric {
+  name: string;
+  value: number;
+  rating: 'good' | 'needs-improvement' | 'poor';
+}
+
+function reportWebVitals(metric: WebVitalsMetric) {
+  const name = metric.name.toUpperCase();
+  if (SUPPORTED_METRICS.includes(name)) {
+    trackEvent({
+      name: `performance_${metric.name.toLowerCase()}_measured`,
+      feature: 'performance',
+      metadata: {
+        raw_value: metric.value,
+        rating: metric.rating,
+      },
+      skipClarity: true,
+    });
+  }
+}
+
 export default function WebVitalsReporter() {
-  useReportWebVitals((metric) => {
-    const name = metric.name.toUpperCase();
-    if (['LCP', 'CLS', 'INP', 'FCP', 'TTFB'].includes(name)) {
-      trackEvent({
-        name: `performance_${metric.name.toLowerCase()}_measured`,
-        feature: 'performance',
-        metadata: {
-          raw_value: metric.value,
-          rating: metric.rating,
-        },
-      });
-    }
-  });
+  useReportWebVitals(reportWebVitals);
 
   return null;
 }

--- a/src/components/WebVitalsReporter.tsx
+++ b/src/components/WebVitalsReporter.tsx
@@ -15,15 +15,17 @@ interface WebVitalsMetric {
 function reportWebVitals(metric: WebVitalsMetric) {
   const name = metric.name.toUpperCase();
   if (SUPPORTED_METRICS.includes(name)) {
-    trackEvent({
-      name: `performance_${metric.name.toLowerCase()}_measured`,
-      feature: 'performance',
-      metadata: {
-        raw_value: metric.value,
-        rating: metric.rating,
+    trackEvent(
+      {
+        name: `performance_${metric.name.toLowerCase()}_measured`,
+        feature: 'performance',
+        metadata: {
+          raw_value: metric.value,
+          rating: metric.rating,
+        },
       },
-      skipClarity: true,
-    });
+      { skipClarity: true }
+    );
   }
 }
 

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -46,11 +46,12 @@ describe('analytics', () => {
     expect(mockClarity).toHaveBeenCalledWith('set', 'method', 'google');
   });
 
-  it('bypasses Microsoft Clarity for performance features but sends to GA4', () => {
+  it('bypasses Microsoft Clarity when skipClarity is true but sends to GA4', () => {
     trackEvent({
       name: 'performance_lcp_measured',
       feature: 'performance',
       metadata: { raw_value: 2500, rating: 'needs-improvement' },
+      skipClarity: true,
     });
 
     const mockGtag = vi.mocked(global.window.gtag);

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -1,0 +1,83 @@
+import { fromPartial } from '@total-typescript/shoehorn';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { setAnalyticsTag, trackEvent, trackPageView } from './analytics';
+
+describe('analytics', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = {
+      ...originalEnv,
+      NEXT_PUBLIC_GA_ID: 'GA-12345',
+      NEXT_PUBLIC_CLARITY_ID: 'CLARITY-12345',
+      NODE_ENV: 'test',
+    };
+
+    // Setup global window properties as mocks using fromPartial
+    global.window = fromPartial({
+      gtag: vi.fn(),
+      clarity: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    delete (global as { window?: unknown }).window;
+  });
+
+  it('sends events to both GA4 and Clarity for standard features', () => {
+    trackEvent({
+      name: 'auth_sign_in_succeeded',
+      feature: 'auth',
+      metadata: { method: 'google' },
+    });
+
+    const mockGtag = vi.mocked(global.window.gtag);
+    const mockClarity = vi.mocked(global.window.clarity!);
+
+    expect(mockGtag).toHaveBeenCalledWith('event', 'auth_sign_in_succeeded', {
+      feature: 'auth',
+      method: 'google',
+    });
+
+    expect(mockClarity).toHaveBeenCalledWith('event', 'auth_sign_in_succeeded');
+    expect(mockClarity).toHaveBeenCalledWith('set', 'feature', 'auth');
+    expect(mockClarity).toHaveBeenCalledWith('set', 'method', 'google');
+  });
+
+  it('bypasses Microsoft Clarity for performance features but sends to GA4', () => {
+    trackEvent({
+      name: 'performance_lcp_measured',
+      feature: 'performance',
+      metadata: { raw_value: 2500, rating: 'needs-improvement' },
+    });
+
+    const mockGtag = vi.mocked(global.window.gtag);
+    const mockClarity = vi.mocked(global.window.clarity!);
+
+    expect(mockGtag).toHaveBeenCalledWith('event', 'performance_lcp_measured', {
+      feature: 'performance',
+      raw_value: 2500,
+      rating: 'needs-improvement',
+    });
+
+    expect(mockClarity).not.toHaveBeenCalled();
+  });
+
+  it('tracks page views correctly', () => {
+    trackPageView('/test-path');
+
+    const mockGtag = vi.mocked(global.window.gtag);
+    expect(mockGtag).toHaveBeenCalledWith('config', 'GA-12345', {
+      page_path: '/test-path',
+    });
+  });
+
+  it('sets analytics tags in Clarity', () => {
+    setAnalyticsTag('test_key', 'test_value');
+
+    const mockClarity = vi.mocked(global.window.clarity!);
+    expect(mockClarity).toHaveBeenCalledWith('set', 'test_key', 'test_value');
+  });
+});

--- a/src/lib/analytics.test.ts
+++ b/src/lib/analytics.test.ts
@@ -47,12 +47,14 @@ describe('analytics', () => {
   });
 
   it('bypasses Microsoft Clarity when skipClarity is true but sends to GA4', () => {
-    trackEvent({
-      name: 'performance_lcp_measured',
-      feature: 'performance',
-      metadata: { raw_value: 2500, rating: 'needs-improvement' },
-      skipClarity: true,
-    });
+    trackEvent(
+      {
+        name: 'performance_lcp_measured',
+        feature: 'performance',
+        metadata: { raw_value: 2500, rating: 'needs-improvement' },
+      },
+      { skipClarity: true }
+    );
 
     const mockGtag = vi.mocked(global.window.gtag);
     const mockClarity = vi.mocked(global.window.clarity!);

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -45,8 +45,6 @@ export interface BehaviorEvent {
    * Do NOT include passwords, tokens, emails, or personal info.
    */
   metadata?: Record<string, string | number | boolean>;
-  /** Optional flag to bypass sending this event to Microsoft Clarity */
-  skipClarity?: boolean;
 }
 
 // ─── Internal helpers ──────────────────────────────────────────────────────────
@@ -79,7 +77,10 @@ function getGtag(): GtagFn | undefined {
  *
  * Do NOT include passwords, tokens, emails, or personal info.
  */
-export function trackEvent(event: BehaviorEvent): void {
+export function trackEvent(
+  event: BehaviorEvent,
+  options?: { skipClarity?: boolean }
+): void {
   // — GA4 —
   const gtag = getGtag();
   if (gtag) {
@@ -90,7 +91,7 @@ export function trackEvent(event: BehaviorEvent): void {
   }
 
   // — Clarity —
-  if (!event.skipClarity) {
+  if (!options?.skipClarity) {
     const clarity = getClarity();
     if (clarity) {
       clarity('event', event.name);
@@ -105,7 +106,7 @@ export function trackEvent(event: BehaviorEvent): void {
 
   // — Local dev debug —
   if (process.env.NODE_ENV === 'development') {
-    console.debug('[analytics] trackEvent', event);
+    console.debug('[analytics] trackEvent', event, options);
   }
 }
 

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -39,7 +39,7 @@ export interface BehaviorEvent {
   /** snake_case event name — format: <feature>_<action> */
   name: string;
   /** Module or feature area this event belongs to */
-  feature?: 'auth' | 'onboarding' | 'reservation' | 'profile';
+  feature?: 'auth' | 'onboarding' | 'reservation' | 'profile' | 'performance';
   /**
    * Optional key-value metadata for additional context.
    * Do NOT include passwords, tokens, emails, or personal info.
@@ -88,13 +88,15 @@ export function trackEvent(event: BehaviorEvent): void {
   }
 
   // — Clarity —
-  const clarity = getClarity();
-  if (clarity) {
-    clarity('event', event.name);
-    if (event.feature) clarity('set', 'feature', event.feature);
-    if (event.metadata) {
-      for (const [key, value] of Object.entries(event.metadata)) {
-        clarity('set', key, String(value));
+  if (event.feature !== 'performance') {
+    const clarity = getClarity();
+    if (clarity) {
+      clarity('event', event.name);
+      if (event.feature) clarity('set', 'feature', event.feature);
+      if (event.metadata) {
+        for (const [key, value] of Object.entries(event.metadata)) {
+          clarity('set', key, String(value));
+        }
       }
     }
   }

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -45,6 +45,8 @@ export interface BehaviorEvent {
    * Do NOT include passwords, tokens, emails, or personal info.
    */
   metadata?: Record<string, string | number | boolean>;
+  /** Optional flag to bypass sending this event to Microsoft Clarity */
+  skipClarity?: boolean;
 }
 
 // ─── Internal helpers ──────────────────────────────────────────────────────────
@@ -88,7 +90,7 @@ export function trackEvent(event: BehaviorEvent): void {
   }
 
   // — Clarity —
-  if (event.feature !== 'performance') {
+  if (!event.skipClarity) {
     const clarity = getClarity();
     if (clarity) {
       clarity('event', event.name);


### PR DESCRIPTION
Capture Core Web Vitals (LCP, CLS, INP, FCP, TTFB) using Next.js useReportWebVitals and report them via trackEvent() analytics pipeline under the 'performance' feature.

- Update BehaviorEvent feature union to support 'performance'.
- Bypass Microsoft Clarity tracking for 'performance' events to prevent session-level tag and metadata contamination.
- Create client component WebVitalsReporter to measure metrics.
- Mount WebVitalsReporter alongside PageViewTracker in Providers.tsx.
- Add complete type-safe tests for WebVitalsReporter and analytics using @total-typescript/shoehorn.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/490
