### PR TITLE
style(ui): replace avoidable inline styles with Tailwind utility classes (X-Tracker #517)

### DIFF
--- a/src/app/profile/[pageUserId]/ui.tsx
+++ b/src/app/profile/[pageUserId]/ui.tsx
@@ -99,7 +99,7 @@ export default function ProfilePageUI({
                 alt={'Avatar of ' + userData.name}
                 fill
                 sizes="160px"
-                style={{ objectFit: 'contain' }}
+                className="object-contain"
                 priority
               />
             </div>

--- a/src/components/landing/HomePageSlider.tsx
+++ b/src/components/landing/HomePageSlider.tsx
@@ -28,11 +28,7 @@ export const HomePageSlider: FC = () => {
       }}
     >
       {sliderList.map(({ name, text, avatar }, index) => (
-        <SwiperSlide
-          className="m-0"
-          key={`${name}_Slide_${index + 1}`}
-          style={{ width: '100%', margin: 0 }}
-        >
+        <SwiperSlide className="m-0 w-full" key={`${name}_Slide_${index + 1}`}>
           <div className="mb-4 flex flex-col gap-10 px-6 py-8 sm:flex-row">
             <div className="flex flex-shrink-0 basis-40 flex-col items-center gap-4">
               <div className="relative size-28 overflow-clip rounded-full">

--- a/src/components/profile/avatar-card/AvatarCard.tsx
+++ b/src/components/profile/avatar-card/AvatarCard.tsx
@@ -37,9 +37,7 @@ export const AvatarCard: FC<Props> = ({
           alt={'Avatar of ' + name}
           fill
           sizes="120px"
-          style={{
-            objectFit: 'contain',
-          }}
+          className="object-contain"
         />
       </div>
 


### PR DESCRIPTION
Replace avoidable inline style={{...}} props with equivalent Tailwind utility classes to improve style consistency and codebase maintainability.

Specifically modified:
- **src/app/profile/[pageUserId]/ui.tsx**: Replaced style={{ objectFit: 'contain' }} with Tailwind's object-contain class.
- **src/components/profile/avatar-card/AvatarCard.tsx**: Replaced style={{ objectFit: 'contain' }} with Tailwind's object-contain class.
- **src/components/landing/HomePageSlider.tsx**: Replaced style={{ width: '100%', margin: 0 }} with Tailwind's sorted m-0 w-full class.

All linters, builders, and tests are passing successfully.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/517
