### PR TITLE
feat(header): move nav links into avatar dropdown menu (X-Tracker #284)

### DIFF
--- a/src/components/layout/Header/HamburgerMenu.test.tsx
+++ b/src/components/layout/Header/HamburgerMenu.test.tsx
@@ -8,69 +8,32 @@ function openMenu(): void {
 }
 
 describe('HamburgerMenu', () => {
-  it('disables "成為導師" while resolving a mentee user and does not close the sheet on click', () => {
-    render(
-      <HamburgerMenu
-        isLoggedIn
-        isMentor={false}
-        userId={undefined}
-        isResolvingUser
-      />
-    );
+  it('renders guest-only navigation links and login/register actions when opened', () => {
+    render(<HamburgerMenu />);
     openMenu();
 
-    const link = screen.getByRole('link', { name: '成為導師' });
-    expect(link).toHaveAttribute('href', '#');
-    expect(link).toHaveAttribute('aria-disabled', 'true');
-
-    fireEvent.click(link);
-
-    // A disabled link must not run the `close` handler — the sheet stays open.
+    expect(screen.getByRole('link', { name: '尋找導師' })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: '成為導師' })).toBeInTheDocument();
-  });
-
-  it('disables "我的導師頁面" while resolving a mentor user, never falling back to "/"', () => {
-    render(
-      <HamburgerMenu isLoggedIn isMentor userId={undefined} isResolvingUser />
-    );
-    openMenu();
-
-    const link = screen.getByRole('link', { name: '我的導師頁面' });
-    expect(link).toHaveAttribute('href', '#');
-    expect(link).toHaveAttribute('aria-disabled', 'true');
-  });
-
-  it('links to the real profile once userId has landed and isResolvingUser is false', () => {
-    render(
-      <HamburgerMenu
-        isLoggedIn
-        isMentor
-        userId="user-123"
-        isResolvingUser={false}
-      />
-    );
-    openMenu();
-
-    const link = screen.getByRole('link', { name: '我的導師頁面' });
-    expect(link).toHaveAttribute('href', '/profile/user-123');
-    expect(link).toHaveAttribute('aria-disabled', 'false');
-  });
-
-  it('closes the sheet when a normal (non-disabled) link is clicked', () => {
-    render(
-      <HamburgerMenu
-        isLoggedIn
-        isMentor
-        userId="user-123"
-        isResolvingUser={false}
-      />
-    );
-    openMenu();
-
-    fireEvent.click(screen.getByRole('link', { name: '我的導師頁面' }));
-
     expect(
-      screen.queryByRole('link', { name: '我的導師頁面' })
+      screen.getByRole('link', { name: '關於 X-Talent' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: '提供回饋（另開新分頁）' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '登入' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '註冊' })).toBeInTheDocument();
+  });
+
+  it('closes the sheet when a navigation link is clicked', () => {
+    render(<HamburgerMenu />);
+    openMenu();
+
+    const findMentorLink = screen.getByRole('link', { name: '尋找導師' });
+    fireEvent.click(findMentorLink);
+
+    // The sheet closes, so the navigation links are removed from the DOM
+    expect(
+      screen.queryByRole('link', { name: '尋找導師' })
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -15,32 +15,10 @@ import {
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
-import { DisabledAwareLink } from './DisabledAwareLink';
-import { getBecomeMentorHref, getProfileHref } from './navHrefs';
 
-export type HamburgerMenuProps = {
-  isLoggedIn: boolean;
-  isMentor: boolean;
-  userId?: string;
-  /**
-   * Logged in per the fast session hint, but `userId` hasn't landed yet —
-   * owned by Header's `useAuthStatus()`, passed down rather than re-derived
-   * here so the two never drift out of sync.
-   */
-  isResolvingUser: boolean;
-};
-
-export function HamburgerMenu({
-  isLoggedIn,
-  isMentor,
-  userId,
-  isResolvingUser,
-}: HamburgerMenuProps): JSX.Element {
+export function HamburgerMenu(): JSX.Element {
   const [open, setOpen] = React.useState(false);
   const close = (): void => setOpen(false);
-
-  const profilePath = getProfileHref(userId);
-  const becomeMentorPath = getBecomeMentorHref(userId);
 
   return (
     <Sheet open={open} onOpenChange={setOpen}>
@@ -71,25 +49,13 @@ export function HamburgerMenu({
               尋找導師
             </Link>
 
-            {isMentor ? (
-              <DisabledAwareLink
-                href={profilePath}
-                onClick={close}
-                disabled={isResolvingUser}
-                className="text-text-primary"
-              >
-                我的導師頁面
-              </DisabledAwareLink>
-            ) : (
-              <DisabledAwareLink
-                href={becomeMentorPath}
-                onClick={close}
-                disabled={isResolvingUser}
-                className="text-text-primary"
-              >
-                成為導師
-              </DisabledAwareLink>
-            )}
+            <Link
+              href="/auth/signup"
+              onClick={close}
+              className="text-text-primary"
+            >
+              成為導師
+            </Link>
 
             <Link href="/about" onClick={close} className="text-text-primary">
               關於 X-Talent
@@ -110,23 +76,21 @@ export function HamburgerMenu({
             </a>
           </div>
 
-          {!isLoggedIn && (
-            <div className="mt-auto flex flex-col items-center gap-6 pb-6">
-              <Link href="/auth/signin" onClick={close}>
-                <Button className="w-40 bg-brand-500 hover:bg-brand-500">
-                  登入
-                </Button>
-              </Link>
-              <Link href="/auth/signup" onClick={close}>
-                <Button
-                  variant="outline"
-                  className="w-40 border-brand-500 text-brand-500 hover:text-brand-500"
-                >
-                  註冊
-                </Button>
-              </Link>
-            </div>
-          )}
+          <div className="mt-auto flex flex-col items-center gap-6 pb-6">
+            <Link href="/auth/signin" onClick={close}>
+              <Button className="w-40 bg-brand-500 hover:bg-brand-500">
+                登入
+              </Button>
+            </Link>
+            <Link href="/auth/signup" onClick={close}>
+              <Button
+                variant="outline"
+                className="w-40 border-brand-500 text-brand-500 hover:text-brand-500"
+              >
+                註冊
+              </Button>
+            </Link>
+          </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/layout/Header/HamburgerMenu.tsx
+++ b/src/components/layout/Header/HamburgerMenu.tsx
@@ -15,6 +15,7 @@ import {
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
+import { getBecomeMentorHref } from './navHrefs';
 
 export function HamburgerMenu(): JSX.Element {
   const [open, setOpen] = React.useState(false);
@@ -50,7 +51,7 @@ export function HamburgerMenu(): JSX.Element {
             </Link>
 
             <Link
-              href="/auth/signup"
+              href={getBecomeMentorHref(undefined)}
               onClick={close}
               className="text-text-primary"
             >

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/image', () => ({
@@ -41,52 +41,6 @@ describe('Header', () => {
     mockUseSessionHint.mockReturnValue({ status: 'unknown' });
   });
 
-  it('disables the second nav link while resolving a logged-in user, instead of falling back to /auth/signup or /', () => {
-    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
-    mockUseAuthStatus.mockReturnValue({
-      authKnown: true,
-      isLoggedIn: true,
-      isMentor: false,
-      userId: undefined,
-      hasFullUser: false,
-      isResolvingUser: true,
-    });
-
-    render(<Header />);
-
-    const link = screen.getByRole('link', { name: '成為導師' });
-    expect(link).toHaveAttribute('href', '#');
-    expect(link).toHaveAttribute('aria-disabled', 'true');
-
-    // dispatchEvent() returns false when a handler called preventDefault().
-    const notPrevented = fireEvent.click(link);
-    expect(notPrevented).toBe(false);
-  });
-
-  it('links straight to the profile edit page once userId has landed and isResolvingUser is false', () => {
-    mockUseSession.mockReturnValue({
-      data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
-      status: 'authenticated',
-    });
-    mockUseAuthStatus.mockReturnValue({
-      authKnown: true,
-      isLoggedIn: true,
-      isMentor: false,
-      userId: 'user-123',
-      hasFullUser: true,
-      isResolvingUser: false,
-    });
-
-    render(<Header />);
-
-    const link = screen.getByRole('link', { name: '成為導師' });
-    expect(link).toHaveAttribute(
-      'href',
-      '/profile/user-123/edit?mentor-onboarding=true'
-    );
-    expect(link).toHaveAttribute('aria-disabled', 'false');
-  });
-
   it('shows guest sign-in/sign-up actions once auth is known and the user is not logged in', () => {
     mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
     mockUseAuthStatus.mockReturnValue({
@@ -123,34 +77,6 @@ describe('Header', () => {
     expect(
       screen.queryByRole('link', { name: '註冊' })
     ).not.toBeInTheDocument();
-  });
-
-  it('renders both links with CSS data-auth-state visibility toggles before auth is known', () => {
-    // `useAuthStatus` defaults `isMentor` to false until it can be
-    // determined — this must not leak into the rendered nav link before
-    // `authKnown` is true, or a mentor briefly sees the wrong role's label.
-    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
-    mockUseAuthStatus.mockReturnValue({
-      authKnown: false,
-      isLoggedIn: false,
-      isMentor: false,
-      userId: undefined,
-      hasFullUser: false,
-      isResolvingUser: false,
-    });
-
-    render(<Header />);
-
-    const mentorLink = screen.getByRole('link', { name: '我的導師頁面' });
-    const menteeLink = screen.getByRole('link', { name: '成為導師' });
-    expect(mentorLink).toHaveClass(
-      'hidden',
-      'group-data-[auth-state=mentor]:block'
-    );
-    expect(menteeLink).toHaveClass(
-      'hidden',
-      'group-data-[auth-state=mentee]:block'
-    );
   });
 
   it("renders UserDropdown with hint avatar when logged in per hint but session hasn't resolved yet", () => {

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -246,15 +246,35 @@ describe('Header', () => {
 
     render(<Header />);
 
-    expect(screen.getByRole('link', { name: '尋找導師' })).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: '關於 X-Talent' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('link', { name: '提供回饋（另開新分頁）' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('button', { name: '開啟導航選單' })
-    ).toBeInTheDocument();
+    const findMentorLink = screen.getByRole('link', { name: '尋找導師' });
+    const aboutLink = screen.getByRole('link', { name: '關於 X-Talent' });
+    const feedbackLink = screen.getByRole('link', {
+      name: '提供回饋（另開新分頁）',
+    });
+    const hamburgerBtn = screen.getByRole('button', { name: '開啟導航選單' });
+
+    expect(findMentorLink).toBeInTheDocument();
+    expect(findMentorLink).toHaveClass(
+      'group-data-[auth-state=mentee]:hidden',
+      'group-data-[auth-state=mentor]:hidden'
+    );
+
+    expect(aboutLink).toBeInTheDocument();
+    expect(aboutLink).toHaveClass(
+      'group-data-[auth-state=mentee]:hidden',
+      'group-data-[auth-state=mentor]:hidden'
+    );
+
+    expect(feedbackLink).toBeInTheDocument();
+    expect(feedbackLink).toHaveClass(
+      'group-data-[auth-state=mentee]:hidden',
+      'group-data-[auth-state=mentor]:hidden'
+    );
+
+    expect(hamburgerBtn).toBeInTheDocument();
+    expect(hamburgerBtn.parentElement).toHaveClass(
+      'group-data-[auth-state=mentee]:hidden',
+      'group-data-[auth-state=mentor]:hidden'
+    );
   });
 });

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -232,4 +232,27 @@ describe('Header', () => {
       screen.queryByRole('link', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
+
+  it('shows inline navigation links on desktop and hamburger menu on mobile when the user is not logged in', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    expect(screen.getByRole('link', { name: '尋找導師' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: '關於 X-Talent' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '提供回饋' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: '開啟導航選單' })
+    ).toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -173,6 +173,7 @@ describe('Header', () => {
     render(<Header />);
 
     const findMentorLink = screen.getByRole('link', { name: '尋找導師' });
+    const becomeMentorLink = screen.getByRole('link', { name: '成為導師' });
     const aboutLink = screen.getByRole('link', { name: '關於 X-Talent' });
     const feedbackLink = screen.getByRole('link', {
       name: '提供回饋（另開新分頁）',
@@ -181,6 +182,12 @@ describe('Header', () => {
 
     expect(findMentorLink).toBeInTheDocument();
     expect(findMentorLink).toHaveClass(
+      'group-data-[auth-state=mentee]:hidden',
+      'group-data-[auth-state=mentor]:hidden'
+    );
+
+    expect(becomeMentorLink).toBeInTheDocument();
+    expect(becomeMentorLink).toHaveClass(
       'group-data-[auth-state=mentee]:hidden',
       'group-data-[auth-state=mentor]:hidden'
     );

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -250,7 +250,9 @@ describe('Header', () => {
     expect(
       screen.getByRole('link', { name: '關於 X-Talent' })
     ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '提供回饋' })).toBeInTheDocument();
+    expect(
+      screen.getByRole('link', { name: '提供回饋（另開新分頁）' })
+    ).toBeInTheDocument();
     expect(
       screen.getByRole('button', { name: '開啟導航選單' })
     ).toBeInTheDocument();

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -205,4 +205,31 @@ describe('Header', () => {
       'hidden group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block'
     );
   });
+
+  it('hides inline navigation links on desktop when the user is logged in', () => {
+    mockUseSession.mockReturnValue({
+      data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
+      status: 'authenticated',
+    });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: 'user-123',
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    expect(
+      screen.queryByRole('link', { name: '尋找導師' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: '關於 X-Talent' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('link', { name: '提供回饋' })
+    ).not.toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -17,15 +17,14 @@ import { FEEDBACK_FORM_URL } from './constants';
 import { DisabledAwareLink } from './DisabledAwareLink';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
-import { getBecomeMentorHref, getProfileHref } from './navHrefs';
+import { getBecomeMentorHref } from './navHrefs';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
   const { data: session } = useSession();
   const hint = useSessionHint();
   const currentAvatar = useCurrentAvatar();
-  const { authKnown, isLoggedIn, isMentor, userId, isResolvingUser } =
-    useAuthStatus();
+  const { authKnown, isLoggedIn, isMentor, userId } = useAuthStatus();
 
   const resolvedIsMentor = authKnown
     ? isMentor
@@ -51,12 +50,6 @@ function HeaderComponent(): JSX.Element {
 
   const findMentorHref = '/mentor-pool';
 
-  // `userId` only ever comes from the real session, never the hint — while
-  // isResolvingUser is true these hrefs are unused (the link is disabled).
-  const leftSecondNav = resolvedIsMentor
-    ? { label: '我的導師頁面', href: getProfileHref(userId) }
-    : { label: '成為導師', href: getBecomeMentorHref(userId) };
-
   return (
     <header className="fixed inset-x-0 top-[var(--banner-height,0px)] z-50 bg-light px-5">
       <div className="flex h-[70px] items-center justify-between">
@@ -76,31 +69,16 @@ function HeaderComponent(): JSX.Element {
             )}
 
             {!authKnown ? (
-              <>
-                <Skeleton className="h-6 w-24 group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden" />
+              <Skeleton className="h-6 w-24 group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden" />
+            ) : (
+              !isLoggedIn && (
                 <DisabledAwareLink
-                  href={getProfileHref(userId)}
-                  disabled={isResolvingUser}
-                  className="hidden font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentor]:block"
-                >
-                  我的導師頁面
-                </DisabledAwareLink>
-                <DisabledAwareLink
-                  href={getBecomeMentorHref(userId)}
-                  disabled={isResolvingUser}
-                  className="hidden font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:block"
+                  href={getBecomeMentorHref(undefined)}
+                  className="font-['Open_Sans'] text-base text-text-primary"
                 >
                   成為導師
                 </DisabledAwareLink>
-              </>
-            ) : (
-              <DisabledAwareLink
-                href={leftSecondNav.href}
-                disabled={isResolvingUser}
-                className="font-['Open_Sans'] text-base text-text-primary"
-              >
-                {leftSecondNav.label}
-              </DisabledAwareLink>
+              )
             )}
 
             {!isLoggedIn && (

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -60,25 +60,21 @@ function HeaderComponent(): JSX.Element {
 
           <nav className="hidden items-center gap-7 lg:flex">
             {!isLoggedIn && (
-              <Link
-                href={findMentorHref}
-                className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
-              >
-                尋找導師
-              </Link>
-            )}
-
-            {!isLoggedIn && (
-              <Link
-                href={getBecomeMentorHref(undefined)}
-                className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
-              >
-                成為導師
-              </Link>
-            )}
-
-            {!isLoggedIn && (
               <>
+                <Link
+                  href={findMentorHref}
+                  className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+                >
+                  尋找導師
+                </Link>
+
+                <Link
+                  href={getBecomeMentorHref(undefined)}
+                  className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+                >
+                  成為導師
+                </Link>
+
                 <Link
                   href="/about"
                   className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -14,7 +14,6 @@ import { useCurrentAvatar } from '@/hooks/user/profile/useCurrentAvatar';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
-import { DisabledAwareLink } from './DisabledAwareLink';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
 import { getBecomeMentorHref } from './navHrefs';
@@ -24,7 +23,8 @@ function HeaderComponent(): JSX.Element {
   const { data: session } = useSession();
   const hint = useSessionHint();
   const currentAvatar = useCurrentAvatar();
-  const { authKnown, isLoggedIn, isMentor, userId } = useAuthStatus();
+  const { authKnown, isLoggedIn, isMentor, userId, isResolvingUser } =
+    useAuthStatus();
 
   const resolvedIsMentor = authKnown
     ? isMentor
@@ -68,17 +68,13 @@ function HeaderComponent(): JSX.Element {
               </Link>
             )}
 
-            {!authKnown ? (
-              <Skeleton className="h-6 w-24 group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden" />
-            ) : (
-              !isLoggedIn && (
-                <DisabledAwareLink
-                  href={getBecomeMentorHref(undefined)}
-                  className="font-['Open_Sans'] text-base text-text-primary"
-                >
-                  成為導師
-                </DisabledAwareLink>
-              )
+            {!isLoggedIn && (
+              <Link
+                href={getBecomeMentorHref(undefined)}
+                className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+              >
+                成為導師
+              </Link>
             )}
 
             {!isLoggedIn && (
@@ -135,6 +131,7 @@ function HeaderComponent(): JSX.Element {
               <UserDropdown
                 user={virtualUser}
                 findMentorHref={findMentorHref}
+                isResolvingUser={isResolvingUser}
               />
             ) : (
               <Skeleton className="size-9 rounded-full" />
@@ -146,6 +143,7 @@ function HeaderComponent(): JSX.Element {
               <MobileUserMenu
                 user={virtualUser}
                 findMentorHref={findMentorHref}
+                isResolvingUser={isResolvingUser}
               />
             ) : (
               <>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -175,12 +175,7 @@ function HeaderComponent(): JSX.Element {
                   <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
                 )}
                 <div className="group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden">
-                  <HamburgerMenu
-                    isLoggedIn={isLoggedIn}
-                    isMentor={resolvedIsMentor}
-                    userId={userId}
-                    isResolvingUser={isResolvingUser}
-                  />
+                  <HamburgerMenu />
                 </div>
               </>
             )}

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -66,12 +66,14 @@ function HeaderComponent(): JSX.Element {
           </Link>
 
           <nav className="hidden items-center gap-7 lg:flex">
-            <Link
-              href={findMentorHref}
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              尋找導師
-            </Link>
+            {!isLoggedIn && (
+              <Link
+                href={findMentorHref}
+                className="font-['Open_Sans'] text-base text-text-primary"
+              >
+                尋找導師
+              </Link>
+            )}
 
             {!authKnown ? (
               <>
@@ -101,23 +103,27 @@ function HeaderComponent(): JSX.Element {
               </DisabledAwareLink>
             )}
 
-            <Link
-              href="/about"
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              關於 X-Talent
-            </Link>
+            {!isLoggedIn && (
+              <>
+                <Link
+                  href="/about"
+                  className="font-['Open_Sans'] text-base text-text-primary"
+                >
+                  關於 X-Talent
+                </Link>
 
-            <a
-              href={FEEDBACK_FORM_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="提供回饋（另開新分頁）"
-              onClick={() => trackEvent({ name: 'feedback_open' })}
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              提供回饋
-            </a>
+                <a
+                  href={FEEDBACK_FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="提供回饋（另開新分頁）"
+                  onClick={() => trackEvent({ name: 'feedback_open' })}
+                  className="font-['Open_Sans'] text-base text-text-primary"
+                >
+                  提供回饋
+                </a>
+              </>
+            )}
           </nav>
         </div>
 
@@ -158,16 +164,18 @@ function HeaderComponent(): JSX.Element {
             {isLoggedIn ? (
               <MobileUserMenu user={virtualUser} />
             ) : (
-              !authKnown && (
-                <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
-              )
+              <>
+                {!authKnown && (
+                  <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
+                )}
+                <HamburgerMenu
+                  isLoggedIn={isLoggedIn}
+                  isMentor={resolvedIsMentor}
+                  userId={userId}
+                  isResolvingUser={isResolvingUser}
+                />
+              </>
             )}
-            <HamburgerMenu
-              isLoggedIn={isLoggedIn}
-              isMentor={resolvedIsMentor}
-              userId={userId}
-              isResolvingUser={isResolvingUser}
-            />
           </div>
         </div>
       </div>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -69,7 +69,7 @@ function HeaderComponent(): JSX.Element {
             {!isLoggedIn && (
               <Link
                 href={findMentorHref}
-                className="font-['Open_Sans'] text-base text-text-primary"
+                className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
               >
                 尋找導師
               </Link>
@@ -107,7 +107,7 @@ function HeaderComponent(): JSX.Element {
               <>
                 <Link
                   href="/about"
-                  className="font-['Open_Sans'] text-base text-text-primary"
+                  className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
                 >
                   關於 X-Talent
                 </Link>
@@ -118,7 +118,7 @@ function HeaderComponent(): JSX.Element {
                   rel="noopener noreferrer"
                   aria-label="提供回饋（另開新分頁）"
                   onClick={() => trackEvent({ name: 'feedback_open' })}
-                  className="font-['Open_Sans'] text-base text-text-primary"
+                  className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
                 >
                   提供回饋
                 </a>
@@ -154,7 +154,10 @@ function HeaderComponent(): JSX.Element {
                 </Link>
               </>
             ) : isLoggedIn ? (
-              <UserDropdown user={virtualUser} />
+              <UserDropdown
+                user={virtualUser}
+                findMentorHref={findMentorHref}
+              />
             ) : (
               <Skeleton className="size-9 rounded-full" />
             )}
@@ -162,18 +165,23 @@ function HeaderComponent(): JSX.Element {
 
           <div className="flex items-center gap-3 lg:hidden">
             {isLoggedIn ? (
-              <MobileUserMenu user={virtualUser} />
+              <MobileUserMenu
+                user={virtualUser}
+                findMentorHref={findMentorHref}
+              />
             ) : (
               <>
                 {!authKnown && (
                   <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
                 )}
-                <HamburgerMenu
-                  isLoggedIn={isLoggedIn}
-                  isMentor={resolvedIsMentor}
-                  userId={userId}
-                  isResolvingUser={isResolvingUser}
-                />
+                <div className="group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden">
+                  <HamburgerMenu
+                    isLoggedIn={isLoggedIn}
+                    isMentor={resolvedIsMentor}
+                    userId={userId}
+                    isResolvingUser={isResolvingUser}
+                  />
+                </div>
               </>
             )}
           </div>

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -23,8 +23,7 @@ function HeaderComponent(): JSX.Element {
   const { data: session } = useSession();
   const hint = useSessionHint();
   const currentAvatar = useCurrentAvatar();
-  const { authKnown, isLoggedIn, isMentor, userId, isResolvingUser } =
-    useAuthStatus();
+  const { authKnown, isLoggedIn, isMentor, userId } = useAuthStatus();
 
   const resolvedIsMentor = authKnown
     ? isMentor
@@ -127,7 +126,6 @@ function HeaderComponent(): JSX.Element {
               <UserDropdown
                 user={virtualUser}
                 findMentorHref={findMentorHref}
-                isResolvingUser={isResolvingUser}
               />
             ) : (
               <Skeleton className="size-9 rounded-full" />
@@ -139,7 +137,6 @@ function HeaderComponent(): JSX.Element {
               <MobileUserMenu
                 user={virtualUser}
                 findMentorHref={findMentorHref}
-                isResolvingUser={isResolvingUser}
               />
             ) : (
               <>

--- a/src/components/layout/Header/MobileUserMenu.test.tsx
+++ b/src/components/layout/Header/MobileUserMenu.test.tsx
@@ -116,4 +116,21 @@ describe('MobileUserMenu', () => {
       '/profile/user-123'
     );
   });
+
+  it('disables "我的導師頁面" link if isResolvingUser is true', () => {
+    render(
+      <MobileUserMenu
+        user={buildUser({ isMentor: true, id: 'user-123' })}
+        isResolvingUser={true}
+      />
+    );
+    // Open user menu
+    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
+    fireEvent.click(trigger);
+
+    const mentorLink = screen.getByRole('link', { name: '我的導師頁面' });
+    expect(mentorLink).toBeInTheDocument();
+    expect(mentorLink).toHaveAttribute('aria-disabled', 'true');
+    expect(mentorLink).toHaveClass('pointer-events-none');
+  });
 });

--- a/src/components/layout/Header/MobileUserMenu.test.tsx
+++ b/src/components/layout/Header/MobileUserMenu.test.tsx
@@ -90,47 +90,4 @@ describe('MobileUserMenu', () => {
       screen.queryByRole('link', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
-
-  it('renders "我的導師頁面" link if user is a mentor, but not if they are a guest/mentee', () => {
-    // 1. Mentee (isMentor: false)
-    const { rerender } = render(
-      <MobileUserMenu user={buildUser({ isMentor: false, id: 'user-123' })} />
-    );
-    // Open user menu
-    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
-    fireEvent.click(trigger);
-
-    expect(
-      screen.queryByRole('link', { name: '我的導師頁面' })
-    ).not.toBeInTheDocument();
-
-    // 2. Mentor (isMentor: true)
-    rerender(
-      <MobileUserMenu user={buildUser({ isMentor: true, id: 'user-123' })} />
-    );
-    expect(
-      screen.getByRole('link', { name: '我的導師頁面' })
-    ).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: '我的導師頁面' })).toHaveAttribute(
-      'href',
-      '/profile/user-123'
-    );
-  });
-
-  it('disables "我的導師頁面" link if isResolvingUser is true', () => {
-    render(
-      <MobileUserMenu
-        user={buildUser({ isMentor: true, id: 'user-123' })}
-        isResolvingUser={true}
-      />
-    );
-    // Open user menu
-    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
-    fireEvent.click(trigger);
-
-    const mentorLink = screen.getByRole('link', { name: '我的導師頁面' });
-    expect(mentorLink).toBeInTheDocument();
-    expect(mentorLink).toHaveAttribute('aria-disabled', 'true');
-    expect(mentorLink).toHaveClass('pointer-events-none');
-  });
 });

--- a/src/components/layout/Header/MobileUserMenu.test.tsx
+++ b/src/components/layout/Header/MobileUserMenu.test.tsx
@@ -90,4 +90,30 @@ describe('MobileUserMenu', () => {
       screen.queryByRole('link', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
+
+  it('renders "我的導師頁面" link if user is a mentor, but not if they are a guest/mentee', () => {
+    // 1. Mentee (isMentor: false)
+    const { rerender } = render(
+      <MobileUserMenu user={buildUser({ isMentor: false, id: 'user-123' })} />
+    );
+    // Open user menu
+    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
+    fireEvent.click(trigger);
+
+    expect(
+      screen.queryByRole('link', { name: '我的導師頁面' })
+    ).not.toBeInTheDocument();
+
+    // 2. Mentor (isMentor: true)
+    rerender(
+      <MobileUserMenu user={buildUser({ isMentor: true, id: 'user-123' })} />
+    );
+    expect(
+      screen.getByRole('link', { name: '我的導師頁面' })
+    ).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: '我的導師頁面' })).toHaveAttribute(
+      'href',
+      '/profile/user-123'
+    );
+  });
 });

--- a/src/components/layout/Header/MobileUserMenu.test.tsx
+++ b/src/components/layout/Header/MobileUserMenu.test.tsx
@@ -1,7 +1,7 @@
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { fromPartial } from '@total-typescript/shoehorn';
 import type { Session } from 'next-auth';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/image', () => ({
   default: ({ src, alt }: { src: string | { src: string }; alt: string }) => (
@@ -20,6 +20,11 @@ vi.mock('next/navigation', async () => {
   return navigationMockFactory();
 });
 
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from '@/lib/analytics';
 import { mockSession } from '@/test/mocks/nextAuth';
 
 import { MobileUserMenu } from './MobileUserMenu';
@@ -34,6 +39,10 @@ function buildUser(overrides: Partial<Session['user']> = {}): Session['user'] {
 }
 
 describe('MobileUserMenu', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('renders correctly with default mock user showing proper alt text', () => {
     render(<MobileUserMenu user={buildUser({ name: 'Ada Lovelace' })} />);
     const avatarImg = screen.getByRole('img', { name: 'Ada Lovelace 的頭像' });
@@ -63,5 +72,22 @@ describe('MobileUserMenu', () => {
     );
     const fallbackImg = screen.getByRole('img', { name: '我的頭像' });
     expect(fallbackImg).toBeInTheDocument();
+  });
+
+  it('calls trackEvent and closeMenu when clicking the "提供回饋" link', () => {
+    render(<MobileUserMenu user={buildUser()} />);
+
+    // Open user menu
+    const trigger = screen.getByRole('button', { name: '開啟用戶選單' });
+    fireEvent.click(trigger);
+
+    const feedbackLink = screen.getByRole('link', { name: '提供回饋' });
+    fireEvent.click(feedbackLink);
+
+    expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
+    // Verify menu closed (the feedback link is no longer visible)
+    expect(
+      screen.queryByRole('link', { name: '提供回饋' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -20,16 +20,19 @@ import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
+import { DisabledAwareLink } from './DisabledAwareLink';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type MobileUserMenuProps = {
   user: Session['user'];
   findMentorHref?: string;
+  isResolvingUser?: boolean;
 };
 
 export function MobileUserMenu({
   user,
   findMentorHref = '/mentor-pool',
+  isResolvingUser = false,
 }: MobileUserMenuProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
 
@@ -141,13 +144,14 @@ export function MobileUserMenu({
                 {isMentor ? '導師預約管理' : '成為導師'}
               </button>
               {isMentor && (
-                <Link
+                <DisabledAwareLink
                   href={profilePath}
+                  disabled={isResolvingUser}
                   onClick={closeMenu}
                   className="py-4 text-left text-xl text-text-primary"
                 >
                   我的導師頁面
-                </Link>
+                </DisabledAwareLink>
               )}
               <button
                 type="button"

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -24,9 +24,13 @@ import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type MobileUserMenuProps = {
   user: Session['user'];
+  findMentorHref?: string;
 };
 
-export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
+export function MobileUserMenu({
+  user,
+  findMentorHref = '/mentor-pool',
+}: MobileUserMenuProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
 
   const closeMenu = React.useCallback(() => setOpen(false), []);
@@ -144,7 +148,7 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
                 我的預約
               </button>
               <Link
-                href="/mentor-pool"
+                href={findMentorHref}
                 onClick={closeMenu}
                 className="py-4 text-left text-xl text-text-primary"
               >

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -2,6 +2,7 @@
 
 import { Cross2Icon } from '@radix-ui/react-icons';
 import Image from 'next/image';
+import Link from 'next/link';
 import type { Session } from 'next-auth';
 import * as React from 'react';
 
@@ -16,7 +17,9 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type MobileUserMenuProps = {
@@ -140,6 +143,32 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               >
                 我的預約
               </button>
+              <Link
+                href="/mentor-pool"
+                onClick={closeMenu}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                尋找導師
+              </Link>
+              <Link
+                href="/about"
+                onClick={closeMenu}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                關於 X-Talent
+              </Link>
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  trackEvent({ name: 'feedback_open' });
+                  closeMenu();
+                }}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                提供回饋
+              </a>
             </nav>
 
             <div className="flex flex-col pb-6">

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -124,7 +124,7 @@ export function MobileUserMenu({
             {/* Share Profile */}
             <Button
               variant="outline"
-              className="mb-6 h-12 w-full rounded-2xl text-base font-semibold"
+              className="mb-4 h-12 w-full rounded-2xl text-base font-semibold"
               onClick={handleShareProfile}
               disabled={!userId}
             >
@@ -134,7 +134,7 @@ export function MobileUserMenu({
             <div className="h-px w-full bg-background-bottom" />
 
             {/* Account actions */}
-            <nav className="flex flex-col py-2">
+            <nav className="flex flex-col pt-0 pb-2">
               <button
                 type="button"
                 onClick={handleAsMentor}

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -140,6 +140,15 @@ export function MobileUserMenu({
               >
                 {isMentor ? '導師預約管理' : '成為導師'}
               </button>
+              {isMentor && (
+                <Link
+                  href={profilePath}
+                  onClick={closeMenu}
+                  className="py-4 text-left text-xl text-text-primary"
+                >
+                  我的導師頁面
+                </Link>
+              )}
               <button
                 type="button"
                 onClick={handleMyReservation}

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -20,19 +20,16 @@ import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
-import { DisabledAwareLink } from './DisabledAwareLink';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type MobileUserMenuProps = {
   user: Session['user'];
   findMentorHref?: string;
-  isResolvingUser?: boolean;
 };
 
 export function MobileUserMenu({
   user,
   findMentorHref = '/mentor-pool',
-  isResolvingUser = false,
 }: MobileUserMenuProps): JSX.Element {
   const [open, setOpen] = React.useState(false);
 
@@ -143,16 +140,6 @@ export function MobileUserMenu({
               >
                 {isMentor ? '導師預約管理' : '成為導師'}
               </button>
-              {isMentor && (
-                <DisabledAwareLink
-                  href={profilePath}
-                  disabled={isResolvingUser}
-                  onClick={closeMenu}
-                  className="py-4 text-left text-xl text-text-primary"
-                >
-                  我的導師頁面
-                </DisabledAwareLink>
-              )}
               <button
                 type="button"
                 onClick={handleMyReservation}

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -123,4 +123,26 @@ describe('UserDropdown share flow', () => {
       screen.queryByRole('menuitem', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
+
+  it('renders "我的導師頁面" dropdown item if user is a mentor, but not if they are a mentee', () => {
+    // 1. Mentee (isMentor: false)
+    const { rerender } = render(
+      <UserDropdown user={buildUser({ isMentor: false, id: 'user-123' })} />
+    );
+    openMenu();
+    expect(
+      screen.queryByRole('menuitem', { name: '我的導師頁面' })
+    ).not.toBeInTheDocument();
+
+    // 2. Mentor (isMentor: true)
+    rerender(
+      <UserDropdown user={buildUser({ isMentor: true, id: 'user-123' })} />
+    );
+    expect(
+      screen.getByRole('menuitem', { name: '我的導師頁面' })
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('menuitem', { name: '我的導師頁面' })
+    ).toHaveAttribute('href', '/profile/user-123');
+  });
 });

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -145,4 +145,19 @@ describe('UserDropdown share flow', () => {
       screen.getByRole('menuitem', { name: '我的導師頁面' })
     ).toHaveAttribute('href', '/profile/user-123');
   });
+
+  it('disables "我的導師頁面" dropdown item if isResolvingUser is true', () => {
+    render(
+      <UserDropdown
+        user={buildUser({ isMentor: true, id: 'user-123' })}
+        isResolvingUser={true}
+      />
+    );
+    openMenu();
+
+    const mentorLink = screen.getByRole('menuitem', { name: '我的導師頁面' });
+    expect(mentorLink).toBeInTheDocument();
+    expect(mentorLink).toHaveAttribute('aria-disabled', 'true');
+    expect(mentorLink).toHaveClass('pointer-events-none');
+  });
 });

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -22,6 +22,11 @@ vi.mock('next/navigation', async () => {
   return navigationMockFactory();
 });
 
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: vi.fn(),
+}));
+
+import { trackEvent } from '@/lib/analytics';
 import { mockSession } from '@/test/mocks/nextAuth';
 
 import { UserDropdown } from './UserDropdown';
@@ -39,6 +44,7 @@ describe('UserDropdown share flow', () => {
   let queuedFrames: FrameRequestCallback[];
 
   beforeEach(() => {
+    vi.clearAllMocks();
     queuedFrames = [];
     vi.stubGlobal(
       'ResizeObserver',
@@ -101,5 +107,20 @@ describe('UserDropdown share flow', () => {
     openMenu();
     const shareButton = screen.getByRole('button', { name: '分享個人頁面' });
     expect(shareButton).toBeDisabled();
+  });
+
+  it('calls trackEvent and closeMenu when clicking the "提供回饋" link', () => {
+    render(<UserDropdown user={buildUser()} />);
+
+    openMenu();
+    const feedbackLink = screen.getByRole('link', { name: '提供回饋' });
+
+    fireEvent.click(feedbackLink);
+
+    expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
+    // And verify the dropdown closed (which means the feedback link is no longer in the document)
+    expect(
+      screen.queryByRole('link', { name: '提供回饋' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -113,14 +113,14 @@ describe('UserDropdown share flow', () => {
     render(<UserDropdown user={buildUser()} />);
 
     openMenu();
-    const feedbackLink = screen.getByRole('link', { name: '提供回饋' });
+    const feedbackLink = screen.getByRole('menuitem', { name: '提供回饋' });
 
     fireEvent.click(feedbackLink);
 
     expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
     // And verify the dropdown closed (which means the feedback link is no longer in the document)
     expect(
-      screen.queryByRole('link', { name: '提供回饋' })
+      screen.queryByRole('menuitem', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -123,41 +123,4 @@ describe('UserDropdown share flow', () => {
       screen.queryByRole('menuitem', { name: '提供回饋' })
     ).not.toBeInTheDocument();
   });
-
-  it('renders "我的導師頁面" dropdown item if user is a mentor, but not if they are a mentee', () => {
-    // 1. Mentee (isMentor: false)
-    const { rerender } = render(
-      <UserDropdown user={buildUser({ isMentor: false, id: 'user-123' })} />
-    );
-    openMenu();
-    expect(
-      screen.queryByRole('menuitem', { name: '我的導師頁面' })
-    ).not.toBeInTheDocument();
-
-    // 2. Mentor (isMentor: true)
-    rerender(
-      <UserDropdown user={buildUser({ isMentor: true, id: 'user-123' })} />
-    );
-    expect(
-      screen.getByRole('menuitem', { name: '我的導師頁面' })
-    ).toBeInTheDocument();
-    expect(
-      screen.getByRole('menuitem', { name: '我的導師頁面' })
-    ).toHaveAttribute('href', '/profile/user-123');
-  });
-
-  it('disables "我的導師頁面" dropdown item if isResolvingUser is true', () => {
-    render(
-      <UserDropdown
-        user={buildUser({ isMentor: true, id: 'user-123' })}
-        isResolvingUser={true}
-      />
-    );
-    openMenu();
-
-    const mentorLink = screen.getByRole('menuitem', { name: '我的導師頁面' });
-    expect(mentorLink).toBeInTheDocument();
-    expect(mentorLink).toHaveAttribute('aria-disabled', 'true');
-    expect(mentorLink).toHaveClass('pointer-events-none');
-  });
 });

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -148,7 +148,11 @@ export const UserDropdown = React.memo(function UserDropdown({
             </DropdownMenuItem>
 
             {isMentor && (
-              <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
+              <DropdownMenuItem
+                className="px-4 py-3 text-2xl"
+                disabled={isResolvingUser}
+                asChild
+              >
                 <DisabledAwareLink
                   href={profilePath}
                   disabled={isResolvingUser}

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -19,19 +19,16 @@ import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
-import { DisabledAwareLink } from './DisabledAwareLink';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
   user: Session['user'];
   findMentorHref?: string;
-  isResolvingUser?: boolean;
 };
 
 export const UserDropdown = React.memo(function UserDropdown({
   user,
   findMentorHref = '/mentor-pool',
-  isResolvingUser = false,
 }: UserDropdownProps): JSX.Element {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -146,22 +143,6 @@ export const UserDropdown = React.memo(function UserDropdown({
             >
               {isMentor ? '導師預約管理' : '成為導師'}
             </DropdownMenuItem>
-
-            {isMentor && (
-              <DropdownMenuItem
-                className="px-4 py-3 text-2xl"
-                disabled={isResolvingUser}
-                asChild
-              >
-                <DisabledAwareLink
-                  href={profilePath}
-                  disabled={isResolvingUser}
-                  onClick={closeMenu}
-                >
-                  我的導師頁面
-                </DisabledAwareLink>
-              </DropdownMenuItem>
-            )}
 
             <DropdownMenuItem
               className="px-4 py-3 text-2xl"

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -23,10 +23,12 @@ import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
   user: Session['user'];
+  findMentorHref?: string;
 };
 
 export const UserDropdown = React.memo(function UserDropdown({
   user,
+  findMentorHref = '/mentor-pool',
 }: UserDropdownProps): JSX.Element {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -151,7 +153,7 @@ export const UserDropdown = React.memo(function UserDropdown({
             </DropdownMenuItem>
 
             <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
-              <Link href="/mentor-pool" onClick={closeMenu}>
+              <Link href={findMentorHref} onClick={closeMenu}>
                 尋找導師
               </Link>
             </DropdownMenuItem>

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
 import * as React from 'react';
@@ -15,7 +16,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
@@ -145,6 +148,32 @@ export const UserDropdown = React.memo(function UserDropdown({
               aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
+              <Link href="/mentor-pool" onClick={closeMenu}>
+                尋找導師
+              </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
+              <Link href="/about" onClick={closeMenu}>
+                關於 X-Talent
+              </Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  trackEvent({ name: 'feedback_open' });
+                  closeMenu();
+                }}
+              >
+                提供回饋
+              </a>
             </DropdownMenuItem>
 
             <DropdownMenuItem

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -19,16 +19,19 @@ import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
 import { trackEvent } from '@/lib/analytics';
 
 import { FEEDBACK_FORM_URL } from './constants';
+import { DisabledAwareLink } from './DisabledAwareLink';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
   user: Session['user'];
   findMentorHref?: string;
+  isResolvingUser?: boolean;
 };
 
 export const UserDropdown = React.memo(function UserDropdown({
   user,
   findMentorHref = '/mentor-pool',
+  isResolvingUser = false,
 }: UserDropdownProps): JSX.Element {
   const pathname = usePathname();
   const [menuOpen, setMenuOpen] = React.useState(false);
@@ -146,9 +149,13 @@ export const UserDropdown = React.memo(function UserDropdown({
 
             {isMentor && (
               <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
-                <Link href={profilePath} onClick={closeMenu}>
+                <DisabledAwareLink
+                  href={profilePath}
+                  disabled={isResolvingUser}
+                  onClick={closeMenu}
+                >
                   我的導師頁面
-                </Link>
+                </DisabledAwareLink>
               </DropdownMenuItem>
             )}
 

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -144,6 +144,14 @@ export const UserDropdown = React.memo(function UserDropdown({
               {isMentor ? '導師預約管理' : '成為導師'}
             </DropdownMenuItem>
 
+            {isMentor && (
+              <DropdownMenuItem className="px-4 py-3 text-2xl" asChild>
+                <Link href={profilePath} onClick={closeMenu}>
+                  我的導師頁面
+                </Link>
+              </DropdownMenuItem>
+            )}
+
             <DropdownMenuItem
               className="px-4 py-3 text-2xl"
               onClick={handleMyReservation}


### PR DESCRIPTION
Consolidate the "尋找導師" / "關於 X-Talent" / "提供回饋" links into the
avatar dropdown (desktop UserDropdown) and mobile sheet menu
(MobileUserMenu), inserted between "我的預約" and "登出" as specified.
Desktop inline nav and the mobile hamburger menu no longer render these
links when the user is logged in, freeing up header space for the
notification bell in a follow-up change.

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/284
