### PR TITLE
chore(ci): exclude major version bumps from dependabot grouping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,14 +10,23 @@ updates:
       interval: 'weekly'
       day: 'monday'
     open-pull-requests-limit: 10
-    # Group pull requests to reduce PR spam (weekly updates)
+    # Group pull requests to reduce PR spam (weekly updates).
+    # Major version bumps are excluded from grouping so they don't get
+    # silently bundled with minor/patch updates and can be reviewed and
+    # migrated one at a time.
     groups:
       production-dependencies:
         dependency-type: 'production'
+        update-types:
+          - 'minor'
+          - 'patch'
         patterns:
           - '*'
       development-dependencies:
         dependency-type: 'development'
+        update-types:
+          - 'minor'
+          - 'patch'
         patterns:
           - '*'
 


### PR DESCRIPTION
## Summary
- Dependabot's `development-dependencies` / `production-dependencies` groups bundled every semver bump together regardless of size. #857 packed 22 dev-dependency updates into one PR, including three breaking majors (ESLint 8→10, TypeScript 5.9→7, Tailwind 3→4) mixed in with safe patch/minor bumps — breaking lint, type-check, and CSS config all at once with no way to review or roll back one migration independently.
- Add `update-types: ['minor', 'patch']` to both groups so major bumps are excluded from grouping. Dependabot will now open one PR per major-version package instead, letting each breaking migration be reviewed and handled on its own.
- Closes #857 (superseded — will be replaced by a scoped minor/patch-only PR plus separate per-package major PRs on the next Dependabot run).

## Test plan
- [x] `pnpm type-check` passes
- [x] `pnpm test` passes (825 tests)
- [ ] Confirm next Dependabot run produces a minor/patch-only PR and separate major-version PRs