### PR TITLE
feat(agents): add cross-tool board-status enforcement hook

### DIFF
--- a/.agents/scripts/check-board-status.sh
+++ b/.agents/scripts/check-board-status.sh
@@ -37,6 +37,7 @@ source .agents/scripts/load-config.sh 2>/dev/null || exit 0
 [ -z "${ORG:-}" ] && exit 0
 
 OPEN_PR_COUNT=$(gh pr list --repo "$ORG/$FRONTEND_REPO" --head "$BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null)
+[ $? -ne 0 ] && exit 0
 
 if [ "${OPEN_PR_COUNT:-0}" -gt 0 ] 2>/dev/null; then
   EXPECTED_OPTION_ID="$PR_REVIEW_OPTION_ID"
@@ -50,20 +51,11 @@ else
   WRONG_LABEL="Backlog"
 fi
 
-ITEM_ID=$(gh api graphql -F login="$ORG" -F issue_number="$ISSUE_NUMBER" -F repo_name="$TRACKER_REPO" -f query='
-  query($login: String!, $issue_number: Int!, $repo_name: String!) {
-    organization(login: $login) {
-      repository(name: $repo_name) {
-        issue(number: $issue_number) {
-          projectItems(first: 5) { nodes { id project { number } } }
-        }
-      }
-    }
-  }
-' --jq ".data.organization.repository.issue.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER) | .id" 2>/dev/null)
-
-if [ -z "$ITEM_ID" ]; then
-  ITEM_ID=$(gh api graphql -F login="$ORG" -F issue_number="$ISSUE_NUMBER" -F repo_name="$FRONTEND_REPO" -f query='
+# Same projectItems lookup against a given repo; only the repo name varies
+# between the tracker-repo attempt and the frontend-repo fallback below.
+get_item_id() {
+  local repo_name="$1"
+  gh api graphql -F login="$ORG" -F issue_number="$ISSUE_NUMBER" -F repo_name="$repo_name" -f query='
     query($login: String!, $issue_number: Int!, $repo_name: String!) {
       organization(login: $login) {
         repository(name: $repo_name) {
@@ -73,8 +65,11 @@ if [ -z "$ITEM_ID" ]; then
         }
       }
     }
-  ' --jq ".data.organization.repository.issue.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER) | .id" 2>/dev/null)
-fi
+  ' --jq ".data.organization.repository.issue.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER) | .id" 2>/dev/null
+}
+
+ITEM_ID=$(get_item_id "$TRACKER_REPO")
+[ -z "$ITEM_ID" ] && ITEM_ID=$(get_item_id "$FRONTEND_REPO")
 [ -z "$ITEM_ID" ] && exit 0
 
 ACTUAL_OPTION_ID=$(gh api graphql -F item_id="$ITEM_ID" -f query='

--- a/.agents/scripts/check-board-status.sh
+++ b/.agents/scripts/check-board-status.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# Core, tool-agnostic check: does the X-Talent-Tracker board status actually
+# match the current branch's real state, instead of trusting that
+# /start-ticket or /submit-pr remembered to run their board-update step?
+#
+# This script has no opinion about which AI CLI is calling it -- it is meant
+# to be wrapped by a thin per-tool adapter (see .agents/scripts/hooks/) that
+# translates its result into that tool's own hook output schema.
+#
+# Expected status is derived from ground truth, not from what commands ran:
+#   - branch has an open PR   -> board should read "PR Review"
+#   - branch has no open PR   -> board should read "In progress"
+#
+# Only flags the two known regressions this was written for:
+#   - expected "In progress" but board still reads "Backlog"
+#   - expected "PR Review"   but board still reads "In progress"
+# Any other actual status (Done, Blocked, a custom column, etc.) is left
+# alone -- this is not the source of truth for the whole board, only a
+# guard against these two known silent-skip failure modes. Every lookup
+# failure (no issue number, config unavailable, no project item, etc.) is
+# treated as OK -- this must never block unrelated work.
+#
+# Contract: prints nothing and exits 0 when there is nothing to report.
+# Prints a human-readable (Traditional Chinese) explanation to stdout and
+# exits 1 when the board is behind. Never exits with any other code.
+
+set -u
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT" || exit 0
+
+BRANCH_NAME=$(git branch --show-current 2>/dev/null)
+ISSUE_NUMBER=$(echo "$BRANCH_NAME" | grep -oE '[0-9]+' | head -n 1)
+[ -z "$ISSUE_NUMBER" ] && exit 0
+
+source .agents/scripts/load-config.sh 2>/dev/null || exit 0
+[ -z "${ORG:-}" ] && exit 0
+
+OPEN_PR_COUNT=$(gh pr list --repo "$ORG/$FRONTEND_REPO" --head "$BRANCH_NAME" --state open --json number --jq 'length' 2>/dev/null)
+
+if [ "${OPEN_PR_COUNT:-0}" -gt 0 ] 2>/dev/null; then
+  EXPECTED_OPTION_ID="$PR_REVIEW_OPTION_ID"
+  EXPECTED_LABEL="PR Review"
+  WRONG_OPTION_ID="$IN_PROGRESS_OPTION_ID"
+  WRONG_LABEL="In progress"
+else
+  EXPECTED_OPTION_ID="$IN_PROGRESS_OPTION_ID"
+  EXPECTED_LABEL="In progress"
+  WRONG_OPTION_ID="$BACKLOG_OPTION_ID"
+  WRONG_LABEL="Backlog"
+fi
+
+ITEM_ID=$(gh api graphql -F login="$ORG" -F issue_number="$ISSUE_NUMBER" -F repo_name="$TRACKER_REPO" -f query='
+  query($login: String!, $issue_number: Int!, $repo_name: String!) {
+    organization(login: $login) {
+      repository(name: $repo_name) {
+        issue(number: $issue_number) {
+          projectItems(first: 5) { nodes { id project { number } } }
+        }
+      }
+    }
+  }
+' --jq ".data.organization.repository.issue.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER) | .id" 2>/dev/null)
+
+if [ -z "$ITEM_ID" ]; then
+  ITEM_ID=$(gh api graphql -F login="$ORG" -F issue_number="$ISSUE_NUMBER" -F repo_name="$FRONTEND_REPO" -f query='
+    query($login: String!, $issue_number: Int!, $repo_name: String!) {
+      organization(login: $login) {
+        repository(name: $repo_name) {
+          issue(number: $issue_number) {
+            projectItems(first: 5) { nodes { id project { number } } }
+          }
+        }
+      }
+    }
+  ' --jq ".data.organization.repository.issue.projectItems.nodes[] | select(.project.number == $PROJECT_NUMBER) | .id" 2>/dev/null)
+fi
+[ -z "$ITEM_ID" ] && exit 0
+
+ACTUAL_OPTION_ID=$(gh api graphql -F item_id="$ITEM_ID" -f query='
+  query($item_id: ID!) {
+    node(id: $item_id) {
+      ... on ProjectV2Item {
+        fieldValues(first: 20) {
+          nodes {
+            ... on ProjectV2ItemFieldSingleSelectValue {
+              optionId
+              field { ... on ProjectV2SingleSelectField { id } }
+            }
+          }
+        }
+      }
+    }
+  }
+' --jq ".data.node.fieldValues.nodes[] | select(.field.id == \"$FIELD_ID\") | .optionId" 2>/dev/null)
+[ -z "$ACTUAL_OPTION_ID" ] && exit 0
+
+[ "$ACTUAL_OPTION_ID" = "$EXPECTED_OPTION_ID" ] && exit 0
+[ "$ACTUAL_OPTION_ID" != "$WRONG_OPTION_ID" ] && exit 0
+
+cat <<EOF
+X-Tracker #$ISSUE_NUMBER 的看板狀態還停在「$WRONG_LABEL」，但目前分支狀態顯示應該是「$EXPECTED_LABEL」。請在結束前執行以下 mutation 把狀態改過來，再結束這個 turn：
+
+gh api graphql -F project_id="$PROJECT_ID" -F item_id="$ITEM_ID" -F field_id="$FIELD_ID" -F option_id="$EXPECTED_OPTION_ID" -f query='
+  mutation(\$project_id: ID!, \$item_id: ID!, \$field_id: ID!, \$option_id: String!) {
+    updateProjectV2ItemFieldValue(
+      input: { projectId: \$project_id, itemId: \$item_id, fieldId: \$field_id, value: { singleSelectOptionId: \$option_id } }
+    ) { projectV2Item { id } }
+  }
+'
+EOF
+exit 1

--- a/.agents/scripts/hooks/README.md
+++ b/.agents/scripts/hooks/README.md
@@ -1,0 +1,23 @@
+# Board-status verification hooks
+
+`check-board-status.sh` (in the parent directory) checks whether the
+X-Talent-Tracker board status actually matches the current branch's real
+state, so `/start-ticket` and `/submit-pr` can't silently skip their
+board-update step. The two files in this directory adapt its output to each
+AI CLI's own hook schema.
+
+## Gemini CLI
+
+Wired automatically — `.gemini/settings.json` is checked into the repo and
+already registers `gemini-verify-board-status.sh` on the `AfterAgent` event.
+Nothing to do.
+
+## Claude Code
+
+**Not wired automatically.** `.claude/` is gitignored in this repo (kept
+local/per-developer; `.agents/` is the shared, cross-tool directory), so
+there is no committed `.claude/settings.json` to carry this hook.
+
+To enable it on your machine: copy the contents of
+`claude-settings.example.json` into your own `.claude/settings.json`
+(merge the `hooks.Stop` entry in if you already have other settings there).

--- a/.agents/scripts/hooks/claude-settings.example.json
+++ b/.agents/scripts/hooks/claude-settings.example.json
@@ -1,0 +1,16 @@
+{
+  "hooks": {
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agents/scripts/hooks/claude-verify-board-status.sh",
+            "timeout": 30,
+            "statusMessage": "Verifying X-Tracker board status..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/.agents/scripts/hooks/claude-verify-board-status.sh
+++ b/.agents/scripts/hooks/claude-verify-board-status.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Claude Code Stop-hook adapter around the shared board-status check.
+# Schema: https://docs.claude.com/en/docs/claude-code/hooks -- Stop hooks
+# block by printing {"decision":"block","reason":"..."} to stdout and
+# exiting 0.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
+STATUS=$?
+
+if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then
+  printf '{"decision":"block","reason":%s}\n' "$(node -e 'console.log(JSON.stringify(process.argv[1]))' "$REASON")"
+fi
+exit 0

--- a/.agents/scripts/hooks/claude-verify-board-status.sh
+++ b/.agents/scripts/hooks/claude-verify-board-status.sh
@@ -7,7 +7,7 @@
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
+REASON="$(bash "$SCRIPT_DIR/../check-board-status.sh")"
 STATUS=$?
 
 if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then

--- a/.agents/scripts/hooks/claude-verify-board-status.sh
+++ b/.agents/scripts/hooks/claude-verify-board-status.sh
@@ -11,6 +11,6 @@ REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
 STATUS=$?
 
 if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then
-  printf '{"decision":"block","reason":%s}\n' "$(node -e 'console.log(JSON.stringify(process.argv[1]))' "$REASON")"
+  printf '{"decision":"block","reason":%s}\n' "$(REASON="$REASON" node -e 'console.log(JSON.stringify(process.env.REASON))')"
 fi
 exit 0

--- a/.agents/scripts/hooks/gemini-verify-board-status.sh
+++ b/.agents/scripts/hooks/gemini-verify-board-status.sh
@@ -7,7 +7,7 @@
 set -u
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
+REASON="$(bash "$SCRIPT_DIR/../check-board-status.sh")"
 STATUS=$?
 
 if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then

--- a/.agents/scripts/hooks/gemini-verify-board-status.sh
+++ b/.agents/scripts/hooks/gemini-verify-board-status.sh
@@ -11,6 +11,6 @@ REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
 STATUS=$?
 
 if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then
-  printf '{"decision":"deny","reason":%s}\n' "$(node -e 'console.log(JSON.stringify(process.argv[1]))' "$REASON")"
+  printf '{"decision":"deny","reason":%s}\n' "$(REASON="$REASON" node -e 'console.log(JSON.stringify(process.env.REASON))')"
 fi
 exit 0

--- a/.agents/scripts/hooks/gemini-verify-board-status.sh
+++ b/.agents/scripts/hooks/gemini-verify-board-status.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Gemini CLI AfterAgent-hook adapter around the shared board-status check.
+# Schema: https://geminicli.com/docs/hooks/reference/ -- AfterAgent hooks
+# reject/retry by printing {"decision":"deny","reason":"..."} to stdout and
+# exiting 0.
+
+set -u
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+REASON="$("$SCRIPT_DIR/../check-board-status.sh")"
+STATUS=$?
+
+if [ "$STATUS" -eq 1 ] && [ -n "$REASON" ]; then
+  printf '{"decision":"deny","reason":%s}\n' "$(node -e 'console.log(JSON.stringify(process.argv[1]))' "$REASON")"
+fi
+exit 0

--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,5 +6,20 @@
       "env": {},
       "trust": true
     }
+  },
+  "hooks": {
+    "AfterAgent": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash .agents/scripts/hooks/gemini-verify-board-status.sh",
+            "timeout": 30000,
+            "name": "verify-board-status"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
/start-ticket and /submit-pr already move the X-Talent-Tracker board
status via gh api graphql, but that step is prose the AI reads and
executes step-by-step, and it has silently no-op'd before (see the
past-incident note in .agents/skills/submit-pr/SKILL.md). Prompt
instructions can be skipped; a hook that checks live GitHub state
after the agent finishes cannot.

Adds check-board-status.sh: a tool-agnostic core that compares the
board's actual status against ground truth (open PR -> should read
"PR Review", no PR -> "In progress") and only flags the two known
regressions (stuck on Backlog / stuck on In progress). Every lookup
failure is treated as non-blocking so it never stops unrelated work.

Two thin adapters translate its result into each CLI's own hook
schema: hooks/claude-verify-board-status.sh (Claude Code Stop hook,
wired locally per-developer since .claude/ isn't checked in) and
hooks/gemini-verify-board-status.sh (Gemini CLI AfterAgent hook,
wired team-wide via .gemini/settings.json).

Also adds .gitattributes (*.sh text eol=lf) so these scripts always
checkout with LF, since this repo had no line-ending enforcement and
core.autocrlf=true on Windows would otherwise corrupt the heredoc in
check-board-status.sh on checkout.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
