### PR TITLE
﻿chore(ci): add dependabot configuration (X-Tracker #508)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,35 @@
+# GitHub Dependabot configuration file
+# Ref: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  # Enable version updates for npm ecosystem (pnpm lockfile at root)
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    # Group pull requests to reduce PR spam (weekly updates)
+    groups:
+      production-dependencies:
+        dependency-type: 'production'
+        patterns:
+          - '*'
+      development-dependencies:
+        dependency-type: 'development'
+        patterns:
+          - '*'
+
+  # Enable version updates for GitHub Actions
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    open-pull-requests-limit: 10
+    # Group GitHub Actions updates
+    groups:
+      github-actions:
+        patterns:
+          - '*'


### PR DESCRIPTION
Add .github/dependabot.yml to automate package and github-actions updates.
Configure weekly Monday schedules and PR grouping for production and development dependencies to avoid PR spam.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/508
