### PR TITLE
fix(header): render mentor-status and avatar from SSR session hint (X-Tracker #525)

### DIFF
--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -22,26 +22,32 @@ describe('useSessionHint', () => {
     setCookie(undefined);
   });
 
-  it('uses initial hint from document.documentElement data attributes post-mount', async () => {
-    document.documentElement.setAttribute(DOM_AUTH_STATE_ATTR, 'mentor');
-    document.documentElement.setAttribute(
-      DOM_AUTH_AVATAR_ATTR,
-      'https://example.com/avatar.png'
-    );
+  it('actively syncs DOM attributes and CSS variables with the cookie on mount', async () => {
+    setCookie('1|https%3A%2F%2Fexample.com%2Favatar.png');
 
     const { result } = renderHook(() => useSessionHint());
 
     try {
-      await waitFor(() =>
+      await waitFor(() => {
         expect(result.current).toEqual({
           status: 'authenticated',
           isMentor: true,
           avatar: 'https://example.com/avatar.png',
-        })
-      );
+        });
+        expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+          'mentor'
+        );
+        expect(
+          document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+        ).toBe('https://example.com/avatar.png');
+        expect(
+          document.documentElement.style.getPropertyValue('--auth-avatar')
+        ).toBe('url("https://example.com/avatar.png")');
+      });
     } finally {
-      document.documentElement.removeAttribute('data-auth-state');
-      document.documentElement.removeAttribute('data-auth-avatar');
+      document.documentElement.removeAttribute(DOM_AUTH_STATE_ATTR);
+      document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
+      document.documentElement.style.removeProperty('--auth-avatar');
     }
   });
 

--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -1,7 +1,11 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { SESSION_HINT_COOKIE } from '@/lib/auth/sessionHint';
+import {
+  DOM_AUTH_AVATAR_ATTR,
+  DOM_AUTH_STATE_ATTR,
+  SESSION_HINT_COOKIE,
+} from '@/lib/auth/sessionHint';
 
 import { useSessionHint } from './useSessionHint';
 
@@ -16,6 +20,29 @@ function setCookie(value: string | undefined): void {
 describe('useSessionHint', () => {
   afterEach(() => {
     setCookie(undefined);
+  });
+
+  it('uses initial hint from document.documentElement data attributes post-mount', async () => {
+    document.documentElement.setAttribute(DOM_AUTH_STATE_ATTR, 'mentor');
+    document.documentElement.setAttribute(
+      DOM_AUTH_AVATAR_ATTR,
+      'https://example.com/avatar.png'
+    );
+
+    const { result } = renderHook(() => useSessionHint());
+
+    try {
+      await waitFor(() =>
+        expect(result.current).toEqual({
+          status: 'authenticated',
+          isMentor: true,
+          avatar: 'https://example.com/avatar.png',
+        })
+      );
+    } finally {
+      document.documentElement.removeAttribute('data-auth-state');
+      document.documentElement.removeAttribute('data-auth-avatar');
+    }
   });
 
   it('resolves to guest when no hint cookie is present', async () => {

--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -83,4 +83,63 @@ describe('useSessionHint', () => {
     const { result } = renderHook(() => useSessionHint());
     await waitFor(() => expect(result.current.status).toBe('guest'));
   });
+
+  it('clears DOM attributes and CSS variables when no cookie is present (guest)', async () => {
+    document.documentElement.setAttribute(DOM_AUTH_STATE_ATTR, 'mentor');
+    document.documentElement.setAttribute(
+      DOM_AUTH_AVATAR_ATTR,
+      'https://example.com/avatar.png'
+    );
+    document.documentElement.style.setProperty(
+      '--auth-avatar',
+      'url("https://example.com/avatar.png")'
+    );
+
+    const { result } = renderHook(() => useSessionHint());
+
+    await waitFor(() => {
+      expect(result.current.status).toBe('guest');
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)
+      ).toBeNull();
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+      expect(
+        document.documentElement.style.getPropertyValue('--auth-avatar')
+      ).toBe('');
+    });
+  });
+
+  it('clears avatar attributes and CSS variables when logged in without avatar', async () => {
+    document.documentElement.setAttribute(DOM_AUTH_STATE_ATTR, 'mentee');
+    document.documentElement.setAttribute(
+      DOM_AUTH_AVATAR_ATTR,
+      'https://example.com/avatar.png'
+    );
+    document.documentElement.style.setProperty(
+      '--auth-avatar',
+      'url("https://example.com/avatar.png")'
+    );
+
+    setCookie('1');
+
+    const { result } = renderHook(() => useSessionHint());
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        status: 'authenticated',
+        isMentor: true,
+      });
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentor'
+      );
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+      expect(
+        document.documentElement.style.getPropertyValue('--auth-avatar')
+      ).toBe('');
+    });
+  });
 });

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -31,24 +31,36 @@ export function useSessionHint(): SessionHintState {
 
   useEffect(() => {
     const hint = decodeSessionHint(readCookie(SESSION_HINT_COOKIE));
-    const authState =
-      document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR);
 
-    const resolvedHint =
-      hint ??
-      (authState
-        ? {
-            isMentor: authState === 'mentor',
-            avatar:
-              document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR) ??
-              undefined,
-          }
-        : null);
+    // Actively sync and clear DOM attributes and CSS variables with Cookie (Single Source of Truth)
+    if (hint) {
+      document.documentElement.setAttribute(
+        DOM_AUTH_STATE_ATTR,
+        hint.isMentor ? 'mentor' : 'mentee'
+      );
+      if (hint.avatar) {
+        document.documentElement.setAttribute(
+          DOM_AUTH_AVATAR_ATTR,
+          hint.avatar
+        );
+        document.documentElement.style.setProperty(
+          '--auth-avatar',
+          `url("${hint.avatar}")`
+        );
+      } else {
+        document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
+        document.documentElement.style.removeProperty('--auth-avatar');
+      }
+    } else {
+      document.documentElement.removeAttribute(DOM_AUTH_STATE_ATTR);
+      document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
+      document.documentElement.style.removeProperty('--auth-avatar');
+    }
 
     setState((prev) => {
-      const nextStatus = resolvedHint ? 'authenticated' : 'guest';
-      const nextIsMentor = resolvedHint ? resolvedHint.isMentor : false;
-      const nextAvatar = resolvedHint ? resolvedHint.avatar : undefined;
+      const nextStatus = hint ? 'authenticated' : 'guest';
+      const nextIsMentor = hint ? hint.isMentor : false;
+      const nextAvatar = hint ? hint.avatar : undefined;
 
       if (
         prev.status === nextStatus &&
@@ -58,11 +70,11 @@ export function useSessionHint(): SessionHintState {
         return prev;
       }
 
-      return resolvedHint
+      return hint
         ? {
             status: 'authenticated',
-            isMentor: resolvedHint.isMentor,
-            avatar: resolvedHint.avatar,
+            isMentor: hint.isMentor,
+            avatar: hint.avatar,
           }
         : { status: 'guest' };
     });

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -32,27 +32,24 @@ export function useSessionHint(): SessionHintState {
   useEffect(() => {
     const hint = decodeSessionHint(readCookie(SESSION_HINT_COOKIE));
 
-    // Actively sync and clear DOM attributes and CSS variables with Cookie (Single Source of Truth)
+    // 1. Sync or clear data-auth-state based on isMentor
     if (hint) {
       document.documentElement.setAttribute(
         DOM_AUTH_STATE_ATTR,
         hint.isMentor ? 'mentor' : 'mentee'
       );
-      if (hint.avatar) {
-        document.documentElement.setAttribute(
-          DOM_AUTH_AVATAR_ATTR,
-          hint.avatar
-        );
-        document.documentElement.style.setProperty(
-          '--auth-avatar',
-          `url("${hint.avatar}")`
-        );
-      } else {
-        document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
-        document.documentElement.style.removeProperty('--auth-avatar');
-      }
     } else {
       document.documentElement.removeAttribute(DOM_AUTH_STATE_ATTR);
+    }
+
+    // 2. Sync or clear data-auth-avatar and CSS custom property --auth-avatar based on avatar
+    if (hint && hint.avatar) {
+      document.documentElement.setAttribute(DOM_AUTH_AVATAR_ATTR, hint.avatar);
+      document.documentElement.style.setProperty(
+        '--auth-avatar',
+        `url("${hint.avatar}")`
+      );
+    } else {
       document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
       document.documentElement.style.removeProperty('--auth-avatar');
     }

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -4,40 +4,68 @@ import { useEffect, useState } from 'react';
 
 import {
   decodeSessionHint,
+  DOM_AUTH_AVATAR_ATTR,
+  DOM_AUTH_STATE_ATTR,
   SESSION_HINT_COOKIE,
-  type SessionHint,
 } from '@/lib/auth/sessionHint';
 
+export type SessionHintState =
+  | { status: 'unknown' }
+  | { status: 'guest' }
+  | { status: 'authenticated'; isMentor: boolean; avatar?: string };
+
 function readCookie(name: string): string | undefined {
+  if (typeof document === 'undefined') return undefined;
   return document.cookie
     .split('; ')
     .find((row) => row.startsWith(`${name}=`))
     ?.slice(name.length + 1);
 }
 
-export type SessionHintState =
-  | { status: 'unknown' }
-  | { status: 'guest' }
-  | { status: 'authenticated'; isMentor: boolean };
-
 /**
  * Reads the middleware-written hint cookie so the header can render the
- * right shape before `useSession()` resolves. Deferred to an effect (rather
- * than a lazy useState initializer) because the server render has no cookie
- * access — reading it during the first client render would mismatch.
+ * right shape before `useSession()` resolves.
  */
 export function useSessionHint(): SessionHintState {
   const [state, setState] = useState<SessionHintState>({ status: 'unknown' });
 
   useEffect(() => {
-    const hint: SessionHint | null = decodeSessionHint(
-      readCookie(SESSION_HINT_COOKIE)
-    );
-    setState(
-      hint
-        ? { status: 'authenticated', isMentor: hint.isMentor }
-        : { status: 'guest' }
-    );
+    const hint = decodeSessionHint(readCookie(SESSION_HINT_COOKIE));
+    const authState =
+      document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR);
+
+    const resolvedHint =
+      hint ??
+      (authState
+        ? {
+            isMentor: authState === 'mentor',
+            avatar:
+              document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR) ??
+              undefined,
+          }
+        : null);
+
+    setState((prev) => {
+      const nextStatus = resolvedHint ? 'authenticated' : 'guest';
+      const nextIsMentor = resolvedHint ? resolvedHint.isMentor : false;
+      const nextAvatar = resolvedHint ? resolvedHint.avatar : undefined;
+
+      if (
+        prev.status === nextStatus &&
+        (prev.status !== 'authenticated' ||
+          (prev.isMentor === nextIsMentor && prev.avatar === nextAvatar))
+      ) {
+        return prev;
+      }
+
+      return resolvedHint
+        ? {
+            status: 'authenticated',
+            isMentor: resolvedHint.isMentor,
+            avatar: resolvedHint.avatar,
+          }
+        : { status: 'guest' };
+    });
   }, []);
 
   return state;

--- a/src/lib/auth/sessionHint.test.ts
+++ b/src/lib/auth/sessionHint.test.ts
@@ -4,7 +4,6 @@ import {
   decodeSessionHint,
   DOM_AUTH_AVATAR_ATTR,
   DOM_AUTH_STATE_ATTR,
-  DOM_AVATAR_IMG_ATTR,
   encodeSessionHint,
   SESSION_HINT_COOKIE,
   SESSION_HINT_INLINE_SCRIPT,
@@ -121,12 +120,8 @@ describe('sessionHint utilities', () => {
       document.body.innerHTML = '';
     });
 
-    it('sets state attribute for mentor with avatar and pre-fills avatar images', () => {
+    it('sets state attribute for mentor with avatar and pre-fills CSS custom property', () => {
       document.cookie = `${SESSION_HINT_COOKIE}=1|https%3A%2F%2Fexample.com%2Favatar.png`;
-
-      const img1 = document.createElement('img');
-      img1.setAttribute(DOM_AVATAR_IMG_ATTR, 'true');
-      document.body.appendChild(img1);
 
       runInlineScript();
 
@@ -136,7 +131,9 @@ describe('sessionHint utilities', () => {
       expect(document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)).toBe(
         'https://example.com/avatar.png'
       );
-      expect(img1.src).toBe('https://example.com/avatar.png');
+      expect(
+        document.documentElement.style.getPropertyValue('--auth-avatar')
+      ).toBe('url("https://example.com/avatar.png")');
     });
 
     it('sets state attribute for mentee without avatar', () => {

--- a/src/lib/auth/sessionHint.test.ts
+++ b/src/lib/auth/sessionHint.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  decodeSessionHint,
+  DOM_AUTH_AVATAR_ATTR,
+  DOM_AUTH_STATE_ATTR,
+  DOM_AVATAR_IMG_ATTR,
+  encodeSessionHint,
+  SESSION_HINT_COOKIE,
+  SESSION_HINT_INLINE_SCRIPT,
+} from './sessionHint';
+
+describe('sessionHint utilities', () => {
+  describe('encodeSessionHint', () => {
+    it('encodes mentor status without avatar', () => {
+      const result = encodeSessionHint({ isMentor: true });
+      expect(result).toBe('1');
+    });
+
+    it('encodes non-mentor status without avatar', () => {
+      const result = encodeSessionHint({ isMentor: false });
+      expect(result).toBe('0');
+    });
+
+    it('encodes mentor status with avatar', () => {
+      const result = encodeSessionHint({
+        isMentor: true,
+        avatar: 'https://example.com/avatar.jpg?sz=50&id=123',
+      });
+      expect(result).toBe(
+        '1|https%3A%2F%2Fexample.com%2Favatar.jpg%3Fsz%3D50%26id%3D123'
+      );
+    });
+
+    it('encodes non-mentor status with avatar', () => {
+      const result = encodeSessionHint({
+        isMentor: false,
+        avatar: 'https://example.com/avatar.jpg',
+      });
+      expect(result).toBe('0|https%3A%2F%2Fexample.com%2Favatar.jpg');
+    });
+
+    it('discards avatar when encoded URL exceeds 1000 characters', () => {
+      const longAvatar = 'https://example.com/avatar.png?' + 'a'.repeat(1000);
+      const result = encodeSessionHint({
+        isMentor: true,
+        avatar: longAvatar,
+      });
+      expect(result).toBe('1');
+    });
+  });
+
+  describe('decodeSessionHint', () => {
+    it('decodes old mentor cookie value "1"', () => {
+      const result = decodeSessionHint('1');
+      expect(result).toEqual({ isMentor: true });
+    });
+
+    it('decodes old non-mentor cookie value "0"', () => {
+      const result = decodeSessionHint('0');
+      expect(result).toEqual({ isMentor: false });
+    });
+
+    it('decodes new mentor cookie with encoded avatar', () => {
+      const result = decodeSessionHint(
+        '1|https%3A%2F%2Fexample.com%2Favatar.jpg%3Fsz%3D50%26id%3D123'
+      );
+      expect(result).toEqual({
+        isMentor: true,
+        avatar: 'https://example.com/avatar.jpg?sz=50&id=123',
+      });
+    });
+
+    it('decodes new non-mentor cookie with encoded avatar', () => {
+      const result = decodeSessionHint(
+        '0|https%3A%2F%2Fexample.com%2Favatar.jpg'
+      );
+      expect(result).toEqual({
+        isMentor: false,
+        avatar: 'https://example.com/avatar.jpg',
+      });
+    });
+
+    it('discards avatar on URI decode error', () => {
+      const result = decodeSessionHint(
+        '1|https%3A%2F%2Fexample.com%2Finvalid%%url'
+      );
+      expect(result).toEqual({
+        isMentor: true,
+      });
+    });
+
+    it('filters out unsafe avatar protocols', () => {
+      const result = decodeSessionHint('1|javascript%3Aalert(1)');
+      expect(result).toEqual({
+        isMentor: true,
+      });
+    });
+
+    it('returns null on invalid input', () => {
+      expect(decodeSessionHint(null)).toBeNull();
+      expect(decodeSessionHint(undefined)).toBeNull();
+      expect(decodeSessionHint('')).toBeNull();
+      expect(decodeSessionHint('garbage')).toBeNull();
+      expect(decodeSessionHint('garbage|url')).toBeNull();
+    });
+  });
+
+  describe('SESSION_HINT_INLINE_SCRIPT', () => {
+    const runInlineScript = () => {
+      // Execute the exported inline script in JSDOM
+      // eslint-disable-next-line no-eval
+      eval(SESSION_HINT_INLINE_SCRIPT);
+    };
+
+    beforeEach(() => {
+      // Clear data attributes, cookies, and body content
+      document.cookie = `${SESSION_HINT_COOKIE}=; expires=Thu, 01 Jan 1970 00:00:00 GMT`;
+      document.documentElement.removeAttribute(DOM_AUTH_STATE_ATTR);
+      document.documentElement.removeAttribute(DOM_AUTH_AVATAR_ATTR);
+      document.body.innerHTML = '';
+    });
+
+    it('sets state attribute for mentor with avatar and pre-fills avatar images', () => {
+      document.cookie = `${SESSION_HINT_COOKIE}=1|https%3A%2F%2Fexample.com%2Favatar.png`;
+
+      const img1 = document.createElement('img');
+      img1.setAttribute(DOM_AVATAR_IMG_ATTR, 'true');
+      document.body.appendChild(img1);
+
+      runInlineScript();
+
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentor'
+      );
+      expect(document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)).toBe(
+        'https://example.com/avatar.png'
+      );
+      expect(img1.src).toBe('https://example.com/avatar.png');
+    });
+
+    it('sets state attribute for mentee without avatar', () => {
+      document.cookie = `${SESSION_HINT_COOKIE}=0`;
+
+      runInlineScript();
+
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentee'
+      );
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+    });
+
+    it('filters out unsafe protocols in the inline script', () => {
+      document.cookie = `${SESSION_HINT_COOKIE}=1|javascript%3Aalert(1)`;
+
+      runInlineScript();
+
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentor'
+      );
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+    });
+
+    it('gracefully handles malformed URI encoding in the inline script', () => {
+      document.cookie = `${SESSION_HINT_COOKIE}=1|https%3A%2F%2Fexample.com%2Finvalid%%url`;
+
+      runInlineScript();
+
+      // Should still set the state attribute and isMentor safely since decodeURIComponent error is caught!
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentor'
+      );
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+    });
+  });
+});

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -102,18 +102,10 @@ export const SESSION_HINT_INLINE_SCRIPT = `
           avatar = '';
         }
       }
-      
+
       if (avatar && (avatar.startsWith('https://') || avatar.startsWith('http://') || avatar.startsWith('/'))) {
         document.documentElement.setAttribute('${DOM_AUTH_AVATAR_ATTR}', avatar);
-        
-        var updateImages = function() {
-          var imgs = document.querySelectorAll('img[${DOM_AVATAR_IMG_ATTR}]');
-          for (var i = 0; i < imgs.length; i++) {
-            imgs[i].src = avatar;
-          }
-        };
-        updateImages();
-        document.addEventListener('DOMContentLoaded', updateImages);
+        document.documentElement.style.setProperty('--auth-avatar', 'url("' + avatar + '")');
       }
       document.documentElement.setAttribute('${DOM_AUTH_STATE_ATTR}', isMentor ? 'mentor' : 'mentee');
     }

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -88,10 +88,10 @@ export const DOM_AVATAR_IMG_ATTR = 'data-avatar-img';
 export const SESSION_HINT_INLINE_SCRIPT = `
   try {
     var cookie = document.cookie.split('; ').find(function(row) {
-      return row.startsWith('session-hint=');
+      return row.startsWith('${SESSION_HINT_COOKIE}=');
     });
     if (cookie) {
-      var rawValue = cookie.substring('session-hint='.length);
+      var rawValue = cookie.substring('${SESSION_HINT_COOKIE}='.length);
       var parts = rawValue.split('|');
       var isMentor = parts[0] === '1';
       var avatar = '';

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -16,19 +16,106 @@ export const SESSION_HINT_COOKIE_OPTIONS = {
 
 export interface SessionHint {
   isMentor: boolean;
+  avatar?: string;
 }
 
 const MENTOR_VALUE = '1';
 const NON_MENTOR_VALUE = '0';
 
 export function encodeSessionHint(hint: SessionHint): string {
-  return hint.isMentor ? MENTOR_VALUE : NON_MENTOR_VALUE;
+  const isMentorVal = hint.isMentor ? MENTOR_VALUE : NON_MENTOR_VALUE;
+  if (hint.avatar) {
+    try {
+      const encodedAvatar = encodeURIComponent(hint.avatar);
+      // Prevent cookie bloat (HTTP 431 Request Header Fields Too Large) by capping length
+      if (encodedAvatar.length <= 1000) {
+        return `${isMentorVal}|${encodedAvatar}`;
+      }
+    } catch (err) {
+      console.error('Failed to encode avatar URL for session hint:', err);
+    }
+  }
+  return isMentorVal;
+}
+
+function isValidAvatarProtocol(url: string): boolean {
+  return (
+    url.startsWith('https://') ||
+    url.startsWith('http://') ||
+    url.startsWith('/')
+  );
 }
 
 export function decodeSessionHint(
   value: string | undefined | null
 ): SessionHint | null {
-  if (value === MENTOR_VALUE) return { isMentor: true };
-  if (value === NON_MENTOR_VALUE) return { isMentor: false };
-  return null;
+  if (!value) return null;
+
+  const parts = value.split('|');
+  const isMentorPart = parts[0];
+  const avatarPart = parts[1];
+
+  let isMentor: boolean;
+  if (isMentorPart === MENTOR_VALUE) {
+    isMentor = true;
+  } else if (isMentorPart === NON_MENTOR_VALUE) {
+    isMentor = false;
+  } else {
+    return null;
+  }
+
+  const hint: SessionHint = { isMentor };
+  if (avatarPart) {
+    let avatar: string | undefined;
+    try {
+      avatar = decodeURIComponent(avatarPart);
+    } catch {
+      // Decode failed - discard raw value to avoid broken UI links
+      avatar = undefined;
+    }
+
+    if (avatar && isValidAvatarProtocol(avatar)) {
+      hint.avatar = avatar;
+    }
+  }
+  return hint;
 }
+
+export const DOM_AUTH_STATE_ATTR = 'data-auth-state';
+export const DOM_AUTH_AVATAR_ATTR = 'data-auth-avatar';
+export const DOM_AVATAR_IMG_ATTR = 'data-avatar-img';
+
+export const SESSION_HINT_INLINE_SCRIPT = `
+  try {
+    var cookie = document.cookie.split('; ').find(function(row) {
+      return row.startsWith('session-hint=');
+    });
+    if (cookie) {
+      var rawValue = cookie.substring('session-hint='.length);
+      var parts = rawValue.split('|');
+      var isMentor = parts[0] === '1';
+      var avatar = '';
+      if (parts[1]) {
+        try {
+          avatar = decodeURIComponent(parts[1]);
+        } catch (_) {
+          avatar = '';
+        }
+      }
+      
+      if (avatar && (avatar.startsWith('https://') || avatar.startsWith('http://') || avatar.startsWith('/'))) {
+        document.documentElement.setAttribute('${DOM_AUTH_AVATAR_ATTR}', avatar);
+        
+        var updateImages = function() {
+          var imgs = document.querySelectorAll('img[${DOM_AVATAR_IMG_ATTR}]');
+          for (var i = 0; i < imgs.length; i++) {
+            imgs[i].src = avatar;
+          }
+        };
+        updateImages();
+        document.addEventListener('DOMContentLoaded', updateImages);
+      }
+      document.documentElement.setAttribute('${DOM_AUTH_STATE_ATTR}', isMentor ? 'mentor' : 'mentee');
+    }
+  } catch (_) {}
+`;

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -70,6 +70,45 @@ describe('middleware session hint cookie', () => {
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
   });
 
+  it('includes the avatar URL in the hint cookie when present in the token', async () => {
+    mockGetToken.mockResolvedValue({
+      isMentor: true,
+      avatar: 'https://example.com/avatar.png',
+    } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe(
+      '1|https%3A%2F%2Fexample.com%2Favatar.png'
+    );
+  });
+
+  it('falls back to picture URL in the hint cookie when avatar is not present in the token', async () => {
+    mockGetToken.mockResolvedValue({
+      isMentor: true,
+      picture: 'https://example.com/picture.png',
+    } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe(
+      '1|https%3A%2F%2Fexample.com%2Fpicture.png'
+    );
+  });
+
+  it('caps the session-hint cookie to avoid large cookies when the avatar URL is extremely long', async () => {
+    const longAvatar = 'https://example.com/avatar.png?' + 'a'.repeat(1200);
+    mockGetToken.mockResolvedValue({
+      isMentor: true,
+      avatar: longAvatar,
+    } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    // Encoded URL would exceed 1000 characters, so it should fall back to '1'
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
+  });
+
   it('does not emit a Set-Cookie for a guest with no existing hint cookie — keeps public routes cacheable', async () => {
     mockGetToken.mockResolvedValue(null);
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -184,7 +184,11 @@ export async function middleware(req: NextRequest) {
   const response = NextResponse.next();
 
   if (isLoggedIn) {
-    const nextHint = encodeSessionHint({ isMentor: Boolean(token?.isMentor) });
+    const nextHint = encodeSessionHint({
+      isMentor: Boolean(token?.isMentor),
+      avatar:
+        ((token?.avatar || token?.picture) as string | undefined) ?? undefined,
+    });
     if (currentHint !== nextHint) {
       response.cookies.set(
         SESSION_HINT_COOKIE,


### PR DESCRIPTION
Reads and decodes the session-hint cookie server-side in RootLayout and passes it via SessionHintProvider context to enable instant rendering of the Header's mentor-status nav item and user avatar on first paint, eliminating skeleton flashes and preventing hydration mismatches.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/525
