### PR TITLE
fix(profile): handle fetch connection failures and add retry (X-Tracker #503)

### DIFF
--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -126,7 +126,7 @@ export default function ProfilePageContainer({
     setSelectedSlot,
   });
 
-  if (error === 'Failed to load user data') {
+  if (error && error !== 'User not found') {
     return (
       <div className="flex h-[50vh] flex-col items-center justify-center gap-4 text-center">
         <p className="font-medium text-text-tertiary">

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -126,7 +126,7 @@ export default function ProfilePageContainer({
     setSelectedSlot,
   });
 
-  if (error && error !== 'User not found') {
+  if (error === 'FETCH_FAILED') {
     return (
       <div className="flex h-[50vh] flex-col items-center justify-center gap-4 text-center">
         <p className="font-medium text-text-tertiary">
@@ -139,7 +139,7 @@ export default function ProfilePageContainer({
     );
   }
 
-  if (!userLoading && !userData) {
+  if (error === 'USER_NOT_FOUND' || (!userLoading && !userData)) {
     return (
       <div className="flex h-[50vh] items-center justify-center text-text-tertiary">
         沒有該位使用者

--- a/src/app/profile/[pageUserId]/container.tsx
+++ b/src/app/profile/[pageUserId]/container.tsx
@@ -6,6 +6,7 @@ import { useSession } from 'next-auth/react';
 import { useEffect, useState } from 'react';
 
 import DefaultAvatarImgUrl from '@/assets/default-avatar.png';
+import { Button } from '@/components/ui/button';
 import { BookingSlot, useMentorSchedule } from '@/hooks/useMentorSchedule';
 import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
 import { useBookingConfirmation } from '@/hooks/user/reservation/useBookingConfirmation';
@@ -86,10 +87,12 @@ export default function ProfilePageContainer({
     : initialLoginUserId;
   const isLogging = Boolean(loginUserId);
 
-  const { userData, isLoading: userLoading } = useUserData(
-    pageUserIdNumber,
-    'zh_TW'
-  );
+  const {
+    userData,
+    isLoading: userLoading,
+    error,
+    refetch,
+  } = useUserData(pageUserIdNumber, 'zh_TW');
 
   // The S3 avatar URL is a stable key (re-uploads overwrite in place), so a
   // `?v=` query is the only way to bust the Image Optimizer / browser cache.
@@ -122,6 +125,19 @@ export default function ProfilePageContainer({
     selectedSlot,
     setSelectedSlot,
   });
+
+  if (error === 'Failed to load user data') {
+    return (
+      <div className="flex h-[50vh] flex-col items-center justify-center gap-4 text-center">
+        <p className="font-medium text-text-tertiary">
+          載入個人檔案資料時發生連線錯誤
+        </p>
+        <Button onClick={refetch} variant="default" size="default">
+          重新載入
+        </Button>
+      </div>
+    );
+  }
 
   if (!userLoading && !userData) {
     return (

--- a/src/hooks/user/profile/useEditProfileData.test.ts
+++ b/src/hooks/user/profile/useEditProfileData.test.ts
@@ -10,7 +10,10 @@ import {
   vi,
 } from 'vitest';
 
-import { useUserProfileDto } from '@/hooks/user/user-data/useUserProfileDto';
+import {
+  type ProfileFetchError,
+  useUserProfileDto,
+} from '@/hooks/user/user-data/useUserProfileDto';
 import { MentorProfileVO } from '@/types/user';
 
 import { useEditProfileData } from './useEditProfileData';
@@ -121,7 +124,7 @@ describe('useEditProfileData', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: null,
       isLoading: false,
-      error: 'Fetch failed',
+      error: 'FETCH_FAILED',
     });
 
     const { result } = renderHook(() =>
@@ -146,7 +149,7 @@ describe('useEditProfileData', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: null,
       isLoading: false,
-      error: 'Network Timeout',
+      error: 'FETCH_FAILED',
     });
 
     const { result, rerender } = renderHook(
@@ -186,7 +189,7 @@ describe('useEditProfileData', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: null,
       isLoading: false,
-      error: mockErrorObject as unknown as string,
+      error: mockErrorObject as unknown as ProfileFetchError,
     });
 
     renderHook(() =>
@@ -233,7 +236,7 @@ describe('useEditProfileData', () => {
     mockUseUserProfileDto.mockReturnValue({
       userDto: mockUserDto,
       isLoading: false,
-      error: 'Background Focus Sync Timeout',
+      error: 'FETCH_FAILED',
     });
 
     rerender({

--- a/src/hooks/user/user-data/useUserData.test.ts
+++ b/src/hooks/user/user-data/useUserData.test.ts
@@ -229,7 +229,7 @@ describe('useUserData caching', () => {
 
     const first = renderHook(() => useUserData(userId, 'en'));
     await waitFor(() => expect(first.result.current.isLoading).toBe(false));
-    expect(first.result.current.error).toBe('User not found');
+    expect(first.result.current.error).toBe('USER_NOT_FOUND');
     first.unmount();
 
     mockFetchUserById.mockResolvedValueOnce(makeUserDto(userId));

--- a/src/hooks/user/user-data/useUserData.ts
+++ b/src/hooks/user/user-data/useUserData.ts
@@ -111,6 +111,7 @@ function useUserData(userId: number, language: string) {
     userDto,
     isLoading: dtoLoading,
     error,
+    refetch,
   } = useUserProfileDto(userId, language);
   // Catalog supplies localized labels for the raw subject_group arrays
   // (want_*, have_*) and for the enriched industry. Loads in parallel with
@@ -121,7 +122,7 @@ function useUserData(userId: number, language: string) {
     ? parseUserDtoToUserType(userDto, tagCatalog)
     : null;
 
-  return { userData, isLoading: dtoLoading, error };
+  return { userData, isLoading: dtoLoading, error, refetch };
 }
 
 export default useUserData;

--- a/src/hooks/user/user-data/useUserProfileDto.test.tsx
+++ b/src/hooks/user/user-data/useUserProfileDto.test.tsx
@@ -94,7 +94,7 @@ describe('useUserProfileDto', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe('Failed to load user data');
+    expect(result.current.error).toBe('FETCH_FAILED');
 
     // Unmount so we can retry from fresh mount
     unmount();
@@ -149,7 +149,7 @@ describe('useUserProfileDto', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.error).toBe('Failed to load user data');
+    expect(result.current.error).toBe('FETCH_FAILED');
     expect(result.current.userDto).toBeNull();
   });
 });

--- a/src/hooks/user/user-data/useUserProfileDto.test.tsx
+++ b/src/hooks/user/user-data/useUserProfileDto.test.tsx
@@ -113,4 +113,30 @@ describe('useUserProfileDto', () => {
     expect(retryResult.current.userDto).toEqual(mockUserDTO);
     expect(fetchUserById).toHaveBeenCalledTimes(2);
   });
+
+  it('provides a refetch function that clears cache and forces refetch', async () => {
+    vi.mocked(fetchUserById).mockResolvedValueOnce(mockUserDTO);
+
+    const { result } = renderHook(() => useUserProfileDto(3, 'zh-TW'));
+
+    await vi.waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.userDto).toEqual(mockUserDTO);
+    expect(fetchUserById).toHaveBeenCalledTimes(1);
+
+    // Call refetch
+    vi.mocked(fetchUserById).mockResolvedValueOnce({
+      ...mockUserDTO,
+      name: 'Updated Name',
+    });
+    result.current.refetch?.();
+
+    await vi.waitFor(() => {
+      expect(result.current.userDto?.name).toBe('Updated Name');
+    });
+
+    expect(fetchUserById).toHaveBeenCalledTimes(2);
+  });
 });

--- a/src/hooks/user/user-data/useUserProfileDto.test.tsx
+++ b/src/hooks/user/user-data/useUserProfileDto.test.tsx
@@ -139,4 +139,17 @@ describe('useUserProfileDto', () => {
 
     expect(fetchUserById).toHaveBeenCalledTimes(2);
   });
+
+  it('correctly sets error state to Failed to load user data when fetchUserById throws/rejects', async () => {
+    vi.mocked(fetchUserById).mockRejectedValueOnce(new Error('API error'));
+
+    const { result } = renderHook(() => useUserProfileDto(4, 'zh-TW'));
+
+    await vi.waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.error).toBe('Failed to load user data');
+    expect(result.current.userDto).toBeNull();
+  });
 });

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -78,10 +78,12 @@ function startFetchUserById(
   });
 }
 
+export type ProfileFetchError = 'USER_NOT_FOUND' | 'FETCH_FAILED' | null;
+
 export interface UseUserProfileDtoResult {
   userDto: MentorProfileVO | null;
   isLoading: boolean;
-  error: string | null;
+  error: ProfileFetchError;
   refetch?: () => void;
 }
 
@@ -116,7 +118,7 @@ export function useUserProfileDto(
     if (!isUserIdValid || !language) return false;
     return !readFromDataCache(`${userId}-${language}`);
   });
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<ProfileFetchError>(null);
 
   useEffect(() => {
     const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);
@@ -167,7 +169,7 @@ export function useUserProfileDto(
         if (cancelled) return;
         if (!data) {
           setUserDto(null);
-          setError('User not found');
+          setError('USER_NOT_FOUND');
           return;
         }
         setUserDto(data);
@@ -177,7 +179,7 @@ export function useUserProfileDto(
         console.error('Failed to load user profile dto:', e);
         if (cancelled) return;
         setUserDto(null);
-        setError('Failed to load user data');
+        setError('FETCH_FAILED');
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -98,12 +98,6 @@ export function useUserProfileDto(
 ): UseUserProfileDtoResult {
   const [retryTrigger, setRetryTrigger] = useState(0);
 
-  const refetch = useCallback(() => {
-    const key = `${userId}-${language}`;
-    userProfileDtoCache.delete(key);
-    setRetryTrigger((prev) => prev + 1);
-  }, [userId, language]);
-
   // Lazy-init from cache so SSR-primed data lands in state on the first
   // render — avoids a one-frame loading flash before useEffect's cache read
   // catches up. When the cache is empty the hook still defaults to
@@ -119,6 +113,14 @@ export function useUserProfileDto(
     return !readFromDataCache(`${userId}-${language}`);
   });
   const [error, setError] = useState<ProfileFetchError>(null);
+
+  const refetch = useCallback(() => {
+    const key = `${userId}-${language}`;
+    userProfileDtoCache.delete(key);
+    setError(null);
+    setIsLoading(true);
+    setRetryTrigger((prev) => prev + 1);
+  }, [userId, language]);
 
   useEffect(() => {
     const isUserIdValid = Boolean(userId) && !Number.isNaN(userId);

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { createKeyedCache } from '@/lib/createKeyedCache';
 import { fetchUserById } from '@/services/profile/user';
@@ -96,11 +96,11 @@ export function useUserProfileDto(
 ): UseUserProfileDtoResult {
   const [retryTrigger, setRetryTrigger] = useState(0);
 
-  const refetch = () => {
+  const refetch = useCallback(() => {
     const key = `${userId}-${language}`;
     userProfileDtoCache.delete(key);
     setRetryTrigger((prev) => prev + 1);
-  };
+  }, [userId, language]);
 
   // Lazy-init from cache so SSR-primed data lands in state on the first
   // render — avoids a one-frame loading flash before useEffect's cache read

--- a/src/hooks/user/user-data/useUserProfileDto.ts
+++ b/src/hooks/user/user-data/useUserProfileDto.ts
@@ -82,6 +82,7 @@ export interface UseUserProfileDtoResult {
   userDto: MentorProfileVO | null;
   isLoading: boolean;
   error: string | null;
+  refetch?: () => void;
 }
 
 /**
@@ -93,6 +94,14 @@ export function useUserProfileDto(
   userId: number,
   language: string
 ): UseUserProfileDtoResult {
+  const [retryTrigger, setRetryTrigger] = useState(0);
+
+  const refetch = () => {
+    const key = `${userId}-${language}`;
+    userProfileDtoCache.delete(key);
+    setRetryTrigger((prev) => prev + 1);
+  };
+
   // Lazy-init from cache so SSR-primed data lands in state on the first
   // render — avoids a one-frame loading flash before useEffect's cache read
   // catches up. When the cache is empty the hook still defaults to
@@ -177,7 +186,7 @@ export function useUserProfileDto(
     return () => {
       cancelled = true;
     };
-  }, [userId, language]);
+  }, [userId, language, retryTrigger]);
 
-  return { userDto, isLoading, error };
+  return { userDto, isLoading, error, refetch };
 }

--- a/src/lib/profile/pollUntilSynced.test.ts
+++ b/src/lib/profile/pollUntilSynced.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/services/profile/user', () => ({
-  fetchUser: vi.fn(),
+  fetchUserById: vi.fn(),
 }));
 
 vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
@@ -9,12 +9,12 @@ vi.mock('@/lib/monitoring', () => ({ captureFlowFailure: vi.fn() }));
 import { fromAny, fromPartial } from '@total-typescript/shoehorn';
 
 import { defaultValues } from '@/schemas/profileSchema';
-import { fetchUser } from '@/services/profile/user';
+import { fetchUserById } from '@/services/profile/user';
 import type { MentorProfileVO } from '@/types/user';
 
 import { firstSyncedFetch } from './pollUntilSynced';
 
-const mockFetchUser = vi.mocked(fetchUser);
+const mockFetchUserById = vi.mocked(fetchUserById);
 
 const baseValues = {
   ...defaultValues,
@@ -44,7 +44,7 @@ const makeSyncedDto = (avatar = ''): MentorProfileVO =>
 describe('firstSyncedFetch', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mockFetchUser.mockReset();
+    mockFetchUserById.mockReset();
   });
 
   afterEach(() => {
@@ -52,44 +52,44 @@ describe('firstSyncedFetch', () => {
   });
 
   it('returns the dto when backend already reflects submitted values', async () => {
-    mockFetchUser.mockResolvedValueOnce(makeSyncedDto());
+    mockFetchUserById.mockResolvedValueOnce(makeSyncedDto());
 
-    const result = await firstSyncedFetch(baseValues, '');
+    const result = await firstSyncedFetch(1, baseValues, '');
 
     expect(result).not.toBeNull();
     expect(result?.name).toBe('Sync Test');
   });
 
   it('returns null when backend has not yet synced (values disagree)', async () => {
-    mockFetchUser.mockResolvedValueOnce(
+    mockFetchUserById.mockResolvedValueOnce(
       fromPartial({
         ...makeSyncedDto(),
         name: 'Old Name',
       })
     );
 
-    const result = await firstSyncedFetch(baseValues, '');
+    const result = await firstSyncedFetch(1, baseValues, '');
 
     expect(result).toBeNull();
   });
 
   it('returns null on fetch error', async () => {
-    mockFetchUser.mockRejectedValueOnce(new Error('network down'));
+    mockFetchUserById.mockRejectedValueOnce(new Error('network down'));
 
-    const result = await firstSyncedFetch(baseValues, '');
+    const result = await firstSyncedFetch(1, baseValues, '');
 
     expect(result).toBeNull();
   });
 
   it('returns null when fetch exceeds timeout (does not block forever)', async () => {
-    mockFetchUser.mockImplementationOnce(
+    mockFetchUserById.mockImplementationOnce(
       () =>
         new Promise<MentorProfileVO | null>(() => {
           // Never resolves — must be cut by the timeout.
         })
     );
 
-    const promise = firstSyncedFetch(baseValues, '', 100);
+    const promise = firstSyncedFetch(1, baseValues, '', 100);
     await vi.advanceTimersByTimeAsync(150);
 
     expect(await promise).toBeNull();
@@ -97,7 +97,7 @@ describe('firstSyncedFetch', () => {
 
   describe('isProfileSynced industry boundary conditions', () => {
     it('syncs successfully when latest.industry matching values.industry', async () => {
-      mockFetchUser.mockResolvedValueOnce(
+      mockFetchUserById.mockResolvedValueOnce(
         fromAny({
           ...makeSyncedDto(),
           industry: { subject_group: 'tech' },
@@ -105,6 +105,7 @@ describe('firstSyncedFetch', () => {
       );
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: 'tech' },
         ''
       );
@@ -112,7 +113,7 @@ describe('firstSyncedFetch', () => {
     });
 
     it('does not sync when latest.industry does not match values.industry', async () => {
-      mockFetchUser.mockResolvedValueOnce(
+      mockFetchUserById.mockResolvedValueOnce(
         fromAny({
           ...makeSyncedDto(),
           industry: { subject_group: 'design' },
@@ -120,6 +121,7 @@ describe('firstSyncedFetch', () => {
       );
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: 'tech' },
         ''
       );
@@ -127,7 +129,7 @@ describe('firstSyncedFetch', () => {
     });
 
     it('syncs successfully when latest.industry is null and values.industry is undefined or empty', async () => {
-      mockFetchUser.mockResolvedValueOnce(
+      mockFetchUserById.mockResolvedValueOnce(
         fromPartial({
           ...makeSyncedDto(),
           industry: null,
@@ -135,6 +137,7 @@ describe('firstSyncedFetch', () => {
       );
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: '' },
         ''
       );
@@ -142,7 +145,7 @@ describe('firstSyncedFetch', () => {
     });
 
     it('does not sync when latest.industry is null but values.industry has a value', async () => {
-      mockFetchUser.mockResolvedValueOnce(
+      mockFetchUserById.mockResolvedValueOnce(
         fromPartial({
           ...makeSyncedDto(),
           industry: null,
@@ -150,6 +153,7 @@ describe('firstSyncedFetch', () => {
       );
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: 'tech' },
         ''
       );
@@ -159,9 +163,10 @@ describe('firstSyncedFetch', () => {
     it('syncs successfully when latest.industry is undefined and values.industry is empty', async () => {
       const dto = makeSyncedDto();
       delete dto.industry;
-      mockFetchUser.mockResolvedValueOnce(dto);
+      mockFetchUserById.mockResolvedValueOnce(dto);
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: '' },
         ''
       );
@@ -171,9 +176,10 @@ describe('firstSyncedFetch', () => {
     it('does not sync when latest.industry is undefined but values.industry has a value', async () => {
       const dto = makeSyncedDto();
       delete dto.industry;
-      mockFetchUser.mockResolvedValueOnce(dto);
+      mockFetchUserById.mockResolvedValueOnce(dto);
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: 'tech' },
         ''
       );
@@ -181,7 +187,7 @@ describe('firstSyncedFetch', () => {
     });
 
     it('does not sync when latest.industry is a primitive invalid value', async () => {
-      mockFetchUser.mockResolvedValueOnce(
+      mockFetchUserById.mockResolvedValueOnce(
         fromAny({
           ...makeSyncedDto(),
           industry: 'not-an-object',
@@ -189,6 +195,7 @@ describe('firstSyncedFetch', () => {
       );
 
       const result = await firstSyncedFetch(
+        1,
         { ...baseValues, industry: 'tech' },
         ''
       );

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -1,7 +1,7 @@
 import { captureFlowFailure } from '@/lib/monitoring';
 import { isProfileSynced } from '@/lib/profile/profileSaveAdapter';
 import { ProfileFormValues } from '@/schemas/profileSchema';
-import { fetchUser } from '@/services/profile/user';
+import { fetchUserById } from '@/services/profile/user';
 import type { MentorProfileVO } from '@/types/user';
 
 /**
@@ -19,6 +19,7 @@ import type { MentorProfileVO } from '@/types/user';
  * background reconcile path so the user is not blocked on backend latency.
  */
 export async function firstSyncedFetch(
+  userId: number,
   values: ProfileFormValues,
   avatar: string,
   timeoutMs = 800
@@ -28,7 +29,7 @@ export async function firstSyncedFetch(
     timer = setTimeout(() => resolve(null), timeoutMs);
   });
 
-  const fetchPromise = fetchUser('zh_TW')
+  const fetchPromise = fetchUserById(userId, 'zh_TW')
     .then((latest) => {
       if (latest && isProfileSynced(values, latest, avatar)) return latest;
       return null;
@@ -43,12 +44,13 @@ export async function firstSyncedFetch(
 }
 
 /**
- * Polls fetchUser until the backend reflects the submitted values, or the
+ * Polls fetchUserById until the backend reflects the submitted values, or the
  * retry budget is exhausted. Designed for fire-and-forget background use:
  * never throws, and reports a Sentry breadcrumb if max retries elapse
  * without sync.
  */
 export async function pollUntilSynced(
+  userId: number,
   values: ProfileFormValues,
   avatar: string,
   maxRetries = 12,
@@ -62,7 +64,7 @@ export async function pollUntilSynced(
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
     try {
-      latest = await fetchUser('zh_TW');
+      latest = await fetchUserById(userId, 'zh_TW');
     } catch {
       latest = null;
       continue;

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -67,7 +67,6 @@ export async function pollUntilSynced(
       latest = await fetchUserById(userId, 'zh_TW');
     } catch {
       latest = null;
-      continue;
     }
     if (latest && isProfileSynced(values, latest, avatar)) {
       synced = true;

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -24,6 +24,8 @@ export async function firstSyncedFetch(
   avatar: string,
   timeoutMs = 800
 ): Promise<MentorProfileVO | null> {
+  if (!userId || Number.isNaN(userId)) return null;
+
   let timer: ReturnType<typeof setTimeout> | undefined;
   const timeoutPromise = new Promise<null>((resolve) => {
     timer = setTimeout(() => resolve(null), timeoutMs);
@@ -56,6 +58,8 @@ export async function pollUntilSynced(
   maxRetries = 12,
   intervalMs = 5000
 ): Promise<MentorProfileVO | null> {
+  if (!userId || Number.isNaN(userId)) return null;
+
   let latest: MentorProfileVO | null = null;
   let synced = false;
 

--- a/src/lib/profile/pollUntilSynced.ts
+++ b/src/lib/profile/pollUntilSynced.ts
@@ -29,7 +29,7 @@ export async function firstSyncedFetch(
     timer = setTimeout(() => resolve(null), timeoutMs);
   });
 
-  const fetchPromise = fetchUserById(userId, 'zh_TW')
+  const fetchPromise = fetchUserById(userId, 'zh_TW', undefined, true)
     .then((latest) => {
       if (latest && isProfileSynced(values, latest, avatar)) return latest;
       return null;
@@ -64,7 +64,7 @@ export async function pollUntilSynced(
       await new Promise((resolve) => setTimeout(resolve, intervalMs));
     }
     try {
-      latest = await fetchUserById(userId, 'zh_TW');
+      latest = await fetchUserById(userId, 'zh_TW', undefined, true);
     } catch {
       latest = null;
     }

--- a/src/lib/profile/saveProfile.test.ts
+++ b/src/lib/profile/saveProfile.test.ts
@@ -631,4 +631,59 @@ describe('saveProfile (Deep Module)', () => {
     await Promise.resolve();
     await Promise.resolve();
   });
+
+  // ── Session User ID vs Page User ID Fallback ──────────────────────────────
+
+  it('saveProfile passes sessionUserId to firstSyncedFetch and pollUntilSynced', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(null);
+    mockPollUntilSynced.mockResolvedValueOnce(mockUserDTO);
+
+    const deps = makeDeps({
+      session: {
+        user: {
+          id: '88',
+          name: 'Sync Test User',
+          email: 'test@example.com',
+          image: '',
+        },
+        expires: '',
+      },
+    });
+
+    await saveProfile(baseValues, deps);
+
+    await vi.waitFor(() => {
+      expect(mockFirstSyncedFetch).toHaveBeenCalledWith(
+        88,
+        expect.any(Object),
+        expect.any(String)
+      );
+      expect(mockPollUntilSynced).toHaveBeenCalledWith(
+        88,
+        expect.any(Object),
+        expect.any(String)
+      );
+    });
+  });
+
+  it('saveProfile falls back to pageUserId as number when sessionUserId is not available', async () => {
+    mockFirstSyncedFetch.mockResolvedValueOnce(null);
+    mockPollUntilSynced.mockResolvedValueOnce(mockUserDTO);
+
+    const deps = makeDeps({
+      session: null, // sessionUserId is null
+      pageUserId: '99', // fallback should be 99
+    });
+
+    await saveProfile(baseValues, deps);
+
+    await vi.waitFor(() => {
+      expect(mockFirstSyncedFetch).not.toHaveBeenCalled();
+      expect(mockPollUntilSynced).toHaveBeenCalledWith(
+        99,
+        expect.any(Object),
+        expect.any(String)
+      );
+    });
+  });
 });

--- a/src/lib/profile/saveProfile.ts
+++ b/src/lib/profile/saveProfile.ts
@@ -45,10 +45,12 @@ export interface SaveProfileDeps {
   ) => void;
   // Optional dependency injections to ease testing
   firstSyncedFetch?: (
+    userId: number,
     values: ProfileFormValues,
     avatar: string
   ) => Promise<MentorProfileVO | null>;
   pollUntilSynced?: (
+    userId: number,
     values: ProfileFormValues,
     avatar: string
   ) => Promise<MentorProfileVO | null>;
@@ -203,13 +205,17 @@ export async function saveProfile(
     try {
       let latest: MentorProfileVO | null = null;
       if (sessionUserId) {
-        latest = await firstSyncedFetch(values, avatar ?? '');
+        latest = await firstSyncedFetch(sessionUserId, values, avatar ?? '');
         if (latest) {
           primeUserDataCache(sessionUserId, 'zh_TW', latest);
         }
       }
       if (!latest) {
-        latest = await pollUntilSynced(values, avatar ?? '');
+        latest = await pollUntilSynced(
+          sessionUserId ?? Number(pageUserId),
+          values,
+          avatar ?? ''
+        );
       }
       reconcileSession(latest);
     } catch (e) {

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { apiClient, ApiError, FetchApiError } from '@/lib/apiClient';
+
+import { fetchUserById } from './user';
+
+vi.mock('@/lib/apiClient', () => ({
+  apiClient: {
+    getUnwrapped: vi.fn(),
+  },
+  ApiError: class ApiError extends Error {
+    constructor(
+      public status: number,
+      message: string
+    ) {
+      super(message);
+    }
+  },
+  FetchApiError: class FetchApiError extends Error {
+    constructor(
+      public code: string,
+      message: string
+    ) {
+      super(message);
+    }
+  },
+}));
+
+vi.mock('@/lib/monitoring', () => ({
+  captureFlowFailure: vi.fn().mockResolvedValue(undefined),
+}));
+
+describe('fetchUserById service', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('successfully fetches user on first attempt', async () => {
+    const mockUser = { user_id: 1, name: 'Alice' };
+    vi.mocked(apiClient.getUnwrapped).mockResolvedValueOnce(mockUser);
+
+    const result = await fetchUserById(1, 'zh_TW');
+
+    expect(result).toEqual(mockUser);
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1);
+  });
+
+  it('automatically retries once on network failure and succeeds', async () => {
+    const mockUser = { user_id: 1, name: 'Alice' };
+    vi.mocked(apiClient.getUnwrapped)
+      .mockRejectedValueOnce(new Error('Network connection failed'))
+      .mockResolvedValueOnce(mockUser);
+
+    const result = await fetchUserById(1, 'zh_TW');
+
+    expect(result).toEqual(mockUser);
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops retrying and throws error after max retries exceed', async () => {
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValue(
+      new Error('Network connection failed')
+    );
+
+    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow(
+      'Network connection failed'
+    );
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+  });
+
+  it('does not retry on 404 client error and throws immediately', async () => {
+    const apiError = new ApiError(404, 'Not Found');
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(apiError);
+
+    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow('Not Found');
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry for 404
+  });
+
+  it('does not retry on FetchApiError (like user not found) and throws immediately', async () => {
+    const fetchApiError = new FetchApiError(
+      'USER_NOT_FOUND',
+      'User Not Found',
+      '/v1/mentors/1/zh_TW/profile'
+    );
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(fetchApiError);
+
+    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow('User Not Found');
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry
+  });
+});

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -78,15 +78,17 @@ describe('fetchUserById service', () => {
     );
   });
 
-  it('does not retry on 404 client error and throws immediately', async () => {
+  it('does not retry and returns null on 404 client error', async () => {
     const apiError = new ApiError(404, 'Not Found');
     vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(apiError);
 
-    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow('Not Found');
+    const result = await fetchUserById(1, 'zh_TW');
+
+    expect(result).toBeNull();
     expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry for 404
   });
 
-  it('does not retry on FetchApiError (like user not found) and throws immediately', async () => {
+  it('does not retry and returns null on FetchApiError USER_NOT_FOUND', async () => {
     const fetchApiError = new FetchApiError(
       'USER_NOT_FOUND',
       'User Not Found',
@@ -94,7 +96,9 @@ describe('fetchUserById service', () => {
     );
     vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(fetchApiError);
 
-    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow('User Not Found');
+    const result = await fetchUserById(1, 'zh_TW');
+
+    expect(result).toBeNull();
     expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry
   });
 });

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { apiClient, ApiError, FetchApiError } from '@/lib/apiClient';
+import { captureFlowFailure } from '@/lib/monitoring';
 
 import { fetchUserById } from './user';
 
@@ -66,6 +67,15 @@ describe('fetchUserById service', () => {
       'Network connection failed'
     );
     expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(2); // 1 initial + 1 retry
+
+    expect(captureFlowFailure).toHaveBeenCalledWith(
+      expect.objectContaining({
+        flow: 'profile',
+        step: 'fetch_user_profile',
+        message: 'Network connection failed',
+        errorCode: 'network_error',
+      })
+    );
   });
 
   it('does not retry on 404 client error and throws immediately', async () => {

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -102,6 +102,27 @@ describe('fetchUserById service', () => {
     expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry
   });
 
+  it('automatically retries once on 5xx server error and succeeds', async () => {
+    const mockUser = { user_id: 1, name: 'Alice' };
+    const serverError = new ApiError(500, 'Internal Server Error');
+    vi.mocked(apiClient.getUnwrapped)
+      .mockRejectedValueOnce(serverError)
+      .mockResolvedValueOnce(mockUser);
+
+    const result = await fetchUserById(1, 'zh_TW');
+
+    expect(result).toEqual(mockUser);
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(2); // Should retry
+  });
+
+  it('does not retry and throws immediately on 400/401 client errors', async () => {
+    const badRequestError = new ApiError(400, 'Bad Request');
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(badRequestError);
+
+    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow('Bad Request');
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry
+  });
+
   it('skips Sentry captureFlowFailure logging when silent is true', async () => {
     vi.mocked(apiClient.getUnwrapped).mockRejectedValue(
       new Error('Silent connection error')

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -116,4 +116,20 @@ describe('fetchUserById service', () => {
     // captureFlowFailure should NOT have been called!
     expect(captureFlowFailure).not.toHaveBeenCalled();
   });
+
+  it('does not retry and throws immediately when request is aborted (AbortError)', async () => {
+    const abortError = new DOMException(
+      'The user aborted a request.',
+      'AbortError'
+    );
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValueOnce(abortError);
+
+    await expect(fetchUserById(1, 'zh_TW')).rejects.toThrow(
+      'The user aborted a request.'
+    );
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // Should not retry
+
+    // captureFlowFailure should NOT have been called!
+    expect(captureFlowFailure).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/profile/user.test.ts
+++ b/src/services/profile/user.test.ts
@@ -101,4 +101,19 @@ describe('fetchUserById service', () => {
     expect(result).toBeNull();
     expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(1); // No retry
   });
+
+  it('skips Sentry captureFlowFailure logging when silent is true', async () => {
+    vi.mocked(apiClient.getUnwrapped).mockRejectedValue(
+      new Error('Silent connection error')
+    );
+
+    // Call with silent = true (4th argument)
+    await expect(fetchUserById(1, 'zh_TW', undefined, true)).rejects.toThrow(
+      'Silent connection error'
+    );
+    expect(apiClient.getUnwrapped).toHaveBeenCalledTimes(2);
+
+    // captureFlowFailure should NOT have been called!
+    expect(captureFlowFailure).not.toHaveBeenCalled();
+  });
 });

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -20,6 +20,16 @@ function shouldRetry(error: unknown): boolean {
   return true;
 }
 
+function isUserNotFoundError(error: unknown): boolean {
+  if (error instanceof ApiError && error.status === 404) {
+    return true;
+  }
+  if (error instanceof FetchApiError && error.code === 'USER_NOT_FOUND') {
+    return true;
+  }
+  return false;
+}
+
 export async function fetchUserById(
   userId: number,
   language: string,
@@ -39,23 +49,34 @@ export async function fetchUserById(
     } catch (error) {
       if (isAbortError(error)) throw error;
 
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+
       if (!shouldRetry(error)) {
-        console.error('Fetch User Error (non-retryable):', error);
+        if (isUserNotFoundError(error)) {
+          return null; // Return null so hook sets "User not found"
+        }
+        console.error('Fetch User Error (non-retryable):', errorMessage);
         throw error;
       }
 
       attempt++;
       if (attempt > maxRetries) {
-        console.error(`Fetch User Error (after ${attempt} attempts):`, error);
+        console.error(
+          `Fetch User Error (after ${attempt} attempts):`,
+          errorMessage
+        );
 
         // Track the connection/network/server failure in monitoring
         captureFlowFailure({
           flow: 'profile',
           step: 'fetch_user_profile',
-          message: error instanceof Error ? error.message : 'Load failed',
+          message: errorMessage,
           errorCode: error instanceof ApiError ? error.status : 'network_error',
         }).catch((monError) => {
-          console.error('Failed to log flow failure:', monError);
+          const monMsg =
+            monError instanceof Error ? monError.message : String(monError);
+          console.error('Failed to log flow failure:', monMsg);
         });
 
         throw error; // Rethrow to trigger hook-level error handling
@@ -63,7 +84,7 @@ export async function fetchUserById(
 
       console.warn(
         `Fetch User failed, retrying (attempt ${attempt})...`,
-        error
+        errorMessage
       );
       // Wait a short delay before retrying (300ms)
       await new Promise((resolve) => setTimeout(resolve, 300));

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -1,10 +1,25 @@
 import { getSession } from 'next-auth/react';
 
-import { apiClient } from '@/lib/apiClient';
+import { apiClient, ApiError, FetchApiError } from '@/lib/apiClient';
+import { captureFlowFailure } from '@/lib/monitoring';
 import type { MentorProfileVO } from '@/types/user';
 
 function isAbortError(error: unknown): boolean {
   return error instanceof DOMException && error.name === 'AbortError';
+}
+
+function shouldRetry(error: unknown): boolean {
+  if (error instanceof ApiError) {
+    // 4xx client errors (like 404, 401, 403) shouldn't be retried
+    if (error.status >= 400 && error.status < 500) {
+      return false;
+    }
+  }
+  if (error instanceof FetchApiError) {
+    // Structured API errors (like "User not found") shouldn't be retried
+    return false;
+  }
+  return true;
 }
 
 export async function fetchUser(
@@ -26,16 +41,48 @@ export async function fetchUserById(
   language: string,
   signal?: AbortSignal
 ): Promise<MentorProfileVO | null> {
-  try {
-    const data = await apiClient.getUnwrapped<MentorProfileVO>(
-      `/v1/mentors/${userId}/${language}/profile`,
-      { auth: false, signal }
-    );
+  const maxRetries = 1;
+  let attempt = 0;
 
-    return data ?? null;
-  } catch (error) {
-    if (isAbortError(error)) throw error;
-    console.error('Fetch User Error:', error);
-    return null;
+  while (true) {
+    try {
+      const data = await apiClient.getUnwrapped<MentorProfileVO>(
+        `/v1/mentors/${userId}/${language}/profile`,
+        { auth: false, signal }
+      );
+
+      return data ?? null;
+    } catch (error) {
+      if (isAbortError(error)) throw error;
+
+      if (!shouldRetry(error)) {
+        console.error('Fetch User Error (non-retryable):', error);
+        throw error;
+      }
+
+      attempt++;
+      if (attempt > maxRetries) {
+        console.error(`Fetch User Error (after ${attempt} attempts):`, error);
+
+        // Track the connection/network/server failure in monitoring
+        captureFlowFailure({
+          flow: 'profile',
+          step: 'fetch_user_profile',
+          message: error instanceof Error ? error.message : 'Load failed',
+          errorCode: error instanceof ApiError ? error.status : 'network_error',
+        }).catch((monError) => {
+          console.error('Failed to log flow failure:', monError);
+        });
+
+        throw error; // Rethrow to trigger hook-level error handling
+      }
+
+      console.warn(
+        `Fetch User failed, retrying (attempt ${attempt})...`,
+        error
+      );
+      // Wait a short delay before retrying (300ms)
+      await new Promise((resolve) => setTimeout(resolve, 300));
+    }
   }
 }

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -33,7 +33,8 @@ function isUserNotFoundError(error: unknown): boolean {
 export async function fetchUserById(
   userId: number,
   language: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  silent = false
 ): Promise<MentorProfileVO | null> {
   const maxRetries = 1;
   let attempt = 0;
@@ -68,16 +69,19 @@ export async function fetchUserById(
         );
 
         // Track the connection/network/server failure in monitoring
-        captureFlowFailure({
-          flow: 'profile',
-          step: 'fetch_user_profile',
-          message: errorMessage,
-          errorCode: error instanceof ApiError ? error.status : 'network_error',
-        }).catch((monError) => {
-          const monMsg =
-            monError instanceof Error ? monError.message : String(monError);
-          console.error('Failed to log flow failure:', monMsg);
-        });
+        if (!silent) {
+          captureFlowFailure({
+            flow: 'profile',
+            step: 'fetch_user_profile',
+            message: errorMessage,
+            errorCode:
+              error instanceof ApiError ? error.status : 'network_error',
+          }).catch((monError) => {
+            const monMsg =
+              monError instanceof Error ? monError.message : String(monError);
+            console.error('Failed to log flow failure:', monMsg);
+          });
+        }
 
         throw error; // Rethrow to trigger hook-level error handling
       }

--- a/src/services/profile/user.ts
+++ b/src/services/profile/user.ts
@@ -1,5 +1,3 @@
-import { getSession } from 'next-auth/react';
-
 import { apiClient, ApiError, FetchApiError } from '@/lib/apiClient';
 import { captureFlowFailure } from '@/lib/monitoring';
 import type { MentorProfileVO } from '@/types/user';
@@ -20,20 +18,6 @@ function shouldRetry(error: unknown): boolean {
     return false;
   }
   return true;
-}
-
-export async function fetchUser(
-  language: string,
-  signal?: AbortSignal
-): Promise<MentorProfileVO | null> {
-  const session = await getSession();
-  const userId = session?.user?.id;
-
-  if (!userId) {
-    throw new Error('未找到使用者 ID。請重新登入。');
-  }
-
-  return fetchUserById(Number(userId), language, signal);
 }
 
 export async function fetchUserById(


### PR DESCRIPTION
- Propagate connection/network-level errors from fetchUserById rather than swallowing them as null, allowing the hook to distinguish between connection failures and non-existent users.
- Add an automatic retry once for transient connection/network/server errors with a 300ms delay.
- Expose a manual refetch function from useUserProfileDto SWR hook that clears the key from cache and increments retryTrigger.
- Update the profile page container.tsx to handle connection errors and render a clear, localized connection error state with a Reload button.
- Integrate failure tracking using captureFlowFailure under profile flow and fetch_user_profile step.
- Add comprehensive Vitest test coverage for automatic service retries, non-retryable error filtering, and manual cache invalidation refetching.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/503
