### PR TITLE
﻿chore(ui): replace MUI icons with lucide-react in SearchBar and MentorFilterDropdown (X-Tracker #493)

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "@emotion/react": "^11.11.3",
     "@emotion/styled": "^11.11.0",
     "@hookform/resolvers": "^3.3.4",
-    "@mui/icons-material": "^5.15.11",
     "@mui/material": "^6.1.6",
     "@radix-ui/react-avatar": "^1.1.10",
     "@radix-ui/react-checkbox": "^1.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,9 +22,6 @@ importers:
       '@hookform/resolvers':
         specifier: ^3.3.4
         version: 3.10.0(react-hook-form@7.71.1(react@18.2.0))
-      '@mui/icons-material':
-        specifier: ^5.15.11
-        version: 5.18.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.48)(react@18.2.0)
       '@mui/material':
         specifier: ^6.1.6
         version: 6.5.0(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
@@ -1545,17 +1542,6 @@ packages:
 
   '@mui/core-downloads-tracker@6.5.0':
     resolution: {integrity: sha512-LGb8t8i6M2ZtS3Drn3GbTI1DVhDY6FJ9crEey2lZ0aN2EMZo8IZBZj9wRf4vqbZHaWjsYgtbOnJw5V8UWbmK2Q==}
-
-  '@mui/icons-material@5.18.0':
-    resolution: {integrity: sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==}
-    engines: {node: '>=12.0.0'}
-    peerDependencies:
-      '@mui/material': ^5.0.0
-      '@types/react': ^17.0.0 || ^18.0.0 || ^19.0.0
-      react: ^17.0.0 || ^18.0.0 || ^19.0.0
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
 
   '@mui/material@6.5.0':
     resolution: {integrity: sha512-yjvtXoFcrPLGtgKRxFaH6OQPtcLPhkloC0BML6rBG5UeldR0nPULR/2E2BfXdo5JNV7j7lOzrrLX2Qf/iSidow==}
@@ -8951,14 +8937,6 @@ snapshots:
       react: 18.2.0
 
   '@mui/core-downloads-tracker@6.5.0': {}
-
-  '@mui/icons-material@5.18.0(@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(@types/react@18.2.48)(react@18.2.0)':
-    dependencies:
-      '@babel/runtime': 7.28.6
-      '@mui/material': 6.5.0(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      react: 18.2.0
-    optionalDependencies:
-      '@types/react': 18.2.48
 
   '@mui/material@6.5.0(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@emotion/styled@11.14.1(@emotion/react@11.14.0(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react@18.2.0))(@types/react@18.2.48)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
     dependencies:

--- a/src/components/filter/MentorFilterDropdown.tsx
+++ b/src/components/filter/MentorFilterDropdown.tsx
@@ -1,7 +1,5 @@
-import ArrowDropDownIcon from '@mui/icons-material/ArrowDropDown';
-import ArrowDropUpIcon from '@mui/icons-material/ArrowDropUp';
-import FilterListIcon from '@mui/icons-material/FilterList';
 import * as Popover from '@radix-ui/react-popover';
+import { ChevronDown, ChevronUp, ListFilter } from 'lucide-react';
 import React, { useCallback, useEffect, useState } from 'react';
 
 import FilterSelect from '@/components/filter/FilterSelect';
@@ -61,13 +59,13 @@ const MentorFilterDropdown = ({
       <Popover.Trigger asChild>
         <button className="flex h-10 w-full items-center justify-center gap-2 rounded-lg border border-background-border px-4 py-1">
           <div className="flex items-center gap-1">
-            <FilterListIcon className="size-5" />
+            <ListFilter className="size-5" />
             <span>篩選</span>
           </div>
           {open ? (
-            <ArrowDropUpIcon className="size-5" />
+            <ChevronUp className="size-5" />
           ) : (
-            <ArrowDropDownIcon className="size-5" />
+            <ChevronDown className="size-5" />
           )}
         </button>
       </Popover.Trigger>

--- a/src/components/ui/avatar-upload.tsx
+++ b/src/components/ui/avatar-upload.tsx
@@ -67,7 +67,7 @@ const AvatarUpload = <T extends FieldValues>({
           id="fileInput"
           type="file"
           accept="image/*"
-          style={{ display: 'none' }}
+          className="hidden"
           onChange={handleUploadAvatar}
         />
 

--- a/src/components/ui/search-bar.tsx
+++ b/src/components/ui/search-bar.tsx
@@ -1,5 +1,4 @@
-import SearchIcon from '@mui/icons-material/Search';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Search } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -84,7 +83,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
 
   return (
     <div className="flex w-full max-w-[846px] items-center rounded-2xl border border-background-border bg-background-white px-3 py-1.5 md:px-6 md:py-4">
-      <SearchIcon
+      <Search
         className="mr-2 size-6 shrink-0 text-text-tertiary"
         aria-hidden="true"
       />
@@ -115,7 +114,7 @@ const SearchBar: React.FC<SearchBarProps> = ({
           <Loader2 className="size-4 animate-spin" aria-hidden="true" />
         ) : (
           <>
-            <SearchIcon className="size-5 md:hidden" aria-hidden="true" />
+            <Search className="size-5 md:hidden" aria-hidden="true" />
             <span className="hidden md:inline">搜尋</span>
           </>
         )}


### PR DESCRIPTION
- Replace ArrowDropDownIcon, ArrowDropUpIcon, and FilterListIcon in MentorFilterDropdown with ChevronDown, ChevronUp, and ListFilter from lucide-react.
- Replace SearchIcon in SearchBar with Search from lucide-react.
- Convert display inline style of the file input in AvatarUpload to Tailwind CSS's utility class "hidden".
- Remove unused @mui/icons-material imports in these components.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/493
