### PR TITLE
fix(middleware): allow unauthenticated access to /api/announcement (X-Tracker #526)

### DIFF
--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -444,3 +444,33 @@ describe('middleware maintenance mode', () => {
     expect(response.headers.get('location')).toContain('/maintenance');
   });
 });
+
+describe('middleware public routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGet.mockResolvedValue(false);
+    delete process.env.EDGE_CONFIG;
+    delete process.env.MAINTENANCE_MODE;
+    delete process.env.NEXT_PUBLIC_MAINTENANCE_MODE;
+  });
+
+  it('allows unauthenticated access to /api/announcement without redirecting', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(makeRequest('/api/announcement'));
+
+    // Should not redirect to sign-in page (NextResponse.next() returns a 200)
+    expect(response.status).toBe(200);
+  });
+
+  it('redirects unauthenticated users to signin for protected api routes', async () => {
+    mockGetToken.mockResolvedValue(null);
+
+    const response = await middleware(
+      makeRequest('/api/protected-route-example')
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toContain('/auth/signin');
+  });
+});

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -18,6 +18,7 @@ export const publicRoutes: string[] = [
   '/mentor-pool',
   '/privacy',
   '/terms',
+  '/api/announcement',
 ];
 
 /**


### PR DESCRIPTION
Unauthenticated visitors currently cannot see the maintenance announcement banner because the middleware redirects any request to non-public routes to /auth/signin.

This PR adds /api/announcement to the list of publicRoutes in src/routes.ts so that unauthenticated guests and users sitting on /auth/signin can fetch the announcement payload successfully. It also adds unit tests to verify the routing logic.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/526
