### PR TITLE
feat(github): configure branch protection rulesets and CODEOWNERS (X-Tracker #505)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# This file designates code owners for the repository.
+# GitHub uses this file to automatically request reviews from the specified users
+# when a pull request modifies any files in this repository.
+
+# Catch-all rule to require review from the core maintainers for all changes
+*       @LowSugarCoke @ChengYiLin @JimmyPan622

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # when a pull request modifies any files in this repository.
 
 # Catch-all rule to require review from the core maintainers for all changes
-*       @LowSugarCoke @ChengYiLin @JimmyPan622
+*       @LowSugarCoke @JimmyPan622

--- a/.github/develop-ruleset.json
+++ b/.github/develop-ruleset.json
@@ -15,7 +15,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": true,
         "require_last_push_approval": false,

--- a/.github/develop-ruleset.json
+++ b/.github/develop-ruleset.json
@@ -1,0 +1,48 @@
+{
+  "name": "develop",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/develop"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Unit & Integration Tests"
+          },
+          {
+            "context": "Format and Lint Check"
+          },
+          {
+            "context": "Security Audit & Unused Dependencies"
+          },
+          {
+            "context": "Bundle Size Budget Check"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/develop-ruleset.json
+++ b/.github/develop-ruleset.json
@@ -44,5 +44,11 @@
       }
     }
   ],
-  "bypass_actors": []
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
 }

--- a/.github/develop-ruleset.json
+++ b/.github/develop-ruleset.json
@@ -15,7 +15,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": true,
         "require_last_push_approval": false,

--- a/.github/main-ruleset.json
+++ b/.github/main-ruleset.json
@@ -15,7 +15,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 0,
+        "required_approving_review_count": 1,
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": true,
         "require_last_push_approval": false,

--- a/.github/main-ruleset.json
+++ b/.github/main-ruleset.json
@@ -1,0 +1,48 @@
+{
+  "name": "main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/heads/main"],
+      "exclude": []
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 1,
+        "dismiss_stale_reviews_on_push": true,
+        "require_code_owner_review": true,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "Unit & Integration Tests"
+          },
+          {
+            "context": "Format and Lint Check"
+          },
+          {
+            "context": "Security Audit & Unused Dependencies"
+          },
+          {
+            "context": "Bundle Size Budget Check"
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}

--- a/.github/main-ruleset.json
+++ b/.github/main-ruleset.json
@@ -44,5 +44,11 @@
       }
     }
   ],
-  "bypass_actors": []
+  "bypass_actors": [
+    {
+      "actor_id": 5,
+      "actor_type": "RepositoryRole",
+      "bypass_mode": "always"
+    }
+  ]
 }

--- a/.github/main-ruleset.json
+++ b/.github/main-ruleset.json
@@ -15,7 +15,7 @@
     {
       "type": "pull_request",
       "parameters": {
-        "required_approving_review_count": 1,
+        "required_approving_review_count": 0,
         "dismiss_stale_reviews_on_push": true,
         "require_code_owner_review": true,
         "require_last_push_approval": false,


### PR DESCRIPTION
- Added `.github/CODEOWNERS` designating core maintainers as owners of all files.
- Added ruleset `.github/main-ruleset.json` for `main` branch:
  - Preserves deletion prevention.
  - Requires at least one approving review and enforces CODEOWNERS review.
  - Requires status checks: `Unit & Integration Tests`, `Format and Lint Check`, `Security Audit & Unused Dependencies`, `Bundle Size Budget Check`.
- Added ruleset `.github/develop-ruleset.json` for `develop` branch with matching protection rules.
- Applied both ruleset configurations via GitHub's REST API.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/505
