### PR TITLE
chore: remove blanket code owner requirement for @JimmyPan622

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 # when a pull request modifies any files in this repository.
 
 # Catch-all rule to require review from the core maintainers for all changes
-*       @LowSugarCoke @JimmyPan622
+*       @LowSugarCoke


### PR DESCRIPTION
## What Does This PR Do?

- Removes @JimmyPan622 from the repo-wide CODEOWNERS catch-all rule, leaving @LowSugarCoke as sole required code owner reviewer
- Reason: the catch-all `*` rule auto-requested him as a required reviewer on every single PR (enforced by branch protection's require_code_owner_review), making him a permanent participant on all PR threads and flooding his inbox with AI Review Pipeline notifications regardless of relevance
- He can still be manually added as a reviewer/assignee per PR when actually relevant; notifications will then follow his actual participation instead of a blanket rule

## Demo

N/A (repo governance config only)

## Screenshot

N/A

## Anything to Note?

This means @LowSugarCoke is now the sole enforced code owner for merge approval on main/develop. Manual review requests to @JimmyPan622 are unaffected and still work as before.
