### PR TITLE
style(auth): migrate password-reset pages to design tokens (X-Tracker #518)

### DIFF
--- a/src/app/auth/password-reset-success/page.tsx
+++ b/src/app/auth/password-reset-success/page.tsx
@@ -11,8 +11,8 @@ export default function Page() {
   return (
     <div className="bg-background-white">
       <main className="px-6 pt-16 pb-20">
-        <div className="mx-auto w-full max-w-[554px] overflow-hidden rounded-[16px] border border-background-border bg-background-white shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
-          <div className="h-[88px] bg-[linear-gradient(90deg,#EAFBFB_0%,#CFEFFF_45%,#EAE4FF_100%)]" />
+        <div className="mx-auto w-full max-w-[554px] overflow-hidden rounded-2xl border border-background-border bg-background-white shadow-card">
+          <div className="h-[88px] bg-auth-card" />
 
           <div className="px-8 pb-10">
             <h1 className="relative -mt-5 text-center text-32 leading-[1.2] font-bold text-text-primary">

--- a/src/app/auth/password-reset/page.tsx
+++ b/src/app/auth/password-reset/page.tsx
@@ -81,7 +81,7 @@ export default function Page() {
   return (
     <div className="bg-background-white">
       <main className="px-6 py-16">
-        <div className="mx-auto w-full max-w-[556px] rounded-[16px] border border-background-border bg-background-white px-9 py-14 shadow-[0_2px_12px_rgba(0,0,0,0.04)]">
+        <div className="mx-auto w-full max-w-[556px] rounded-2xl border border-background-border bg-background-white px-9 py-14 shadow-card">
           <div className="mx-auto w-full max-w-[484px]">
             <h1 className="mb-8 text-center text-32 leading-[1.2] font-bold text-text-primary">
               重設密碼


### PR DESCRIPTION
Migrated password-reset/page.tsx and password-reset-success/page.tsx to use shadow-card, rounded-2xl, and bg-auth-card design tokens instead of hardcoded arbitrary Tailwind values.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/518
