### PR TITLE
fix(auth): decode session-hint cookie value and add userId to the hint (X-Tracker #525)

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -143,11 +143,13 @@ describe('Header', () => {
 
     const mentorLink = screen.getByRole('link', { name: '我的導師頁面' });
     const menteeLink = screen.getByRole('link', { name: '成為導師' });
-    expect(mentorLink.parentElement).toHaveClass(
-      'hidden group-data-[auth-state=mentor]:block'
+    expect(mentorLink).toHaveClass(
+      'hidden',
+      'group-data-[auth-state=mentor]:block'
     );
-    expect(menteeLink.parentElement).toHaveClass(
-      'hidden group-data-[auth-state=mentee]:block'
+    expect(menteeLink).toHaveClass(
+      'hidden',
+      'group-data-[auth-state=mentee]:block'
     );
   });
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -75,27 +75,21 @@ function HeaderComponent(): JSX.Element {
 
             {!authKnown ? (
               <>
-                <div className="group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden">
-                  <Skeleton className="h-6 w-24" />
-                </div>
-                <div className="hidden group-data-[auth-state=mentor]:block">
-                  <DisabledAwareLink
-                    href={getProfileHref(userId)}
-                    disabled={isResolvingUser}
-                    className="font-['Open_Sans'] text-base text-text-primary"
-                  >
-                    我的導師頁面
-                  </DisabledAwareLink>
-                </div>
-                <div className="hidden group-data-[auth-state=mentee]:block">
-                  <DisabledAwareLink
-                    href={getBecomeMentorHref(userId)}
-                    disabled={isResolvingUser}
-                    className="font-['Open_Sans'] text-base text-text-primary"
-                  >
-                    成為導師
-                  </DisabledAwareLink>
-                </div>
+                <Skeleton className="h-6 w-24 group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden" />
+                <DisabledAwareLink
+                  href={getProfileHref(userId)}
+                  disabled={isResolvingUser}
+                  className="hidden font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentor]:block"
+                >
+                  我的導師頁面
+                </DisabledAwareLink>
+                <DisabledAwareLink
+                  href={getBecomeMentorHref(userId)}
+                  disabled={isResolvingUser}
+                  className="hidden font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:block"
+                >
+                  成為導師
+                </DisabledAwareLink>
               </>
             ) : (
               <DisabledAwareLink

--- a/src/hooks/user/auth/useAuthStatus.test.ts
+++ b/src/hooks/user/auth/useAuthStatus.test.ts
@@ -118,4 +118,24 @@ describe('useAuthStatus', () => {
       isResolvingUser: false,
     });
   });
+
+  it('uses the hint userId and clears isResolvingUser when the session is still loading but hint has a userId', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseSessionHint.mockReturnValue({
+      status: 'authenticated',
+      isMentor: true,
+      userId: 'user-123',
+    });
+
+    const { result } = renderHook(() => useAuthStatus());
+
+    expect(result.current).toEqual({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: true,
+      userId: 'user-123',
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+  });
 });

--- a/src/hooks/user/auth/useAuthStatus.ts
+++ b/src/hooks/user/auth/useAuthStatus.ts
@@ -9,13 +9,19 @@ export interface AuthStatus {
   authKnown: boolean;
   isLoggedIn: boolean;
   isMentor: boolean;
+  /**
+   * The real session's id once it lands; before that, falls back to the
+   * fast hint cookie's id (non-authoritative, but already public via the
+   * `/profile/{userId}` URL) so nav links don't have to sit disabled while
+   * waiting on `useSession()`.
+   */
   userId: string | undefined;
   /** Whether the full `useSession()` payload (id, avatar, email, …) has landed. */
   hasFullUser: boolean;
   /**
-   * Logged in per the fast hint cookie, but the full session — and with it
-   * `userId` — hasn't arrived yet. Any link that needs `userId` must be
-   * disabled during this window rather than falling back to a signed-out
+   * Logged in, but neither the real session nor the hint cookie has a
+   * usable `userId` yet. Any link that needs `userId` must be disabled
+   * during this window rather than falling back to a signed-out
    * destination like `/auth/signup` or `/`.
    */
   isResolvingUser: boolean;
@@ -31,8 +37,8 @@ export function useAuthStatus(): AuthStatus {
   const { data: session, status } = useSession();
   const hint = useSessionHint();
 
-  const userId = session?.user?.id;
-  const hasFullUser = Boolean(userId);
+  const realUserId = session?.user?.id;
+  const hasFullUser = Boolean(realUserId);
   // `status` only reliably means "no session data at all" when there is no
   // cached session yet — during a NextAuth `update()` call `status` flips
   // back to "loading" while `data` still holds the previous session. Gate on
@@ -49,7 +55,14 @@ export function useAuthStatus(): AuthStatus {
     : sessionSettled
       ? false
       : hint.status === 'authenticated' && hint.isMentor;
-  const isResolvingUser = isLoggedIn && !hasFullUser;
+  const userId = hasFullUser
+    ? realUserId
+    : sessionSettled
+      ? undefined
+      : hint.status === 'authenticated'
+        ? hint.userId
+        : undefined;
+  const isResolvingUser = isLoggedIn && !userId;
 
   return {
     authKnown,

--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -291,4 +291,23 @@ describe('useSessionHint', () => {
       ).toBe('');
     });
   });
+
+  it('gracefully handles malformed URI encoding in cookie in useSessionHint without throwing', async () => {
+    setCookie('1||https%3A%2F%2Fexample.com%2Finvalid%%url');
+
+    const { result } = renderHook(() => useSessionHint());
+
+    await waitFor(() => {
+      expect(result.current).toEqual({
+        status: 'authenticated',
+        isMentor: true,
+      });
+      expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
+        'mentor'
+      );
+      expect(
+        document.documentElement.getAttribute(DOM_AUTH_AVATAR_ATTR)
+      ).toBeNull();
+    });
+  });
 });

--- a/src/hooks/user/auth/useSessionHint.test.ts
+++ b/src/hooks/user/auth/useSessionHint.test.ts
@@ -153,7 +153,7 @@ describe('useSessionHint', () => {
   });
 
   it('actively syncs DOM attributes and style property when hint is resolved with avatar', async () => {
-    setCookie('1|https%3A%2F%2Fexample.com%2Favatar.png');
+    setCookie('1||https%3A%2F%2Fexample.com%2Favatar.png');
 
     const { result } = renderHook(() => useSessionHint());
 
@@ -176,7 +176,9 @@ describe('useSessionHint', () => {
   });
 
   it('escapes double quotes in avatar URL to prevent CSS injection in style property', async () => {
-    setCookie('1|https%3A%2F%2Fexample.com%2Favatar.png%22%3Bbackground%3Ared');
+    setCookie(
+      '1||https%3A%2F%2Fexample.com%2Favatar.png%22%3Bbackground%3Ared'
+    );
 
     const { result } = renderHook(() => useSessionHint());
 
@@ -242,6 +244,7 @@ describe('useSessionHint', () => {
         status: 'authenticated',
         isMentor: true,
         avatar: 'https://example.com/real-avatar.png',
+        userId: 'user-123',
       });
       expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
         'mentor'
@@ -274,6 +277,7 @@ describe('useSessionHint', () => {
         status: 'authenticated',
         isMentor: true,
         avatar: 'javascript:alert(1)',
+        userId: 'user-123',
       });
       expect(document.documentElement.getAttribute(DOM_AUTH_STATE_ATTR)).toBe(
         'mentor'

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -8,6 +8,7 @@ import {
   DOM_AUTH_AVATAR_ATTR,
   DOM_AUTH_STATE_ATTR,
   isValidAvatarProtocol,
+  safeDecodeURIComponent,
   SESSION_HINT_COOKIE,
 } from '@/lib/auth/sessionHint';
 
@@ -33,11 +34,7 @@ function readCookie(name: string): string | undefined {
   // (including our own `|` separator), so it must be decoded once on read.
   // Fall back to the raw value on failure rather than discarding the whole
   // hint - `decodeSessionHint` still safely handles a malformed avatar part.
-  try {
-    return decodeURIComponent(raw);
-  } catch {
-    return raw;
-  }
+  return safeDecodeURIComponent(raw);
 }
 
 function updateAvatarStyle(avatar: string | undefined): void {

--- a/src/hooks/user/auth/useSessionHint.ts
+++ b/src/hooks/user/auth/useSessionHint.ts
@@ -14,14 +14,30 @@ import {
 export type SessionHintState =
   | { status: 'unknown' }
   | { status: 'guest' }
-  | { status: 'authenticated'; isMentor: boolean; avatar?: string };
+  | {
+      status: 'authenticated';
+      isMentor: boolean;
+      avatar?: string;
+      userId?: string;
+    };
 
 function readCookie(name: string): string | undefined {
   if (typeof document === 'undefined') return undefined;
-  return document.cookie
+  const raw = document.cookie
     .split('; ')
     .find((row) => row.startsWith(`${name}=`))
     ?.slice(name.length + 1);
+  if (raw === undefined) return undefined;
+
+  // `response.cookies.set()` encodeURIComponent's the whole value on write
+  // (including our own `|` separator), so it must be decoded once on read.
+  // Fall back to the raw value on failure rather than discarding the whole
+  // hint - `decodeSessionHint` still safely handles a malformed avatar part.
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
 }
 
 function updateAvatarStyle(avatar: string | undefined): void {
@@ -82,6 +98,7 @@ export function useSessionHint(): SessionHintState {
     if (status === 'authenticated' && session?.user) {
       const realIsMentor = session.user.isMentor ?? false;
       const realAvatar = session.user.avatar ?? undefined;
+      const realUserId = session.user.id ?? undefined;
 
       document.documentElement.setAttribute(
         DOM_AUTH_STATE_ATTR,
@@ -93,7 +110,8 @@ export function useSessionHint(): SessionHintState {
         if (
           prev.status === 'authenticated' &&
           prev.isMentor === realIsMentor &&
-          prev.avatar === realAvatar
+          prev.avatar === realAvatar &&
+          prev.userId === realUserId
         ) {
           return prev;
         }
@@ -101,6 +119,7 @@ export function useSessionHint(): SessionHintState {
           status: 'authenticated',
           isMentor: realIsMentor,
           avatar: realAvatar,
+          userId: realUserId,
         };
       });
       return;
@@ -129,7 +148,8 @@ export function useSessionHint(): SessionHintState {
         if (
           prev.status === 'authenticated' &&
           prev.isMentor === hint.isMentor &&
-          prev.avatar === hint.avatar
+          prev.avatar === hint.avatar &&
+          prev.userId === hint.userId
         ) {
           return prev;
         }
@@ -138,6 +158,7 @@ export function useSessionHint(): SessionHintState {
           status: 'authenticated',
           isMentor: hint.isMentor,
           avatar: hint.avatar,
+          userId: hint.userId,
         };
       });
     }

--- a/src/lib/auth/sessionHint.test.ts
+++ b/src/lib/auth/sessionHint.test.ts
@@ -17,17 +17,37 @@ describe('sessionHint utilities', () => {
           isMentor: true,
           avatar: 'https://example.com/avatar.png',
         })
-      ).toBe('1|https%3A%2F%2Fexample.com%2Favatar.png');
+      ).toBe('1||https%3A%2F%2Fexample.com%2Favatar.png');
     });
 
-    it('omits avatar when not provided', () => {
+    it('serializes a mentor flag, userId, and an avatar URL', () => {
+      expect(
+        encodeSessionHint({
+          isMentor: true,
+          userId: 'user-123',
+          avatar: 'https://example.com/avatar.png',
+        })
+      ).toBe('1|user-123|https%3A%2F%2Fexample.com%2Favatar.png');
+    });
+
+    it('serializes a mentor flag and userId without an avatar', () => {
+      expect(encodeSessionHint({ isMentor: true, userId: 'user-123' })).toBe(
+        '1|user-123'
+      );
+    });
+
+    it('omits avatar and userId when not provided', () => {
       expect(encodeSessionHint({ isMentor: false })).toBe('0');
     });
 
     it('caps avatar URL length by completely omitting long avatar URLs', () => {
       const longUrl = 'https://example.com/' + 'a'.repeat(2000) + '.png';
-      const encoded = encodeSessionHint({ isMentor: true, avatar: longUrl });
-      expect(encoded).toBe('1');
+      const encoded = encodeSessionHint({
+        isMentor: true,
+        userId: 'user-123',
+        avatar: longUrl,
+      });
+      expect(encoded).toBe('1|user-123');
     });
 
     it('falls back to mentor status only when the avatar URL contains an unencodable lone surrogate', () => {
@@ -42,7 +62,7 @@ describe('sessionHint utilities', () => {
   describe('decodeSessionHint', () => {
     it('resolves valid cookie containing avatar URL', () => {
       expect(
-        decodeSessionHint('1|https%3A%2F%2Fexample.com%2Favatar.png')
+        decodeSessionHint('1||https%3A%2F%2Fexample.com%2Favatar.png')
       ).toEqual({
         isMentor: true,
         avatar: 'https://example.com/avatar.png',
@@ -54,18 +74,35 @@ describe('sessionHint utilities', () => {
       expect(decodeSessionHint('0')).toEqual({ isMentor: false });
     });
 
+    it('resolves valid cookie containing userId and an avatar URL', () => {
+      expect(
+        decodeSessionHint('1|user-123|https%3A%2F%2Fexample.com%2Favatar.png')
+      ).toEqual({
+        isMentor: true,
+        userId: 'user-123',
+        avatar: 'https://example.com/avatar.png',
+      });
+    });
+
+    it('resolves valid cookie with userId only', () => {
+      expect(decodeSessionHint('1|user-123')).toEqual({
+        isMentor: true,
+        userId: 'user-123',
+      });
+    });
+
     it('filters out unsafe protocol (scheme) avatars during decoding', () => {
-      expect(decodeSessionHint('1|javascript%3Aalert(1)')).toEqual({
+      expect(decodeSessionHint('1||javascript%3Aalert(1)')).toEqual({
         isMentor: true,
       });
-      expect(decodeSessionHint('1|data%3Atext%2Fhtml%2Calert(1)')).toEqual({
+      expect(decodeSessionHint('1||data%3Atext%2Fhtml%2Calert(1)')).toEqual({
         isMentor: true,
       });
     });
 
     it('recovers from uri decode errors gracefully', () => {
       expect(
-        decodeSessionHint('1|https%3A%2F%2Fexample.com%2F%invalid')
+        decodeSessionHint('1||https%3A%2F%2Fexample.com%2F%invalid')
       ).toEqual({
         isMentor: true,
       });
@@ -97,7 +134,7 @@ describe('sessionHint utilities', () => {
     });
 
     it('sets state attribute for mentor with avatar and pre-fills style property with quote escaping', () => {
-      document.cookie = `${SESSION_HINT_COOKIE}=1|https%3A%2F%2Fexample.com%2Favatar.png%22%3Bbackground%3Ared`;
+      document.cookie = `${SESSION_HINT_COOKIE}=1||https%3A%2F%2Fexample.com%2Favatar.png%22%3Bbackground%3Ared`;
 
       runInlineScript();
 
@@ -128,7 +165,7 @@ describe('sessionHint utilities', () => {
     });
 
     it('filters out unsafe protocols in the inline script', () => {
-      document.cookie = `${SESSION_HINT_COOKIE}=1|javascript%3Aalert(1)`;
+      document.cookie = `${SESSION_HINT_COOKIE}=1||javascript%3Aalert(1)`;
 
       runInlineScript();
 
@@ -144,7 +181,7 @@ describe('sessionHint utilities', () => {
     });
 
     it('gracefully handles malformed URI encoding in the inline script', () => {
-      document.cookie = `${SESSION_HINT_COOKIE}=1|https%3A%2F%2Fexample.com%2Finvalid%%url`;
+      document.cookie = `${SESSION_HINT_COOKIE}=1||https%3A%2F%2Fexample.com%2Finvalid%%url`;
 
       runInlineScript();
 

--- a/src/lib/auth/sessionHint.test.ts
+++ b/src/lib/auth/sessionHint.test.ts
@@ -5,6 +5,7 @@ import {
   DOM_AUTH_AVATAR_ATTR,
   DOM_AUTH_STATE_ATTR,
   encodeSessionHint,
+  safeDecodeURIComponent,
   SESSION_HINT_COOKIE,
   SESSION_HINT_INLINE_SCRIPT,
 } from './sessionHint';
@@ -108,12 +109,30 @@ describe('sessionHint utilities', () => {
       });
     });
 
+    it('discards avatar URL from being parsed as userId in legacy format to ensure backward compatibility', () => {
+      expect(
+        decodeSessionHint('1|https%3A%2F%2Fexample.com%2Favatar.png')
+      ).toEqual({
+        isMentor: true,
+      });
+    });
+
     it('returns null on falsy/garbage inputs', () => {
       expect(decodeSessionHint(null as never)).toBeNull();
       expect(decodeSessionHint(undefined)).toBeNull();
       expect(decodeSessionHint('')).toBeNull();
       expect(decodeSessionHint('garbage')).toBeNull();
       expect(decodeSessionHint('garbage|url')).toBeNull();
+    });
+  });
+
+  describe('safeDecodeURIComponent', () => {
+    it('returns decoded value when valid', () => {
+      expect(safeDecodeURIComponent('hello%20world')).toBe('hello world');
+    });
+
+    it('returns raw value on malformed URI error', () => {
+      expect(safeDecodeURIComponent('%invalid')).toBe('%invalid');
     });
   });
 

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -16,6 +16,10 @@ export const SESSION_HINT_COOKIE_OPTIONS = {
 
 export interface SessionHint {
   isMentor: boolean;
+  // Not secret - already public via the `/profile/{userId}` URL. Included so
+  // nav links can resolve their real href before `useSession()` lands,
+  // instead of sitting disabled the whole time. Never used for authorization.
+  userId?: string;
   avatar?: string;
 }
 
@@ -24,21 +28,24 @@ const NON_MENTOR_VALUE = '0';
 
 export function encodeSessionHint(hint: SessionHint): string {
   const isMentorVal = hint.isMentor ? MENTOR_VALUE : NON_MENTOR_VALUE;
+  const userIdPart = hint.userId ? encodeURIComponent(hint.userId) : '';
+  const base = userIdPart ? `${isMentorVal}|${userIdPart}` : isMentorVal;
+
   if (!hint.avatar) {
-    return isMentorVal;
+    return base;
   }
   try {
     const encodedAvatar = encodeURIComponent(hint.avatar);
     // Completely omit avatar URL if its encoded form exceeds 1000 characters
     // to avoid massive cookie header overhead (HTTP 431) and broken truncated URLs.
     if (encodedAvatar.length <= 1000) {
-      return `${isMentorVal}|${encodedAvatar}`;
+      return `${isMentorVal}|${userIdPart}|${encodedAvatar}`;
     }
   } catch {
     // Lone surrogate or otherwise invalid UTF-16 in the avatar URL - fall
-    // back to mentor status only rather than crashing the caller.
+    // back to mentor status (and userId) only rather than crashing the caller.
   }
-  return isMentorVal;
+  return base;
 }
 
 export function isValidAvatarProtocol(url: string): boolean {
@@ -58,7 +65,8 @@ export function decodeSessionHint(
 
   const parts = cookieValue.split('|');
   const isMentorPart = parts[0];
-  const avatarPart = parts[1];
+  const userIdPart = parts[1];
+  const avatarPart = parts[2];
 
   let isMentor: boolean;
   if (isMentorPart === MENTOR_VALUE) {
@@ -70,6 +78,18 @@ export function decodeSessionHint(
   }
 
   const hint: SessionHint = { isMentor };
+
+  if (userIdPart) {
+    try {
+      const userId = decodeURIComponent(userIdPart);
+      if (userId) {
+        hint.userId = userId;
+      }
+    } catch {
+      // Malformed userId segment - ignore, don't let it break isMentor/avatar.
+    }
+  }
+
   if (avatarPart) {
     let avatar: string | undefined;
     try {
@@ -96,13 +116,16 @@ export const SESSION_HINT_INLINE_SCRIPT = `
     });
     if (cookie) {
       var rawValue = cookie.substring('${SESSION_HINT_COOKIE}='.length);
+      try {
+        rawValue = decodeURIComponent(rawValue);
+      } catch (_) {}
       var parts = rawValue.split('|');
       if (parts[0] === '1' || parts[0] === '0') {
         var isMentor = parts[0] === '1';
         var avatar = '';
-        if (parts[1]) {
+        if (parts[2]) {
           try {
-            avatar = decodeURIComponent(parts[1]);
+            avatar = decodeURIComponent(parts[2]);
           } catch (_) {
             avatar = '';
           }

--- a/src/lib/auth/sessionHint.ts
+++ b/src/lib/auth/sessionHint.ts
@@ -56,6 +56,14 @@ export function isValidAvatarProtocol(url: string): boolean {
   );
 }
 
+export function safeDecodeURIComponent(val: string): string {
+  try {
+    return decodeURIComponent(val);
+  } catch {
+    return val;
+  }
+}
+
 export function decodeSessionHint(
   cookieValue: string | undefined | null
 ): SessionHint | null {
@@ -82,7 +90,7 @@ export function decodeSessionHint(
   if (userIdPart) {
     try {
       const userId = decodeURIComponent(userIdPart);
-      if (userId) {
+      if (userId && !isValidAvatarProtocol(userId)) {
         hint.userId = userId;
       }
     } catch {

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -70,6 +70,26 @@ describe('middleware session hint cookie', () => {
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1');
   });
 
+  it('includes the userId in the hint cookie when present in the token', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true, id: 'user-123' } as never);
+
+    const response = await middleware(makeRequest('/'));
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe('1|user-123');
+  });
+
+  it('does not re-emit Set-Cookie when the stored hint is the encoded form actually written by .cookies.set()', async () => {
+    mockGetToken.mockResolvedValue({ isMentor: true, id: 'user-123' } as never);
+    // `.cookies.set()` encodeURIComponent's the whole value on write
+    // (including our own `|` separator) - this is what the browser really
+    // sends back on the next request, not the raw `1|user-123` form.
+    const response = await middleware(
+      makeRequest('/', encodeURIComponent('1|user-123'))
+    );
+
+    expect(response.cookies.get(SESSION_HINT_COOKIE)).toBeUndefined();
+  });
+
   it('includes the avatar URL in the hint cookie when present in the token', async () => {
     mockGetToken.mockResolvedValue({
       isMentor: true,
@@ -79,7 +99,7 @@ describe('middleware session hint cookie', () => {
     const response = await middleware(makeRequest('/'));
 
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe(
-      '1|https%3A%2F%2Fexample.com%2Favatar.png'
+      '1||https%3A%2F%2Fexample.com%2Favatar.png'
     );
   });
 
@@ -92,7 +112,7 @@ describe('middleware session hint cookie', () => {
     const response = await middleware(makeRequest('/'));
 
     expect(response.cookies.get(SESSION_HINT_COOKIE)?.value).toBe(
-      '1|https%3A%2F%2Fexample.com%2Fpicture.png'
+      '1||https%3A%2F%2Fexample.com%2Fpicture.png'
     );
   });
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -5,6 +5,7 @@ import { match } from 'path-to-regexp';
 
 import {
   encodeSessionHint,
+  safeDecodeURIComponent,
   SESSION_HINT_COOKIE,
   SESSION_HINT_COOKIE_OPTIONS,
 } from '@/lib/auth/sessionHint';
@@ -141,14 +142,10 @@ export async function middleware(req: NextRequest) {
   // encodeURIComponent's on write — decode once so it's comparable to a
   // freshly computed `encodeSessionHint()` result below.
   const rawCurrentHint = req.cookies.get(SESSION_HINT_COOKIE)?.value;
-  let currentHint = rawCurrentHint;
-  if (rawCurrentHint !== undefined) {
-    try {
-      currentHint = decodeURIComponent(rawCurrentHint);
-    } catch {
-      currentHint = rawCurrentHint;
-    }
-  }
+  const currentHint =
+    rawCurrentHint !== undefined
+      ? safeDecodeURIComponent(rawCurrentHint)
+      : undefined;
 
   // -------- 2. Allow NextAuth API routes through unconditionally --------
   const isApiAuthRoute = pathname.startsWith(apiAuthPrefix);

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -137,7 +137,18 @@ export async function middleware(req: NextRequest) {
 
   const hasRefreshError = token?.error === 'RefreshTokenError';
   const isLoggedIn = !!token && !hasRefreshError;
-  const currentHint = req.cookies.get(SESSION_HINT_COOKIE)?.value;
+  // `req.cookies.get()` returns the raw stored value, which `.cookies.set()`
+  // encodeURIComponent's on write — decode once so it's comparable to a
+  // freshly computed `encodeSessionHint()` result below.
+  const rawCurrentHint = req.cookies.get(SESSION_HINT_COOKIE)?.value;
+  let currentHint = rawCurrentHint;
+  if (rawCurrentHint !== undefined) {
+    try {
+      currentHint = decodeURIComponent(rawCurrentHint);
+    } catch {
+      currentHint = rawCurrentHint;
+    }
+  }
 
   // -------- 2. Allow NextAuth API routes through unconditionally --------
   const isApiAuthRoute = pathname.startsWith(apiAuthPrefix);
@@ -186,6 +197,7 @@ export async function middleware(req: NextRequest) {
   if (isLoggedIn) {
     const nextHint = encodeSessionHint({
       isMentor: Boolean(token?.isMentor),
+      userId: (token?.id as string | undefined) ?? undefined,
       avatar:
         ((token?.avatar || token?.picture) as string | undefined) ?? undefined,
     });


### PR DESCRIPTION
response.cookies.set() encodeURIComponent's the whole cookie value on
write, including our own | separator, but the two read paths
(pre-hydration inline script and useSessionHint's readCookie()) split
the raw, still-encoded string on a literal | that no longer existed.
Decoding silently failed every time, so the mentor/mentee label rendered
before hydration was always wrong until the real useSession() call
corrected it, producing a visible flicker between the wrong and right label.

Also folds userId into the hint cookie (isMentor|userId|avatar) so nav
links depending on it don't have to sit disabled/grey until the full
useSession() round trip lands. The id is already public via
/profile/{userId} and this cookie is UI-only, never used for auth
decisions. middleware.ts's own change-detection comparison had the same
missing-decode bug, causing it to rewrite the cookie on every request
instead of only when it actually changed.

Also removes a redundant wrapper div around the mentor/mentee nav
links in Header.tsx so the authKnown false to true swap replaces one DOM
node instead of three, reducing a layout jiggle during that transition.

Modified:
- src/lib/auth/sessionHint.ts - decode-before-split fix, userId field
- src/middleware.ts - include token.id, decode before change-comparison
- src/hooks/user/auth/useSessionHint.ts - decode-before-split fix, userId in state
- src/hooks/user/auth/useAuthStatus.ts - fall back to hint's userId while resolving
- src/components/layout/Header/Header.tsx - drop wrapper divs

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/525
