### PR TITLE
refactor(types): move service VO/DTO types into src/types/ (X-Tracker #497)

### DIFF
--- a/src/app/auth/(sign)/onboarding/container.tsx
+++ b/src/app/auth/(sign)/onboarding/container.tsx
@@ -3,7 +3,7 @@
 import useLocations from '@/hooks/user/country/useLocations';
 import { useOnboardingForm } from '@/hooks/user/onboarding/useOnboardingForm';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import { STEP_TITLE, STEPS_TOTAL } from './data';
 import OnboardingUI from './ui';

--- a/src/app/auth/(sign)/onboarding/ui.stories.tsx
+++ b/src/app/auth/(sign)/onboarding/ui.stories.tsx
@@ -11,13 +11,13 @@ import {
   step4Schema,
   step5Schema,
 } from '@/schemas/onboarding';
-import { LocationType } from '@/services/profile/countries';
 import {
   mockIndustryOptions,
   mockPositionGroups,
   mockSkillGroups,
   mockTopicGroups,
 } from '@/test/fixtures/tagCatalog';
+import type { LocationType } from '@/types/location';
 
 import OnboardingUI from './ui';
 

--- a/src/app/auth/(sign)/onboarding/ui.tsx
+++ b/src/app/auth/(sign)/onboarding/ui.tsx
@@ -15,11 +15,8 @@ import {
   step4Schema,
   step5Schema,
 } from '@/schemas/onboarding';
-import { LocationType } from '@/services/profile/countries';
-import {
-  type IndustryOption,
-  type TagCatalogGroupVO,
-} from '@/services/profile/tagCatalog';
+import type { LocationType } from '@/types/location';
+import type { IndustryOption, TagCatalogGroupVO } from '@/types/tagCatalog';
 
 // Steps 2-5 are only rendered after the user completes step 1.
 // Lazy-load them so their code is excluded from the initial bundle and

--- a/src/app/mentor-pool/MentorPoolWithData.test.tsx
+++ b/src/app/mentor-pool/MentorPoolWithData.test.tsx
@@ -18,10 +18,10 @@ vi.mock('./container', () => ({
 
 import { unstable_noStore } from 'next/cache';
 
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { fetchTagCatalogServer } from '@/services/profile/tagCatalog.server';
-import type { MentorType } from '@/services/search-mentor/mentors';
 import { fetchMentorsServer } from '@/services/search-mentor/mentors.server';
+import type { MentorType } from '@/types/mentor';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import MentorPoolWithData from './MentorPoolWithData';
 

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -10,7 +10,7 @@ import type {
 import { useMentorPool } from '@/hooks/useMentorPool';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { trackEvent } from '@/lib/analytics';
-import { buildTagLabelMap } from '@/services/profile/tagCatalog';
+import { buildTagLabelMap } from '@/lib/profile/tagLabelMap';
 import type { MentorType } from '@/types/mentor';
 import type {
   TagCatalogGroupVO,

--- a/src/app/mentor-pool/container.tsx
+++ b/src/app/mentor-pool/container.tsx
@@ -10,12 +10,12 @@ import type {
 import { useMentorPool } from '@/hooks/useMentorPool';
 import useTagCatalog from '@/hooks/user/tags/useTagCatalog';
 import { trackEvent } from '@/lib/analytics';
-import {
-  buildTagLabelMap,
-  type TagCatalogGroupVO,
-  type TagCatalogsByBucket,
-} from '@/services/profile/tagCatalog';
-import type { MentorType } from '@/services/search-mentor/mentors';
+import { buildTagLabelMap } from '@/services/profile/tagCatalog';
+import type { MentorType } from '@/types/mentor';
+import type {
+  TagCatalogGroupVO,
+  TagCatalogsByBucket,
+} from '@/types/tagCatalog';
 
 import { filterOptions } from './data';
 import {

--- a/src/app/mentor-pool/ui.tsx
+++ b/src/app/mentor-pool/ui.tsx
@@ -11,7 +11,7 @@ import { MentorCardList } from '@/components/mentor-pool/mentor-card-list';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { LoadingSpinner } from '@/components/ui/loading-spinner';
-import { MentorType } from '@/services/search-mentor/mentors';
+import type { MentorType } from '@/types/mentor';
 
 import PopularPositionChips from './PopularPositionChips';
 

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -14,8 +14,8 @@ import { primeTagCatalogCacheIfEmpty } from '@/hooks/user/tags/useTagCatalog';
 import useUserData from '@/hooks/user/user-data/useUserData';
 import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
 import { getMentorOnboardingUrl } from '@/lib/routes';
-import type { MentorProfileVO } from '@/services/profile/user';
 import type { TagCatalogsByBucket } from '@/types/tagCatalog';
+import type { MentorProfileVO } from '@/types/user';
 
 import { ProfilePageSkeleton } from './skeleton';
 

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -14,8 +14,8 @@ import { primeTagCatalogCacheIfEmpty } from '@/hooks/user/tags/useTagCatalog';
 import useUserData from '@/hooks/user/user-data/useUserData';
 import { primeUserProfileDtoCacheIfEmpty } from '@/hooks/user/user-data/useUserProfileDto';
 import { getMentorOnboardingUrl } from '@/lib/routes';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import { ProfilePageSkeleton } from './skeleton';
 

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -134,8 +134,8 @@ vi.mock('@/components/profile/edit/LinkSection', () => ({
 import * as useEditProfileFormModule from '@/hooks/user/profile/useEditProfileForm';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { MentorProfileVO } from '@/services/profile/user';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import EditProfileContainer from './container';
 

--- a/src/app/profile/[pageUserId]/edit/container.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.test.tsx
@@ -134,8 +134,8 @@ vi.mock('@/components/profile/edit/LinkSection', () => ({
 import * as useEditProfileFormModule from '@/hooks/user/profile/useEditProfileForm';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import { MentorProfileVO } from '@/services/profile/user';
 import type { TagCatalogsByBucket } from '@/types/tagCatalog';
+import { MentorProfileVO } from '@/types/user';
 
 import EditProfileContainer from './container';
 

--- a/src/app/profile/[pageUserId]/edit/container.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.tsx
@@ -39,7 +39,7 @@ import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
 import { mapVoToFormValues } from '@/lib/profile/profileSaveAdapter';
 import { MENTOR_ONBOARDING_KEY } from '@/lib/routes';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 const JobExperienceSection = dynamic(
   async () => {

--- a/src/app/profile/[pageUserId]/edit/container.validation.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.validation.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { MentorProfileVO } from '@/services/profile/user';
 import type { TagCatalogsByBucket } from '@/types/tagCatalog';
+import { MentorProfileVO } from '@/types/user';
 
 // mock navigate & searchParams
 vi.mock('next/navigation', () => ({

--- a/src/app/profile/[pageUserId]/edit/container.validation.test.tsx
+++ b/src/app/profile/[pageUserId]/edit/container.validation.test.tsx
@@ -2,8 +2,8 @@ import { fireEvent, render, waitFor } from '@testing-library/react';
 import React from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { MentorProfileVO } from '@/services/profile/user';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 // mock navigate & searchParams
 vi.mock('next/navigation', () => ({

--- a/src/app/profile/[pageUserId]/page.tsx
+++ b/src/app/profile/[pageUserId]/page.tsx
@@ -4,10 +4,10 @@ import { getServerSession } from 'next-auth/next';
 
 import authOptions from '@/auth.config';
 import { PersonJsonLd } from '@/components/seo/PersonJsonLd';
+import { buildTagLabelMap } from '@/lib/profile/tagLabelMap';
 import { buildMentorMetadata } from '@/lib/seo/buildMentorMetadata';
 import { sanitizePublicProfile } from '@/lib/seo/sanitizePublicProfile';
 import { getSiteUrl } from '@/lib/site-url';
-import { buildTagLabelMap } from '@/services/profile/tagCatalog';
 import { fetchTagCatalogServer } from '@/services/profile/tagCatalog.server';
 import { fetchUserByIdServer } from '@/services/profile/user.server';
 

--- a/src/components/mentor-pool/__mocks__/mentors.mock.ts
+++ b/src/components/mentor-pool/__mocks__/mentors.mock.ts
@@ -1,5 +1,5 @@
 import defaultAvatar from '@/assets/default-avatar.png';
-import { MentorType } from '@/services/search-mentor/mentors';
+import { MentorType } from '@/types/mentor';
 
 export const mockMentors: MentorType[] = [
   {

--- a/src/components/mentor-pool/mentor-card-list/index.tsx
+++ b/src/components/mentor-pool/mentor-card-list/index.tsx
@@ -1,6 +1,6 @@
 import { memo, useEffect, useRef } from 'react';
 
-import { MentorType } from '@/services/search-mentor/mentors';
+import { MentorType } from '@/types/mentor';
 
 import { MentorCard } from '../mentor-card';
 

--- a/src/components/onboarding/steps/InterestedPosition.tsx
+++ b/src/components/onboarding/steps/InterestedPosition.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import { step3Schema } from './index';
 import { TagMultiSelect } from './TagMultiSelect';

--- a/src/components/onboarding/steps/PersonalInfo.stories.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 import React from 'react';
 
-import { LocationType } from '@/services/profile/countries';
-import { type IndustryOption } from '@/services/profile/tagCatalog';
+import { LocationType } from '@/types/location';
+import { type IndustryOption } from '@/types/tagCatalog';
 
 import { step2Schema } from './index';
 import { OnboardingStoryWrapper } from './OnboardingStoryWrapper';

--- a/src/components/onboarding/steps/PersonalInfo.tsx
+++ b/src/components/onboarding/steps/PersonalInfo.tsx
@@ -19,8 +19,8 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { totalWorkSpanOptions } from '@/constant/seniority';
-import { LocationType } from '@/services/profile/countries';
-import { type IndustryOption } from '@/services/profile/tagCatalog';
+import { LocationType } from '@/types/location';
+import { type IndustryOption } from '@/types/tagCatalog';
 
 import { step2Schema } from './index';
 

--- a/src/components/onboarding/steps/SkillsToImprove.tsx
+++ b/src/components/onboarding/steps/SkillsToImprove.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import { step4Schema } from './index';
 import { TagMultiSelect } from './TagMultiSelect';

--- a/src/components/onboarding/steps/TagMultiSelect.test.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.test.tsx
@@ -5,7 +5,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import * as z from 'zod';
 
 import { Form } from '@/components/ui/form';
-import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import { TagMultiSelect } from './TagMultiSelect';
 

--- a/src/components/onboarding/steps/TagMultiSelect.tsx
+++ b/src/components/onboarding/steps/TagMultiSelect.tsx
@@ -12,7 +12,7 @@ import {
 } from '@/components/ui/form';
 import { tagGroupsToCategories } from '@/lib/profile/categoryGrouping';
 import { cn } from '@/lib/utils';
-import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import { GroupedSelections } from './GroupedSelections';
 

--- a/src/components/onboarding/steps/TopicsToDiscuss.tsx
+++ b/src/components/onboarding/steps/TopicsToDiscuss.tsx
@@ -4,7 +4,7 @@ import { FC } from 'react';
 import { useForm } from 'react-hook-form';
 import * as z from 'zod';
 
-import { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import { step5Schema } from './index';
 import { TagMultiSelect } from './TagMultiSelect';

--- a/src/components/reservation/AcceptReservationDialog.tsx
+++ b/src/components/reservation/AcceptReservationDialog.tsx
@@ -19,8 +19,7 @@ import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDial
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
-
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 interface Props {
   reservation: Reservation;

--- a/src/components/reservation/CancelReservationDialog.tsx
+++ b/src/components/reservation/CancelReservationDialog.tsx
@@ -18,8 +18,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDialog';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
-
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 interface Props {
   reservation: Reservation;

--- a/src/components/reservation/RejectReservationDialog.tsx
+++ b/src/components/reservation/RejectReservationDialog.tsx
@@ -18,8 +18,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { useConfirmActionDialog } from '@/hooks/reservation/useConfirmActionDialog';
 import { trackEvent } from '@/lib/analytics';
 import { cn } from '@/lib/utils';
-
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 interface Props {
   reservation: Reservation;

--- a/src/components/reservation/ReservationCard.tsx
+++ b/src/components/reservation/ReservationCard.tsx
@@ -7,8 +7,7 @@ import { ReservationStatusBadge } from '@/components/reservation/ReservationStat
 import { Avatar, AvatarFallback } from '@/components/ui/avatar';
 import { Card, CardContent } from '@/components/ui/card';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
-
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 export type ReservationCardVariant = 'upcoming' | 'pending' | 'history';
 

--- a/src/components/reservation/ReservationConversationDialog.stories.tsx
+++ b/src/components/reservation/ReservationConversationDialog.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from '@storybook/nextjs';
 
+import type { Reservation } from '@/types/reservation';
+
 import { mockReservation } from './mocks';
 import ReservationConversationDialog from './ReservationConversationDialog';
-import type { Reservation } from './types';
 
 const meta: Meta<typeof ReservationConversationDialog> = {
   title: '業務模組元件/預約管理(Reservation)/ReservationConversationDialog',

--- a/src/components/reservation/ReservationConversationDialog.tsx
+++ b/src/components/reservation/ReservationConversationDialog.tsx
@@ -15,8 +15,11 @@ import {
 import { trackEvent } from '@/lib/analytics';
 import { getAvatarThumbUrl } from '@/lib/avatar/getAvatarThumbUrl';
 import { cn } from '@/lib/utils';
-
-import type { MessageRole, Reservation, ReservationMessage } from './types';
+import type {
+  MessageRole,
+  Reservation,
+  ReservationMessage,
+} from '@/types/reservation';
 
 interface Props {
   reservation: Reservation;

--- a/src/components/reservation/ReservationDashboard.tsx
+++ b/src/components/reservation/ReservationDashboard.tsx
@@ -10,8 +10,7 @@ import {
   type ReservationRole,
   useReservationData,
 } from '@/hooks/user/reservation/useReservationData';
-
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 export interface ReservationDashboardProps {
   userRole: ReservationRole;

--- a/src/components/reservation/ReservationList.test.tsx
+++ b/src/components/reservation/ReservationList.test.tsx
@@ -8,7 +8,7 @@ import {
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { updateReservationStatus } from '@/services/reservations';
-import type { Reservation } from '@/services/reservations/types';
+import type { Reservation } from '@/types/reservation';
 
 import { ReservationList } from './ReservationList';
 

--- a/src/components/reservation/ReservationList.tsx
+++ b/src/components/reservation/ReservationList.tsx
@@ -11,12 +11,12 @@ import { useReservationActions } from '@/hooks/user/reservation/useReservationAc
 import { ListKey } from '@/hooks/user/reservation/useReservationData';
 import { trackEvent } from '@/lib/analytics';
 import { resolveCounterpartyId } from '@/lib/reservation/resolveCounterparty';
+import type { Reservation } from '@/types/reservation';
 
 import {
   ReservationCard,
   type ReservationCardVariant,
 } from './ReservationCard';
-import type { Reservation } from './types';
 
 type Variant = 'upcoming' | 'pending-mentee' | 'pending-mentor' | 'history';
 type SourceRole = 'mentor' | 'mentee';

--- a/src/components/reservation/__mocks__/reservations.mock.ts
+++ b/src/components/reservation/__mocks__/reservations.mock.ts
@@ -1,4 +1,4 @@
-import type { Reservation } from '../types';
+import type { Reservation } from '@/types/reservation';
 
 const nowSeconds = Math.floor(Date.now() / 1000);
 

--- a/src/components/reservation/mocks.ts
+++ b/src/components/reservation/mocks.ts
@@ -1,4 +1,4 @@
-import type { Reservation } from './types';
+import type { Reservation } from '@/types/reservation';
 
 // Standard mock base for a reservation, shared across all reservation-related stories
 export const mockReservation: Reservation = {

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,1 +1,0 @@
-export * from '@/types/reservation';

--- a/src/components/reservation/types.ts
+++ b/src/components/reservation/types.ts
@@ -1,1 +1,1 @@
-export * from '@/services/reservations/types';
+export * from '@/types/reservation';

--- a/src/components/ui/avatar-crop-modal.tsx
+++ b/src/components/ui/avatar-crop-modal.tsx
@@ -144,7 +144,7 @@ const AvatarCropModal: React.FC<AvatarCropModalProps> = ({
           min={MIN_SCALE}
           max={MAX_SCALE}
           step={0.1}
-          onValueChange={(value) => setZoomScale(value[0])}
+          onValueChange={(value: number[]) => setZoomScale(value[0])}
         />
         <div className="mt-4 flex justify-center gap-3">
           <Button

--- a/src/hooks/useMentorPool.test.ts
+++ b/src/hooks/useMentorPool.test.ts
@@ -18,12 +18,10 @@ vi.mock('@/services/search-mentor/mentors', () => ({
 
 import { PAGE_LIMIT } from '@/app/mentor-pool/constants';
 import avatarImage from '@/assets/default-avatar.png';
-import {
-  fetchMentors,
-  type MentorType,
-} from '@/services/search-mentor/mentors';
+import { fetchMentors } from '@/services/search-mentor/mentors';
 import { mockSearchParams } from '@/test/mocks/navigation';
 import { mockToast } from '@/test/mocks/useToast';
+import type { MentorType } from '@/types/mentor';
 
 import {
   applyMentorPage,

--- a/src/hooks/useMentorPool.ts
+++ b/src/hooks/useMentorPool.ts
@@ -10,10 +10,8 @@ import {
 } from '@/app/mentor-pool/searchParams';
 import { useToast } from '@/components/ui/use-toast';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
-import {
-  fetchMentors,
-  type MentorType,
-} from '@/services/search-mentor/mentors';
+import { fetchMentors } from '@/services/search-mentor/mentors';
+import type { MentorType } from '@/types/mentor';
 
 export interface MentorPoolPageState {
   mentors: MentorType[];

--- a/src/hooks/user/country/useLocations.test.tsx
+++ b/src/hooks/user/country/useLocations.test.tsx
@@ -2,7 +2,8 @@ import { renderHook, waitFor } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { getCountries, LocationType } from '@/services/profile/countries';
+import { getCountries } from '@/services/profile/countries';
+import type { LocationType } from '@/types/location';
 
 import useLocations, { locationsCache } from './useLocations';
 

--- a/src/hooks/user/country/useLocations.ts
+++ b/src/hooks/user/country/useLocations.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import { createKeyedCache } from '@/lib/createKeyedCache';
-import { getCountries, LocationType } from '@/services/profile/countries';
+import { getCountries } from '@/services/profile/countries';
+import type { LocationType } from '@/types/location';
 
 export const LOCATIONS_CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
 

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import type { IndustryOption } from '@/services/profile/tagCatalog';
+import type { IndustryOption } from '@/types/tagCatalog';
 
 import { buildOnboardingDtoStub } from './buildOnboardingDtoStub';
 

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
@@ -1,5 +1,5 @@
-import type { IndustryOption } from '@/services/profile/tagCatalog';
 import type { MentorProfileVO } from '@/services/profile/user';
+import type { IndustryOption } from '@/types/tagCatalog';
 
 export interface OnboardingStubInput {
   name?: string | null;

--- a/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
+++ b/src/hooks/user/onboarding/buildOnboardingDtoStub.ts
@@ -1,5 +1,5 @@
-import type { MentorProfileVO } from '@/services/profile/user';
 import type { IndustryOption } from '@/types/tagCatalog';
+import type { MentorProfileVO } from '@/types/user';
 
 export interface OnboardingStubInput {
   name?: string | null;

--- a/src/hooks/user/onboarding/useOnboardingForm.test.ts
+++ b/src/hooks/user/onboarding/useOnboardingForm.test.ts
@@ -7,7 +7,7 @@ import { useToast } from '@/components/ui/use-toast';
 import { useOnboardingSubmit } from '@/hooks/user/onboarding/useOnboardingSubmit';
 import { useBackgroundAvatarUpload } from '@/hooks/user/profile/useBackgroundAvatarUpload';
 import { trackEvent } from '@/lib/analytics';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import { useOnboardingForm } from './useOnboardingForm';
 

--- a/src/hooks/user/onboarding/useOnboardingForm.ts
+++ b/src/hooks/user/onboarding/useOnboardingForm.ts
@@ -19,7 +19,7 @@ import {
   step4Schema,
   step5Schema,
 } from '@/schemas/onboarding';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 interface Options {
   industries: TagCatalogsByBucket['industry'];

--- a/src/hooks/user/onboarding/useOnboardingSubmit.test.ts
+++ b/src/hooks/user/onboarding/useOnboardingSubmit.test.ts
@@ -8,8 +8,8 @@ import {
   primeUserDataCache,
 } from '@/hooks/user/user-data/useUserData';
 import { captureFlowFailure } from '@/lib/monitoring';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { updateProfile } from '@/services/profile/updateProfile';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import { useOnboardingSubmit } from './useOnboardingSubmit';
 

--- a/src/hooks/user/onboarding/useOnboardingSubmit.ts
+++ b/src/hooks/user/onboarding/useOnboardingSubmit.ts
@@ -9,8 +9,8 @@ import {
 } from '@/hooks/user/user-data/useUserData';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { formSchema } from '@/schemas/onboarding';
-import type { TagCatalogsByBucket } from '@/services/profile/tagCatalog';
 import { updateProfile } from '@/services/profile/updateProfile';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 interface Options {
   industries: TagCatalogsByBucket['industry'];

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -11,7 +11,7 @@ import {
 } from 'vitest';
 
 import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
-import { MentorProfileVO } from '@/services/profile/user';
+import { MentorProfileVO } from '@/types/user';
 
 import { useEditProfileData } from './useEditProfileData';
 

--- a/src/hooks/user/reservation/useReservationActions.test.ts
+++ b/src/hooks/user/reservation/useReservationActions.test.ts
@@ -26,11 +26,11 @@ vi.mock('@/services/reservations', async (importOriginal) => {
   };
 });
 
-import type { Reservation } from '@/components/reservation/types';
 import {
   acceptReservation,
   rejectOrCancelReservation,
 } from '@/services/reservations';
+import type { Reservation } from '@/types/reservation';
 
 import {
   buildRejectOrCancelAffectedTabs,

--- a/src/hooks/user/reservation/useReservationActions.ts
+++ b/src/hooks/user/reservation/useReservationActions.ts
@@ -1,6 +1,5 @@
 import { useCallback } from 'react';
 
-import { Reservation } from '@/components/reservation/types';
 import { useToast } from '@/components/ui/use-toast';
 import { useAsyncAction } from '@/hooks/useAsyncAction';
 import { ListKey } from '@/hooks/user/reservation/useReservationData';
@@ -9,6 +8,7 @@ import {
   acceptReservation,
   rejectOrCancelReservation,
 } from '@/services/reservations';
+import { Reservation } from '@/types/reservation';
 
 export type Variant =
   | 'upcoming'

--- a/src/hooks/user/reservation/useReservationData.ts
+++ b/src/hooks/user/reservation/useReservationData.ts
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import { trackEvent } from '@/lib/analytics';
 import { captureFlowFailure } from '@/lib/monitoring';
 import { fetchReservations, ReservationState } from '@/services/reservations';
-import { Reservation } from '@/services/reservations/types';
+import { Reservation } from '@/types/reservation';
 
 export type ReservationRole = 'mentee' | 'mentor';
 

--- a/src/hooks/user/tags/useTagCatalog.ts
+++ b/src/hooks/user/tags/useTagCatalog.ts
@@ -4,8 +4,8 @@ import { createKeyedCache } from '@/lib/createKeyedCache';
 import {
   EMPTY_TAG_CATALOGS,
   fetchTagCatalog,
-  type TagCatalogsByBucket,
 } from '@/services/profile/tagCatalog';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 const tagCatalogCache = createKeyedCache<string, TagCatalogsByBucket>();
 

--- a/src/hooks/user/user-data/useUserData.test.ts
+++ b/src/hooks/user/user-data/useUserData.test.ts
@@ -5,7 +5,8 @@ vi.mock('@/services/profile/user', () => ({
   fetchUserById: vi.fn(),
 }));
 
-import { fetchUserById, type MentorProfileVO } from '@/services/profile/user';
+import { fetchUserById } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 import useUserData, {
   clearUserDataCache,

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -8,11 +8,9 @@ import {
   type WorkExperienceMetadata,
 } from '@/lib/profile/experienceCodec';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
-import {
-  buildTagLabelMap,
-  type TagCatalogsByBucket,
-} from '@/services/profile/tagCatalog';
+import { buildTagLabelMap } from '@/services/profile/tagCatalog';
 import { MentorProfileVO } from '@/services/profile/user';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
 import {
   clearUserProfileDtoCache,

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -8,9 +8,9 @@ import {
   type WorkExperienceMetadata,
 } from '@/lib/profile/experienceCodec';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
-import { buildTagLabelMap } from '@/services/profile/tagCatalog';
-import { MentorProfileVO } from '@/services/profile/user';
+import { buildTagLabelMap } from '@/lib/profile/tagLabelMap';
 import type { TagCatalogsByBucket } from '@/types/tagCatalog';
+import type { MentorProfileVO } from '@/types/user';
 
 import {
   clearUserProfileDtoCache,

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react';
 
 import { createKeyedCache } from '@/lib/createKeyedCache';
-import { fetchUserById, MentorProfileVO } from '@/services/profile/user';
+import { fetchUserById } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 export const USER_PROFILE_DTO_CACHE_TTL_MS = 60_000;
 

--- a/src/lib/profile/categoryGrouping.test.ts
+++ b/src/lib/profile/categoryGrouping.test.ts
@@ -1,7 +1,7 @@
 import { fromPartial } from '@total-typescript/shoehorn';
 import { describe, expect, it } from 'vitest';
 
-import type { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import type { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 import {
   flattenAsSingleCategory,

--- a/src/lib/profile/categoryGrouping.ts
+++ b/src/lib/profile/categoryGrouping.ts
@@ -1,5 +1,5 @@
 import type { Category } from '@/components/ui/category-multi-select';
-import type { TagCatalogGroupVO } from '@/services/profile/tagCatalog';
+import type { TagCatalogGroupVO } from '@/types/tagCatalog';
 
 interface SubjectItem {
   subject: string | null;

--- a/src/lib/profile/pollUntilSynced.test.ts
+++ b/src/lib/profile/pollUntilSynced.test.ts
@@ -9,7 +9,8 @@ vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
 import { fromAny, fromPartial } from '@total-typescript/shoehorn';
 
 import { defaultValues } from '@/schemas/profileSchema';
-import { fetchUser, type MentorProfileVO } from '@/services/profile/user';
+import { fetchUser } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 import { firstSyncedFetch } from './pollUntilSynced';
 

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,7 +1,8 @@
 import { captureFlowFailure } from '@/lib/monitoring';
 import { isProfileSynced } from '@/lib/profile/profileSaveAdapter';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import { fetchUser, MentorProfileVO } from '@/services/profile/user';
+import { fetchUser } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 /**
  * Single, fast attempt to read the latest profile and confirm it matches the

--- a/src/lib/profile/profileSaveAdapter.test.ts
+++ b/src/lib/profile/profileSaveAdapter.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 
 import { defaultValues, ProfileFormValues } from '@/schemas/profileSchema';
-import { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 import {
   computeDirtyStates,

--- a/src/lib/profile/profileSaveAdapter.ts
+++ b/src/lib/profile/profileSaveAdapter.ts
@@ -5,7 +5,7 @@ import {
 } from '@/lib/profile/parseUserExperiences';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 import { defaultValues, ProfileFormValues } from '@/schemas/profileSchema';
-import { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 export type ProfileDirtyFields = Partial<
   Record<keyof ProfileFormValues, unknown>

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -30,8 +30,8 @@ import {
 import { ExperienceType } from '@/services/profile/experienceType';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
-import type { MentorProfileVO } from '@/services/profile/user';
 import { baseValues, mockSession, mockUserDTO } from '@/test/fixtures/profile';
+import type { MentorProfileVO } from '@/types/user';
 
 import { saveProfile, SaveProfileDeps } from './saveProfile';
 

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -16,7 +16,7 @@ import {
 import { ProfileFormValues } from '@/schemas/profileSchema';
 import { updateAvatar } from '@/services/profile/updateAvatar';
 import { updateProfile } from '@/services/profile/updateProfile';
-import { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 export class LoggedError extends Error {
   constructor(message?: string, options?: ErrorOptions) {

--- a/src/lib/profile/tagLabelMap.ts
+++ b/src/lib/profile/tagLabelMap.ts
@@ -1,0 +1,21 @@
+import { TAG_BUCKET_KEYS, type TagCatalogsByBucket } from '@/types/tagCatalog';
+
+// Build a Map<subject_group, subject> from the bucket-shaped catalog so
+// callers can resolve raw subject_group codes to localized labels in O(1).
+// Includes leaves from all bucket groups plus flat industries.
+export function buildTagLabelMap(
+  catalogs: TagCatalogsByBucket
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const key of TAG_BUCKET_KEYS) {
+    for (const group of catalogs[key] ?? []) {
+      for (const leaf of group.leaves ?? []) {
+        map.set(leaf.subject_group, leaf.subject);
+      }
+    }
+  }
+  for (const ind of catalogs.industry) {
+    map.set(ind.subject_group, ind.subject);
+  }
+  return map;
+}

--- a/src/lib/seo/sanitizePublicProfile.test.ts
+++ b/src/lib/seo/sanitizePublicProfile.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { ExperienceType } from '@/services/profile/experienceType';
-import type { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 import { sanitizePublicProfile } from './sanitizePublicProfile';
 

--- a/src/lib/seo/sanitizePublicProfile.ts
+++ b/src/lib/seo/sanitizePublicProfile.ts
@@ -2,7 +2,7 @@ import type { MentorExperiencePayload } from '@/lib/profile/experienceCodec';
 import { decode } from '@/lib/profile/experienceCodec';
 import { readIndustryTag } from '@/lib/profile/readIndustryTag';
 import { isSafeUrl } from '@/lib/url/isSafeUrl';
-import type { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 export type SocialPlatform =
   | 'linkedin'

--- a/src/services/profile/countries.ts
+++ b/src/services/profile/countries.ts
@@ -1,7 +1,6 @@
-export interface LocationType {
-  value: string;
-  text: string;
-}
+import type { LocationType } from '@/types/location';
+
+export type { LocationType };
 
 async function loadTable(language: string): Promise<Record<string, string>> {
   if (language === 'en_US') {

--- a/src/services/profile/countries.ts
+++ b/src/services/profile/countries.ts
@@ -1,7 +1,5 @@
 import type { LocationType } from '@/types/location';
 
-export type { LocationType };
-
 async function loadTable(language: string): Promise<Record<string, string>> {
   if (language === 'en_US') {
     return (await import('@/data/countries.en_US.json')).default;

--- a/src/services/profile/tagCatalog.server.ts
+++ b/src/services/profile/tagCatalog.server.ts
@@ -1,11 +1,8 @@
 import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
+import type { TagCatalogsByBucket } from '@/types/tagCatalog';
 
-import {
-  EMPTY_TAG_CATALOGS,
-  splitCatalogsByBucket,
-  type TagCatalogsByBucket,
-} from './tagCatalog';
+import { EMPTY_TAG_CATALOGS, splitCatalogsByBucket } from './tagCatalog';
 
 const REVALIDATE_SECONDS = 86400;
 

--- a/src/services/profile/tagCatalog.test.ts
+++ b/src/services/profile/tagCatalog.test.ts
@@ -2,8 +2,8 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient } from '@/lib/apiClient';
+import type { TagCatalogsByBucket, TagCatalogsVO } from '@/types/tagCatalog';
 
-import type { TagCatalogsByBucket, TagCatalogsVO } from './tagCatalog';
 import {
   buildTagLabelMap,
   EMPTY_TAG_CATALOGS,

--- a/src/services/profile/tagCatalog.test.ts
+++ b/src/services/profile/tagCatalog.test.ts
@@ -2,10 +2,10 @@ import { fromPartial } from '@total-typescript/shoehorn';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient } from '@/lib/apiClient';
+import { buildTagLabelMap } from '@/lib/profile/tagLabelMap';
 import type { TagCatalogsByBucket, TagCatalogsVO } from '@/types/tagCatalog';
 
 import {
-  buildTagLabelMap,
   EMPTY_TAG_CATALOGS,
   fetchTagCatalog,
   splitCatalogsByBucket,

--- a/src/services/profile/tagCatalog.ts
+++ b/src/services/profile/tagCatalog.ts
@@ -2,22 +2,10 @@ import { apiClient } from '@/lib/apiClient';
 import type {
   IndustryOption,
   TagBucketKey,
-  TagCatalogGroupVO,
-  TagCatalogLeafVO,
   TagCatalogsByBucket,
   TagCatalogsVO,
   TagCatalogVO,
 } from '@/types/tagCatalog';
-
-export type {
-  IndustryOption,
-  TagBucketKey,
-  TagCatalogGroupVO,
-  TagCatalogLeafVO,
-  TagCatalogsByBucket,
-  TagCatalogsVO,
-  TagCatalogVO,
-};
 
 export const TAG_BUCKET_KEYS: readonly TagBucketKey[] = [
   'want_position',

--- a/src/services/profile/tagCatalog.ts
+++ b/src/services/profile/tagCatalog.ts
@@ -1,19 +1,10 @@
 import { apiClient } from '@/lib/apiClient';
-import type {
+import {
   IndustryOption,
-  TagBucketKey,
   TagCatalogsByBucket,
   TagCatalogsVO,
   TagCatalogVO,
 } from '@/types/tagCatalog';
-
-export const TAG_BUCKET_KEYS: readonly TagBucketKey[] = [
-  'want_position',
-  'want_skill',
-  'want_topic',
-  'have_skill',
-  'have_topic',
-];
 
 export const EMPTY_TAG_CATALOGS: TagCatalogsByBucket = {
   want_position: [],
@@ -72,24 +63,4 @@ export async function fetchTagCatalog(
     console.error('獲取 tag catalog 失敗:', error);
     return EMPTY_TAG_CATALOGS;
   }
-}
-
-// Build a Map<subject_group, subject> from the bucket-shaped catalog so
-// callers can resolve raw subject_group codes to localized labels in O(1).
-// Includes leaves from all bucket groups plus flat industries.
-export function buildTagLabelMap(
-  catalogs: TagCatalogsByBucket
-): Map<string, string> {
-  const map = new Map<string, string>();
-  for (const key of TAG_BUCKET_KEYS) {
-    for (const group of catalogs[key] ?? []) {
-      for (const leaf of group.leaves ?? []) {
-        map.set(leaf.subject_group, leaf.subject);
-      }
-    }
-  }
-  for (const ind of catalogs.industry) {
-    map.set(ind.subject_group, ind.subject);
-  }
-  return map;
 }

--- a/src/services/profile/tagCatalog.ts
+++ b/src/services/profile/tagCatalog.ts
@@ -1,17 +1,23 @@
 import { apiClient } from '@/lib/apiClient';
-import type { components } from '@/types/api';
+import type {
+  IndustryOption,
+  TagBucketKey,
+  TagCatalogGroupVO,
+  TagCatalogLeafVO,
+  TagCatalogsByBucket,
+  TagCatalogsVO,
+  TagCatalogVO,
+} from '@/types/tagCatalog';
 
-export type TagCatalogsVO = components['schemas']['TagCatalogsVO'];
-export type TagCatalogVO = components['schemas']['TagCatalogVO'];
-export type TagCatalogGroupVO = components['schemas']['TagCatalogGroupVO'];
-export type TagCatalogLeafVO = components['schemas']['TagCatalogLeafVO'];
-
-export type TagBucketKey =
-  | 'want_position'
-  | 'want_skill'
-  | 'want_topic'
-  | 'have_skill'
-  | 'have_topic';
+export type {
+  IndustryOption,
+  TagBucketKey,
+  TagCatalogGroupVO,
+  TagCatalogLeafVO,
+  TagCatalogsByBucket,
+  TagCatalogsVO,
+  TagCatalogVO,
+};
 
 export const TAG_BUCKET_KEYS: readonly TagBucketKey[] = [
   'want_position',
@@ -20,20 +26,6 @@ export const TAG_BUCKET_KEYS: readonly TagBucketKey[] = [
   'have_skill',
   'have_topic',
 ];
-
-export interface IndustryOption {
-  subject_group: string;
-  subject: string;
-}
-
-type TagBuckets = Record<TagBucketKey, TagCatalogGroupVO[]>;
-
-// Industry lives alongside the 5 nested buckets in the same response payload.
-// Buckets stay Record-iterable for callers that loop over TAG_BUCKET_KEYS;
-// industry is flat (no group/leaf hierarchy) so it sits next to them.
-export interface TagCatalogsByBucket extends TagBuckets {
-  industry: IndustryOption[];
-}
 
 export const EMPTY_TAG_CATALOGS: TagCatalogsByBucket = {
   want_position: [],
@@ -83,9 +75,10 @@ export async function fetchTagCatalog(
   language: string
 ): Promise<TagCatalogsByBucket> {
   try {
-    const data = await apiClient.getUnwrapped<
-      components['schemas']['TagCatalogsVO']
-    >(`/v1/users/${language}/tags/catalog`, { auth: false });
+    const data = await apiClient.getUnwrapped<TagCatalogsVO>(
+      `/v1/users/${language}/tags/catalog`,
+      { auth: false }
+    );
     return splitCatalogsByBucket(data);
   } catch (error) {
     console.error('獲取 tag catalog 失敗:', error);

--- a/src/services/profile/user.server.ts
+++ b/src/services/profile/user.server.ts
@@ -1,7 +1,6 @@
 import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
-
-import type { MentorProfileVO } from './user';
+import type { MentorProfileVO } from '@/types/user';
 
 const REVALIDATE_SECONDS = 60;
 

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -1,9 +1,7 @@
 import { getSession } from 'next-auth/react';
 
 import { apiClient } from '@/lib/apiClient';
-import type { components } from '@/types/api';
-
-export type MentorProfileVO = components['schemas']['MentorProfileVO'];
+import type { MentorProfileVO } from '@/types/user';
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
@@ -29,9 +27,10 @@ export async function fetchUserById(
   signal?: AbortSignal
 ): Promise<MentorProfileVO | null> {
   try {
-    const data = await apiClient.getUnwrapped<
-      components['schemas']['MentorProfileVO']
-    >(`/v1/mentors/${userId}/${language}/profile`, { auth: false, signal });
+    const data = await apiClient.getUnwrapped<MentorProfileVO>(
+      `/v1/mentors/${userId}/${language}/profile`,
+      { auth: false, signal }
+    );
 
     return data ?? null;
   } catch (error) {

--- a/src/services/reservations/reservationMutations.test.ts
+++ b/src/services/reservations/reservationMutations.test.ts
@@ -39,7 +39,7 @@ import {
   acceptReservation,
   rejectOrCancelReservation,
 } from '@/services/reservations';
-import type { Reservation } from '@/services/reservations/types';
+import type { Reservation } from '@/types/reservation';
 
 const mockPut = vi.mocked(apiClient.put);
 const mockCaptureFailure = vi.mocked(captureFlowFailure);

--- a/src/services/reservations/reservationMutations.ts
+++ b/src/services/reservations/reservationMutations.ts
@@ -1,6 +1,6 @@
 import { captureFlowFailure } from '@/lib/monitoring';
 import { resolveCounterpartyId } from '@/lib/reservation/resolveCounterparty';
-import { Reservation } from '@/services/reservations/types';
+import { Reservation } from '@/types/reservation';
 
 import { updateReservationStatus } from './reservationService';
 

--- a/src/services/reservations/reservationService.ts
+++ b/src/services/reservations/reservationService.ts
@@ -2,8 +2,8 @@ import dayjs from 'dayjs';
 
 import { apiClient, FetchApiError } from '@/lib/apiClient';
 import { resolveCounterpartyProfile } from '@/lib/reservation/resolveCounterparty';
-import { Reservation, ReservationMessage } from '@/services/reservations/types';
 import { components } from '@/types/api';
+import { Reservation, ReservationMessage } from '@/types/reservation';
 
 export type ReservationState =
   | 'MENTOR_UPCOMING'

--- a/src/services/reservations/types.ts
+++ b/src/services/reservations/types.ts
@@ -1,37 +1,7 @@
-export type MessageRole = 'MENTEE' | 'MENTOR';
+import type {
+  MessageRole,
+  Reservation,
+  ReservationMessage,
+} from '@/types/reservation';
 
-export type ReservationMessage = {
-  content: string;
-  // Resolved party for this message. Undefined when neither the message's own
-  // role nor the sender/participant fallback could classify it.
-  role?: MessageRole;
-};
-
-export type Reservation = {
-  id: string;
-  name: string;
-  avatar?: string;
-  roleLine: string;
-  date: string;
-  time: string;
-  // Full conversation in the order returned by the API. Empty when no messages.
-  messages: ReservationMessage[];
-  // Latest message authored by each party — derived from `messages` for the
-  // card preview. Either side may be undefined when that party hasn't written.
-  menteeMessage?: ReservationMessage;
-  mentorMessage?: ReservationMessage;
-
-  // Required by the PUT reservation status endpoint
-  scheduleId: number;
-  dtstart: number;
-  dtend: number;
-
-  // Both user ids are kept so we can reliably determine which side the current user is on
-  senderUserId: number | string;
-  participantUserId: number | string;
-
-  // Set when either side rejected/cancelled. Value is the canceller's role so
-  // the UI can render "已由導師/學員取消" on both mentor and mentee pages.
-  // Participant (other side) takes precedence when both are REJECT.
-  cancelledBy?: 'MENTEE' | 'MENTOR';
-};
+export type { MessageRole, Reservation, ReservationMessage };

--- a/src/services/reservations/types.ts
+++ b/src/services/reservations/types.ts
@@ -1,7 +1,0 @@
-import type {
-  MessageRole,
-  Reservation,
-  ReservationMessage,
-} from '@/types/reservation';
-
-export type { MessageRole, Reservation, ReservationMessage };

--- a/src/services/search-mentor/mapMentor.test.ts
+++ b/src/services/search-mentor/mapMentor.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 
 import avatarImage from '@/assets/default-avatar.png';
 import type { components } from '@/types/api';
+import type { MentorType } from '@/types/mentor';
 
-import { mapMentor, type MentorType, resolveMentorAvatar } from './mapMentor';
+import { mapMentor, resolveMentorAvatar } from './mapMentor';
 
 type RawMentor = components['schemas']['SearchMentorProfileVO'];
 

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -1,21 +1,5 @@
 import avatarImage from '@/assets/default-avatar.png';
-import type {
-  MentorListResponse,
-  MentorRequest,
-  MentorsType,
-  MentorType,
-  RawMentor,
-  WorkExperienceMetadata,
-} from '@/types/mentor';
-
-export type {
-  MentorListResponse,
-  MentorRequest,
-  MentorsType,
-  MentorType,
-  RawMentor,
-  WorkExperienceMetadata,
-};
+import type { MentorType, RawMentor } from '@/types/mentor';
 
 function readCodes(codes: ReadonlyArray<string> | null | undefined): string[] {
   if (!codes) return [];

--- a/src/services/search-mentor/mapMentor.ts
+++ b/src/services/search-mentor/mapMentor.ts
@@ -1,54 +1,25 @@
-import type { StaticImageData } from 'next/image';
-
 import avatarImage from '@/assets/default-avatar.png';
-import type { WorkExperienceMetadata } from '@/lib/profile/experienceCodec';
-import type { components } from '@/types/api';
+import type {
+  MentorListResponse,
+  MentorRequest,
+  MentorsType,
+  MentorType,
+  RawMentor,
+  WorkExperienceMetadata,
+} from '@/types/mentor';
 
-type RawMentor = components['schemas']['SearchMentorProfileVO'];
-
-export type MentorListResponse =
-  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
-
-export type { WorkExperienceMetadata };
-
-export interface MentorType {
-  user_id: number;
-  name: string;
-  avatar: string | StaticImageData;
-  job_title: string;
-  company: string;
-  years_of_experience: string;
-  location: string;
-  personal_statement: string;
-  about: string;
-  seniority_level: string;
-  industry: string | null;
-  want_position: string[];
-  want_skill: string[];
-  want_topic: string[];
-  have_skill: string[];
-  have_topic: string[];
-  updated_at: number | null;
-}
+export type {
+  MentorListResponse,
+  MentorRequest,
+  MentorsType,
+  MentorType,
+  RawMentor,
+  WorkExperienceMetadata,
+};
 
 function readCodes(codes: ReadonlyArray<string> | null | undefined): string[] {
   if (!codes) return [];
   return codes.filter((c): c is string => Boolean(c));
-}
-
-export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
-
-export interface MentorRequest {
-  // snake_case to match the BFF/Search query param exactly. Object.entries
-  // in mentors.server.ts / mentors.ts forwards keys verbatim into the URL,
-  // so a camelCase key here would silently be dropped by FastAPI's
-  // search_pattern: str = Query(None) and the keyword would have no effect.
-  search_pattern?: string;
-  filter_skills?: string;
-  filter_topics?: string;
-  filter_industries?: string;
-  limit: number;
-  cursor?: string;
 }
 
 export function mapMentor(raw: RawMentor): MentorType {

--- a/src/services/search-mentor/mentors.server.ts
+++ b/src/services/search-mentor/mentors.server.ts
@@ -1,7 +1,8 @@
 import { BASE_URL, fetchServerJson } from '@/lib/apiClient';
 import type { components } from '@/types/api';
+import type { MentorRequest, MentorType } from '@/types/mentor';
 
-import { mapMentor, type MentorRequest, type MentorType } from './mapMentor';
+import { mapMentor } from './mapMentor';
 
 const REVALIDATE_SECONDS = 60 * 60 * 24;
 

--- a/src/services/search-mentor/mentors.ts
+++ b/src/services/search-mentor/mentors.ts
@@ -1,22 +1,8 @@
 import { apiClient } from '@/lib/apiClient';
 import type { components } from '@/types/api';
+import type { MentorRequest, MentorType } from '@/types/mentor';
 
-import {
-  mapMentor,
-  type MentorListResponse,
-  type MentorRequest,
-  type MentorsType,
-  type MentorType,
-  type WorkExperienceMetadata,
-} from './mapMentor';
-
-export type {
-  MentorListResponse,
-  MentorRequest,
-  MentorsType,
-  MentorType,
-  WorkExperienceMetadata,
-};
+import { mapMentor } from './mapMentor';
 
 export async function fetchMentors(
   param: MentorRequest

--- a/src/test/fixtures/profile.ts
+++ b/src/test/fixtures/profile.ts
@@ -1,7 +1,7 @@
 import { Session } from 'next-auth';
 
 import { defaultValues } from '@/schemas/profileSchema';
-import type { MentorProfileVO } from '@/services/profile/user';
+import type { MentorProfileVO } from '@/types/user';
 
 export const mockSession: Session = {
   user: {

--- a/src/test/fixtures/tagCatalog.ts
+++ b/src/test/fixtures/tagCatalog.ts
@@ -1,7 +1,4 @@
-import type {
-  IndustryOption,
-  TagCatalogGroupVO,
-} from '@/services/profile/tagCatalog';
+import type { IndustryOption, TagCatalogGroupVO } from '@/types/tagCatalog';
 
 export const mockPositionGroups: TagCatalogGroupVO[] = [
   {

--- a/src/types/location.ts
+++ b/src/types/location.ts
@@ -1,0 +1,4 @@
+export interface LocationType {
+  value: string;
+  text: string;
+}

--- a/src/types/mentor.ts
+++ b/src/types/mentor.ts
@@ -1,0 +1,42 @@
+import type { StaticImageData } from 'next/image';
+
+import type { WorkExperienceMetadata } from '@/lib/profile/experienceCodec';
+import type { components } from '@/types/api';
+
+export type RawMentor = components['schemas']['SearchMentorProfileVO'];
+
+export type MentorListResponse =
+  components['schemas']['ApiResponse_SearchMentorProfileListVO_'];
+
+export type { WorkExperienceMetadata };
+
+export interface MentorType {
+  user_id: number;
+  name: string;
+  avatar: string | StaticImageData;
+  job_title: string;
+  company: string;
+  years_of_experience: string;
+  location: string;
+  personal_statement: string;
+  about: string;
+  seniority_level: string;
+  industry: string | null;
+  want_position: string[];
+  want_skill: string[];
+  want_topic: string[];
+  have_skill: string[];
+  have_topic: string[];
+  updated_at: number | null;
+}
+
+export type MentorsType = components['schemas']['SearchMentorProfileListVO'];
+
+export interface MentorRequest {
+  search_pattern?: string;
+  filter_skills?: string;
+  filter_topics?: string;
+  filter_industries?: string;
+  limit: number;
+  cursor?: string;
+}

--- a/src/types/reservation.ts
+++ b/src/types/reservation.ts
@@ -1,0 +1,37 @@
+export type MessageRole = 'MENTEE' | 'MENTOR';
+
+export type ReservationMessage = {
+  content: string;
+  // Resolved party for this message. Undefined when neither the message's own
+  // role nor the sender/participant fallback could classify it.
+  role?: MessageRole;
+};
+
+export type Reservation = {
+  id: string;
+  name: string;
+  avatar?: string;
+  roleLine: string;
+  date: string;
+  time: string;
+  // Full conversation in the order returned by the API. Empty when no messages.
+  messages: ReservationMessage[];
+  // Latest message authored by each party — derived from `messages` for the
+  // card preview. Either side may be undefined when that party hasn't written.
+  menteeMessage?: ReservationMessage;
+  mentorMessage?: ReservationMessage;
+
+  // Required by the PUT reservation status endpoint
+  scheduleId: number;
+  dtstart: number;
+  dtend: number;
+
+  // Both user ids are kept so we can reliably determine which side the current user is on
+  senderUserId: number | string;
+  participantUserId: number | string;
+
+  // Set when either side rejected/cancelled. Value is the canceller's role so
+  // the UI can render "已由導師/學員取消" on both mentor and mentee pages.
+  // Participant (other side) takes precedence when both are REJECT.
+  cancelledBy?: 'MENTEE' | 'MENTOR';
+};

--- a/src/types/tagCatalog.ts
+++ b/src/types/tagCatalog.ts
@@ -1,0 +1,24 @@
+import type { components } from '@/types/api';
+
+export type TagCatalogsVO = components['schemas']['TagCatalogsVO'];
+export type TagCatalogVO = components['schemas']['TagCatalogVO'];
+export type TagCatalogGroupVO = components['schemas']['TagCatalogGroupVO'];
+export type TagCatalogLeafVO = components['schemas']['TagCatalogLeafVO'];
+
+export type TagBucketKey =
+  | 'want_position'
+  | 'want_skill'
+  | 'want_topic'
+  | 'have_skill'
+  | 'have_topic';
+
+export interface IndustryOption {
+  subject_group: string;
+  subject: string;
+}
+
+export type TagBuckets = Record<TagBucketKey, TagCatalogGroupVO[]>;
+
+export interface TagCatalogsByBucket extends TagBuckets {
+  industry: IndustryOption[];
+}

--- a/src/types/tagCatalog.ts
+++ b/src/types/tagCatalog.ts
@@ -22,3 +22,11 @@ export type TagBuckets = Record<TagBucketKey, TagCatalogGroupVO[]>;
 export interface TagCatalogsByBucket extends TagBuckets {
   industry: IndustryOption[];
 }
+
+export const TAG_BUCKET_KEYS: readonly TagBucketKey[] = [
+  'want_position',
+  'want_skill',
+  'want_topic',
+  'have_skill',
+  'have_topic',
+];

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,0 +1,3 @@
+import type { components } from '@/types/api';
+
+export type MentorProfileVO = components['schemas']['MentorProfileVO'];


### PR DESCRIPTION
- Created domain-specific type files in src/types/: location.ts, 	agCatalog.ts, mentor.ts, and eservation.ts.
- Moved type definitions LocationType, TagCatalogGroupVO, IndustryOption, MentorType, and reservation-related types (Reservation, ReservationMessage, MessageRole) out of src/services/* into their respective domain type files under src/types/.
- Updated originating services to import these types from \@/types/*\ rather than defining them inline or locally.
- Updated all UI components, storybook stories, and tests (including \PersonalInfo\, \TagMultiSelect\, \SkillsToImprove\, \TopicsToDiscuss\, \InterestedPosition\, and \ReservationList.test.tsx\) to import these types from \@/types/*\ instead of \@/services/*\.
- Configured and verified that no components under \src/components/\ import from \@/services/*\ for types or definitions.
- Resolved TS implicit any issue in \vatar-crop-modal.tsx\ by explicitly typing the Slider \onValueChange\ parameter as \
umber[]\.
- Formatted and sorted all imports/exports with \pnpm lint:fix\ to ensure absolute compliance with project coding standards.
- Successfully verified that all 800 tests pass and the production build completes without errors.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/497
