### PR TITLE
ci: bump default Node.js version to 22

### DIFF
--- a/.github/actions/setup-env/action.yml
+++ b/.github/actions/setup-env/action.yml
@@ -5,7 +5,7 @@ inputs:
   node-version:
     description: 'Node.js version to set up'
     required: false
-    default: '20'
+    default: '22'
   pnpm-version:
     description: 'PNPM version to set up'
     required: false

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v7
         with:
-          node-version: 20
+          node-version: 22
           cache: pnpm
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary
- Several pending Dependabot updates (`@testing-library/jest-dom` 7.x, `jsdom` 30.x, `lint-staged` 17.x) declare `engines.node: >=22`, which makes `pnpm install --frozen-lockfile` fail on CI with `ERR_PNPM_UNSUPPORTED_ENGINE` since our workflows are pinned to Node 20.
- Bumps the default `node-version` in the shared `setup-env` composite action (used by most workflows) and the standalone `e2e.yml` workflow from 20 to 22.
- Project's own `package.json` engines field (`>=20.19.0`) already permits Node 22, no change needed there.

## Test plan
- [ ] CI passes on this PR with Node 22
- [ ] Re-run the blocked Dependabot PRs (#865, #869, #870) after this merges to confirm they now install successfully