### PR TITLE
feat(ui): migrate MentorPoolHero gradient to named design tokens (X-Tracker #519)

### DIFF
--- a/src/app/mentor-pool/MentorPoolHero.tsx
+++ b/src/app/mentor-pool/MentorPoolHero.tsx
@@ -1,6 +1,6 @@
 export default function MentorPoolHero() {
   return (
-    <section className="flex h-[202px] w-full items-center justify-center bg-[linear-gradient(to_right,#FFFFEF_0%,#FFF6FF_19%,#F7F2FB_42%,#E4FFFF_100%)] px-4 text-xl font-semibold md:text-3xl xl:rounded-br-[120px]">
+    <section className="flex h-[202px] w-full items-center justify-center bg-mentor-hero px-4 text-xl font-semibold md:text-3xl xl:rounded-br-[120px]">
       和 Mentors 一起提升你的職涯經驗吧！
     </section>
   );

--- a/src/design/tokens/color-values.ts
+++ b/src/design/tokens/color-values.ts
@@ -63,6 +63,12 @@ export const rawColors = {
   'auth-gradient-2': '200 100% 91%', // #CFEFFF
   'auth-gradient-3': '253 100% 95%', // #EAE4FF
 
+  // Mentor pool hero gradient tokens
+  'mentor-hero-gradient-1': '60 100% 97%', // #FFFFEF
+  'mentor-hero-gradient-2': '300 100% 98%', // #FFF6FF
+  'mentor-hero-gradient-3': '273 53% 97%', // #F7F2FB
+  'mentor-hero-gradient-4': '180 100% 95%', // #E4FFFF
+
   // Legacy / Landing page specific colors
   navy: '219 59% 22%', // #172E59
   'logo-blue': '200 100% 18%', // #003C5A

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -93,6 +93,12 @@ module.exports = {
     2: 'hsl(var(--color-auth-gradient-2) / <alpha-value>)',
     3: 'hsl(var(--color-auth-gradient-3) / <alpha-value>)',
   },
+  'mentor-hero-gradient': {
+    1: 'hsl(var(--color-mentor-hero-gradient-1) / <alpha-value>)',
+    2: 'hsl(var(--color-mentor-hero-gradient-2) / <alpha-value>)',
+    3: 'hsl(var(--color-mentor-hero-gradient-3) / <alpha-value>)',
+    4: 'hsl(var(--color-mentor-hero-gradient-4) / <alpha-value>)',
+  },
   // [Item 3: Legacy landing-only tokens]
   // 經過全面代碼檢索（grep），以下 5 個 Token 仍被 (landing)/about、(landing)/page、(landing)/terms、(landing)/privacy、mentor-pool/PopularPositionChips 以及 components/landing/HomePageSlider 廣泛調用，為防樣式損壞，依據工程規範維持保留。
   navy: 'hsl(var(--color-navy) / <alpha-value>)',

--- a/src/design/tokens/tokens.test.ts
+++ b/src/design/tokens/tokens.test.ts
@@ -14,6 +14,13 @@ describe('Design Tokens Configuration', () => {
       expect(rawColors['auth-gradient-3']).toBe('253 100% 95%');
     });
 
+    it('should have the new mentor hero gradient stop colors in raw colors', () => {
+      expect(rawColors['mentor-hero-gradient-1']).toBe('60 100% 97%');
+      expect(rawColors['mentor-hero-gradient-2']).toBe('300 100% 98%');
+      expect(rawColors['mentor-hero-gradient-3']).toBe('273 53% 97%');
+      expect(rawColors['mentor-hero-gradient-4']).toBe('180 100% 95%');
+    });
+
     it('should correctly map raw colors into the Tailwind color export', () => {
       expect(colors['auth-gradient']).toBeDefined();
       expect(colors['auth-gradient'][1]).toBe(
@@ -24,6 +31,22 @@ describe('Design Tokens Configuration', () => {
       );
       expect(colors['auth-gradient'][3]).toBe(
         'hsl(var(--color-auth-gradient-3) / <alpha-value>)'
+      );
+    });
+
+    it('should correctly map mentor hero gradient raw colors into the Tailwind color export', () => {
+      expect(colors['mentor-hero-gradient']).toBeDefined();
+      expect(colors['mentor-hero-gradient'][1]).toBe(
+        'hsl(var(--color-mentor-hero-gradient-1) / <alpha-value>)'
+      );
+      expect(colors['mentor-hero-gradient'][2]).toBe(
+        'hsl(var(--color-mentor-hero-gradient-2) / <alpha-value>)'
+      );
+      expect(colors['mentor-hero-gradient'][3]).toBe(
+        'hsl(var(--color-mentor-hero-gradient-3) / <alpha-value>)'
+      );
+      expect(colors['mentor-hero-gradient'][4]).toBe(
+        'hsl(var(--color-mentor-hero-gradient-4) / <alpha-value>)'
       );
     });
   });

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -42,6 +42,13 @@
       hsl(var(--color-auth-gradient-2)) 45%,
       hsl(var(--color-auth-gradient-3)) 100%
     );
+    --bg-mentor-hero: linear-gradient(
+      90deg,
+      hsl(var(--color-mentor-hero-gradient-1)) 0%,
+      hsl(var(--color-mentor-hero-gradient-2)) 19%,
+      hsl(var(--color-mentor-hero-gradient-3)) 42%,
+      hsl(var(--color-mentor-hero-gradient-4)) 100%
+    );
   }
 }
 

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -58,6 +58,11 @@
   --color-auth-gradient-1: 180 63% 95%; /* #EAFBFB */
   --color-auth-gradient-2: 200 100% 91%; /* #CFEFFF */
   --color-auth-gradient-3: 253 100% 95%; /* #EAE4FF */
+  /* Mentor pool hero gradient tokens */
+  --color-mentor-hero-gradient-1: 60 100% 97%; /* #FFFFEF */
+  --color-mentor-hero-gradient-2: 300 100% 98%; /* #FFF6FF */
+  --color-mentor-hero-gradient-3: 273 53% 97%; /* #F7F2FB */
+  --color-mentor-hero-gradient-4: 180 100% 95%; /* #E4FFFF */
   /* Legacy / Landing page specific colors */
   --color-navy: 219 59% 22%; /* #172E59 */
   --color-logo-blue: 200 100% 18%; /* #003C5A */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,6 +34,7 @@ export const theme = {
     },
     backgroundImage: {
       'auth-card': 'var(--bg-auth-card)',
+      'mentor-hero': 'var(--bg-mentor-hero)',
     },
     keyframes: {
       'accordion-down': {


### PR DESCRIPTION
Migrated the arbitrary inline linear-gradient background from MentorPoolHero.tsx into a central, reusable design token.

Modified Files:
- **src/design/tokens/color-values.ts**: Added HSL color stop values (mentor-hero-gradient-1 through 4) representing the original hex colors.
- **src/design/tokens/color.ts**: Mapped the color stops into Tailwind export.
- **src/design/tokens/tokens.test.ts**: Added unit tests to assert correct definition and mapping.
- **src/styles/tokens.css**: Regenerated CSS custom properties for the new tokens.
- **src/styles/global.css**: Defined --bg-mentor-hero under :root.
- **tailwind.config.js**: Registered mentor-hero background image pointing to the CSS custom property.
- **src/app/mentor-pool/MentorPoolHero.tsx**: Refactored the section to use bg-mentor-hero instead of an arbitrary inline style.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/519
