### PR TITLE
chore(cleanup): remove redundant react-app-env.d.ts (X-Tracker #500)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,7 +33,6 @@ yarn-error.log*
 
 # typescript
 *.tsbuildinfo
-next-env.d.ts
 
 # env
 .env

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/building-your-application/configuring/typescript for more information.

--- a/src/types/react-app-env.d.ts
+++ b/src/types/react-app-env.d.ts
@@ -1,6 +1,0 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-declare module '*.png';
-declare module '*.jpeg';
-declare module '*.jpg';
-declare module '*.svg';
-declare module '*.webp';

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="next/image-types/global" />

--- a/types.d.ts
+++ b/types.d.ts
@@ -1,1 +1,0 @@
-/// <reference types="next/image-types/global" />


### PR DESCRIPTION
Remove the Create-React-App-era \src/types/react-app-env.d.ts\ declaration file.
This file declares modules like \*.png\/\*.svg\/\*.jpg\ as loosely-typed \ny\ which can silently shadow Next.js's more accurate \StaticImageData\ types.
The project's own \
ext-env.d.ts\ already references \
ext/image-types/global\ which handles static asset types properly.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/500
