### PR TITLE
refactor(auth): route GoogleButton through useGoogleAuth hook (X-Tracker #492)

### DIFF
--- a/src/app/auth/(sign)/signin/page.tsx
+++ b/src/app/auth/(sign)/signin/page.tsx
@@ -2,7 +2,7 @@
 
 import AuthTitle from '@/components/auth/AuthTitle';
 import Divider from '@/components/auth/Divider';
-import GoogleSignUpButton from '@/components/auth/GoogleButton';
+import GoogleButton from '@/components/auth/GoogleButton';
 import SignInForm from '@/components/auth/signin/SignInForm';
 import useSignInForm from '@/hooks/auth/useSignInForm';
 
@@ -15,7 +15,7 @@ export default function Page() {
         <AuthTitle>登入 X-Talent 帳戶</AuthTitle>
         <SignInForm {...signInFormProps} />
         <Divider>或</Divider>
-        <GoogleSignUpButton
+        <GoogleButton
           isSubmitting={signInFormProps.isSubmitting}
           label="使用 Google 帳號登入"
           isSignIn={true}

--- a/src/app/auth/(sign)/signup/page.tsx
+++ b/src/app/auth/(sign)/signup/page.tsx
@@ -1,7 +1,8 @@
 'use client';
+
 import AuthTitle from '@/components/auth/AuthTitle';
 import Divider from '@/components/auth/Divider';
-import GoogleSignUpButton from '@/components/auth/GoogleButton';
+import GoogleButton from '@/components/auth/GoogleButton';
 import SignUpForm from '@/components/auth/signup/SignUpForm';
 import useSignUpForm from '@/hooks/auth/useSignUpForm';
 
@@ -14,7 +15,7 @@ export default function Page() {
         <AuthTitle>註冊 X-Talent 帳戶</AuthTitle>
         <SignUpForm {...signUpFormProps} />
         <Divider>或</Divider>
-        <GoogleSignUpButton
+        <GoogleButton
           isSubmitting={signUpFormProps.isSubmitting}
           label="使用 Google 帳號註冊"
           isSignIn={false}

--- a/src/components/auth/GoogleButton.stories.tsx
+++ b/src/components/auth/GoogleButton.stories.tsx
@@ -1,15 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
-import GoogleSignUpButton from './GoogleButton';
+import GoogleButton from './GoogleButton';
 
-const meta: Meta<typeof GoogleSignUpButton> = {
+const meta: Meta<typeof GoogleButton> = {
   title: '業務模組元件/會員驗證(Auth)/GoogleButton',
-  component: GoogleSignUpButton,
+  component: GoogleButton,
   tags: ['autodocs'],
 };
 
 export default meta;
-type Story = StoryObj<typeof GoogleSignUpButton>;
+type Story = StoryObj<typeof GoogleButton>;
 
 export const SignInButton: Story = {
   args: {

--- a/src/components/auth/GoogleButton.test.tsx
+++ b/src/components/auth/GoogleButton.test.tsx
@@ -3,7 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 
 import { useGoogleAuth } from '@/hooks/auth/useGoogleAuth';
 
-import GoogleSignUpButton from './GoogleButton';
+import GoogleButton from './GoogleButton';
 
 vi.mock('@/hooks/auth/useGoogleAuth', () => ({
   useGoogleAuth: vi.fn(),
@@ -11,7 +11,7 @@ vi.mock('@/hooks/auth/useGoogleAuth', () => ({
 
 const mockUseGoogleAuth = vi.mocked(useGoogleAuth);
 
-describe('GoogleSignUpButton', () => {
+describe('GoogleButton', () => {
   it('renders correctly and handles click', () => {
     const handleGoogleAuth = vi.fn();
     mockUseGoogleAuth.mockReturnValue({
@@ -20,7 +20,7 @@ describe('GoogleSignUpButton', () => {
     });
 
     render(
-      <GoogleSignUpButton
+      <GoogleButton
         isSubmitting={false}
         isSignIn={true}
         label="使用 Google 帳號登入"
@@ -43,7 +43,7 @@ describe('GoogleSignUpButton', () => {
     });
 
     render(
-      <GoogleSignUpButton
+      <GoogleButton
         isSubmitting={false}
         isSignIn={false}
         label="使用 Google 帳號註冊"
@@ -65,7 +65,7 @@ describe('GoogleSignUpButton', () => {
     });
 
     render(
-      <GoogleSignUpButton
+      <GoogleButton
         isSubmitting={true}
         isSignIn={true}
         label="使用 Google 帳號登入"
@@ -83,7 +83,7 @@ describe('GoogleSignUpButton', () => {
     });
 
     render(
-      <GoogleSignUpButton
+      <GoogleButton
         isSubmitting={false}
         isSignIn={true}
         label="使用 Google 帳號登入"

--- a/src/components/auth/GoogleButton.test.tsx
+++ b/src/components/auth/GoogleButton.test.tsx
@@ -1,0 +1,96 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { useGoogleAuth } from '@/hooks/auth/useGoogleAuth';
+
+import GoogleSignUpButton from './GoogleButton';
+
+vi.mock('@/hooks/auth/useGoogleAuth', () => ({
+  useGoogleAuth: vi.fn(),
+}));
+
+const mockUseGoogleAuth = vi.mocked(useGoogleAuth);
+
+describe('GoogleSignUpButton', () => {
+  it('renders correctly and handles click', () => {
+    const handleGoogleAuth = vi.fn();
+    mockUseGoogleAuth.mockReturnValue({
+      handleGoogleAuth,
+      isPending: false,
+    });
+
+    render(
+      <GoogleSignUpButton
+        isSubmitting={false}
+        isSignIn={true}
+        label="使用 Google 帳號登入"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /使用 Google 帳號登入/ });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+    expect(handleGoogleAuth).toHaveBeenCalledWith(true);
+  });
+
+  it('renders sign up label and passes false to handleGoogleAuth on click', () => {
+    const handleGoogleAuth = vi.fn();
+    mockUseGoogleAuth.mockReturnValue({
+      handleGoogleAuth,
+      isPending: false,
+    });
+
+    render(
+      <GoogleSignUpButton
+        isSubmitting={false}
+        isSignIn={false}
+        label="使用 Google 帳號註冊"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /使用 Google 帳號註冊/ });
+    expect(button).toBeInTheDocument();
+    expect(button).not.toBeDisabled();
+
+    fireEvent.click(button);
+    expect(handleGoogleAuth).toHaveBeenCalledWith(false);
+  });
+
+  it('is disabled when isSubmitting is true', () => {
+    mockUseGoogleAuth.mockReturnValue({
+      handleGoogleAuth: vi.fn(),
+      isPending: false,
+    });
+
+    render(
+      <GoogleSignUpButton
+        isSubmitting={true}
+        isSignIn={true}
+        label="使用 Google 帳號登入"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /使用 Google 帳號登入/ });
+    expect(button).toBeDisabled();
+  });
+
+  it('is disabled when isPending is true', () => {
+    mockUseGoogleAuth.mockReturnValue({
+      handleGoogleAuth: vi.fn(),
+      isPending: true,
+    });
+
+    render(
+      <GoogleSignUpButton
+        isSubmitting={false}
+        isSignIn={true}
+        label="使用 Google 帳號登入"
+      />
+    );
+
+    const button = screen.getByRole('button', { name: /使用 Google 帳號登入/ });
+    expect(button).toBeDisabled();
+  });
+});

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -1,12 +1,6 @@
-import { useRouter } from 'next/navigation';
-
 import { GoogleColor } from '@/components/icon';
 import { Button } from '@/components/ui/button';
-import { useToast } from '@/components/ui/use-toast';
-import {
-  getGoogleAuthorizeLoginUrl,
-  getGoogleAuthorizeSignupUrl,
-} from '@/services/auth/googleAuthorize';
+import { useGoogleAuth } from '@/hooks/auth/useGoogleAuth';
 
 interface GoogleSignUpButtonProps {
   isSubmitting: boolean;
@@ -19,29 +13,17 @@ export default function GoogleSignUpButton({
   label,
   isSignIn,
 }: GoogleSignUpButtonProps) {
-  const { toast } = useToast();
-  const router = useRouter();
+  const { handleGoogleAuth, isPending } = useGoogleAuth();
 
   const handleGoogleSignUp = async () => {
-    try {
-      const { authorization_url } = isSignIn
-        ? await getGoogleAuthorizeLoginUrl()
-        : await getGoogleAuthorizeSignupUrl();
-      router.push(authorization_url);
-    } catch {
-      toast({
-        variant: 'destructive',
-        title: '註冊失敗',
-        description: '無法完成 Google 註冊，請稍後再試。',
-      });
-    }
+    await handleGoogleAuth(isSignIn);
   };
 
   return (
     <Button
       variant="outline"
       className="h-12 w-full rounded-full"
-      disabled={isSubmitting}
+      disabled={isSubmitting || isPending}
       onClick={handleGoogleSignUp}
     >
       <GoogleColor className="mr-3 text-xl" />

--- a/src/components/auth/GoogleButton.tsx
+++ b/src/components/auth/GoogleButton.tsx
@@ -2,17 +2,17 @@ import { GoogleColor } from '@/components/icon';
 import { Button } from '@/components/ui/button';
 import { useGoogleAuth } from '@/hooks/auth/useGoogleAuth';
 
-interface GoogleSignUpButtonProps {
+interface GoogleButtonProps {
   isSubmitting: boolean;
   isSignIn: boolean;
   label: string;
 }
 
-export default function GoogleSignUpButton({
+export default function GoogleButton({
   isSubmitting,
   label,
   isSignIn,
-}: GoogleSignUpButtonProps) {
+}: GoogleButtonProps) {
   const { handleGoogleAuth, isPending } = useGoogleAuth();
 
   const handleGoogleSignUp = async () => {

--- a/src/hooks/auth/useGoogleAuth.test.ts
+++ b/src/hooks/auth/useGoogleAuth.test.ts
@@ -1,0 +1,123 @@
+import { act, renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('next/navigation', async () => {
+  const { navigationMockFactory } = await import('@/test/mocks/navigation');
+  return navigationMockFactory();
+});
+
+vi.mock('@/components/ui/use-toast', async () => {
+  const { useToastMockFactory } = await import('@/test/mocks/useToast');
+  return useToastMockFactory();
+});
+
+vi.mock('@/services/auth/googleAuthorize', () => ({
+  getGoogleAuthorizeLoginUrl: vi.fn(),
+  getGoogleAuthorizeSignupUrl: vi.fn(),
+}));
+
+import {
+  getGoogleAuthorizeLoginUrl,
+  getGoogleAuthorizeSignupUrl,
+} from '@/services/auth/googleAuthorize';
+import { mockRouter } from '@/test/mocks/navigation';
+import { mockToast } from '@/test/mocks/useToast';
+
+import { useGoogleAuth } from './useGoogleAuth';
+
+const mockGetGoogleAuthorizeLoginUrl = vi.mocked(getGoogleAuthorizeLoginUrl);
+const mockGetGoogleAuthorizeSignupUrl = vi.mocked(getGoogleAuthorizeSignupUrl);
+
+describe('useGoogleAuth', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should redirect to login authorize URL on success when isSignIn is true', async () => {
+    mockGetGoogleAuthorizeLoginUrl.mockResolvedValueOnce({
+      authorization_url: 'https://google.com/auth/login',
+      state: 'mock-state',
+    });
+
+    const { result } = renderHook(() => useGoogleAuth());
+
+    await act(async () => {
+      await result.current.handleGoogleAuth(true);
+    });
+
+    expect(mockGetGoogleAuthorizeLoginUrl).toHaveBeenCalledTimes(1);
+    expect(mockGetGoogleAuthorizeSignupUrl).not.toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      'https://google.com/auth/login'
+    );
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should redirect to signup authorize URL on success when isSignIn is false', async () => {
+    mockGetGoogleAuthorizeSignupUrl.mockResolvedValueOnce({
+      authorization_url: 'https://google.com/auth/signup',
+      state: 'mock-state',
+    });
+
+    const { result } = renderHook(() => useGoogleAuth());
+
+    await act(async () => {
+      await result.current.handleGoogleAuth(false);
+    });
+
+    expect(mockGetGoogleAuthorizeSignupUrl).toHaveBeenCalledTimes(1);
+    expect(mockGetGoogleAuthorizeLoginUrl).not.toHaveBeenCalled();
+    expect(mockRouter.push).toHaveBeenCalledWith(
+      'https://google.com/auth/signup'
+    );
+    expect(mockToast).not.toHaveBeenCalled();
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should trigger destructive toast when login request fails', async () => {
+    mockGetGoogleAuthorizeLoginUrl.mockRejectedValueOnce(
+      new Error('API error')
+    );
+
+    const { result } = renderHook(() => useGoogleAuth());
+
+    await act(async () => {
+      await result.current.handleGoogleAuth(true);
+    });
+
+    expect(mockGetGoogleAuthorizeLoginUrl).toHaveBeenCalledTimes(1);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '無法完成 Google 註冊，請稍後再試。',
+      })
+    );
+    expect(result.current.isPending).toBe(false);
+  });
+
+  it('should trigger destructive toast when signup request fails', async () => {
+    mockGetGoogleAuthorizeSignupUrl.mockRejectedValueOnce(
+      new Error('API error')
+    );
+
+    const { result } = renderHook(() => useGoogleAuth());
+
+    await act(async () => {
+      await result.current.handleGoogleAuth(false);
+    });
+
+    expect(mockGetGoogleAuthorizeSignupUrl).toHaveBeenCalledTimes(1);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '無法完成 Google 註冊，請稍後再試。',
+      })
+    );
+    expect(result.current.isPending).toBe(false);
+  });
+});

--- a/src/hooks/auth/useGoogleAuth.test.ts
+++ b/src/hooks/auth/useGoogleAuth.test.ts
@@ -51,7 +51,7 @@ describe('useGoogleAuth', () => {
       'https://google.com/auth/login'
     );
     expect(mockToast).not.toHaveBeenCalled();
-    expect(result.current.isPending).toBe(false);
+    expect(result.current.isPending).toBe(true);
   });
 
   it('should redirect to signup authorize URL on success when isSignIn is false', async () => {
@@ -72,7 +72,7 @@ describe('useGoogleAuth', () => {
       'https://google.com/auth/signup'
     );
     expect(mockToast).not.toHaveBeenCalled();
-    expect(result.current.isPending).toBe(false);
+    expect(result.current.isPending).toBe(true);
   });
 
   it('should trigger destructive toast when login request fails', async () => {

--- a/src/hooks/auth/useGoogleAuth.test.ts
+++ b/src/hooks/auth/useGoogleAuth.test.ts
@@ -91,8 +91,8 @@ describe('useGoogleAuth', () => {
     expect(mockToast).toHaveBeenCalledWith(
       expect.objectContaining({
         variant: 'destructive',
-        title: '註冊失敗',
-        description: '無法完成 Google 註冊，請稍後再試。',
+        title: '登入失敗',
+        description: '無法完成 Google 登入，請稍後再試。',
       })
     );
     expect(result.current.isPending).toBe(false);

--- a/src/hooks/auth/useGoogleAuth.ts
+++ b/src/hooks/auth/useGoogleAuth.ts
@@ -1,0 +1,37 @@
+import { useRouter } from 'next/navigation';
+import { useState } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
+import {
+  getGoogleAuthorizeLoginUrl,
+  getGoogleAuthorizeSignupUrl,
+} from '@/services/auth/googleAuthorize';
+
+export function useGoogleAuth() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const [isPending, setIsPending] = useState(false);
+
+  const handleGoogleAuth = async (isSignIn: boolean) => {
+    setIsPending(true);
+    try {
+      const { authorization_url } = isSignIn
+        ? await getGoogleAuthorizeLoginUrl()
+        : await getGoogleAuthorizeSignupUrl();
+      router.push(authorization_url);
+    } catch {
+      toast({
+        variant: 'destructive',
+        title: '註冊失敗',
+        description: '無法完成 Google 註冊，請稍後再試。',
+      });
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  return {
+    handleGoogleAuth,
+    isPending,
+  };
+}

--- a/src/hooks/auth/useGoogleAuth.ts
+++ b/src/hooks/auth/useGoogleAuth.ts
@@ -27,7 +27,6 @@ export function useGoogleAuth() {
           ? '無法完成 Google 登入，請稍後再試。'
           : '無法完成 Google 註冊，請稍後再試。',
       });
-    } finally {
       setIsPending(false);
     }
   };

--- a/src/hooks/auth/useGoogleAuth.ts
+++ b/src/hooks/auth/useGoogleAuth.ts
@@ -22,8 +22,10 @@ export function useGoogleAuth() {
     } catch {
       toast({
         variant: 'destructive',
-        title: '註冊失敗',
-        description: '無法完成 Google 註冊，請稍後再試。',
+        title: isSignIn ? '登入失敗' : '註冊失敗',
+        description: isSignIn
+          ? '無法完成 Google 登入，請稍後再試。'
+          : '無法完成 Google 註冊，請稍後再試。',
       });
     } finally {
       setIsPending(false);


### PR DESCRIPTION
Refactor GoogleButton to consume data and handle OAuth flow through the newly created useGoogleAuth hook. This aligns the component with the project standard of components only consuming data and invoking services via hooks, decoupling presentation from API services. Specifically: - Created useGoogleAuth hook to encapsulate getGoogleAuthorizeLoginUrl / getGoogleAuthorizeSignupUrl calls, router redirect, and toast notifications. - Simplified GoogleSignUpButton to utilize the useGoogleAuth hook and handle pending states properly. - Added comprehensive unit tests for useGoogleAuth hook and GoogleSignUpButton component.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/492
