### PR TITLE
fix(mentor-schedule): resolve cross-month bucket when editing recurring occurrences (X-Tracker #522)

### DIFF
--- a/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.stories.tsx
@@ -101,7 +101,7 @@ const defaultScheduleMock: UseMentorScheduleReturn = {
   allowedDates: [todayStr, '2026-08-04'],
   generateBookingSlots: () => [],
   addSlotForSelectedDate: () => ({ added: 1, skipped: 0 }),
-  updateDraftSlot: () => true,
+  updateDraftSlot: () => ({ success: true }),
   deleteDraftSlot: () => {},
   confirmChanges: async () => ({ ok: true }),
   resetChanges: () => {},

--- a/src/components/profile/reservation/MentorScheduleDialog.test.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.test.tsx
@@ -87,7 +87,7 @@ const mockSchedule = {
   allowedDates: ['2026-07-26'],
   generateBookingSlots: vi.fn(),
   addSlotForSelectedDate: vi.fn().mockReturnValue({ added: 1, skipped: 0 }),
-  updateDraftSlot: vi.fn().mockReturnValue(true),
+  updateDraftSlot: vi.fn().mockReturnValue({ success: true }),
   deleteDraftSlot: vi.fn(),
   confirmChanges: vi.fn().mockResolvedValue({ ok: true }),
   resetChanges: vi.fn(),
@@ -320,9 +320,9 @@ describe('MentorScheduleDialog', () => {
     expect(screen.queryByText('新增可預約時段')).not.toBeInTheDocument();
   });
 
-  it('shows precise destruct warning toast when updateDraftSlot throws TARGET_MONTH_NOT_LOADED error', () => {
+  it('shows precise destruct warning toast when updateDraftSlot returns TARGET_MONTH_NOT_LOADED reason', () => {
     const mockUpdateDraftSlotWithError = vi.fn().mockImplementation(() => {
-      throw new Error('TARGET_MONTH_NOT_LOADED');
+      return { success: false, reason: 'TARGET_MONTH_NOT_LOADED' };
     });
 
     const mockScheduleWithError = {

--- a/src/components/profile/reservation/MentorScheduleDialog.test.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.test.tsx
@@ -2,6 +2,7 @@ import { fireEvent, render, screen, within } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UseMentorScheduleReturn } from '@/hooks/useMentorSchedule';
+import { mockToast } from '@/test/mocks/useToast';
 
 import MentorScheduleDialog from './MentorScheduleDialog';
 
@@ -317,5 +318,39 @@ describe('MentorScheduleDialog', () => {
     // Even though activeDialog has been set to null, the EditSlotModal form should still hold the values of
     // the last slot, ensuring that the fields don't empty out or flicker during the fade-out exit animation.
     expect(screen.queryByText('新增可預約時段')).not.toBeInTheDocument();
+  });
+
+  it('shows precise destruct warning toast when updateDraftSlot throws TARGET_MONTH_NOT_LOADED error', () => {
+    const mockUpdateDraftSlotWithError = vi.fn().mockImplementation(() => {
+      throw new Error('TARGET_MONTH_NOT_LOADED');
+    });
+
+    const mockScheduleWithError = {
+      ...mockSchedule,
+      updateDraftSlot: mockUpdateDraftSlotWithError,
+    } as unknown as UseMentorScheduleReturn;
+
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockScheduleWithError}
+      />
+    );
+
+    const firstSlot = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    fireEvent.click(firstSlot!);
+    expect(screen.getByText('編輯時段')).toBeInTheDocument();
+
+    const editSubmitBtn = screen.getByRole('button', { name: '完成' });
+    fireEvent.click(editSubmitBtn);
+
+    expect(mockUpdateDraftSlotWithError).toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      description: '目標月份排程尚未載入，請先在行事曆中切換至目標月份。',
+    });
   });
 });

--- a/src/components/profile/reservation/MentorScheduleDialog.test.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.test.tsx
@@ -353,4 +353,38 @@ describe('MentorScheduleDialog', () => {
       description: '目標月份排程尚未載入，請先在行事曆中切換至目標月份。',
     });
   });
+
+  it('shows precise generic error toast when updateDraftSlot returns success: false without a specific reason', () => {
+    const mockUpdateDraftSlotWithError = vi.fn().mockImplementation(() => {
+      return { success: false }; // returns success: false without reason
+    });
+
+    const mockScheduleWithError = {
+      ...mockSchedule,
+      updateDraftSlot: mockUpdateDraftSlotWithError,
+    } as unknown as UseMentorScheduleReturn;
+
+    render(
+      <MentorScheduleDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        schedule={mockScheduleWithError}
+      />
+    );
+
+    const firstSlot = screen
+      .getByText('10:00 – 10:30')
+      .closest('[role="button"]');
+    fireEvent.click(firstSlot!);
+    expect(screen.getByText('編輯時段')).toBeInTheDocument();
+
+    const editSubmitBtn = screen.getByRole('button', { name: '完成' });
+    fireEvent.click(editSubmitBtn);
+
+    expect(mockUpdateDraftSlotWithError).toHaveBeenCalled();
+    expect(mockToast).toHaveBeenCalledWith({
+      variant: 'destructive',
+      description: '更新時段失敗，發生未知的錯誤，請稍後再試。',
+    });
+  });
 });

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -384,8 +384,7 @@ export default function MentorScheduleDialog({
               return;
             }
           } catch (e: unknown) {
-            const err = e as Error;
-            if (err.message === 'TARGET_MONTH_NOT_LOADED') {
+            if (e instanceof Error && e.message === 'TARGET_MONTH_NOT_LOADED') {
               toast({
                 variant: 'destructive',
                 description:
@@ -394,7 +393,7 @@ export default function MentorScheduleDialog({
             } else {
               toast({
                 variant: 'destructive',
-                description: err.message || '更新時段失敗',
+                description: e instanceof Error ? e.message : '更新時段失敗',
               });
             }
             return;

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -382,10 +382,15 @@ export default function MentorScheduleDialog({
                 description:
                   '目標月份排程尚未載入，請先在行事曆中切換至目標月份。',
               });
-            } else {
+            } else if (result.reason === 'OVERLAP') {
               toast({
                 variant: 'destructive',
                 description: '此時段與其他時段重疊',
+              });
+            } else {
+              toast({
+                variant: 'destructive',
+                description: '更新時段失敗，發生未知的錯誤，請稍後再試。',
               });
             }
             return;

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -367,19 +367,36 @@ export default function MentorScheduleDialog({
         onClose={() => setActiveDialog(null)}
         onSubmit={(form) => {
           if (activeDialog?.kind !== 'edit') return;
-          const ok = updateDraftSlot(
-            activeDialog.id,
-            activeDialog.occurrenceUnix,
-            {
-              startTime: `${form.startHour}:${form.startMinute}`,
-              durationMinutes: form.durationMinutes,
+          try {
+            const ok = updateDraftSlot(
+              activeDialog.id,
+              activeDialog.occurrenceUnix,
+              {
+                startTime: `${form.startHour}:${form.startMinute}`,
+                durationMinutes: form.durationMinutes,
+              }
+            );
+            if (!ok) {
+              toast({
+                variant: 'destructive',
+                description: '此時段與其他時段重疊',
+              });
+              return;
             }
-          );
-          if (!ok) {
-            toast({
-              variant: 'destructive',
-              description: '此時段與其他時段重疊',
-            });
+          } catch (e: unknown) {
+            const err = e as Error;
+            if (err.message === 'TARGET_MONTH_NOT_LOADED') {
+              toast({
+                variant: 'destructive',
+                description:
+                  '目標月份排程尚未載入，請先在行事曆中切換至目標月份。',
+              });
+            } else {
+              toast({
+                variant: 'destructive',
+                description: err.message || '更新時段失敗',
+              });
+            }
             return;
           }
           setActiveDialog(null);

--- a/src/components/profile/reservation/MentorScheduleDialog.tsx
+++ b/src/components/profile/reservation/MentorScheduleDialog.tsx
@@ -367,24 +367,16 @@ export default function MentorScheduleDialog({
         onClose={() => setActiveDialog(null)}
         onSubmit={(form) => {
           if (activeDialog?.kind !== 'edit') return;
-          try {
-            const ok = updateDraftSlot(
-              activeDialog.id,
-              activeDialog.occurrenceUnix,
-              {
-                startTime: `${form.startHour}:${form.startMinute}`,
-                durationMinutes: form.durationMinutes,
-              }
-            );
-            if (!ok) {
-              toast({
-                variant: 'destructive',
-                description: '此時段與其他時段重疊',
-              });
-              return;
+          const result = updateDraftSlot(
+            activeDialog.id,
+            activeDialog.occurrenceUnix,
+            {
+              startTime: `${form.startHour}:${form.startMinute}`,
+              durationMinutes: form.durationMinutes,
             }
-          } catch (e: unknown) {
-            if (e instanceof Error && e.message === 'TARGET_MONTH_NOT_LOADED') {
+          );
+          if (!result.success) {
+            if (result.reason === 'TARGET_MONTH_NOT_LOADED') {
               toast({
                 variant: 'destructive',
                 description:
@@ -393,7 +385,7 @@ export default function MentorScheduleDialog({
             } else {
               toast({
                 variant: 'destructive',
-                description: e instanceof Error ? e.message : '更新時段失敗',
+                description: '此時段與其他時段重疊',
               });
             }
             return;

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -158,9 +158,9 @@ describe('useMentorSchedule', () => {
       {
         id: 101,
         type: 'ALLOW' as const,
-        dtstart: 1774390000, // occurrence 1 (July 26, 2026 12:46:40 PM UTC)
-        dtend: 1774391800,
-        rrule: 'FREQ=WEEKLY;COUNT=2', // next is 1774994800 (August 2, 2026 12:46:40 PM UTC)
+        dtstart: 1785070000, // occurrence 1 (July 26, 2026 12:46:40 PM UTC)
+        dtend: 1785071800,
+        rrule: 'FREQ=WEEKLY;COUNT=2', // next is 1785674800 (August 2, 2026 12:46:40 PM UTC)
         exdate: [],
       },
     ];
@@ -175,25 +175,25 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft).toHaveLength(2);
 
     act(() => {
-      // Update occurrence 1 (1774390000)
-      const success = result.current.updateDraftSlot(101, 1774390000, {
+      // Update occurrence 1 (1785070000)
+      const success = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:00', // Move to 13:00
         durationMinutes: 45,
       });
       expect(success).toBe(true);
     });
 
-    // The parent slot 101 should now have 1774390000 in its exdate (leaving only 1 active weekly occurrence).
+    // The parent slot 101 should now have 1785070000 in its exdate (leaving only 1 active weekly occurrence).
     // A new detached non-recurring slot (negative temporary ID) should be created at 13:00.
     // So there should be 2 slots in parsedDraft now:
-    // - The remaining weekly occurrence (starts at 1774994800, slot 101)
+    // - The remaining weekly occurrence (starts at 1785674800, slot 101)
     // - The detached, updated slot (starts at 13:00 local, negative temporary ID)
     expect(result.current.parsedDraft).toHaveLength(2);
 
     const parentOcc = result.current.parsedDraft.find((s) => s.id === 101);
-    expect(parentOcc?.occurrenceUnix).toBe(1774994800); // the remaining weekly occurrence is untouched
+    expect(parentOcc?.occurrenceUnix).toBe(1785674800); // the remaining weekly occurrence is untouched
 
-    const baseDate = dayjs(1774390000 * 1000).format('YYYY-MM-DD');
+    const baseDate = dayjs(1785070000 * 1000).format('YYYY-MM-DD');
     const expectedTime = buildDateTime(baseDate, '13:00');
     const expectedUnix = Math.floor(expectedTime.valueOf() / 1000);
 
@@ -334,5 +334,73 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft).toHaveLength(1);
     expect(result.current.parsedDraft[0].id).toBe(101);
     expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1774994800);
+  });
+
+  it('regression: a recurring ALLOW row whose weekly occurrences cross a month boundary, edited on a cross-boundary occurrence, ends up in exactly one month buffer with no duplicate representation', async () => {
+    // Parent slot 101 starts on July 26, 2026 (Month 7) -> 1785070000
+    // Weekly recurrence count=2 -> Second occurrence is August 2, 2026 (Month 8) -> 1785674800
+    const mockRawsJuly: RawMentorTimeslot[] = [
+      {
+        id: 101,
+        type: 'ALLOW' as const,
+        dtstart: 1785070000,
+        dtend: 1785071800,
+        rrule: 'FREQ=WEEKLY;COUNT=2',
+        exdate: [],
+      },
+    ];
+
+    // Mock loadMonthScheduleCached for July to return mockRawsJuly, and for August to return []
+    mockLoadMonthScheduleCached.mockImplementation((ref) => {
+      if (ref.year === 2026 && ref.month === 7) {
+        return {
+          cached: mockRawsJuly,
+          revalidate: Promise.resolve(mockRawsJuly),
+        };
+      }
+      return {
+        cached: [],
+        revalidate: Promise.resolve([]),
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMentorSchedule({
+        backend: { userId: '123', year: 2026, month: 7 },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    // There should be 2 active occurrences of slot 101 initially (one in Month 7, one in Month 8)
+    expect(result.current.parsedDraft).toHaveLength(2);
+
+    act(() => {
+      // Edit the August 2 occurrence (1785674800 - Month 8)
+      // Since it is edited, it should detach from the parent in July and be stored in August's buffer
+      const success = result.current.updateDraftSlot(101, 1785674800, {
+        startTime: '13:00', // Move to 13:00
+        durationMinutes: 45,
+      });
+      expect(success).toBe(true);
+    });
+
+    // Total active occurrences should still be 2:
+    // - One in July (the original parent row with exdate)
+    // - One in August (the detached non-recurring slot)
+    expect(result.current.parsedDraft).toHaveLength(2);
+
+    const julyOcc = result.current.parsedDraft.find((s) => s.id === 101);
+    expect(julyOcc?.occurrenceUnix).toBe(1785070000); // July occurrence remains untouched under original parent ID
+
+    const baseDate = dayjs(1785674800 * 1000).format('YYYY-MM-DD');
+    const expectedTime = buildDateTime(baseDate, '13:00');
+    const expectedUnix = Math.floor(expectedTime.valueOf() / 1000);
+
+    const augustOcc = result.current.parsedDraft.find((s) => s.id < 0);
+    expect(augustOcc?.occurrenceUnix).toBe(expectedUnix); // the detached occurrence is updated to 13:00 local of August 2
+    expect(augustOcc?.durationMinutes).toBe(45);
   });
 });

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -615,4 +615,70 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft[0].id).toBe(101);
     expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1785070000);
   });
+
+  it('regression: a recurring ALLOW row whose weekly occurrences cross a month boundary, deleted on a cross-boundary occurrence, successfully exdates the row across all monthly buffers and prevents duplicate representation', async () => {
+    // Parent slot 101 starts on July 26, 2026 (Month 7) -> 1785070000
+    // Weekly recurrence count=2 -> Second occurrence is August 2, 2026 (Month 8) -> 1785674800
+    const mockRawsJuly: RawMentorTimeslot[] = [
+      {
+        id: 101,
+        type: 'ALLOW' as const,
+        dtstart: 1785070000,
+        dtend: 1785071800,
+        rrule: 'FREQ=WEEKLY;COUNT=2',
+        exdate: [],
+      },
+    ];
+
+    // Mock loadMonthScheduleCached for both July and August to return mockRawsJuly (simulating parent row loaded in both months)
+    mockLoadMonthScheduleCached.mockImplementation((ref) => {
+      if (ref.year === 2026 && (ref.month === 7 || ref.month === 8)) {
+        return {
+          cached: mockRawsJuly,
+          revalidate: Promise.resolve(mockRawsJuly),
+        };
+      }
+      return {
+        cached: [],
+        revalidate: Promise.resolve([]),
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMentorSchedule({
+        backend: { userId: '123', year: 2026, month: 7 },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    // There should be 2 active occurrences of slot 101 initially (one in Month 7, one in Month 8)
+    expect(result.current.parsedDraft).toHaveLength(2);
+
+    act(() => {
+      // Delete the August 2 occurrence (1785674800 - Month 8)
+      // Since it is deleted, it should add 1785674800 to the exdate of row 101 in BOTH July and August buffers!
+      result.current.deleteDraftSlot(101, 1785674800);
+    });
+
+    // Total active occurrences should now be 1:
+    // - Only the July 26 occurrence (since August 2 is exdated on all copies of parent row 101)
+    expect(result.current.parsedDraft).toHaveLength(1);
+
+    const julyOcc = result.current.parsedDraft[0];
+    expect(julyOcc.occurrenceUnix).toBe(1785070000); // Only the July 26 occurrence remains
+    expect(julyOcc.id).toBe(101);
+
+    // Verify both months are marked dirty by ensuring confirmChanges requests syncing for both (Testing Finding 1)
+    const mockSyncMonths = vi.mocked(syncMonths);
+    await result.current.confirmChanges();
+    expect(mockSyncMonths).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ ref: expect.objectContaining({ month: 7 }) }),
+        expect.objectContaining({ ref: expect.objectContaining({ month: 8 }) }),
+      ])
+    );
+  });
 });

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -29,8 +29,8 @@ describe('useMentorSchedule', () => {
     {
       id: 101,
       type: 'ALLOW' as const,
-      dtstart: 1774390000,
-      dtend: 1774391800,
+      dtstart: 1785070000,
+      dtend: 1785071800,
       rrule: undefined,
       exdate: [],
     },
@@ -59,9 +59,9 @@ describe('useMentorSchedule', () => {
 
     expect(result.current.parsedDraft).toHaveLength(1);
     const slot = result.current.parsedDraft[0];
-    expect(slot.occurrenceId).toBe('101_1774390000');
+    expect(slot.occurrenceId).toBe('101_1785070000');
     expect(slot.id).toBe(101);
-    expect(slot.occurrenceUnix).toBe(1774390000);
+    expect(slot.occurrenceUnix).toBe(1785070000);
   });
 
   it('correctly updates a draft slot', async () => {
@@ -72,14 +72,14 @@ describe('useMentorSchedule', () => {
     });
 
     act(() => {
-      const success = result.current.updateDraftSlot(101, 1774390000, {
+      const success = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:00',
         durationMinutes: 45,
       });
       expect(success).toBe(true);
     });
 
-    const baseDate = dayjs(1774390000 * 1000).format('YYYY-MM-DD');
+    const baseDate = dayjs(1785070000 * 1000).format('YYYY-MM-DD');
     const expectedTime = buildDateTime(baseDate, '13:00');
     const expectedUnix = Math.floor(expectedTime.valueOf() / 1000);
 
@@ -99,14 +99,14 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft).toHaveLength(1);
 
     act(() => {
-      result.current.deleteDraftSlot(101, 1774390000);
+      result.current.deleteDraftSlot(101, 1785070000);
     });
 
     expect(result.current.parsedDraft).toHaveLength(0);
   });
 
   it('prevents updateDraftSlot when it causes an overlap conflict', async () => {
-    const baseDate = dayjs(1774390000 * 1000).format('YYYY-MM-DD');
+    const baseDate = dayjs(1785070000 * 1000).format('YYYY-MM-DD');
 
     // Slot 102 will start at 13:45 in local timezone
     const slot102Start = buildDateTime(baseDate, '13:45');
@@ -116,8 +116,8 @@ describe('useMentorSchedule', () => {
       {
         id: 101,
         type: 'ALLOW' as const,
-        dtstart: 1774390000,
-        dtend: 1774391800,
+        dtstart: 1785070000,
+        dtend: 1785071800,
         rrule: undefined,
         exdate: [],
       },
@@ -141,7 +141,7 @@ describe('useMentorSchedule', () => {
       // Slot 101 starts at 13:30, ends at 14:15 (45 mins duration).
       // Slot 102 starts at 13:45, ends at 14:15.
       // This is a direct overlap conflict!
-      const success = result.current.updateDraftSlot(101, 1774390000, {
+      const success = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:30',
         durationMinutes: 45,
       });
@@ -150,7 +150,7 @@ describe('useMentorSchedule', () => {
 
     // Check that slot 101 is unchanged
     const slot101 = result.current.parsedDraft.find((s) => s.id === 101);
-    expect(slot101?.occurrenceUnix).toBe(1774390000);
+    expect(slot101?.occurrenceUnix).toBe(1785070000);
   });
 
   it('correctly detaches a single occurrence of a recurring slot on update', async () => {
@@ -310,9 +310,9 @@ describe('useMentorSchedule', () => {
       {
         id: 101,
         type: 'ALLOW' as const,
-        dtstart: 1774390000, // occurrence 1 (July 26, 2026 12:46:40 PM UTC)
-        dtend: 1774391800,
-        rrule: 'FREQ=WEEKLY;COUNT=2', // next is 1774994800
+        dtstart: 1785070000, // occurrence 1 (July 26, 2026 12:46:40 PM UTC)
+        dtend: 1785071800,
+        rrule: 'FREQ=WEEKLY;COUNT=2', // next is 1785674800
         exdate: [],
       },
     ];
@@ -326,14 +326,14 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft).toHaveLength(2);
 
     act(() => {
-      // Delete occurrence 1 (1774390000)
-      result.current.deleteDraftSlot(101, 1774390000);
+      // Delete occurrence 1 (1785070000)
+      result.current.deleteDraftSlot(101, 1785070000);
     });
 
-    // Parent should exdate 1774390000, leaving only the second weekly occurrence (1774994800) active.
+    // Parent should exdate 1785070000, leaving only the second weekly occurrence (1785674800) active.
     expect(result.current.parsedDraft).toHaveLength(1);
     expect(result.current.parsedDraft[0].id).toBe(101);
-    expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1774994800);
+    expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1785674800);
   });
 
   it('regression: a recurring ALLOW row whose weekly occurrences cross a month boundary, edited on a cross-boundary occurrence, ends up in exactly one month buffer with no duplicate representation', async () => {
@@ -402,5 +402,61 @@ describe('useMentorSchedule', () => {
     const augustOcc = result.current.parsedDraft.find((s) => s.id < 0);
     expect(augustOcc?.occurrenceUnix).toBe(expectedUnix); // the detached occurrence is updated to 13:00 local of August 2
     expect(augustOcc?.durationMinutes).toBe(45);
+  });
+
+  it('regression: a non-recurring ALLOW slot edited to fall in a different calendar month is correctly moved to the target month buffer', async () => {
+    // Parent slot 101 starts on July 26, 2026 (Month 7) -> 1785070000 (no rrule)
+    const mockRawsJuly: RawMentorTimeslot[] = [
+      {
+        id: 101,
+        type: 'ALLOW' as const,
+        dtstart: 1785070000,
+        dtend: 1785071800,
+        rrule: undefined,
+        exdate: [],
+      },
+    ];
+
+    // Mock loadMonthScheduleCached for July to return mockRawsJuly, and for August to return []
+    mockLoadMonthScheduleCached.mockImplementation((ref) => {
+      if (ref.year === 2026 && ref.month === 7) {
+        return {
+          cached: mockRawsJuly,
+          revalidate: Promise.resolve(mockRawsJuly),
+        };
+      }
+      return {
+        cached: [],
+        revalidate: Promise.resolve([]),
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMentorSchedule({
+        backend: { userId: '123', year: 2026, month: 7 },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(1);
+
+    // Edit occurrence of slot 101, but the base Date is set to August 2, 2026 (1785674800)
+    // Under the new code, this non-recurring slot is correctly removed from July and added to August buffer.
+    act(() => {
+      const success = result.current.updateDraftSlot(101, 1785674800, {
+        startTime: '13:00',
+        durationMinutes: 45,
+      });
+      expect(success).toBe(true);
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(1);
+    const updatedSlot = result.current.parsedDraft[0];
+    expect(updatedSlot.id).toBe(101); // remains slot 101
+    expect(updatedSlot.occurrenceUnix).toBe(1785675600); // has been moved to August 2, 13:00!
+    expect(updatedSlot.dateKey).toBe('2026-08-02');
   });
 });

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -509,7 +509,9 @@ describe('useMentorSchedule', () => {
         durationMinutes: 45,
       });
     } catch (e: unknown) {
-      editError = e as Error;
+      if (e instanceof Error) {
+        editError = e;
+      }
     }
 
     expect(success).toBe(false);

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -459,4 +459,135 @@ describe('useMentorSchedule', () => {
     expect(updatedSlot.occurrenceUnix).toBe(1785675600); // has been moved to August 2, 13:00!
     expect(updatedSlot.dateKey).toBe('2026-08-02');
   });
+
+  it('regression: a cross-month edit/move blocks editing and throws an error if the target month is not cached/loaded', async () => {
+    // Parent slot 101 starts on July 26, 2026 (Month 7) -> 1785070000
+    const mockRawsJuly: RawMentorTimeslot[] = [
+      {
+        id: 101,
+        type: 'ALLOW' as const,
+        dtstart: 1785070000,
+        dtend: 1785071800,
+        rrule: undefined,
+        exdate: [],
+      },
+    ];
+
+    // Mock loadMonthScheduleCached: July returns cached data, but August returns cached: undefined
+    mockLoadMonthScheduleCached.mockImplementation((ref) => {
+      if (ref.year === 2026 && ref.month === 7) {
+        return {
+          cached: mockRawsJuly,
+          revalidate: Promise.resolve(mockRawsJuly),
+        };
+      }
+      return {
+        cached: undefined, // Cache miss for August!
+        revalidate: Promise.resolve([]),
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMentorSchedule({
+        backend: { userId: '123', year: 2026, month: 7 },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    expect(result.current.parsedDraft).toHaveLength(1);
+
+    // Edit the slot to August 2, 2026 (1785674800)
+    // Since August has a cache miss, updateDraftSlot should throw an error, blocking the edit
+    let editError: Error | null = null;
+    let success = false;
+    try {
+      success = result.current.updateDraftSlot(101, 1785674800, {
+        startTime: '13:00',
+        durationMinutes: 45,
+      });
+    } catch (e: unknown) {
+      editError = e as Error;
+    }
+
+    expect(success).toBe(false);
+    expect(editError?.message).toBe('TARGET_MONTH_NOT_LOADED');
+    // Ensure the slot remains in July unchanged
+    expect(result.current.parsedDraft).toHaveLength(1);
+    expect(result.current.parsedDraft[0].id).toBe(101);
+    expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1785070000);
+  });
+
+  it('regression: a cross-month edit/move blocks editing if there is an overlap conflict with existing slots in the target month', async () => {
+    // Parent slot 101 starts on July 26, 2026 (Month 7) -> 1785070000
+    const mockRawsJuly: RawMentorTimeslot[] = [
+      {
+        id: 101,
+        type: 'ALLOW' as const,
+        dtstart: 1785070000,
+        dtend: 1785071800,
+        rrule: undefined,
+        exdate: [],
+      },
+    ];
+
+    // August has an existing slot at 13:00 (1785675600)
+    const mockRawsAugust: RawMentorTimeslot[] = [
+      {
+        id: 202,
+        type: 'ALLOW' as const,
+        dtstart: 1785675600, // August 2, 13:00 UTC
+        dtend: 1785677400, // +30 mins
+        rrule: undefined,
+        exdate: [],
+      },
+    ];
+
+    // Mock loadMonthScheduleCached
+    mockLoadMonthScheduleCached.mockImplementation((ref) => {
+      if (ref.year === 2026 && ref.month === 7) {
+        return {
+          cached: mockRawsJuly,
+          revalidate: Promise.resolve(mockRawsJuly),
+        };
+      }
+      if (ref.year === 2026 && ref.month === 8) {
+        return {
+          cached: mockRawsAugust,
+          revalidate: Promise.resolve(mockRawsAugust),
+        };
+      }
+      return {
+        cached: [],
+        revalidate: Promise.resolve([]),
+      };
+    });
+
+    const { result } = renderHook(() =>
+      useMentorSchedule({
+        backend: { userId: '123', year: 2026, month: 7 },
+      })
+    );
+
+    await waitFor(() => {
+      expect(result.current.loaded).toBe(true);
+    });
+
+    // Edit slot 101 to August 2 at 13:00 (1785674800 with patch 13:00 results in 1785675600)
+    // This overlaps with August slot 202, so it should be blocked and return false!
+    act(() => {
+      const success = result.current.updateDraftSlot(101, 1785674800, {
+        startTime: '13:00',
+        durationMinutes: 45, // overlaps with 13:00 - 13:30 of slot 202
+      });
+      expect(success).toBe(false);
+    });
+
+    // Ensure slot 101 remains in July and is not moved or modified
+    expect(result.current.parsedDraft).toHaveLength(1);
+    expect(result.current.parsedDraft[0].id).toBe(101);
+    expect(result.current.parsedDraft[0].occurrenceUnix).toBe(1785070000);
+  });
 });

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -358,9 +358,9 @@ describe('useMentorSchedule', () => {
       },
     ];
 
-    // Mock loadMonthScheduleCached for July to return mockRawsJuly, and for August to return []
+    // Mock loadMonthScheduleCached for July and also August to return mockRawsJuly (simulating parent row loaded in both months)
     mockLoadMonthScheduleCached.mockImplementation((ref) => {
-      if (ref.year === 2026 && ref.month === 7) {
+      if (ref.year === 2026 && (ref.month === 7 || ref.month === 8)) {
         return {
           cached: mockRawsJuly,
           revalidate: Promise.resolve(mockRawsJuly),

--- a/src/hooks/useMentorSchedule.test.ts
+++ b/src/hooks/useMentorSchedule.test.ts
@@ -16,13 +16,20 @@ import {
   buildDateTime,
   RawMentorTimeslot,
 } from '@/lib/profile/scheduleHelpers';
-import { loadMonthScheduleCached } from '@/services/mentor-schedule/sync';
+import {
+  loadMonthScheduleCached,
+  syncMonths,
+} from '@/services/mentor-schedule/sync';
 
 const mockLoadMonthScheduleCached = vi.mocked(loadMonthScheduleCached);
 
 describe('useMentorSchedule', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
+    vi.mocked(syncMonths).mockResolvedValue([
+      { monthKey: '2026-07', outcome: { ok: true, raws: [] } },
+      { monthKey: '2026-08', outcome: { ok: true, raws: [] } },
+    ]);
   });
 
   const defaultMockRaws: RawMentorTimeslot[] = [
@@ -72,11 +79,11 @@ describe('useMentorSchedule', () => {
     });
 
     act(() => {
-      const success = result.current.updateDraftSlot(101, 1785070000, {
+      const res = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:00',
         durationMinutes: 45,
       });
-      expect(success).toBe(true);
+      expect(res.success).toBe(true);
     });
 
     const baseDate = dayjs(1785070000 * 1000).format('YYYY-MM-DD');
@@ -141,11 +148,12 @@ describe('useMentorSchedule', () => {
       // Slot 101 starts at 13:30, ends at 14:15 (45 mins duration).
       // Slot 102 starts at 13:45, ends at 14:15.
       // This is a direct overlap conflict!
-      const success = result.current.updateDraftSlot(101, 1785070000, {
+      const res = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:30',
         durationMinutes: 45,
       });
-      expect(success).toBe(false);
+      expect(res.success).toBe(false);
+      expect(res.reason).toBe('OVERLAP');
     });
 
     // Check that slot 101 is unchanged
@@ -176,11 +184,11 @@ describe('useMentorSchedule', () => {
 
     act(() => {
       // Update occurrence 1 (1785070000)
-      const success = result.current.updateDraftSlot(101, 1785070000, {
+      const res = result.current.updateDraftSlot(101, 1785070000, {
         startTime: '13:00', // Move to 13:00
         durationMinutes: 45,
       });
-      expect(success).toBe(true);
+      expect(res.success).toBe(true);
     });
 
     // The parent slot 101 should now have 1785070000 in its exdate (leaving only 1 active weekly occurrence).
@@ -380,11 +388,11 @@ describe('useMentorSchedule', () => {
     act(() => {
       // Edit the August 2 occurrence (1785674800 - Month 8)
       // Since it is edited, it should detach from the parent in July and be stored in August's buffer
-      const success = result.current.updateDraftSlot(101, 1785674800, {
+      const res = result.current.updateDraftSlot(101, 1785674800, {
         startTime: '13:00', // Move to 13:00
         durationMinutes: 45,
       });
-      expect(success).toBe(true);
+      expect(res.success).toBe(true);
     });
 
     // Total active occurrences should still be 2:
@@ -402,6 +410,16 @@ describe('useMentorSchedule', () => {
     const augustOcc = result.current.parsedDraft.find((s) => s.id < 0);
     expect(augustOcc?.occurrenceUnix).toBe(expectedUnix); // the detached occurrence is updated to 13:00 local of August 2
     expect(augustOcc?.durationMinutes).toBe(45);
+
+    // Verify both months are marked dirty by ensuring confirmChanges requests syncing for both (Testing Finding 1)
+    const mockSyncMonths = vi.mocked(syncMonths);
+    await result.current.confirmChanges();
+    expect(mockSyncMonths).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ ref: expect.objectContaining({ month: 7 }) }),
+        expect.objectContaining({ ref: expect.objectContaining({ month: 8 }) }),
+      ])
+    );
   });
 
   it('regression: a non-recurring ALLOW slot edited to fall in a different calendar month is correctly moved to the target month buffer', async () => {
@@ -446,11 +464,11 @@ describe('useMentorSchedule', () => {
     // Edit occurrence of slot 101, but the base Date is set to August 2, 2026 (1785674800)
     // Under the new code, this non-recurring slot is correctly removed from July and added to August buffer.
     act(() => {
-      const success = result.current.updateDraftSlot(101, 1785674800, {
+      const res = result.current.updateDraftSlot(101, 1785674800, {
         startTime: '13:00',
         durationMinutes: 45,
       });
-      expect(success).toBe(true);
+      expect(res.success).toBe(true);
     });
 
     expect(result.current.parsedDraft).toHaveLength(1);
@@ -458,6 +476,16 @@ describe('useMentorSchedule', () => {
     expect(updatedSlot.id).toBe(101); // remains slot 101
     expect(updatedSlot.occurrenceUnix).toBe(1785675600); // has been moved to August 2, 13:00!
     expect(updatedSlot.dateKey).toBe('2026-08-02');
+
+    // Verify both months are marked dirty by ensuring confirmChanges requests syncing for both (Testing Finding 1)
+    const mockSyncMonths = vi.mocked(syncMonths);
+    await result.current.confirmChanges();
+    expect(mockSyncMonths).toHaveBeenCalledWith(
+      expect.arrayContaining([
+        expect.objectContaining({ ref: expect.objectContaining({ month: 7 }) }),
+        expect.objectContaining({ ref: expect.objectContaining({ month: 8 }) }),
+      ])
+    );
   });
 
   it('regression: a cross-month edit/move blocks editing and throws an error if the target month is not cached/loaded', async () => {
@@ -500,22 +528,16 @@ describe('useMentorSchedule', () => {
     expect(result.current.parsedDraft).toHaveLength(1);
 
     // Edit the slot to August 2, 2026 (1785674800)
-    // Since August has a cache miss, updateDraftSlot should throw an error, blocking the edit
-    let editError: Error | null = null;
-    let success = false;
-    try {
-      success = result.current.updateDraftSlot(101, 1785674800, {
+    // Since August has a cache miss, updateDraftSlot should return TARGET_MONTH_NOT_LOADED, blocking the edit
+    act(() => {
+      const res = result.current.updateDraftSlot(101, 1785674800, {
         startTime: '13:00',
         durationMinutes: 45,
       });
-    } catch (e: unknown) {
-      if (e instanceof Error) {
-        editError = e;
-      }
-    }
+      expect(res.success).toBe(false);
+      expect(res.reason).toBe('TARGET_MONTH_NOT_LOADED');
+    });
 
-    expect(success).toBe(false);
-    expect(editError?.message).toBe('TARGET_MONTH_NOT_LOADED');
     // Ensure the slot remains in July unchanged
     expect(result.current.parsedDraft).toHaveLength(1);
     expect(result.current.parsedDraft[0].id).toBe(101);
@@ -578,13 +600,14 @@ describe('useMentorSchedule', () => {
     });
 
     // Edit slot 101 to August 2 at 13:00 (1785674800 with patch 13:00 results in 1785675600)
-    // This overlaps with August slot 202, so it should be blocked and return false!
+    // This overlaps with August slot 202, so it should be blocked and return OVERLAP!
     act(() => {
-      const success = result.current.updateDraftSlot(101, 1785674800, {
+      const res = result.current.updateDraftSlot(101, 1785674800, {
         startTime: '13:00',
         durationMinutes: 45, // overlaps with 13:00 - 13:30 of slot 202
       });
-      expect(success).toBe(false);
+      expect(res.success).toBe(false);
+      expect(res.reason).toBe('OVERLAP');
     });
 
     // Ensure slot 101 remains in July and is not moved or modified

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -553,7 +553,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           });
           if (!cached) {
             // Cache miss for target month, block the edit to prevent data loss
-            return false;
+            throw new Error('TARGET_MONTH_NOT_LOADED');
           }
           targetDraft = cached;
         }

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -299,13 +299,18 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     return out;
   }, [draftByMonth]);
 
-  const parsedDraft = useMemo(
-    () =>
-      allDraftRaws
-        .flatMap(formatTimeslot)
-        .sort((a, b) => a.start.getTime() - b.start.getTime()),
-    [allDraftRaws]
-  );
+  const parsedDraft = useMemo(() => {
+    const formatted = allDraftRaws.flatMap(formatTimeslot);
+    const seen = new Set<string>();
+    const out: ParsedMentorTimeslot[] = [];
+    for (const slot of formatted) {
+      if (!seen.has(slot.occurrenceId)) {
+        seen.add(slot.occurrenceId);
+        out.push(slot);
+      }
+    }
+    return out.sort((a, b) => a.start.getTime() - b.start.getTime());
+  }, [allDraftRaws]);
 
   const draftForSelectedDate = useMemo(
     () =>
@@ -522,6 +527,10 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const parentMonthKey = findMonthForSlotId(id);
         if (!parentMonthKey) return { success: false };
 
+        // Helper to append exdate cleanly
+        const appendExdate = (exdates: number[], unix: number) =>
+          exdates.includes(unix) ? exdates : [...exdates, unix];
+
         // Fetch parentDraft outside state setter from ref
         const currentDraftsMap = draftByMonthRef.current;
         const parentDraft = currentDraftsMap.get(parentMonthKey) ?? [];
@@ -584,9 +593,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             r.id === id
               ? {
                   ...r,
-                  exdate: r.exdate.includes(occurrenceUnix)
-                    ? r.exdate
-                    : [...r.exdate, occurrenceUnix],
+                  exdate: appendExdate(r.exdate, occurrenceUnix),
                 }
               : r
           );
@@ -632,9 +639,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           if (isRecurring) {
             const updatedParent: RawMentorTimeslot = {
               ...latestTarget,
-              exdate: latestTarget.exdate.includes(occurrenceUnix)
-                ? latestTarget.exdate
-                : [...latestTarget.exdate, occurrenceUnix],
+              exdate: appendExdate(latestTarget.exdate, occurrenceUnix),
             };
             const detachedRow: RawMentorTimeslot = {
               id: nextTempId(Array.from(nextDraft.values()).flat()),
@@ -645,23 +650,21 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
               exdate: [],
             };
 
-            if (targetMonthKey === parentMonthKey) {
-              const intermediate = currentParentDraft.map((r) =>
-                r.id === id ? updatedParent : r
-              );
-              nextDraft.set(parentMonthKey, [...intermediate, detachedRow]);
-            } else {
-              // Update parent draft
-              nextDraft.set(
-                parentMonthKey,
-                currentParentDraft.map((r) => (r.id === id ? updatedParent : r))
-              );
-              // Update target draft
-              nextDraft.set(targetMonthKey, [
-                ...currentTargetDraft,
-                detachedRow,
-              ]);
-            }
+            // Recursively update parent row's exdate across ALL loaded month buffers (Correctness Finding 1)
+            nextDraft.forEach((mDraft, mKey) => {
+              if (mDraft.some((r: RawMentorTimeslot) => r.id === id)) {
+                nextDraft.set(
+                  mKey,
+                  mDraft.map((r: RawMentorTimeslot) =>
+                    r.id === id ? updatedParent : r
+                  )
+                );
+              }
+            });
+
+            // Append the new detached row to the target month buffer
+            const updatedTargetDraft = nextDraft.get(targetMonthKey) ?? [];
+            nextDraft.set(targetMonthKey, [...updatedTargetDraft, detachedRow]);
           } else {
             // Non-recurring slot
             const updatedSlot: RawMentorTimeslot = {

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -51,6 +51,11 @@ type Options = {
 
 export type SlotDurationMinutes = 30 | 45 | 60;
 
+export type UpdateDraftSlotResult = {
+  success: boolean;
+  reason?: 'OVERLAP' | 'TARGET_MONTH_NOT_LOADED';
+};
+
 export type UseMentorScheduleReturn = {
   /** Sticky: true once any month has resolved. Use this for first-paint skeletons. */
   loaded: boolean;
@@ -93,7 +98,7 @@ export type UseMentorScheduleReturn = {
       startTime?: string; // HH:mm
       durationMinutes?: SlotDurationMinutes;
     }
-  ) => boolean;
+  ) => UpdateDraftSlotResult;
 
   /**
    * Delete a single occurrence. Non-recurring rows are removed entirely; on
@@ -515,13 +520,13 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     useCallback(
       (id, occurrenceUnix, patch) => {
         const parentMonthKey = findMonthForSlotId(id);
-        if (!parentMonthKey) return false;
+        if (!parentMonthKey) return { success: false };
 
         // Fetch parentDraft outside state setter from ref
         const currentDraftsMap = draftByMonthRef.current;
         const parentDraft = currentDraftsMap.get(parentMonthKey) ?? [];
         const target = parentDraft.find((r) => r.id === id);
-        if (!target) return false;
+        if (!target) return { success: false };
 
         // Date math computed once outside of updater function
         const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
@@ -529,7 +534,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
 
         const s = buildDateTime(baseDate, startHM);
-        if (!s.isValid()) return false;
+        if (!s.isValid()) return { success: false };
 
         const newDtstart = Math.floor(s.valueOf() / 1000);
         const oldDurationSeconds = target.dtend - target.dtstart;
@@ -542,7 +547,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           durationSeconds === oldDurationSeconds;
 
         if (isRecurring && noChange) {
-          return true;
+          return { success: true };
         }
 
         const targetMonthKey = monthKeyFromUnix(newDtstart);
@@ -559,7 +564,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           });
           if (!cached) {
             // Cache miss for target month, block the edit to prevent data loss
-            throw new Error('TARGET_MONTH_NOT_LOADED');
+            return { success: false, reason: 'TARGET_MONTH_NOT_LOADED' };
           }
           targetDraft = cached;
         }
@@ -596,7 +601,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             durationSeconds
           )
         ) {
-          return false;
+          return { success: false, reason: 'OVERLAP' };
         }
 
         // Side-effect: update savedByMonth outside updater if initializing target month
@@ -693,7 +698,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           markDirty(targetMonthKey);
         }
 
-        return true;
+        return { success: true };
       },
       [findMonthForSlotId, markDirty, backend.userId]
     );

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -16,6 +16,7 @@ import {
   hasAnyOccurrenceOverlap,
   MonthKey,
   monthKeyFromDateStr,
+  monthKeyFromUnix,
   monthKeyFromYearMonth,
   nextTempId,
   ParsedMentorTimeslot,
@@ -508,20 +509,22 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, occurrenceUnix, patch) => {
-        const monthKey = findMonthForSlotId(id);
-        if (!monthKey) return false;
+        const parentMonthKey = findMonthForSlotId(id);
+        if (!parentMonthKey) return false;
 
         let succeeded = false;
-        updateMonthDraft(monthKey, (prev) => {
-          const target = prev.find((r) => r.id === id);
-          if (!target) return prev;
+
+        setDraftByMonth((prevDraft) => {
+          const parentDraft = prevDraft.get(parentMonthKey) ?? [];
+          const target = parentDraft.find((r) => r.id === id);
+          if (!target) return prevDraft;
 
           const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
           const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
           const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
 
           const s = buildDateTime(baseDate, startHM);
-          if (!s.isValid()) return prev;
+          if (!s.isValid()) return prevDraft;
 
           const newDtstart = Math.floor(s.valueOf() / 1000);
           const oldDurationSeconds = target.dtend - target.dtstart;
@@ -539,12 +542,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             // Submitting the edit modal without changes shouldn't surface
             // an overlap error — report success and skip the mutation.
             succeeded = true;
-            return prev;
+            return prevDraft;
           }
 
+          const targetMonthKey = monthKeyFromUnix(newDtstart);
+
           // Build the prospective next state and overlap-check it against
-          // candidate occurrences (excluding the parent row, whose own
-          // occurrence at occurrenceUnix is being replaced/exdated).
           if (isRecurring) {
             const updatedParent: RawMentorTimeslot = {
               ...target,
@@ -553,54 +556,129 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
                 : [...target.exdate, occurrenceUnix],
             };
             const detachedRow: RawMentorTimeslot = {
-              id: nextTempId(prev),
+              id: nextTempId(allDraftRaws),
               type: 'ALLOW' as const,
               dtstart: newDtstart,
               dtend: newDtstart + durationSeconds,
               rrule: undefined,
               exdate: [],
             };
-            const intermediate = prev.map((r) =>
-              r.id === id ? updatedParent : r
-            );
-            if (
-              hasAnyOccurrenceOverlap(
-                intermediate,
-                null,
-                [newDtstart],
-                durationSeconds
-              )
-            ) {
-              return prev;
+
+            if (targetMonthKey === parentMonthKey) {
+              const intermediate = parentDraft.map((r) =>
+                r.id === id ? updatedParent : r
+              );
+              if (
+                hasAnyOccurrenceOverlap(
+                  intermediate,
+                  null,
+                  [newDtstart],
+                  durationSeconds
+                )
+              ) {
+                return prevDraft;
+              }
+              succeeded = true;
+              const nextDraft = new Map(prevDraft);
+              nextDraft.set(parentMonthKey, [...intermediate, detachedRow]);
+              return nextDraft;
+            } else {
+              // Different month!
+              // 1. Fetch/ensure target month's draft is loaded
+              let targetDraft = prevDraft.get(targetMonthKey);
+              const isTargetLoaded = !!targetDraft;
+              if (!targetDraft) {
+                const { year, month } = parseMonthKey(targetMonthKey);
+                const { cached } = loadMonthScheduleCached({
+                  userId: backend.userId,
+                  year,
+                  month,
+                });
+                targetDraft = cached ?? [];
+              }
+
+              // Check overlap in target draft
+              if (
+                hasAnyOccurrenceOverlap(
+                  targetDraft,
+                  null,
+                  [newDtstart],
+                  durationSeconds
+                )
+              ) {
+                return prevDraft;
+              }
+
+              succeeded = true;
+
+              // Ensure targetMonthKey is initialized in savedByMonth too
+              if (!isTargetLoaded) {
+                setSavedByMonth((prevSaved) => {
+                  const nextSaved = new Map(prevSaved);
+                  nextSaved.set(targetMonthKey, targetDraft!);
+                  return nextSaved;
+                });
+              }
+
+              const nextDraft = new Map(prevDraft);
+              // Update parent draft (exdate added)
+              nextDraft.set(
+                parentMonthKey,
+                parentDraft.map((r) => (r.id === id ? updatedParent : r))
+              );
+              // Update target draft (detached row appended)
+              nextDraft.set(targetMonthKey, [...targetDraft, detachedRow]);
+              return nextDraft;
             }
-            succeeded = true;
-            return [...intermediate, detachedRow];
           }
 
           if (
-            hasAnyOccurrenceOverlap(prev, id, [newDtstart], durationSeconds)
+            hasAnyOccurrenceOverlap(
+              parentDraft,
+              id,
+              [newDtstart],
+              durationSeconds
+            )
           ) {
-            return prev;
+            return prevDraft;
           }
 
           succeeded = true;
-          return prev.map((r) =>
-            r.id === id
-              ? {
-                  ...r,
-                  dtstart: newDtstart,
-                  dtend: newDtstart + durationSeconds,
-                  rrule: undefined,
-                  exdate: [],
-                }
-              : r
+          const nextDraft = new Map(prevDraft);
+          nextDraft.set(
+            parentMonthKey,
+            parentDraft.map((r) =>
+              r.id === id
+                ? {
+                    ...r,
+                    dtstart: newDtstart,
+                    dtend: newDtstart + durationSeconds,
+                    rrule: undefined,
+                    exdate: [],
+                  }
+                : r
+            )
           );
+          return nextDraft;
         });
 
-        if (succeeded) markDirty(monthKey);
+        if (succeeded) {
+          markDirty(parentMonthKey);
+          const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
+          const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
+          const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
+          const s = buildDateTime(baseDate, startHM);
+          if (s.isValid()) {
+            const newDtstart = Math.floor(s.valueOf() / 1000);
+            const targetMonthKey = monthKeyFromUnix(newDtstart);
+            if (targetMonthKey !== parentMonthKey) {
+              markDirty(targetMonthKey);
+            }
+          }
+        }
         return succeeded;
       },
-      [findMonthForSlotId, updateMonthDraft, markDirty]
+      [findMonthForSlotId, markDirty, allDraftRaws, backend.userId]
     );
 
   const deleteDraftSlot = useCallback(

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -506,14 +506,20 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       [selectedDate, updateMonthDraft, markDirty]
     );
 
+  const draftByMonthRef = useRef(draftByMonth);
+  useEffect(() => {
+    draftByMonthRef.current = draftByMonth;
+  }, [draftByMonth]);
+
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, occurrenceUnix, patch) => {
         const parentMonthKey = findMonthForSlotId(id);
         if (!parentMonthKey) return false;
 
-        // Fetch parentDraft outside state setter
-        const parentDraft = draftByMonth.get(parentMonthKey) ?? [];
+        // Fetch parentDraft outside state setter from ref
+        const currentDraftsMap = draftByMonthRef.current;
+        const parentDraft = currentDraftsMap.get(parentMonthKey) ?? [];
         const target = parentDraft.find((r) => r.id === id);
         if (!target) return false;
 
@@ -541,8 +547,8 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         const targetMonthKey = monthKeyFromUnix(newDtstart);
 
-        // Fetch / ensure target draft is loaded/cached outside state setter
-        let targetDraft = draftByMonth.get(targetMonthKey);
+        // Fetch / ensure target draft is loaded/cached outside state setter from ref
+        let targetDraft = currentDraftsMap.get(targetMonthKey);
         const isTargetLoaded = !!targetDraft;
         if (!targetDraft) {
           const { year, month } = parseMonthKey(targetMonthKey);
@@ -558,67 +564,39 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           targetDraft = cached;
         }
 
-        // Check overlap in target month buffer before applying state changes
+        // Global overlap check across all loaded/cached months' drafts
+        const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
+        const draftsToCheck = [...allCurrentDrafts];
+        if (!isTargetLoaded) {
+          draftsToCheck.push(...targetDraft);
+        }
+
+        // Prepare the intermediate drafts for overlap checking by simulating the exdate/move
+        let intermediateDraftsToCheck = draftsToCheck;
         if (isRecurring) {
-          if (targetMonthKey === parentMonthKey) {
-            const updatedParent: RawMentorTimeslot = {
-              ...target,
-              exdate: target.exdate.includes(occurrenceUnix)
-                ? target.exdate
-                : [...target.exdate, occurrenceUnix],
-            };
-            const intermediate = parentDraft.map((r) =>
-              r.id === id ? updatedParent : r
-            );
-            if (
-              hasAnyOccurrenceOverlap(
-                intermediate,
-                null,
-                [newDtstart],
-                durationSeconds
-              )
-            ) {
-              return false;
-            }
-          } else {
-            // Different month
-            if (
-              hasAnyOccurrenceOverlap(
-                targetDraft,
-                null,
-                [newDtstart],
-                durationSeconds
-              )
-            ) {
-              return false;
-            }
-          }
-        } else {
-          // Non-recurring slot
-          if (targetMonthKey === parentMonthKey) {
-            if (
-              hasAnyOccurrenceOverlap(
-                parentDraft,
-                id,
-                [newDtstart],
-                durationSeconds
-              )
-            ) {
-              return false;
-            }
-          } else {
-            // Different month
-            if (
-              hasAnyOccurrenceOverlap(
-                targetDraft,
-                null,
-                [newDtstart],
-                durationSeconds
-              )
-            ) {
-              return false;
-            }
-          }
+          // If recurring, we simulate exdating the parent row
+          intermediateDraftsToCheck = draftsToCheck.map((r) =>
+            r.id === id
+              ? {
+                  ...r,
+                  exdate: r.exdate.includes(occurrenceUnix)
+                    ? r.exdate
+                    : [...r.exdate, occurrenceUnix],
+                }
+              : r
+          );
+        }
+
+        // Run unified overlap check
+        if (
+          hasAnyOccurrenceOverlap(
+            intermediateDraftsToCheck,
+            isRecurring ? null : id, // ignore current row ID only if it is non-recurring
+            [newDtstart],
+            durationSeconds
+          )
+        ) {
+          return false;
         }
 
         // Side-effect: update savedByMonth outside updater if initializing target month
@@ -642,12 +620,16 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           const currentParentDraft = nextDraft.get(parentMonthKey) ?? [];
           const currentTargetDraft = nextDraft.get(targetMonthKey) ?? [];
 
+          // Solve stale closure by querying the latest target state from currentParentDraft
+          const latestTarget = currentParentDraft.find((r) => r.id === id);
+          if (!latestTarget) return prevDraft;
+
           if (isRecurring) {
             const updatedParent: RawMentorTimeslot = {
-              ...target,
-              exdate: target.exdate.includes(occurrenceUnix)
-                ? target.exdate
-                : [...target.exdate, occurrenceUnix],
+              ...latestTarget,
+              exdate: latestTarget.exdate.includes(occurrenceUnix)
+                ? latestTarget.exdate
+                : [...latestTarget.exdate, occurrenceUnix],
             };
             const detachedRow: RawMentorTimeslot = {
               id: nextTempId(Array.from(nextDraft.values()).flat()),
@@ -678,7 +660,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           } else {
             // Non-recurring slot
             const updatedSlot: RawMentorTimeslot = {
-              ...target,
+              ...latestTarget,
               dtstart: newDtstart,
               dtend: newDtstart + durationSeconds,
               rrule: undefined,
@@ -713,7 +695,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         return true;
       },
-      [findMonthForSlotId, markDirty, backend.userId, draftByMonth]
+      [findMonthForSlotId, markDirty, backend.userId]
     );
 
   const deleteDraftSlot = useCallback(

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -111,6 +111,9 @@ export type UseMentorScheduleReturn = {
   resetChanges: () => void;
 };
 
+const appendExdate = (exdates: number[], unix: number): number[] =>
+  exdates.includes(unix) ? exdates : [...exdates, unix];
+
 export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const { backend } = opts;
 
@@ -521,15 +524,83 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     draftByMonthRef.current = draftByMonth;
   }, [draftByMonth]);
 
+  const ensureTargetMonthLoaded = useCallback(
+    (
+      targetMonthKey: MonthKey,
+      currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>
+    ) => {
+      let targetDraft = currentDraftsMap.get(targetMonthKey);
+      if (!targetDraft) {
+        const { year, month } = parseMonthKey(targetMonthKey);
+        const { cached } = loadMonthScheduleCached({
+          userId: backend.userId,
+          year,
+          month,
+        });
+        if (!cached) {
+          return null;
+        }
+        targetDraft = cached;
+      }
+      return targetDraft;
+    },
+    [backend.userId]
+  );
+
+  const checkCrossMonthOverlap = useCallback(
+    ({
+      id,
+      occurrenceUnix,
+      newDtstart,
+      durationSeconds,
+      isRecurring,
+      currentDraftsMap,
+      targetDraft,
+    }: {
+      id: number;
+      occurrenceUnix: number;
+      newDtstart: number;
+      durationSeconds: number;
+      isRecurring: boolean;
+      currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>;
+      targetDraft: RawMentorTimeslot[];
+    }): boolean => {
+      const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
+      const draftsToCheck = [...allCurrentDrafts];
+      const isTargetLoaded = currentDraftsMap.has(monthKeyFromUnix(newDtstart));
+      if (!isTargetLoaded) {
+        draftsToCheck.push(...targetDraft);
+      }
+
+      let intermediateDraftsToCheck = draftsToCheck;
+      if (isRecurring) {
+        // If recurring, we simulate exdating the parent row
+        intermediateDraftsToCheck = draftsToCheck.map((r: RawMentorTimeslot) =>
+          r.id === id
+            ? {
+                ...r,
+                exdate: appendExdate(r.exdate, occurrenceUnix),
+              }
+            : r
+        );
+      }
+
+      // Run unified overlap check
+      return hasAnyOccurrenceOverlap(
+        intermediateDraftsToCheck,
+        isRecurring ? null : id, // ignore current row ID only if it is non-recurring
+        [newDtstart],
+        durationSeconds
+      );
+    },
+    []
+  );
+
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, occurrenceUnix, patch) => {
         const parentMonthKey = findMonthForSlotId(id);
         if (!parentMonthKey) return { success: false };
-
-        // Helper to append exdate cleanly
-        const appendExdate = (exdates: number[], unix: number) =>
-          exdates.includes(unix) ? exdates : [...exdates, unix];
 
         // Fetch parentDraft outside state setter from ref
         const currentDraftsMap = draftByMonthRef.current;
@@ -562,52 +633,26 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const targetMonthKey = monthKeyFromUnix(newDtstart);
 
         // Fetch / ensure target draft is loaded/cached outside state setter from ref
-        let targetDraft = currentDraftsMap.get(targetMonthKey);
-        const isTargetLoaded = !!targetDraft;
+        const targetDraft = ensureTargetMonthLoaded(
+          targetMonthKey,
+          currentDraftsMap
+        );
         if (!targetDraft) {
-          const { year, month } = parseMonthKey(targetMonthKey);
-          const { cached } = loadMonthScheduleCached({
-            userId: backend.userId,
-            year,
-            month,
-          });
-          if (!cached) {
-            // Cache miss for target month, block the edit to prevent data loss
-            return { success: false, reason: 'TARGET_MONTH_NOT_LOADED' };
-          }
-          targetDraft = cached;
+          return { success: false, reason: 'TARGET_MONTH_NOT_LOADED' };
         }
-
-        // Global overlap check across all loaded/cached months' drafts
-        const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
-        const draftsToCheck = [...allCurrentDrafts];
-        if (!isTargetLoaded) {
-          draftsToCheck.push(...targetDraft);
-        }
-
-        // Prepare the intermediate drafts for overlap checking by simulating the exdate/move
-        let intermediateDraftsToCheck = draftsToCheck;
-        if (isRecurring) {
-          // If recurring, we simulate exdating the parent row
-          intermediateDraftsToCheck = draftsToCheck.map((r) =>
-            r.id === id
-              ? {
-                  ...r,
-                  exdate: appendExdate(r.exdate, occurrenceUnix),
-                }
-              : r
-          );
-        }
+        const isTargetLoaded = currentDraftsMap.has(targetMonthKey);
 
         // Run unified overlap check
-        if (
-          hasAnyOccurrenceOverlap(
-            intermediateDraftsToCheck,
-            isRecurring ? null : id, // ignore current row ID only if it is non-recurring
-            [newDtstart],
-            durationSeconds
-          )
-        ) {
+        const hasOverlap = checkCrossMonthOverlap({
+          id,
+          occurrenceUnix,
+          newDtstart,
+          durationSeconds,
+          isRecurring,
+          currentDraftsMap,
+          targetDraft,
+        });
+        if (hasOverlap) {
           return { success: false, reason: 'OVERLAP' };
         }
 
@@ -703,7 +748,12 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         return { success: true };
       },
-      [findMonthForSlotId, markDirty, backend.userId]
+      [
+        findMonthForSlotId,
+        markDirty,
+        ensureTargetMonthLoaded,
+        checkCrossMonthOverlap,
+      ]
     );
 
   const deleteDraftSlot = useCallback(

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -156,8 +156,7 @@ function checkCrossMonthOverlap({
   currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>;
   targetDraft: RawMentorTimeslot[];
 }): boolean {
-  const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
-  const draftsToCheck = [...allCurrentDrafts];
+  const draftsToCheck = Array.from(currentDraftsMap.values()).flat();
   const isTargetLoaded = currentDraftsMap.has(monthKeyFromUnix(newDtstart));
   if (!isTargetLoaded) {
     draftsToCheck.push(...targetDraft);
@@ -590,19 +589,14 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       [selectedDate, updateMonthDraft, markDirty]
     );
 
-  const draftByMonthRef = useRef(draftByMonth);
-  useEffect(() => {
-    draftByMonthRef.current = draftByMonth;
-  }, [draftByMonth]);
-
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, occurrenceUnix, patch) => {
         const parentMonthKey = findMonthForSlotId(id);
         if (!parentMonthKey) return { success: false };
 
-        // Fetch parentDraft outside state setter from ref
-        const currentDraftsMap = draftByMonthRef.current;
+        // Fetch parentDraft outside state setter
+        const currentDraftsMap = draftByMonth;
         const parentDraft = currentDraftsMap.get(parentMonthKey) ?? [];
         const target = parentDraft.find((r) => r.id === id);
         if (!target) return { success: false };
@@ -751,7 +745,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         return { success: true };
       },
-      [findMonthForSlotId, markDirty, backend.userId]
+      [findMonthForSlotId, markDirty, backend.userId, draftByMonth]
     );
 
   const deleteDraftSlot = useCallback(
@@ -823,14 +817,14 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
       }
 
       // Mark all months that contain this parent row as dirty (so exdates are synchronized on save)
-      const currentDraftsMap = draftByMonthRef.current;
+      const currentDraftsMap = draftByMonth;
       currentDraftsMap.forEach((mDraft, mKey) => {
         if (mDraft.some((r: RawMentorTimeslot) => r.id === id)) {
           markDirty(mKey);
         }
       });
     },
-    [findMonthForSlotId, markDirty]
+    [findMonthForSlotId, markDirty, draftByMonth]
   );
 
   const confirmChanges = useCallback(async (): Promise<SyncResult> => {

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -512,42 +512,136 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const parentMonthKey = findMonthForSlotId(id);
         if (!parentMonthKey) return false;
 
-        let succeeded = false;
+        // Fetch parentDraft outside state setter
+        const parentDraft = draftByMonth.get(parentMonthKey) ?? [];
+        const target = parentDraft.find((r) => r.id === id);
+        if (!target) return false;
 
+        // Date math computed once outside of updater function
+        const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
+        const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
+        const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
+
+        const s = buildDateTime(baseDate, startHM);
+        if (!s.isValid()) return false;
+
+        const newDtstart = Math.floor(s.valueOf() / 1000);
+        const oldDurationSeconds = target.dtend - target.dtstart;
+        const durationSeconds =
+          (patch.durationMinutes ?? Math.round(oldDurationSeconds / 60)) * 60;
+
+        const isRecurring = !!target.rrule;
+        const noChange =
+          newDtstart === occurrenceUnix &&
+          durationSeconds === oldDurationSeconds;
+
+        if (isRecurring && noChange) {
+          return true;
+        }
+
+        const targetMonthKey = monthKeyFromUnix(newDtstart);
+
+        // Fetch / ensure target draft is loaded/cached outside state setter
+        let targetDraft = draftByMonth.get(targetMonthKey);
+        const isTargetLoaded = !!targetDraft;
+        if (!targetDraft) {
+          const { year, month } = parseMonthKey(targetMonthKey);
+          const { cached } = loadMonthScheduleCached({
+            userId: backend.userId,
+            year,
+            month,
+          });
+          if (!cached) {
+            // Cache miss for target month, block the edit to prevent data loss
+            return false;
+          }
+          targetDraft = cached;
+        }
+
+        // Check overlap in target month buffer before applying state changes
+        if (isRecurring) {
+          if (targetMonthKey === parentMonthKey) {
+            const updatedParent: RawMentorTimeslot = {
+              ...target,
+              exdate: target.exdate.includes(occurrenceUnix)
+                ? target.exdate
+                : [...target.exdate, occurrenceUnix],
+            };
+            const intermediate = parentDraft.map((r) =>
+              r.id === id ? updatedParent : r
+            );
+            if (
+              hasAnyOccurrenceOverlap(
+                intermediate,
+                null,
+                [newDtstart],
+                durationSeconds
+              )
+            ) {
+              return false;
+            }
+          } else {
+            // Different month
+            if (
+              hasAnyOccurrenceOverlap(
+                targetDraft,
+                null,
+                [newDtstart],
+                durationSeconds
+              )
+            ) {
+              return false;
+            }
+          }
+        } else {
+          // Non-recurring slot
+          if (targetMonthKey === parentMonthKey) {
+            if (
+              hasAnyOccurrenceOverlap(
+                parentDraft,
+                id,
+                [newDtstart],
+                durationSeconds
+              )
+            ) {
+              return false;
+            }
+          } else {
+            // Different month
+            if (
+              hasAnyOccurrenceOverlap(
+                targetDraft,
+                null,
+                [newDtstart],
+                durationSeconds
+              )
+            ) {
+              return false;
+            }
+          }
+        }
+
+        // Side-effect: update savedByMonth outside updater if initializing target month
+        if (!isTargetLoaded) {
+          setSavedByMonth((prevSaved) => {
+            const nextSaved = new Map(prevSaved);
+            nextSaved.set(targetMonthKey, targetDraft!);
+            return nextSaved;
+          });
+        }
+
+        // Now run the pure state transformation on draftByMonth
         setDraftByMonth((prevDraft) => {
-          const parentDraft = prevDraft.get(parentMonthKey) ?? [];
-          const target = parentDraft.find((r) => r.id === id);
-          if (!target) return prevDraft;
+          const nextDraft = new Map(prevDraft);
 
-          const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
-          const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
-          const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
-
-          const s = buildDateTime(baseDate, startHM);
-          if (!s.isValid()) return prevDraft;
-
-          const newDtstart = Math.floor(s.valueOf() / 1000);
-          const oldDurationSeconds = target.dtend - target.dtstart;
-          const durationSeconds =
-            (patch.durationMinutes ?? Math.round(oldDurationSeconds / 60)) * 60;
-
-          // Recurring row: detach this occurrence (exdate it on the parent,
-          // emit a new non-recurring row with the patch) so sibling weeks
-          // stay untouched. Non-recurring row: mutate it in place.
-          const isRecurring = !!target.rrule;
-          const noChange =
-            newDtstart === occurrenceUnix &&
-            durationSeconds === oldDurationSeconds;
-          if (isRecurring && noChange) {
-            // Submitting the edit modal without changes shouldn't surface
-            // an overlap error — report success and skip the mutation.
-            succeeded = true;
-            return prevDraft;
+          // Lazy initialize target month in draft Map if not yet loaded
+          if (!nextDraft.has(targetMonthKey)) {
+            nextDraft.set(targetMonthKey, targetDraft!);
           }
 
-          const targetMonthKey = monthKeyFromUnix(newDtstart);
+          const currentParentDraft = nextDraft.get(parentMonthKey) ?? [];
+          const currentTargetDraft = nextDraft.get(targetMonthKey) ?? [];
 
-          // Build the prospective next state and overlap-check it against
           if (isRecurring) {
             const updatedParent: RawMentorTimeslot = {
               ...target,
@@ -556,7 +650,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
                 : [...target.exdate, occurrenceUnix],
             };
             const detachedRow: RawMentorTimeslot = {
-              id: nextTempId(allDraftRaws),
+              id: nextTempId(Array.from(nextDraft.values()).flat()),
               type: 'ALLOW' as const,
               dtstart: newDtstart,
               dtend: newDtstart + durationSeconds,
@@ -565,120 +659,61 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
             };
 
             if (targetMonthKey === parentMonthKey) {
-              const intermediate = parentDraft.map((r) =>
+              const intermediate = currentParentDraft.map((r) =>
                 r.id === id ? updatedParent : r
               );
-              if (
-                hasAnyOccurrenceOverlap(
-                  intermediate,
-                  null,
-                  [newDtstart],
-                  durationSeconds
-                )
-              ) {
-                return prevDraft;
-              }
-              succeeded = true;
-              const nextDraft = new Map(prevDraft);
               nextDraft.set(parentMonthKey, [...intermediate, detachedRow]);
-              return nextDraft;
             } else {
-              // Different month!
-              // 1. Fetch/ensure target month's draft is loaded
-              let targetDraft = prevDraft.get(targetMonthKey);
-              const isTargetLoaded = !!targetDraft;
-              if (!targetDraft) {
-                const { year, month } = parseMonthKey(targetMonthKey);
-                const { cached } = loadMonthScheduleCached({
-                  userId: backend.userId,
-                  year,
-                  month,
-                });
-                targetDraft = cached ?? [];
-              }
-
-              // Check overlap in target draft
-              if (
-                hasAnyOccurrenceOverlap(
-                  targetDraft,
-                  null,
-                  [newDtstart],
-                  durationSeconds
-                )
-              ) {
-                return prevDraft;
-              }
-
-              succeeded = true;
-
-              // Ensure targetMonthKey is initialized in savedByMonth too
-              if (!isTargetLoaded) {
-                setSavedByMonth((prevSaved) => {
-                  const nextSaved = new Map(prevSaved);
-                  nextSaved.set(targetMonthKey, targetDraft!);
-                  return nextSaved;
-                });
-              }
-
-              const nextDraft = new Map(prevDraft);
-              // Update parent draft (exdate added)
+              // Update parent draft
               nextDraft.set(
                 parentMonthKey,
-                parentDraft.map((r) => (r.id === id ? updatedParent : r))
+                currentParentDraft.map((r) => (r.id === id ? updatedParent : r))
               );
-              // Update target draft (detached row appended)
-              nextDraft.set(targetMonthKey, [...targetDraft, detachedRow]);
-              return nextDraft;
+              // Update target draft
+              nextDraft.set(targetMonthKey, [
+                ...currentTargetDraft,
+                detachedRow,
+              ]);
+            }
+          } else {
+            // Non-recurring slot
+            const updatedSlot: RawMentorTimeslot = {
+              ...target,
+              dtstart: newDtstart,
+              dtend: newDtstart + durationSeconds,
+              rrule: undefined,
+              exdate: [],
+            };
+
+            if (targetMonthKey === parentMonthKey) {
+              nextDraft.set(
+                parentMonthKey,
+                currentParentDraft.map((r) => (r.id === id ? updatedSlot : r))
+              );
+            } else {
+              // Remove from parent draft and add to target draft
+              nextDraft.set(
+                parentMonthKey,
+                currentParentDraft.filter((r) => r.id !== id)
+              );
+              nextDraft.set(targetMonthKey, [
+                ...currentTargetDraft,
+                updatedSlot,
+              ]);
             }
           }
 
-          if (
-            hasAnyOccurrenceOverlap(
-              parentDraft,
-              id,
-              [newDtstart],
-              durationSeconds
-            )
-          ) {
-            return prevDraft;
-          }
-
-          succeeded = true;
-          const nextDraft = new Map(prevDraft);
-          nextDraft.set(
-            parentMonthKey,
-            parentDraft.map((r) =>
-              r.id === id
-                ? {
-                    ...r,
-                    dtstart: newDtstart,
-                    dtend: newDtstart + durationSeconds,
-                    rrule: undefined,
-                    exdate: [],
-                  }
-                : r
-            )
-          );
           return nextDraft;
         });
 
-        if (succeeded) {
-          markDirty(parentMonthKey);
-          const baseDate = dayjs(occurrenceUnix * 1000).format('YYYY-MM-DD');
-          const fmtHM = (sec: number) => dayjs(sec * 1000).format('HH:mm');
-          const startHM = patch.startTime ?? fmtHM(occurrenceUnix);
-          const s = buildDateTime(baseDate, startHM);
-          if (s.isValid()) {
-            const newDtstart = Math.floor(s.valueOf() / 1000);
-            const targetMonthKey = monthKeyFromUnix(newDtstart);
-            if (targetMonthKey !== parentMonthKey) {
-              markDirty(targetMonthKey);
-            }
-          }
+        markDirty(parentMonthKey);
+        if (targetMonthKey !== parentMonthKey) {
+          markDirty(targetMonthKey);
         }
-        return succeeded;
+
+        return true;
       },
-      [findMonthForSlotId, markDirty, allDraftRaws, backend.userId]
+      [findMonthForSlotId, markDirty, backend.userId, draftByMonth]
     );
 
   const deleteDraftSlot = useCallback(

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -625,7 +625,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           newDtstart === occurrenceUnix &&
           durationSeconds === oldDurationSeconds;
 
-        if (isRecurring && noChange) {
+        if (noChange) {
           return { success: true };
         }
 
@@ -741,10 +741,13 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
           return nextDraft;
         });
 
-        markDirty(parentMonthKey);
-        if (targetMonthKey !== parentMonthKey) {
-          markDirty(targetMonthKey);
-        }
+        // Mark all months containing this parent row (and target month) dirty to sync exdates (Correctness Finding 1)
+        currentDraftsMap.forEach((mDraft, mKey) => {
+          if (mDraft.some((r: RawMentorTimeslot) => r.id === id)) {
+            markDirty(mKey);
+          }
+        });
+        markDirty(targetMonthKey);
 
         return { success: true };
       },

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -114,6 +114,77 @@ export type UseMentorScheduleReturn = {
 const appendExdate = (exdates: number[], unix: number): number[] =>
   exdates.includes(unix) ? exdates : [...exdates, unix];
 
+function ensureTargetMonthLoaded({
+  targetMonthKey,
+  currentDraftsMap,
+  userId,
+}: {
+  targetMonthKey: MonthKey;
+  currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>;
+  userId: string;
+}): RawMentorTimeslot[] | null {
+  let targetDraft = currentDraftsMap.get(targetMonthKey);
+  if (!targetDraft) {
+    const { year, month } = parseMonthKey(targetMonthKey);
+    const { cached } = loadMonthScheduleCached({
+      userId,
+      year,
+      month,
+    });
+    if (!cached) {
+      return null;
+    }
+    targetDraft = cached;
+  }
+  return targetDraft;
+}
+
+function checkCrossMonthOverlap({
+  id,
+  occurrenceUnix,
+  newDtstart,
+  durationSeconds,
+  isRecurring,
+  currentDraftsMap,
+  targetDraft,
+}: {
+  id: number;
+  occurrenceUnix: number;
+  newDtstart: number;
+  durationSeconds: number;
+  isRecurring: boolean;
+  currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>;
+  targetDraft: RawMentorTimeslot[];
+}): boolean {
+  const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
+  const draftsToCheck = [...allCurrentDrafts];
+  const isTargetLoaded = currentDraftsMap.has(monthKeyFromUnix(newDtstart));
+  if (!isTargetLoaded) {
+    draftsToCheck.push(...targetDraft);
+  }
+
+  let intermediateDraftsToCheck = draftsToCheck;
+  if (isRecurring) {
+    // If recurring, we simulate exdating the parent row
+    intermediateDraftsToCheck = draftsToCheck.map((r: RawMentorTimeslot) =>
+      r.id === id
+        ? {
+            ...r,
+            exdate: appendExdate(r.exdate, occurrenceUnix),
+          }
+        : r
+    );
+  }
+
+  // Run unified overlap check
+  return hasAnyOccurrenceOverlap(
+    intermediateDraftsToCheck,
+    isRecurring ? null : id, // ignore current row ID only if it is non-recurring
+    [newDtstart],
+    durationSeconds
+  );
+}
+
 export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
   const { backend } = opts;
 
@@ -524,78 +595,6 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
     draftByMonthRef.current = draftByMonth;
   }, [draftByMonth]);
 
-  const ensureTargetMonthLoaded = useCallback(
-    (
-      targetMonthKey: MonthKey,
-      currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>
-    ) => {
-      let targetDraft = currentDraftsMap.get(targetMonthKey);
-      if (!targetDraft) {
-        const { year, month } = parseMonthKey(targetMonthKey);
-        const { cached } = loadMonthScheduleCached({
-          userId: backend.userId,
-          year,
-          month,
-        });
-        if (!cached) {
-          return null;
-        }
-        targetDraft = cached;
-      }
-      return targetDraft;
-    },
-    [backend.userId]
-  );
-
-  const checkCrossMonthOverlap = useCallback(
-    ({
-      id,
-      occurrenceUnix,
-      newDtstart,
-      durationSeconds,
-      isRecurring,
-      currentDraftsMap,
-      targetDraft,
-    }: {
-      id: number;
-      occurrenceUnix: number;
-      newDtstart: number;
-      durationSeconds: number;
-      isRecurring: boolean;
-      currentDraftsMap: Map<MonthKey, RawMentorTimeslot[]>;
-      targetDraft: RawMentorTimeslot[];
-    }): boolean => {
-      const allCurrentDrafts = Array.from(currentDraftsMap.values()).flat();
-      const draftsToCheck = [...allCurrentDrafts];
-      const isTargetLoaded = currentDraftsMap.has(monthKeyFromUnix(newDtstart));
-      if (!isTargetLoaded) {
-        draftsToCheck.push(...targetDraft);
-      }
-
-      let intermediateDraftsToCheck = draftsToCheck;
-      if (isRecurring) {
-        // If recurring, we simulate exdating the parent row
-        intermediateDraftsToCheck = draftsToCheck.map((r: RawMentorTimeslot) =>
-          r.id === id
-            ? {
-                ...r,
-                exdate: appendExdate(r.exdate, occurrenceUnix),
-              }
-            : r
-        );
-      }
-
-      // Run unified overlap check
-      return hasAnyOccurrenceOverlap(
-        intermediateDraftsToCheck,
-        isRecurring ? null : id, // ignore current row ID only if it is non-recurring
-        [newDtstart],
-        durationSeconds
-      );
-    },
-    []
-  );
-
   const updateDraftSlot: UseMentorScheduleReturn['updateDraftSlot'] =
     useCallback(
       (id, occurrenceUnix, patch) => {
@@ -633,10 +632,11 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
         const targetMonthKey = monthKeyFromUnix(newDtstart);
 
         // Fetch / ensure target draft is loaded/cached outside state setter from ref
-        const targetDraft = ensureTargetMonthLoaded(
+        const targetDraft = ensureTargetMonthLoaded({
           targetMonthKey,
-          currentDraftsMap
-        );
+          currentDraftsMap,
+          userId: backend.userId,
+        });
         if (!targetDraft) {
           return { success: false, reason: 'TARGET_MONTH_NOT_LOADED' };
         }
@@ -748,12 +748,7 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
         return { success: true };
       },
-      [
-        findMonthForSlotId,
-        markDirty,
-        ensureTargetMonthLoaded,
-        checkCrossMonthOverlap,
-      ]
+      [findMonthForSlotId, markDirty, backend.userId]
     );
 
   const deleteDraftSlot = useCallback(

--- a/src/hooks/useMentorSchedule.ts
+++ b/src/hooks/useMentorSchedule.ts
@@ -708,49 +708,81 @@ export function useMentorSchedule(opts: Options): UseMentorScheduleReturn {
 
   const deleteDraftSlot = useCallback(
     (id: number, occurrenceUnix: number) => {
-      const monthKey = findMonthForSlotId(id);
-      if (!monthKey) return;
+      const parentMonthKey = findMonthForSlotId(id);
+      if (!parentMonthKey) return;
 
-      let removedFromDraft = false;
-      updateMonthDraft(monthKey, (prev) => {
-        const target = prev.find((r) => r.id === id);
-        if (!target) return prev;
+      let fullyRemovedFromSomeMonth = false;
 
-        // Recurring row: only this occurrence is removed via exdate. If that
-        // would empty the row of active occurrences, drop the row entirely.
+      setDraftByMonth((prevDraft) => {
+        const nextDraft = new Map(prevDraft);
+
+        const parentDraft = nextDraft.get(parentMonthKey) ?? [];
+        const target = parentDraft.find((r) => r.id === id);
+        if (!target) return prevDraft;
+
         if (target.rrule) {
           const updatedExdate = target.exdate.includes(occurrenceUnix)
             ? target.exdate
             : [...target.exdate, occurrenceUnix];
-          const updated: RawMentorTimeslot = {
+          const updatedParent: RawMentorTimeslot = {
             ...target,
             exdate: updatedExdate,
           };
-          if (activeOccurrences(updated).length === 0) {
-            removedFromDraft = true;
-            return prev.filter((r) => r.id !== id);
-          }
-          return prev.map((r) => (r.id === id ? updated : r));
+
+          const isFullyEmpty = activeOccurrences(updatedParent).length === 0;
+
+          // Recursively update or remove parent row across ALL loaded month buffers (Correctness Finding 1)
+          nextDraft.forEach((mDraft, mKey) => {
+            if (mDraft.some((r: RawMentorTimeslot) => r.id === id)) {
+              if (isFullyEmpty) {
+                fullyRemovedFromSomeMonth = true;
+                nextDraft.set(
+                  mKey,
+                  mDraft.filter((r: RawMentorTimeslot) => r.id !== id)
+                );
+              } else {
+                nextDraft.set(
+                  mKey,
+                  mDraft.map((r: RawMentorTimeslot) =>
+                    r.id === id ? updatedParent : r
+                  )
+                );
+              }
+            }
+          });
+        } else {
+          fullyRemovedFromSomeMonth = true;
+          // Non-recurring slot: remove entirely from parent draft
+          nextDraft.set(
+            parentMonthKey,
+            parentDraft.filter((r: RawMentorTimeslot) => r.id !== id)
+          );
         }
 
-        removedFromDraft = true;
-        return prev.filter((r) => r.id !== id);
+        return nextDraft;
       });
 
       // Only persisted rows that were fully removed need a backend DELETE.
       // Detached/exdated rrule rows ride the next save via rrule + exdate.
-      if (removedFromDraft && id > 0) {
+      if (fullyRemovedFromSomeMonth && id > 0) {
         setPendingDeleteByMonth((prev) => {
-          const current = prev.get(monthKey) ?? [];
+          const current = prev.get(parentMonthKey) ?? [];
           if (current.includes(id)) return prev;
           const next = new Map(prev);
-          next.set(monthKey, [...current, id]);
+          next.set(parentMonthKey, [...current, id]);
           return next;
         });
       }
-      markDirty(monthKey);
+
+      // Mark all months that contain this parent row as dirty (so exdates are synchronized on save)
+      const currentDraftsMap = draftByMonthRef.current;
+      currentDraftsMap.forEach((mDraft, mKey) => {
+        if (mDraft.some((r: RawMentorTimeslot) => r.id === id)) {
+          markDirty(mKey);
+        }
+      });
     },
-    [findMonthForSlotId, updateMonthDraft, markDirty]
+    [findMonthForSlotId, markDirty]
   );
 
   const confirmChanges = useCallback(async (): Promise<SyncResult> => {


### PR DESCRIPTION
When editing a single occurrence of a recurring ALLOW timeslot, calculate its target month and save the resulting detached row in that month's buffer instead of the parent's. If the target month's buffer is not yet loaded, initialize/lazy-load it using cached schedule data. This prevents the same slot from appearing in multiple months' schedule data.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/522
