### PR TITLE
feat(design): add shadow-card and auth background gradient tokens (X-Tracker #515)

### DIFF
--- a/src/design/tokens/color-values.ts
+++ b/src/design/tokens/color-values.ts
@@ -58,6 +58,11 @@ export const rawColors = {
   'avatar-border': '180 16% 76%', // #B7CBCB
   'avatar-overlay': '0 0% 44%', // #6F6F6F
 
+  // Auth page gradient tokens
+  'auth-gradient-1': '180 63% 95%', // #EAFBFB
+  'auth-gradient-2': '200 100% 91%', // #CFEFFF
+  'auth-gradient-3': '253 100% 95%', // #EAE4FF
+
   // Legacy / Landing page specific colors
   navy: '219 59% 22%', // #172E59
   'logo-blue': '200 100% 18%', // #003C5A

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -88,6 +88,11 @@ module.exports = {
     border: 'hsl(var(--color-avatar-border) / <alpha-value>)',
     overlay: 'hsl(var(--color-avatar-overlay) / <alpha-value>)',
   },
+  'auth-gradient': {
+    1: 'hsl(var(--color-auth-gradient-1) / <alpha-value>)',
+    2: 'hsl(var(--color-auth-gradient-2) / <alpha-value>)',
+    3: 'hsl(var(--color-auth-gradient-3) / <alpha-value>)',
+  },
   // [Item 3: Legacy landing-only tokens]
   // 經過全面代碼檢索（grep），以下 5 個 Token 仍被 (landing)/about、(landing)/page、(landing)/terms、(landing)/privacy、mentor-pool/PopularPositionChips 以及 components/landing/HomePageSlider 廣泛調用，為防樣式損壞，依據工程規範維持保留。
   navy: 'hsl(var(--color-navy) / <alpha-value>)',

--- a/src/design/tokens/shadow.ts
+++ b/src/design/tokens/shadow.ts
@@ -1,0 +1,3 @@
+module.exports = {
+  card: '0 2px 12px rgba(0, 0, 0, 0.04)',
+};

--- a/src/design/tokens/tokens.test.ts
+++ b/src/design/tokens/tokens.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest';
+
+// @ts-expect-error - color.ts is a CommonJS module
+import colors from './color';
+import { rawColors } from './color-values';
+// @ts-expect-error - shadow.ts is a CommonJS module
+import shadows from './shadow';
+
+describe('Design Tokens Configuration', () => {
+  describe('Color values and mapping', () => {
+    it('should have the new auth gradient stop colors in raw colors', () => {
+      expect(rawColors['auth-gradient-1']).toBe('180 63% 95%');
+      expect(rawColors['auth-gradient-2']).toBe('200 100% 91%');
+      expect(rawColors['auth-gradient-3']).toBe('253 100% 95%');
+    });
+
+    it('should correctly map raw colors into the Tailwind color export', () => {
+      expect(colors['auth-gradient']).toBeDefined();
+      expect(colors['auth-gradient'][1]).toBe(
+        'hsl(var(--color-auth-gradient-1) / <alpha-value>)'
+      );
+      expect(colors['auth-gradient'][2]).toBe(
+        'hsl(var(--color-auth-gradient-2) / <alpha-value>)'
+      );
+      expect(colors['auth-gradient'][3]).toBe(
+        'hsl(var(--color-auth-gradient-3) / <alpha-value>)'
+      );
+    });
+  });
+
+  describe('Shadow values', () => {
+    it('should have the shadow-card token defined in shadow.ts', () => {
+      expect(shadows.card).toBe('0 2px 12px rgba(0, 0, 0, 0.04)');
+    });
+  });
+});

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -36,6 +36,12 @@
     --ring: var(--color-brand-500);
 
     --radius: 0.5rem;
+    --bg-auth-card: linear-gradient(
+      90deg,
+      hsl(var(--color-auth-gradient-1)) 0%,
+      hsl(var(--color-auth-gradient-2)) 45%,
+      hsl(var(--color-auth-gradient-3)) 100%
+    );
   }
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -54,6 +54,10 @@
   --color-avatar-background: 180 57% 97%; /* #F4FCFC */
   --color-avatar-border: 180 16% 76%; /* #B7CBCB */
   --color-avatar-overlay: 0 0% 44%; /* #6F6F6F */
+  /* Auth page gradient tokens */
+  --color-auth-gradient-1: 180 63% 95%; /* #EAFBFB */
+  --color-auth-gradient-2: 200 100% 91%; /* #CFEFFF */
+  --color-auth-gradient-3: 253 100% 95%; /* #EAE4FF */
   /* Legacy / Landing page specific colors */
   --color-navy: 219 59% 22%; /* #172E59 */
   --color-logo-blue: 200 100% 18%; /* #003C5A */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,5 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const colors = require('./src/design/tokens/color');
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const shadows = require('./src/design/tokens/shadow');
 
 export const content = ['./src/**/*.{js,jsx,ts,tsx}'];
 
@@ -26,6 +28,13 @@ export const theme = {
       lg: 'var(--radius)',
       md: 'calc(var(--radius) - 2px)',
       sm: 'calc(var(--radius) - 4px)',
+    },
+    boxShadow: {
+      card: shadows.card,
+    },
+    backgroundImage: {
+      'auth-card':
+        'linear-gradient(90deg, hsl(var(--color-auth-gradient-1)) 0%, hsl(var(--color-auth-gradient-2)) 45%, hsl(var(--color-auth-gradient-3)) 100%)',
     },
     keyframes: {
       'accordion-down': {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -33,8 +33,7 @@ export const theme = {
       card: shadows.card,
     },
     backgroundImage: {
-      'auth-card':
-        'linear-gradient(90deg, hsl(var(--color-auth-gradient-1)) 0%, hsl(var(--color-auth-gradient-2)) 45%, hsl(var(--color-auth-gradient-3)) 100%)',
+      'auth-card': 'var(--bg-auth-card)',
     },
     keyframes: {
       'accordion-down': {


### PR DESCRIPTION
Add missing shadow-card boxShadow scale and reusable gradient stops for the auth-page background.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/515
