### PR TITLE
feat(middleware): implement maintenance mode bypass mechanism (X-Tracker #512)

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -342,6 +342,28 @@ describe('middleware maintenance mode', () => {
     const cookie = response.cookies.get('maintenance_bypass');
     expect(cookie).toBeDefined();
     expect(cookie?.value).toBe('test-secret-bypass');
+
+    // Verify detailed cookie properties
+    expect(cookie?.httpOnly).toBe(true);
+    expect(cookie?.sameSite).toBe('lax');
+    expect(cookie?.path).toBe('/');
+    expect(cookie?.maxAge).toBe(7200);
+  });
+
+  it('redirects and correctly preserves other query parameters (including multi-value/array params) when cleaning up bypass parameter', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+
+    const req = new NextRequest(
+      'https://example.com/some-page?bypass=test-secret-bypass&foo=bar&category=A&category=B'
+    );
+    const response = await middleware(req);
+
+    // Should redirect to clean URL, preserving other parameters (including duplicate/array parameters)
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/some-page?foo=bar&category=A&category=B'
+    );
   });
 
   it('does not bypass maintenance when bypass token is empty/not configured', async () => {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -322,4 +322,103 @@ describe('middleware maintenance mode', () => {
     expect(response.status).toBe(307);
     expect(response.headers.get('location')).toContain('/maintenance');
   });
+
+  it('redirects and sets bypass cookie when correct bypass query param is provided', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+
+    const req = new NextRequest(
+      'https://example.com/some-page?bypass=test-secret-bypass'
+    );
+    const response = await middleware(req);
+
+    // Should redirect to clean URL without the query param
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'https://example.com/some-page'
+    );
+
+    // Cookie should be set with correct value and options
+    const cookie = response.cookies.get('maintenance_bypass');
+    expect(cookie).toBeDefined();
+    expect(cookie?.value).toBe('test-secret-bypass');
+  });
+
+  it('does not bypass maintenance when bypass token is empty/not configured', async () => {
+    delete process.env.MAINTENANCE_BYPASS_TOKEN;
+    process.env.MAINTENANCE_MODE = 'true';
+
+    const req = new NextRequest(
+      'https://example.com/some-page?bypass=something'
+    );
+    const response = await middleware(req);
+
+    // Should redirect to /maintenance since token is not configured
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/maintenance');
+  });
+
+  it('does not bypass maintenance when incorrect query token is provided', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+
+    const req = new NextRequest(
+      'https://example.com/some-page?bypass=wrong-token'
+    );
+    const response = await middleware(req);
+
+    // Should redirect to /maintenance since token is incorrect
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/maintenance');
+  });
+
+  it('bypasses maintenance check and proceeds to session/auth checks when a valid bypass cookie is present', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+    mockGetToken.mockResolvedValue(null); // Not logged in
+
+    const req = new NextRequest('https://example.com/reservation/mentee', {
+      headers: {
+        cookie: 'maintenance_bypass=test-secret-bypass',
+      },
+    });
+    const response = await middleware(req);
+
+    // Should bypass maintenance check, but still run session/auth checks
+    // Since /reservation/mentee is a protected route and user is not logged in, it should redirect to signin
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/signin');
+  });
+
+  it('bypasses maintenance check and allows API routes when a valid bypass cookie is present', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+    mockGetToken.mockResolvedValue({} as never); // Logged in
+
+    const req = new NextRequest('https://example.com/api/mentors', {
+      headers: {
+        cookie: 'maintenance_bypass=test-secret-bypass',
+      },
+    });
+    const response = await middleware(req);
+
+    // Should bypass maintenance check and proceed to normal API handler (returns 200/next)
+    expect(response.status).toBe(200);
+  });
+
+  it('does not bypass maintenance check when bypass cookie is incorrect', async () => {
+    process.env.MAINTENANCE_BYPASS_TOKEN = 'test-secret-bypass';
+    process.env.MAINTENANCE_MODE = 'true';
+
+    const req = new NextRequest('https://example.com/some-page', {
+      headers: {
+        cookie: 'maintenance_bypass=wrong-cookie-value',
+      },
+    });
+    const response = await middleware(req);
+
+    // Should redirect to /maintenance
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/maintenance');
+  });
 });

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -62,6 +62,33 @@ export async function middleware(req: NextRequest) {
     return NextResponse.next();
   }
 
+  // -------- 0.05 Check Maintenance Bypass --------
+  const bypassParam = nextUrl.searchParams.get('bypass');
+  const bypassToken = process.env.MAINTENANCE_BYPASS_TOKEN;
+
+  // If correct bypass token is in query param, set cookie and redirect to clear the URL query param
+  if (bypassToken && bypassParam === bypassToken) {
+    const nextUrlClean = new URL(pathname, nextUrl);
+    nextUrl.searchParams.forEach((val, key) => {
+      if (key !== 'bypass') {
+        nextUrlClean.searchParams.set(key, val);
+      }
+    });
+
+    const response = NextResponse.redirect(nextUrlClean);
+    response.cookies.set('maintenance_bypass', bypassToken, {
+      httpOnly: true,
+      secure: process.env.NODE_ENV === 'production',
+      sameSite: 'lax',
+      path: '/',
+      maxAge: 7200, // 2 hours
+    });
+    return response;
+  }
+
+  const bypassCookie = req.cookies.get('maintenance_bypass')?.value;
+  const hasValidBypass = !!(bypassToken && bypassCookie === bypassToken);
+
   // -------- 0.1 Check Maintenance Mode --------
   let isInMaintenanceMode = false;
   const isEnvMaintenance =
@@ -73,6 +100,11 @@ export async function middleware(req: NextRequest) {
   } else if (process.env.EDGE_CONFIG) {
     const value = await getWithTimeout('isInMaintenanceMode', 500);
     isInMaintenanceMode = value === true || value === 'true';
+  }
+
+  // Override maintenance mode if a valid bypass token is present
+  if (hasValidBypass) {
+    isInMaintenanceMode = false;
   }
 
   const isMaintenancePage = pathname === '/maintenance';

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -68,12 +68,8 @@ export async function middleware(req: NextRequest) {
 
   // If correct bypass token is in query param, set cookie and redirect to clear the URL query param
   if (bypassToken && bypassParam === bypassToken) {
-    const nextUrlClean = new URL(pathname, nextUrl);
-    nextUrl.searchParams.forEach((val, key) => {
-      if (key !== 'bypass') {
-        nextUrlClean.searchParams.set(key, val);
-      }
-    });
+    const nextUrlClean = new URL(req.url);
+    nextUrlClean.searchParams.delete('bypass');
 
     const response = NextResponse.redirect(nextUrlClean);
     response.cookies.set('maintenance_bypass', bypassToken, {


### PR DESCRIPTION
Introduce an internal testing bypass mechanism for maintenance mode using a secure bypass token.

- Detects 'bypass' query parameter on incoming requests and validates against MAINTENANCE_BYPASS_TOKEN.
- Sets a secure, httpOnly 'maintenance_bypass' cookie with a 2-hour duration and redirects to clean URL.
- Inspects the cookie on subsequent requests to allow bypass of the maintenance redirection and 503 blocks.
- Adds 6 new unit tests to thoroughly verify the correctness and security boundaries of the bypass mechanism.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/512
