### PR TITLE
feat(header): adjust mobile and desktop header menu layout (X-Tracker #284)

### DIFF
--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -66,12 +66,14 @@ function HeaderComponent(): JSX.Element {
           </Link>
 
           <nav className="hidden items-center gap-7 lg:flex">
-            <Link
-              href={findMentorHref}
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              尋找導師
-            </Link>
+            {!isLoggedIn && (
+              <Link
+                href={findMentorHref}
+                className="font-['Open_Sans'] text-base text-text-primary"
+              >
+                尋找導師
+              </Link>
+            )}
 
             {!authKnown ? (
               <>
@@ -101,23 +103,27 @@ function HeaderComponent(): JSX.Element {
               </DisabledAwareLink>
             )}
 
-            <Link
-              href="/about"
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              關於 X-Talent
-            </Link>
+            {!isLoggedIn && (
+              <>
+                <Link
+                  href="/about"
+                  className="font-['Open_Sans'] text-base text-text-primary"
+                >
+                  關於 X-Talent
+                </Link>
 
-            <a
-              href={FEEDBACK_FORM_URL}
-              target="_blank"
-              rel="noopener noreferrer"
-              aria-label="提供回饋（另開新分頁）"
-              onClick={() => trackEvent({ name: 'feedback_open' })}
-              className="font-['Open_Sans'] text-base text-text-primary"
-            >
-              提供回饋
-            </a>
+                <a
+                  href={FEEDBACK_FORM_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  aria-label="提供回饋（另開新分頁）"
+                  onClick={() => trackEvent({ name: 'feedback_open' })}
+                  className="font-['Open_Sans'] text-base text-text-primary"
+                >
+                  提供回饋
+                </a>
+              </>
+            )}
           </nav>
         </div>
 
@@ -162,12 +168,14 @@ function HeaderComponent(): JSX.Element {
                 <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
               )
             )}
-            <HamburgerMenu
-              isLoggedIn={isLoggedIn}
-              isMentor={resolvedIsMentor}
-              userId={userId}
-              isResolvingUser={isResolvingUser}
-            />
+            {!isLoggedIn && (
+              <HamburgerMenu
+                isLoggedIn={isLoggedIn}
+                isMentor={resolvedIsMentor}
+                userId={userId}
+                isResolvingUser={isResolvingUser}
+              />
+            )}
           </div>
         </div>
       </div>

--- a/src/components/layout/Header/MobileUserMenu.tsx
+++ b/src/components/layout/Header/MobileUserMenu.tsx
@@ -2,6 +2,7 @@
 
 import { Cross2Icon } from '@radix-ui/react-icons';
 import Image from 'next/image';
+import Link from 'next/link';
 import type { Session } from 'next-auth';
 import * as React from 'react';
 
@@ -16,7 +17,9 @@ import {
   SheetTrigger,
 } from '@/components/ui/sheet';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type MobileUserMenuProps = {
@@ -140,6 +143,33 @@ export function MobileUserMenu({ user }: MobileUserMenuProps): JSX.Element {
               >
                 我的預約
               </button>
+
+              <Link
+                href="/mentor-pool"
+                onClick={closeMenu}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                尋找導師
+              </Link>
+              <Link
+                href="/about"
+                onClick={closeMenu}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                關於 X-Talent
+              </Link>
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => {
+                  trackEvent({ name: 'feedback_open' });
+                  closeMenu();
+                }}
+                className="py-4 text-left text-xl text-text-primary"
+              >
+                提供回饋
+              </a>
             </nav>
 
             <div className="flex flex-col pb-6">

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
 import * as React from 'react';
@@ -15,7 +16,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
@@ -145,6 +148,34 @@ export const UserDropdown = React.memo(function UserDropdown({
               aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <Link href="/mentor-pool">尋找導師</Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <Link href="/about">關於 X-Talent</Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => trackEvent({ name: 'feedback_open' })}
+              >
+                提供回饋
+              </a>
             </DropdownMenuItem>
 
             <DropdownMenuItem


### PR DESCRIPTION
Merge hamburger menu navigation links and user avatar dropdown menu items on both mobile and desktop/tablet devices when logged in.

## What Does This PR Do?
- **Mobile**: Merge "尋找導師", "關於 X-Talent", "提供回饋" into the headshot dropdown menu (`MobileUserMenu`) and hide `HamburgerMenu` when logged in.
- **Desktop**: Hide "尋找導師", "關於 X-Talent", "提供回饋" from the main header and display them in the avatar dropdown menu (`UserDropdown`) between "我的預約" and "登出".
- Avoid duplicates and redundant "我的導師頁面" button when merging mobile menus.

## Screenshot
N/A

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/284
