### PR TITLE
fix: remove conflicting pnpm version from e2e workflow

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -33,8 +33,6 @@ jobs:
 
       - name: Set up PNPM
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
 
       - name: Set up Node.js
         uses: actions/setup-node@v7


### PR DESCRIPTION
## What Does This PR Do?

- Removes the hardcoded `version: 9` input on `pnpm/action-setup@v6` in `.github/workflows/e2e.yml`
- `pnpm/action-setup@v6` now reads the pnpm version solely from `package.json`'s `packageManager: pnpm@9.15.9` field
- Fixes CI failure: https://github.com/Xchange-Taiwan/X-Talent-Frontend/actions/runs/30867686499/job/91862966722, where the action errored with "Multiple versions of pnpm specified" because both the workflow input and `packageManager` were set

## Demo

N/A (CI workflow change)

## Screenshot

N/A

## Anything to Note?

Future pnpm upgrades only need to update `package.json`'s `packageManager` field.
