### PR TITLE
ci: add OpenAPI types check workflow for pull requests

### DIFF
--- a/.github/workflows/openapi-types-check.yml
+++ b/.github/workflows/openapi-types-check.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Check for differences
         id: check-diff
         run: |
-          if ! git diff --exit-code src/types/api.ts; then
+          if ! git diff --exit-code --ignore-space-at-eol src/types/api.ts; then
             echo "::error file=src/types/api.ts::API types (src/types/api.ts) are out of sync with the BFF OpenAPI spec."
             echo "=========================================================================="
             echo "❌ 錯誤：前端 API 型別定義 (src/types/api.ts) 與後端 BFF OpenAPI spec 不同步！"

--- a/.github/workflows/openapi-types-check.yml
+++ b/.github/workflows/openapi-types-check.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@v4
 
       - name: Set up environment
         uses: ./.github/actions/setup-env

--- a/.github/workflows/openapi-types-check.yml
+++ b/.github/workflows/openapi-types-check.yml
@@ -1,0 +1,84 @@
+name: OpenAPI Types Check
+
+on:
+  pull_request:
+    branches: ['**']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  openapi-types-check:
+    runs-on: ubuntu-latest
+    name: OpenAPI Types Check
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Set up environment
+        uses: ./.github/actions/setup-env
+
+      - name: Regenerate API types
+        id: regenerate-types
+        env:
+          BFF_OPENAPI_URL: ${{ secrets.BFF_OPENAPI_URL || vars.BFF_OPENAPI_URL }}
+        run: |
+          if [ -z "$BFF_OPENAPI_URL" ]; then
+            echo "❌ Error: BFF_OPENAPI_URL is not set as a GitHub Secret or Repository Variable."
+            echo "Please configure BFF_OPENAPI_URL in your repository settings."
+            exit 1
+          fi
+          pnpm run generate:types
+
+      - name: Check for differences
+        id: check-diff
+        run: |
+          if ! git diff --exit-code src/types/api.ts; then
+            echo "::error file=src/types/api.ts::API types (src/types/api.ts) are out of sync with the BFF OpenAPI spec."
+            echo "=========================================================================="
+            echo "❌ 錯誤：前端 API 型別定義 (src/types/api.ts) 與後端 BFF OpenAPI spec 不同步！"
+            echo "這表示後端的 API 契約或欄位型別已經變動，而前端目前的型別檔案尚未更新。"
+            echo ""
+            echo "👉 修正方式："
+            echo "   1. 在本地專案根目錄下，確保設定好 BFF_OPENAPI_URL 變數。"
+            echo "   2. 執行：pnpm generate:types"
+            echo "   3. 將更新後的 'src/types/api.ts' 提交 (commit) 並推送到 PR。"
+            echo "=========================================================================="
+            exit 1
+          else
+            echo "✅ API types are perfectly in sync with the BFF OpenAPI spec."
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          echo "## OpenAPI Types Check Summary" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ steps.check-diff.outcome }}" == "success" ]]; then
+            echo "### ✅ Status: Passed" >> $GITHUB_STEP_SUMMARY
+            echo "API types in \`src/types/api.ts\` are perfectly in sync with the backend BFF OpenAPI spec." >> $GITHUB_STEP_SUMMARY
+          elif [[ "${{ steps.check-diff.outcome }}" == "failure" ]]; then
+            echo "### ❌ Status: Failed" >> $GITHUB_STEP_SUMMARY
+            echo "API types in \`src/types/api.ts\` are **out of sync** with the backend BFF OpenAPI spec." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "#### 🔍 Reason / 原因" >> $GITHUB_STEP_SUMMARY
+            echo "後端的 API 契約或欄位型別已經變動，而前端目前的型別檔案尚未更新。" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "#### 🛠️ How to Fix / 修正方式" >> $GITHUB_STEP_SUMMARY
+            echo "1. 在本地專案根目錄，確保設定好 \`BFF_OPENAPI_URL\`（例如在 \`.env\` 或 \`.env.development.local\` 中）。" >> $GITHUB_STEP_SUMMARY
+            echo "2. 執行指令重新產生型別：" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "   pnpm generate:types" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+            echo "3. 將更新後的 \`src/types/api.ts\` 提交 (commit) 並推送到 PR：" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`bash" >> $GITHUB_STEP_SUMMARY
+            echo "   git add src/types/api.ts" >> $GITHUB_STEP_SUMMARY
+            echo "   git commit -m \"chore: update API types from BFF OpenAPI spec\"" >> $GITHUB_STEP_SUMMARY
+            echo "   git push" >> $GITHUB_STEP_SUMMARY
+            echo "   \`\`\`" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "### ⚠️ Status: Skipped or Failed to run" >> $GITHUB_STEP_SUMMARY
+            echo "Could not complete the OpenAPI types sync check. Please verify if \`BFF_OPENAPI_URL\` is correctly configured." >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/openapi-types-check.yml
+++ b/.github/workflows/openapi-types-check.yml
@@ -32,11 +32,8 @@ jobs:
           fi
           pnpm run generate:types
 
-      - name: Debug generated types
-        run: |
-          echo "=== Top of generated api.ts ==="
-          head -n 60 src/types/api.ts
-          echo "=== End of Top ==="
+      - name: Format generated types
+        run: pnpm exec prettier --write src/types/api.ts
 
       - name: Check for differences
         id: check-diff

--- a/.github/workflows/openapi-types-check.yml
+++ b/.github/workflows/openapi-types-check.yml
@@ -32,6 +32,12 @@ jobs:
           fi
           pnpm run generate:types
 
+      - name: Debug generated types
+        run: |
+          echo "=== Top of generated api.ts ==="
+          head -n 60 src/types/api.ts
+          echo "=== End of Top ==="
+
       - name: Check for differences
         id: check-diff
         run: |

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -402,6 +402,23 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/v1/users/{user_id}/reservations/{reservation_id}/google-meet': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** Get Reservation Meet Link */
+    get: operations['get_reservation_meet_link_api_v1_users__user_id__reservations__reservation_id__google_meet_get'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/v1/users/{user_id}/reservations/{reservation_id}': {
     parameters: {
       query?: never;
@@ -608,6 +625,21 @@ export interface components {
       msg: string;
       data?: components['schemas']['EmailSentVO'] | null;
     };
+    /**
+     * ApiResponse[Error]
+     * @description The `{code, msg, data}` envelope every BFF error handler returns.
+     *
+     *     Declare it through a route's `responses=` so the published OpenAPI document
+     *     carries a typed schema for the failure paths, not only the success one.
+     */
+    ApiResponse_Error_: {
+      /** Code */
+      code: string;
+      /** Msg */
+      msg: string;
+      /** Data */
+      data?: null;
+    };
     /** ApiResponse_FileInfoListVO_ */
     ApiResponse_FileInfoListVO_: {
       /**
@@ -663,6 +695,20 @@ export interface components {
        */
       msg: string;
       data?: components['schemas']['LoginResponseVO'] | null;
+    };
+    /** ApiResponse[MeetLinkVO] */
+    ApiResponse_MeetLinkVO_: {
+      /**
+       * Code
+       * @default 0
+       */
+      code: string;
+      /**
+       * Msg
+       * @default ok
+       */
+      msg: string;
+      data?: components['schemas']['MeetLinkVO'] | null;
     };
     /** ApiResponse[MentorProfileVO] */
     ApiResponse_MentorProfileVO_: {
@@ -1103,6 +1149,11 @@ export interface components {
     LoginResponseVO: {
       auth: components['schemas']['AuthVO'];
       user: components['schemas']['ProfileVO'];
+    };
+    /** MeetLinkVO */
+    MeetLinkVO: {
+      /** Meet Url */
+      meet_url: string;
     };
     /**
      * MentorProfileDTO
@@ -2772,6 +2823,47 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+      /** @description Validation Error */
+      422: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['HTTPValidationError'];
+        };
+      };
+    };
+  };
+  get_reservation_meet_link_api_v1_users__user_id__reservations__reservation_id__google_meet_get: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        user_id: number;
+        reservation_id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description Successful Response */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiResponse_MeetLinkVO_'];
+        };
+      };
+      /** @description No Google Meet link: the reservation is unknown to this user, or its meeting is not SCHEDULED */
+      404: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ApiResponse_Error_'];
+        };
       };
       /** @description Validation Error */
       422: {


### PR DESCRIPTION
This adds an independent GitHub Actions workflow that regenerates and checks 'src/types/api.ts' against the BFF OpenAPI spec. It fails the PR check if types are out of sync, provides detailed error output and recovery instructions, and outputs a nice markdown summary.
