### PR TITLE
chore(lavish): add profile view/edit page reproductions

### DIFF
--- a/.lavish/profile-edit.html
+++ b/.lavish/profile-edit.html
@@ -1,0 +1,1164 @@
+<title>Profile Edit Page — Reproduction</title>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@300;400;500;700&display=swap" rel="stylesheet" />
+<script src="https://cdn.tailwindcss.com"></script>
+<script>
+  tailwind.config = {
+    theme: {
+      extend: {
+        fontFamily: { sans: ['"Noto Sans TC"', 'sans-serif'] },
+        colors: {
+          text: { primary: '#1E2026', secondary: '#474D57', tertiary: '#76808F', disable: '#AEB4BC', white: '#FFFFFF' },
+          background: { bottom: '#F5F5F5', 'bottom-secondary': '#FAFAFA', white: '#FFFFFF', border: '#E6E8EA' },
+          brand: { 50: '#EAFAFA', 100: '#D5F5F5', 200: '#ABEAEA', 300: '#80E0E0', 400: '#56D5D5', 500: '#2CCBCB', 600: '#23A2A2', 700: '#1A7A7A', 800: '#125151', 900: '#092929' },
+          gray: { 100: '#E9E9E9', 200: '#D2D2D2', 300: '#BCBCBC', 400: '#A5A5A5', 500: '#8F8F8F', 600: '#727272', 700: '#565656', 800: '#393939', 900: '#1D1D1D' },
+          status: {
+            success: { default: '#00BA34', active: '#2EC659' },
+            error: { default: '#EE3911', active: '#F15D3C' },
+            warning: { default: '#EEBE11', active: '#F1CA3C' },
+            info: { default: '#EE7C11', active: '#F1943C' },
+          },
+          blue: { default: '#5DE5FF', active: '#97EEFF' },
+          pink: { default: '#FF6397', active: '#FF9BBD' },
+          light: '#FFFFFF',
+          dark: '#282828',
+          avatar: { background: '#F4FCFC', border: '#B7CBCB', overlay: '#6F6F6F' },
+        },
+      },
+    },
+  };
+</script>
+<style>
+  :root { color-scheme: light; }
+  body { font-family: 'Noto Sans TC', sans-serif; background: #F5F5F5; }
+
+  /* ---------- device frame (container-query based RWD, per reproduce-component skill) ---------- */
+  .device-frame { container-type: inline-size; container-name: frame; position: relative; }
+
+  .rc-avatar-hint { opacity: 0; transition: opacity .2s; }
+  .rc-avatar-box:hover .rc-avatar-hint { opacity: .75; }
+
+  /* Section: flex-col -> lg:flex-row (1024px container) */
+  .rc-section { display: flex; flex-direction: column; }
+  @container frame (min-width: 1024px) { .rc-section { flex-direction: row; } }
+
+  /* EditPageHeader: chevron sm:hidden / cancel button hidden sm:inline-flex (640px) */
+  .rc-back-chevron { display: inline-block; }
+  .rc-cancel-btn { display: none; }
+  @container frame (min-width: 640px) {
+    .rc-back-chevron { display: none; }
+    .rc-cancel-btn { display: inline-flex; }
+  }
+
+  /* repeatable card rows: stacked -> md:flex (768px) */
+  .rc-md-flex { display: block; }
+  .rc-md-flex > * + * { margin-top: 1rem; }
+  @container frame (min-width: 768px) {
+    .rc-md-flex { display: flex; gap: 1.5rem; }
+    .rc-md-flex > * + * { margin-top: 0; }
+    .rc-md-flex.rc-gap-2 { gap: .5rem; }
+    .rc-mb0-md { margin-bottom: 0 !important; }
+  }
+  .rc-basis-half { flex-grow: 1; }
+  @container frame (min-width: 768px) { .rc-basis-half { flex-basis: 50%; } }
+  .rc-tilde-md { display: none; }
+  .rc-zhi-md { display: block; }
+  @container frame (min-width: 768px) { .rc-tilde-md { display: block; } .rc-zhi-md { display: none; } }
+  .rc-label-invisible-md { visibility: hidden; }
+  @container frame (min-width: 768px) { .rc-label-invisible-md { visibility: visible; } }
+
+  /* portal layer: overlays are siblings of the frame's own box, not nested inside
+     the small sticky header — mirrors where Radix actually portals (document.body) */
+  .rc-portal-layer { position: absolute; inset: 0; z-index: 50; pointer-events: none; }
+  .rc-portal-layer.rc-open { pointer-events: auto; }
+
+  .rc-dialog-overlay { position: absolute; inset: 0; background: rgba(40,40,40,.8); opacity: 0; transition: opacity .15s; }
+  .rc-portal-layer.rc-open .rc-dialog-overlay { opacity: 1; }
+  .rc-dialog-content { position: absolute; top: 50%; left: 50%; transform: translate(-50%, -46%) scale(.97); opacity: 0; transition: all .15s; }
+  .rc-portal-layer.rc-open .rc-dialog-content { transform: translate(-50%, -50%) scale(1); opacity: 1; }
+
+  .rc-popover-content { position: absolute; opacity: 0; transform: translateY(-4px) scale(.98); transition: all .12s; pointer-events: none; }
+  .rc-popover-open .rc-popover-content { opacity: 1; transform: translateY(0) scale(1); pointer-events: auto; }
+
+  ::-webkit-scrollbar { width: 8px; height: 8px; }
+  ::-webkit-scrollbar-thumb { background: #E6E8EA; border-radius: 999px; }
+
+  [data-req]:not([data-req="true"]) .req-star { display: none; }
+  [data-role="mentee"] .mentor-only { display: none; }
+
+  [data-saving="true"] .save-idle { display: none; }
+  [data-saving="false"] .save-busy { display: none; }
+  [data-saving="true"] [data-disable-when-saving] { pointer-events: none; opacity: .5; }
+
+  [data-loading="true"] .loaded-view { display: none; }
+  [data-loading="false"] .loading-view { display: none; }
+  [data-error="true"] .loaded-view, [data-error="true"] .loading-view { display: none; }
+  [data-error="false"] .error-view { display: none; }
+
+  [data-errors="false"] .validation-msg { display: none; }
+  [data-errors="false"] .validation-ring { box-shadow: none !important; border-color: #E6E8EA !important; }
+  [data-errors="true"] .validation-ring { border-color: #EE3911 !important; }
+
+  [data-avatar="empty"] .avatar-uploaded-img { display: none; }
+  [data-avatar="uploaded"] .avatar-empty-icon { display: none; }
+  [data-avatar="error"] .avatar-uploaded-img { display: none; }
+  [data-avatar]:not([data-avatar="error"]) .avatar-err-msg { display: none; }
+  [data-avatar="error"] .rc-avatar-box { border-color: #EE3911; }
+
+  .rc-hide-reorder .rc-reorder { display: none; }
+  .rc-hide-delete .rc-item-delete { display: none; }
+
+  select.rc-native { appearance: none; background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%2376808F' stroke-width='2'%3E%3Cpath d='M6 9l6 6 6-6'/%3E%3C/svg%3E"); background-repeat: no-repeat; background-position: right .6rem center; }
+
+  /* ---------- real site Header (Header.tsx / HamburgerMenu.tsx / UserDropdown.tsx / MobileUserMenu.tsx / ShareProfileDialog.tsx) ---------- */
+  :root {
+    --color-text-primary: #1E2026;
+    --color-text-tertiary: #76808F;
+    --color-background-white: #FFFFFF;
+    --color-background-border: #E6E8EA;
+    --color-background-bottom: #F5F5F5;
+    --color-brand-500: #2CCBCB;
+    --color-brand-900: #092929;
+    --color-light: #FFFFFF;
+  }
+  .xt-header { height: 70px; background: var(--color-light); padding: 0 20px; display: flex; align-items: center; border-bottom: 1px solid var(--color-background-border); }
+  .xt-header-inner { width: 100%; height: 100%; display: flex; align-items: center; justify-content: space-between; }
+  .xt-left { display: flex; align-items: center; gap: 40px; min-width: 0; }
+  .xt-logo { display: flex; align-items: center; flex-shrink: 0; }
+  .xt-logo svg { display: block; height: 26px; width: auto; }
+  .xt-nav { display: none; align-items: center; gap: 28px; }
+  .xt-nav a { font-family: 'Open Sans', 'Noto Sans TC', sans-serif; font-size: 16px; color: var(--color-text-primary); text-decoration: none; white-space: nowrap; }
+  .xt-nav a:hover { color: #14807f; }
+  .xt-right { display: flex; align-items: center; gap: 12px; }
+  .xt-right-desktop { display: none; align-items: center; gap: 12px; }
+  .xt-right-mobile { display: flex; align-items: center; gap: 12px; }
+  /* reuses this file's existing container-name "frame" (the same simulated device width the rest of the reproduction reacts to), matching Header.tsx's real lg: (1024px) breakpoint */
+  @container frame (min-width: 1024px) {
+    .xt-nav { display: flex; }
+    .xt-right-desktop { display: flex; }
+    .xt-right-mobile { display: none; }
+  }
+  .btn { appearance: none; border: none; font: inherit; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 500; height: 40px; padding: 0 16px; border-radius: 6px; white-space: nowrap; }
+  .btn-primary { background: var(--color-brand-500); color: var(--color-text-primary); }
+  .btn-outline { background: var(--color-background-white); color: var(--color-text-primary); border: 1px solid var(--color-background-border); }
+  .btn-outline:hover { background: var(--color-background-bottom); }
+  .icon-btn { appearance: none; border: none; background: transparent; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; border-radius: 6px; color: var(--color-text-primary); }
+  .icon-btn:hover { background: var(--color-background-bottom); }
+  .avatar { border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: 700; color: #06403f; background: linear-gradient(135deg, #9bf1ef, #4fdad6); flex-shrink: 0; }
+  .avatar-32 { width: 32px; height: 32px; font-size: 13px; }
+  .avatar-56 { width: 56px; height: 56px; font-size: 20px; }
+  .avatar-64 { width: 64px; height: 64px; font-size: 22px; }
+  .dropdown-trigger { appearance: none; border: none; background: transparent; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; padding: 2px; }
+  .dropdown-trigger .chev { font-size: 19px; line-height: 1; color: var(--color-text-primary); transition: transform .15s ease; }
+  .dropdown-trigger[aria-expanded="true"] .chev { transform: rotate(180deg); }
+  .dropdown-anchor { position: relative; }
+  .dropdown-panel { position: absolute; top: calc(100% + 4px); right: 0; width: 360px; max-width: calc(100vw - 32px); max-height: 440px; overflow-y: auto; background: var(--color-background-white); border: 1px solid var(--color-background-border); border-radius: 16px; box-shadow: 0 12px 32px -8px rgba(16,24,40,.22); z-index: 60; transform-origin: top right; opacity: 0; transform: scale(.96); pointer-events: none; transition: opacity .12s ease, transform .12s ease; }
+  .dropdown-panel.is-open { opacity: 1; transform: scale(1); pointer-events: auto; }
+  .dd-profile { width: 100%; display: flex; align-items: center; gap: 16px; padding: 24px 24px 16px; background: none; border: none; cursor: pointer; text-align: left; font: inherit; }
+  .dd-profile .name { font-size: 22px; font-weight: 600; color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .dd-share { padding: 0 24px 20px; }
+  .dd-share .btn { width: 100%; height: 56px; border-radius: 16px; font-size: 17px; font-weight: 600; }
+  .dd-divider { height: 1px; background: var(--color-background-bottom); }
+  .dd-items { padding: 12px 8px; display: flex; flex-direction: column; }
+  .dd-item { appearance: none; border: none; background: none; text-align: left; font: inherit; font-size: 17px; color: var(--color-text-primary); padding: 12px 16px; border-radius: 6px; cursor: pointer; }
+  .dd-item:hover { background: var(--color-background-bottom); }
+  /* mobile sheets (HamburgerMenu.tsx / MobileUserMenu.tsx) — portalled as siblings of #app's content, not nested inside the 70px header box, so inset:0 resolves against the full page like Radix's real document.body portal target */
+  .rc-sheet-overlay { position: absolute; inset: 0; background: rgba(255,255,255,.8); backdrop-filter: blur(2px); z-index: 70; opacity: 0; pointer-events: none; transition: opacity .2s ease; }
+  .rc-sheet-overlay.is-open { opacity: 1; pointer-events: auto; }
+  .rc-sheet-panel { position: absolute; inset: 0 0 0 auto; width: 100%; max-width: 360px; background: var(--color-background-white); z-index: 71; padding: 24px; display: flex; flex-direction: column; transform: translateX(100%); transition: transform .32s cubic-bezier(.32,.72,0,1); box-shadow: -8px 0 24px -12px rgba(16,24,40,.2); }
+  .rc-sheet-panel.is-open { transform: translateX(0); }
+  .rc-sheet-close { margin-left: auto; appearance: none; border: none; background: none; cursor: pointer; color: var(--color-brand-900); padding: 4px; display: inline-flex; }
+  .rc-sheet-nav-links { flex: 1; min-height: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 32px; font-size: 22px; }
+  .rc-sheet-nav-links a { color: var(--color-text-primary); text-decoration: none; }
+  .rc-sheet-user-profile { display: flex; align-items: center; gap: 16px; padding: 16px 0 24px; text-align: left; background: none; border: none; cursor: pointer; font: inherit; width: 100%; }
+  .rc-sheet-user-profile .name { font-size: 20px; font-weight: 600; color: var(--color-text-primary); }
+  .rc-sheet-user-profile .subtitle { margin-top: 4px; font-size: 13px; color: var(--color-text-tertiary); }
+  .rc-sheet-user-share { margin-bottom: 24px; }
+  .rc-sheet-user-share .btn { width: 100%; height: 48px; border-radius: 16px; font-size: 15px; font-weight: 600; }
+  .rc-sheet-user-nav { display: flex; flex-direction: column; padding: 8px 0; }
+  .rc-sheet-user-nav button, .rc-sheet-user-bottom button { appearance: none; border: none; background: none; text-align: left; font: inherit; padding: 14px 0; font-size: 17px; color: var(--color-text-primary); cursor: pointer; }
+  .rc-sheet-user-bottom { display: flex; flex-direction: column; padding-bottom: 16px; }
+
+  /* ---------- Footer.tsx ---------- */
+  .rc-footer { display: flex; width: 100%; background: #282828; padding-bottom: 50px; }
+  .rc-footer-inner { display: flex; width: 100%; flex-direction: column; align-items: center; padding: 50px 20px 0; }
+  .rc-footer-logo { display: flex; flex-direction: column; align-items: center; }
+  .rc-footer-cols { margin-top: 32px; display: flex; flex-direction: column; gap: 32px; color: #FFFFFF; }
+  .rc-footer-col { display: flex; flex-direction: column; align-items: center; }
+  .rc-footer-col-title { margin-bottom: 20px; font-size: 1.25rem; font-weight: 700; letter-spacing: 0.085em; }
+  .rc-footer-col-links { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  .rc-footer-col-links a { color: #FFFFFF; text-decoration: none; font-weight: 400; }
+  .rc-footer-col-links a:hover { text-decoration: underline; }
+  @container frame (min-width: 768px) {
+    .rc-footer { min-height: 290px; }
+    .rc-footer-inner { flex-direction: row; align-items: flex-start; justify-content: space-between; padding: 50px 70px 0; }
+    .rc-footer-logo, .rc-footer-col, .rc-footer-col-links { align-items: flex-start; }
+    .rc-footer-cols { margin-top: 0; flex-direction: row; gap: 0 64px; }
+  }
+</style>
+
+<div class="min-h-screen">
+
+  <!-- ================= reproduction chrome (not part of the real app) ================= -->
+  <div class="sticky top-0 z-[60] border-b border-background-border bg-white/95 backdrop-blur px-4 py-3 lg:px-8">
+    <div class="mx-auto flex max-w-[1900px] flex-wrap items-center justify-between gap-3">
+      <div>
+        <p class="text-sm font-bold text-text-primary">個人檔案 · 編輯頁重現 (Profile Edit — reproduction)</p>
+        <p class="text-xs text-text-tertiary">src/app/profile/[pageUserId]/edit — 對照 container.tsx 目前狀態,非靜態截圖</p>
+      </div>
+      <div class="flex items-center gap-2 text-xs text-text-tertiary">
+        <span>Frame width</span>
+        <input id="widthSlider" type="range" min="360" max="1440" value="1440" class="w-32 accent-brand-500" />
+        <span id="widthLabel" class="w-14 tabular-nums text-text-secondary">1440px</span>
+        <button id="presetSm" class="rounded-full border border-background-border px-2 py-1 hover:bg-background-bottom">375</button>
+        <button id="presetMd" class="rounded-full border border-background-border px-2 py-1 hover:bg-background-bottom">820</button>
+        <button id="presetLg" class="rounded-full border border-background-border px-2 py-1 hover:bg-background-bottom">1440</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="mx-auto flex max-w-[1900px] flex-col gap-6 p-4 lg:flex-row lg:items-start lg:p-8">
+
+    <!-- ================= control panel ================= -->
+    <aside class="w-full shrink-0 space-y-5 rounded-2xl border border-background-border bg-white p-5 lg:sticky lg:top-20 lg:w-72">
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">頁面狀態</p>
+        <div class="space-y-2">
+          <label class="flex items-center justify-between text-sm">
+            <span>容器載入中 (isContainerLoading)</span>
+            <input type="checkbox" id="ctlLoading" class="size-4 accent-brand-500" />
+          </label>
+          <label class="flex items-center justify-between text-sm">
+            <span>載入失敗 (isError)</span>
+            <input type="checkbox" id="ctlError" class="size-4 accent-brand-500" />
+          </label>
+          <label class="flex items-center justify-between text-sm">
+            <span>儲存中 (isSaving)</span>
+            <input type="checkbox" id="ctlSaving" class="size-4 accent-brand-500" />
+          </label>
+        </div>
+      </div>
+
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">身份 (isMentorRole)</p>
+        <select id="ctlRole" class="rc-native w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">
+          <option value="mentee">一般用戶</option>
+          <option value="mentor">既有導師</option>
+          <option value="onboarding">導師申請中 (onboarding)</option>
+        </select>
+      </div>
+
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">資料</p>
+        <label class="flex items-center justify-between text-sm">
+          <span>已預填欄位 (prefilled)</span>
+          <input type="checkbox" id="ctlPrefilled" class="size-4 accent-brand-500" checked />
+        </label>
+        <label class="mt-2 flex items-center justify-between text-sm">
+          <span>顯示驗證錯誤 (zod errors)</span>
+          <input type="checkbox" id="ctlErrors" class="size-4 accent-brand-500" />
+        </label>
+      </div>
+
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">頭像 (AvatarUpload)</p>
+        <select id="ctlAvatar" class="rc-native w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">
+          <option value="empty">未上傳</option>
+          <option value="uploaded">已上傳</option>
+          <option value="error">驗證錯誤</option>
+        </select>
+      </div>
+
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">工作經驗筆數</p>
+        <div class="flex gap-2" id="ctlJobs">
+          <button data-v="0" class="rc-count-btn rounded-full border px-3 py-1 text-sm">0</button>
+          <button data-v="1" class="rc-count-btn rounded-full border px-3 py-1 text-sm">1</button>
+          <button data-v="2" class="rc-count-btn rounded-full border px-3 py-1 text-sm">2</button>
+        </div>
+      </div>
+
+      <div>
+        <p class="mb-2 text-xs font-bold tracking-wide text-text-tertiary uppercase">教育經歷筆數</p>
+        <div class="flex gap-2" id="ctlEdus">
+          <button data-v="0" class="rc-count-btn rounded-full border px-3 py-1 text-sm">0</button>
+          <button data-v="1" class="rc-count-btn rounded-full border px-3 py-1 text-sm">1</button>
+          <button data-v="2" class="rc-count-btn rounded-full border px-3 py-1 text-sm">2</button>
+        </div>
+      </div>
+
+      <div class="space-y-2 border-t border-background-border pt-4">
+        <button id="openUnsaved" class="w-full rounded-full border border-background-border bg-white px-3 py-2 text-sm hover:bg-background-bottom">開啟「尚未儲存的變更」對話框</button>
+        <button id="scrollDemo" class="w-full rounded-full border border-background-border bg-white px-3 py-2 text-sm hover:bg-background-bottom">模擬送出失敗 → 捲動至錯誤區塊</button>
+      </div>
+
+      <p class="border-t border-background-border pt-3 text-[11px] leading-relaxed text-text-tertiary">
+        設計來源：本專案自有 tokens / components（src/design/tokens、src/components/ui/*、tailwind.config.js）。
+      </p>
+    </aside>
+
+    <!-- ================= reproduced page ================= -->
+    <main class="min-w-0 flex-1">
+      <div class="rounded-2xl border border-background-border bg-background-bottom-secondary p-2 lg:p-4">
+        <div id="frame" class="device-frame mx-auto overflow-hidden rounded-xl bg-white shadow-sm" style="width: 1440px; max-width: 100%;">
+          <div id="app" data-role="mentor" data-loading="false" data-error="false" data-saving="false" data-prefilled="true" data-errors="false" data-avatar="empty" data-jobs="1" data-edus="1" class="relative">
+
+            <!-- real site Header (Header.tsx) — edit page is only ever reached while logged in, so this always renders the logged-in desktop/mobile state; identity (name/avatar/role label) is kept in sync with the role + prefilled controls in the sidebar via updateHeaderIdentity(). Rendered as a normal in-flow 70px bar (not position:sticky) because this reproduction's own dev-toolbar above already occupies the sticky top:0 slot — EditPageHeader's `sticky top-0` below still sticks correctly once you scroll past this bar, matching its behavior before this fix (height unchanged at 70px, so the sticky offset math is unaffected). -->
+            <header class="xt-header">
+              <div class="xt-header-inner">
+                <div class="xt-left">
+                  <a href="#" class="xt-logo" onclick="return false;" aria-label="Go to homepage">
+                    <svg width="151" height="30" viewBox="0 0 151 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                      <g clip-path="url(#clip0_edit_18)">
+                        <path d="M74.6777 23.754C74.3889 23.7619 74.1041 23.6915 73.8603 23.552C73.6165 23.4126 73.4249 23.2105 73.3104 22.972L69.8298 16.5585L66.4985 22.9272C66.3727 23.1849 66.1625 23.402 65.8961 23.5497C65.6296 23.6974 65.3194 23.7687 65.0067 23.754C64.7237 23.7426 64.4491 23.6635 64.2115 23.5248C63.9738 23.386 63.7818 23.1928 63.655 22.9649C63.5283 22.7371 63.4716 22.483 63.4907 22.2289C63.5098 21.9748 63.604 21.7298 63.7637 21.5194L67.7664 14.3686L64.3107 7.66469C64.1759 7.43812 64.1071 7.18454 64.111 6.92764C64.1149 6.67073 64.1912 6.4189 64.3327 6.19569C64.4743 5.97248 64.6766 5.78518 64.9205 5.65128C65.1645 5.51739 65.4422 5.44126 65.7278 5.43006C66.0489 5.40701 66.3692 5.483 66.6358 5.64549C66.9025 5.80797 67.0995 6.04724 67.1945 6.3239L70.0038 12.268L73.0121 6.39094C73.1192 6.10269 73.3271 5.85333 73.6049 5.68013C73.8828 5.50694 74.2156 5.41923 74.5535 5.43006C75.8214 5.43006 76.418 6.54738 75.7716 7.66469L72.1419 14.3686L76.0451 21.5418C76.1667 21.765 76.2265 22.0114 76.2194 22.2599C76.2123 22.5084 76.1384 22.7516 76.0041 22.9688C75.8698 23.1861 75.6791 23.371 75.4481 23.5077C75.2172 23.6444 74.9529 23.729 74.6777 23.754V23.754Z" fill="#003C5A"/>
+                        <path d="M78.4068 16.4022C78.4034 16.2663 78.4307 16.1313 78.4869 16.0052C78.5432 15.8791 78.6274 15.7646 78.7343 15.6685C78.8412 15.5724 78.9685 15.4968 79.1088 15.4463C79.2491 15.3957 79.3994 15.3711 79.5505 15.3742H83.4784C83.6445 15.3522 83.8138 15.3627 83.9749 15.4049C84.1361 15.447 84.2852 15.5198 84.4122 15.6184C84.5392 15.717 84.6412 15.8391 84.711 15.9763C84.7809 16.1134 84.8169 16.2625 84.8169 16.4133C84.8169 16.5642 84.7809 16.7132 84.711 16.8504C84.6412 16.9876 84.5392 17.1096 84.4122 17.2082C84.2852 17.3068 84.1361 17.3796 83.9749 17.4217C83.8138 17.4639 83.6445 17.4744 83.4784 17.4524H79.5007C79.2018 17.4408 78.9198 17.3243 78.7153 17.128C78.5108 16.9316 78.4 16.671 78.4068 16.4022V16.4022Z" fill="#003C5A"/>
+                        <path d="M92.4038 22.3241C92.3546 22.6812 92.162 23.0098 91.8621 23.248C91.5621 23.4863 91.1756 23.6178 90.7753 23.6178C90.375 23.6178 89.9886 23.4863 89.6887 23.248C89.3888 23.0098 89.1961 22.6812 89.147 22.3241V7.93306H85.7908C85.6103 7.9361 85.4309 7.9064 85.2635 7.84571C85.0961 7.78501 84.944 7.69455 84.8163 7.57981C84.6887 7.46507 84.5881 7.32842 84.5206 7.17793C84.453 7.02745 84.4199 6.86628 84.4233 6.70404C84.4198 6.54281 84.4529 6.3826 84.5207 6.23329C84.5885 6.08398 84.6897 5.94869 84.8177 5.83571C84.9457 5.72272 85.098 5.63441 85.2653 5.57622C85.4326 5.51803 85.6115 5.4912 85.7908 5.49732H95.7352C95.9124 5.49428 96.0884 5.5234 96.2528 5.58297C96.4172 5.64254 96.5666 5.73129 96.6919 5.84396C96.8173 5.95662 96.9161 6.0909 96.9824 6.23867C97.0486 6.38645 97.081 6.54474 97.0777 6.70404C97.0845 6.86519 97.0545 7.02589 96.9898 7.1763C96.9251 7.3267 96.8269 7.46358 96.7012 7.57865C96.5755 7.69373 96.425 7.78456 96.2589 7.8455C96.0928 7.90644 95.9146 7.93622 95.7352 7.93306H92.4038V22.3241Z" fill="#003C5A"/>
+                        <path d="M106.276 14.4583V22.4136C106.283 22.5894 106.25 22.7646 106.179 22.9286C106.108 23.0925 106 23.2418 105.863 23.3672C105.726 23.4926 105.562 23.5917 105.38 23.6583C105.199 23.7248 105.005 23.7575 104.809 23.7543C104.611 23.7606 104.414 23.7302 104.23 23.665C104.046 23.5998 103.879 23.5014 103.739 23.3756C103.599 23.2498 103.489 23.0994 103.417 22.934C103.344 22.7685 103.311 22.5914 103.318 22.4136C102.948 22.8971 102.449 23.2894 101.867 23.5549C101.285 23.8203 100.638 23.9504 99.9861 23.9332C97.5 23.9332 96.1576 22.4583 96.1576 19.8885C96.1576 17.3186 97.9475 15.6203 101.403 15.6203H103.168V14.1678C103.222 13.8809 103.202 13.5868 103.111 13.3077C103.02 13.0285 102.859 12.7717 102.641 12.5565C102.423 12.3414 102.154 12.1735 101.853 12.0655C101.553 11.9575 101.229 11.9122 100.906 11.9332C99.9906 12.0269 99.0847 12.1837 98.1962 12.4024C98.0451 12.4085 97.8942 12.3869 97.7527 12.3391C97.6111 12.2912 97.4819 12.2182 97.3727 12.1242C97.2635 12.0302 97.1766 11.9173 97.1173 11.7923C97.058 11.6673 97.0275 11.5327 97.0276 11.3968C97.0235 11.1541 97.1092 10.9171 97.2712 10.723C97.4332 10.5288 97.6623 10.3886 97.9226 10.3242C99.0755 9.96882 100.284 9.78025 101.503 9.76557C102.181 9.72452 102.86 9.82125 103.491 10.0486C104.122 10.276 104.688 10.6283 105.146 11.0791C105.605 11.5299 105.944 12.0678 106.14 12.6528C106.336 13.2378 106.382 13.855 106.276 14.4583ZM103.168 21.1622V17.3857H102C99.9613 17.3857 99.0912 18.0784 99.0912 19.7991C99.0912 21.5197 99.6879 22.0337 101.006 22.0337C101.424 22.0363 101.838 21.9508 102.214 21.7839C102.589 21.6171 102.916 21.3736 103.168 21.0728V21.1622Z" fill="#003C5A"/>
+                        <path d="M111.323 4.00025C111.528 3.99417 111.733 4.02568 111.924 4.09286C112.116 4.16005 112.29 4.26151 112.437 4.39108C112.583 4.52066 112.699 4.67565 112.777 4.84663C112.854 5.01761 112.893 5.20101 112.889 5.38572V22.369C112.889 22.7423 112.724 23.1005 112.43 23.3645C112.137 23.6285 111.738 23.7768 111.323 23.7768C110.907 23.7768 110.509 23.6285 110.215 23.3645C109.922 23.1005 109.757 22.7423 109.757 22.369V5.38572C109.753 5.20101 109.792 5.01761 109.869 4.84663C109.947 4.67565 110.063 4.52066 110.209 4.39108C110.356 4.26151 110.53 4.16005 110.721 4.09286C110.913 4.02568 111.117 3.99417 111.323 4.00025Z" fill="#003C5A"/>
+                        <path d="M126.041 22.2573C126.037 22.4629 125.969 22.6634 125.847 22.8369C125.724 23.0104 125.55 23.1501 125.345 23.2405C124.268 23.7815 123.047 24.0444 121.814 24.0003C118.085 24.0003 115.848 21.3857 115.848 16.8718C115.848 12.3578 118.011 9.81031 121.342 9.81031C124.673 9.81031 126.19 12.0449 126.19 16.0226C126.19 17.0058 125.668 17.5421 124.624 17.5421H118.93C118.93 20.4025 120.149 21.8997 122.212 21.8997C123.182 21.7847 124.133 21.5671 125.046 21.2516C125.188 21.2506 125.328 21.2769 125.458 21.3286C125.588 21.3804 125.703 21.4564 125.797 21.5516C125.892 21.6469 125.962 21.7591 126.004 21.8808C126.046 22.0025 126.058 22.1308 126.041 22.2573V22.2573ZM118.93 15.8662H123.555C123.555 13.0282 122.834 11.8885 121.441 11.8885C120.049 11.8885 118.98 13.2293 118.93 15.8662Z" fill="#003C5A"/>
+                        <path d="M139.739 14.1007V22.3688C139.743 22.5516 139.705 22.7331 139.629 22.9026C139.553 23.072 139.439 23.226 139.295 23.3553C139.151 23.4845 138.98 23.5864 138.792 23.655C138.603 23.7235 138.401 23.7573 138.198 23.7543C137.99 23.7602 137.783 23.729 137.589 23.6623C137.395 23.5956 137.217 23.4948 137.067 23.3659C136.917 23.2369 136.796 23.0823 136.713 22.9112C136.63 22.74 136.585 22.5556 136.582 22.3688V14.4582C136.582 12.827 135.911 11.9554 134.593 11.9554C134.109 11.9721 133.635 12.085 133.205 12.2859C132.775 12.4868 132.4 12.7708 132.107 13.1174V22.3688C132.107 22.7422 131.942 23.1003 131.648 23.3643C131.354 23.6283 130.956 23.7766 130.541 23.7766C130.125 23.7766 129.727 23.6283 129.433 23.3643C129.139 23.1003 128.975 22.7422 128.975 22.3688V11.1956C128.975 10.84 129.132 10.499 129.411 10.2476C129.691 9.99612 130.071 9.85482 130.466 9.85482C130.862 9.85482 131.241 9.99612 131.521 10.2476C131.801 10.499 131.958 10.84 131.958 11.1956V11.5532C132.442 11.0063 133.054 10.5609 133.749 10.2483C134.445 9.93568 135.208 9.76329 135.985 9.74312C138.272 9.81016 139.739 11.4191 139.739 14.1007Z" fill="#003C5A"/>
+                        <path d="M150.28 22.3686C150.274 22.6053 150.196 22.836 150.056 23.0365C149.916 23.237 149.719 23.4 149.485 23.5083C148.79 23.8227 148.025 23.9909 147.247 23.9999C146.756 24.0203 146.265 23.9434 145.811 23.7745C145.356 23.6057 144.948 23.3491 144.616 23.0229C144.284 22.6967 144.036 22.3089 143.889 21.8869C143.742 21.4649 143.7 21.0191 143.767 20.5809V12.0222H142.722C142.583 12.0194 142.446 11.9915 142.319 11.9403C142.192 11.889 142.077 11.8154 141.982 11.7238C141.887 11.6322 141.814 11.5244 141.766 11.4068C141.718 11.2892 141.697 11.1641 141.703 11.039C141.693 10.9132 141.712 10.7868 141.758 10.6678C141.805 10.5488 141.878 10.4397 141.974 10.3474C142.07 10.2551 142.186 10.1815 142.314 10.1314C142.443 10.0812 142.582 10.0555 142.722 10.0558H143.767V7.55295C143.767 7.17957 143.932 6.82151 144.225 6.55749C144.519 6.29348 144.917 6.14518 145.333 6.14518C145.748 6.14518 146.147 6.29348 146.44 6.55749C146.734 6.82151 146.899 7.17957 146.899 7.55295V10.1675H149.236C149.526 10.1675 149.804 10.2711 150.01 10.4555C150.215 10.6399 150.33 10.89 150.33 11.1507C150.33 11.4115 150.215 11.6616 150.01 11.846C149.804 12.0304 149.526 12.134 149.236 12.134H146.899V20.6926C146.899 21.5641 147.198 21.8993 147.894 21.8993C148.59 21.8993 148.888 21.5642 149.336 21.5642C149.578 21.5639 149.811 21.6471 149.987 21.7968C150.162 21.9466 150.267 22.1512 150.28 22.3686Z" fill="#003C5A"/>
+                      </g>
+                      <path d="M41.8876 16.4878C44.5017 16.4878 46.6209 14.4925 46.6209 12.0313C46.6209 9.56997 44.5017 7.57471 41.8876 7.57471C39.2735 7.57471 37.1543 9.56997 37.1543 12.0313C37.1543 14.4925 39.2735 16.4878 41.8876 16.4878Z" fill="#003C5A"/>
+                      <path d="M41.9651 0C38.4686 0 35.2971 1.32445 32.9895 3.46929L32.7532 3.69177C31.7379 4.65122 31.7379 6.2051 32.7569 7.16454C33.7759 8.12399 35.43 8.12399 36.449 7.16107L36.6669 6.9525C38.1954 5.53766 40.2556 4.80765 42.4118 4.92584C46.2 5.13094 49.2792 8.02318 49.5081 11.5898C49.7739 15.7161 46.2849 19.1506 41.9614 19.1506C39.9676 19.1506 38.0883 18.4241 36.6632 17.1101L22.035 3.46929C19.7274 1.32445 16.5595 0 13.0594 0C5.81911 0 -0.0181448 5.66976 0.291994 12.5527C0.565212 18.6709 5.77481 23.6698 12.2656 24.0417C12.8563 24.0765 13.4397 24.0695 14.0083 24.0313C15.5626 23.9235 16.7035 22.6165 16.4414 21.1703C16.2125 19.9119 15.0125 19.0255 13.6944 19.1298C13.484 19.1472 13.2735 19.1541 13.0594 19.1541C8.7359 19.1541 5.24683 15.7161 5.51267 11.5933C5.74158 8.02666 8.82082 5.13789 12.6089 4.92932C14.7688 4.81113 16.8254 5.54114 18.3539 6.95597L32.9895 20.6002C35.3968 22.8389 38.7418 24.1808 42.4229 24.0626C49.1832 23.8401 54.6439 18.591 54.7435 12.2225C54.8506 5.48552 49.0872 0 41.9651 0Z" fill="#003C5A"/>
+                      <path d="M27.514 21.0904C26.8826 21.0904 26.2845 21.2085 25.7344 21.4171L17.512 13.6755C17.7262 13.168 17.8443 12.6118 17.8443 12.0313C17.8443 9.57007 15.725 7.57471 13.111 7.57471C10.497 7.57471 8.37769 9.57007 8.37769 12.0313C8.37769 14.4924 10.497 16.4878 13.111 16.4878C13.7276 16.4878 14.3146 16.3766 14.8537 16.1749L23.0982 23.9374C22.8915 24.4345 22.7807 24.9768 22.7807 25.5434C22.7807 28.0046 24.9 30 27.514 30C30.128 30 32.2473 28.0046 32.2473 25.5434C32.2473 23.0857 30.128 21.0904 27.514 21.0904ZM28.9576 25.5469C28.9576 25.5504 28.9576 25.5504 28.9576 25.5539C28.9539 26.3012 28.3078 26.9061 27.514 26.9061C27.5103 26.9061 27.5103 26.9061 27.5066 26.9061C26.7128 26.9026 26.0704 26.2943 26.0704 25.5469C26.0704 25.4635 26.0815 25.3835 26.0962 25.307C26.0999 25.2862 26.1036 25.2653 26.111 25.2445C26.1295 25.1715 26.1516 25.0985 26.1811 25.0324C26.1885 25.015 26.1996 24.9977 26.207 24.9803C26.2218 24.949 26.2365 24.9177 26.255 24.8864C26.2587 24.8829 26.2624 24.8795 26.2661 24.8795C26.3879 24.6778 26.5651 24.5075 26.7756 24.3893C26.7756 24.3858 26.7793 24.3858 26.783 24.3824C26.8236 24.3615 26.8642 24.3406 26.9048 24.3233C26.9343 24.3094 26.9676 24.2989 26.9971 24.285C27.0562 24.2642 27.1189 24.2468 27.1817 24.2294C27.2076 24.2224 27.2297 24.219 27.2556 24.2155C27.3368 24.2016 27.4217 24.1912 27.5103 24.1912C28.3115 24.1877 28.9576 24.796 28.9576 25.5469Z" fill="#003C5A"/>
+                      <defs><clipPath id="clip0_edit_18"><rect width="86.7403" height="20" fill="white" transform="translate(63.5399 4)"/></clipPath></defs>
+                    </svg>
+                  </a>
+                  <nav class="xt-nav">
+                    <a href="#" onclick="return false;">尋找導師</a>
+                    <a href="#" class="role-label" onclick="return false;">我的導師頁面</a>
+                    <a href="#" onclick="return false;">關於 X-Talent</a>
+                    <a href="#" onclick="return false;">提供回饋</a>
+                  </nav>
+                </div>
+                <div class="xt-right">
+                  <div class="xt-right-desktop">
+                    <div class="dropdown-anchor" id="hdrDropdownAnchor">
+                      <button type="button" class="dropdown-trigger" id="hdrDropdownTrigger" aria-label="開啟用戶選單" aria-expanded="false">
+                        <span class="avatar avatar-32" id="hdrAvatar32">陳</span>
+                        <span class="chev" aria-hidden="true">▾</span>
+                      </button>
+                      <div class="dropdown-panel" id="hdrDropdownPanel" role="menu">
+                        <button type="button" class="dd-profile">
+                          <span class="avatar avatar-56" id="hdrAvatar56">陳</span>
+                          <span class="name" id="hdrName">陳雅婷</span>
+                        </button>
+                        <div class="dd-share"><button type="button" class="btn btn-outline" id="hdrShareBtn">分享個人頁面</button></div>
+                        <div class="dd-divider"></div>
+                        <div class="dd-items">
+                          <button type="button" class="dd-item role-label" role="menuitem">我的導師頁面</button>
+                          <button type="button" class="dd-item" role="menuitem">我的預約</button>
+                          <button type="button" class="dd-item" role="menuitem">登出</button>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="xt-right-mobile">
+                    <button type="button" class="icon-btn" id="hdrMobileAvatarTrigger" aria-label="開啟用戶選單">
+                      <span class="avatar avatar-32" id="hdrMobileAvatar32">陳</span>
+                    </button>
+                    <button type="button" class="icon-btn" id="hdrHamburgerTrigger" aria-label="開啟導航選單">
+                      <svg width="22" height="22" viewBox="0 0 22 22" fill="none"><path d="M3 6H19M3 11H19M3 16H19" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </header>
+
+            <div class="loading-view flex h-[50vh] w-full items-center justify-center">
+              <span role="status" class="inline-flex">
+                <svg class="size-8 animate-spin text-text-tertiary" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity=".25"/><path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/></svg>
+              </span>
+            </div>
+
+            <div class="error-view flex min-h-[400px] flex-col items-center justify-center gap-4">
+              <p class="text-lg font-medium text-status-error-default">載入失敗，請稍後再試。</p>
+              <button class="rounded-md border border-background-border bg-white px-4 py-2 text-sm hover:bg-background-bottom">重新整理</button>
+            </div>
+
+            <div class="loaded-view mx-auto w-11/12 max-w-[1064px] pb-20">
+
+              <!-- EditPageHeader -->
+              <div class="sticky top-0 z-40 mb-6 flex justify-between border-b border-background-border bg-white/95 py-4 backdrop-blur">
+                <div class="flex items-center gap-3">
+                  <svg class="rc-back-chevron size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg>
+                  <p class="text-4xl font-bold whitespace-nowrap header-title">編輯個人頁面</p>
+                </div>
+                <div class="flex items-center gap-4">
+                  <button class="rc-cancel-btn grow rounded-full border border-background-border bg-white px-6 py-3 text-sm hover:bg-background-bottom" data-disable-when-saving>取消</button>
+                  <button class="min-w-[88px] rounded-full bg-brand-500 px-4 py-3 text-sm font-medium whitespace-nowrap hover:bg-brand-500/90" data-disable-when-saving id="submitBtn">
+                    <span class="save-idle">儲存</span>
+                    <span class="save-busy inline-flex items-center"><svg class="mr-2 size-4 animate-spin" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="10" stroke="currentColor" stroke-width="3" opacity=".25"/><path d="M12 2a10 10 0 0 1 10 10" stroke="currentColor" stroke-width="3" stroke-linecap="round"/></svg>儲存中...</span>
+                  </button>
+                </div>
+              </div>
+
+              <form class="space-y-10">
+
+                <!-- Avatar Section -->
+                <div class="rc-section border-t-2 border-background-border pt-10 first:border-t-0 first:pt-0">
+                  <div class="max-w-80 grow">
+                    <p class="mb-4 text-xl font-bold"><span class="req-star text-status-error-default" data-req="__avatarReq">* </span>個人頭像</p>
+                  </div>
+                  <div class="grow">
+                    <div class="mb-10 flex flex-col items-center lg:items-start">
+                      <div class="rc-avatar-box group relative flex size-36 cursor-pointer items-center justify-center overflow-hidden rounded-full border-2 border-avatar-border bg-avatar-background lg:h-[150px] lg:w-[150px]">
+                        <div class="rc-avatar-hint absolute inset-0 flex items-center justify-center bg-avatar-overlay">
+                          <svg class="size-12 text-avatar-border" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><path d="M4 8a2 2 0 0 1 2-2h1l1-2h8l1 2h1a2 2 0 0 1 2 2v9a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2z"/><circle cx="12" cy="13" r="3.5"/></svg>
+                        </div>
+                        <svg class="avatar-empty-icon size-12 text-avatar-border" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5"><rect x="3" y="3" width="18" height="18" rx="2"/><circle cx="9" cy="9" r="2"/><path d="M21 15l-5-5L5 21"/></svg>
+                        <img class="avatar-uploaded-img size-full rounded-full object-cover" src="https://images.unsplash.com/photo-1633332755192-727a05c4013d?w=300&h=300&fit=crop&crop=faces" alt="Avatar Preview" />
+                      </div>
+                      <p class="avatar-err-msg mt-2 text-center text-sm font-medium text-status-error-default lg:text-left">請上傳大頭貼</p>
+                    </div>
+                  </div>
+                </div>
+
+                <!-- Name -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>姓名</p></div>
+                  <div class="grow">
+                    <input class="validation-ring flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm placeholder:text-text-tertiary focus-visible:ring focus-visible:ring-brand-500 focus-visible:outline-none field-name" placeholder="請填入您的姓名" />
+                    <p class="validation-msg mt-2 text-sm font-medium text-status-error-default">請輸入姓名</p>
+                  </div>
+                </div>
+
+                <!-- About -->
+                <div class="rc-section border-t-2 border-background-border pt-10" id="sec-about">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="req-star text-status-error-default" data-req="__mentorReq">* </span>關於我</p></div>
+                  <div class="grow">
+                    <textarea rows="10" class="validation-ring block w-full rounded-md border border-background-border bg-transparent px-3 py-2 text-sm placeholder:text-text-tertiary focus-visible:ring focus-visible:ring-brand-500 focus-visible:outline-none field-about"></textarea>
+                    <p class="validation-msg mt-2 text-sm font-medium text-status-error-default">請填寫「關於我」</p>
+                  </div>
+                </div>
+
+                <!-- have_topic (mentor only) -->
+                <div class="rc-section mentor-only border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>我能提供的服務</p></div>
+                  <div class="grow" data-category-select data-search-placeholder="搜尋服務"></div>
+                </div>
+
+                <!-- have_skill (mentor only) -->
+                <div class="rc-section mentor-only border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>專業能力</p></div>
+                  <div class="grow" data-category-select data-search-placeholder="搜尋專業能力"></div>
+                </div>
+
+                <!-- Location -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>地區</p></div>
+                  <div class="grow">
+                    <select class="rc-native flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">
+                      <option>請選擇地區</option><option>台灣</option><option>日本</option><option>美國</option><option>新加坡</option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- Years of experience -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>經驗</p></div>
+                  <div class="grow">
+                    <select class="rc-native flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">
+                      <option>請填入您的經驗</option><option>1-3 年</option><option>3-5 年</option><option>5-10 年</option><option>10 年以上</option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- Industry -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="req-star text-status-error-default" data-req="__mentorReq">* </span>產業</p></div>
+                  <div class="grow">
+                    <select class="rc-native flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">
+                      <option>請選擇產業</option><option>軟體工程</option><option>產品管理</option><option>設計</option><option>行銷</option>
+                    </select>
+                  </div>
+                </div>
+
+                <!-- want_position -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>有興趣多了解的職位</p></div>
+                  <div class="grow" data-category-select data-search-placeholder="搜尋職位"></div>
+                </div>
+
+                <!-- want_skill -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>想多了解、加強的技能</p></div>
+                  <div class="grow" data-category-select data-search-placeholder="搜尋技能"></div>
+                </div>
+
+                <!-- want_topic -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="text-status-error-default">* </span>想多了解的主題</p></div>
+                  <div class="grow" data-category-select data-search-placeholder="搜尋主題"></div>
+                </div>
+
+                <!-- Work experiences -->
+                <div id="work_experiences" class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="req-star text-status-error-default" data-req="__mentorReq">* </span>工作經驗</p></div>
+                  <div class="grow">
+                    <div id="jobList"></div>
+                    <button type="button" id="addJob" class="rounded-full px-4 py-3 text-sm font-medium text-brand-500 hover:bg-background-bottom">
+                      <svg class="mr-2 inline size-5 -mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>新增
+                    </button>
+                    <p class="validation-msg mt-2 text-sm font-medium text-status-error-default">請至少填寫一筆完整的工作經驗</p>
+                  </div>
+                </div>
+
+                <!-- Educations -->
+                <div id="educations" class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold"><span class="req-star text-status-error-default" data-req="__mentorReq">* </span>教育經歷</p></div>
+                  <div class="grow">
+                    <div id="eduList"></div>
+                    <button type="button" id="addEdu" class="rounded-full px-4 py-3 text-sm font-medium text-brand-500 hover:bg-background-bottom">
+                      <svg class="mr-2 inline size-5 -mt-0.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>新增
+                    </button>
+                    <p class="validation-msg mt-2 text-sm font-medium text-status-error-default">請至少填寫一筆完整的教育經歷</p>
+                  </div>
+                </div>
+
+                <!-- Links -->
+                <div class="rc-section border-t-2 border-background-border pt-10">
+                  <div class="max-w-80 grow"><p class="mb-4 text-xl font-bold">個人連結</p></div>
+                  <div class="grow" id="linksList"></div>
+                </div>
+
+              </form>
+
+              <!-- Footer.tsx -->
+              <footer class="rc-footer">
+                <div class="rc-footer-inner">
+                  <div class="rc-footer-logo">
+                    <div style="width:146px;height:39px;display:flex;align-items:center;font-weight:700;color:#fff;font-size:15px;letter-spacing:.02em;">XChange</div>
+                  </div>
+                  <div class="rc-footer-cols">
+                    <div class="rc-footer-col">
+                      <p class="rc-footer-col-title">關於</p>
+                      <div class="rc-footer-col-links">
+                        <a href="#" onclick="return false;">隱私權政策</a>
+                        <a href="#" onclick="return false;">服務條款</a>
+                      </div>
+                    </div>
+                    <div class="rc-footer-col">
+                      <p class="rc-footer-col-title">相關連結</p>
+                      <div class="rc-footer-col-links">
+                        <a href="#" onclick="return false;">XChange Website</a>
+                        <a href="#" onclick="return false;">X-IMPACT Podcast</a>
+                        <a href="#" onclick="return false;">XChange Medium</a>
+                      </div>
+                    </div>
+                    <div class="rc-footer-col">
+                      <p class="rc-footer-col-title">XChange 社群連結</p>
+                      <div class="rc-footer-col-links">
+                        <a href="#" onclick="return false;">Facebook 粉絲專頁</a>
+                        <a href="#" onclick="return false;">Instagram 商業檔案</a>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </footer>
+            </div>
+          </div>
+
+          <!-- mobile nav sheet (HamburgerMenu.tsx) -->
+          <div class="rc-sheet-overlay" id="hdrNavSheetOverlay"></div>
+          <div class="rc-sheet-panel" id="hdrNavSheetPanel" role="dialog" aria-label="導航選單">
+            <button type="button" class="rc-sheet-close" id="hdrNavSheetClose" aria-label="關閉導航選單">
+              <svg width="26" height="26" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <div class="rc-sheet-nav-links">
+              <a href="#" onclick="return false;">尋找導師</a>
+              <a href="#" class="role-label" onclick="return false;">我的導師頁面</a>
+              <a href="#" onclick="return false;">關於 X-Talent</a>
+              <a href="#" onclick="return false;">提供回饋</a>
+            </div>
+          </div>
+
+          <!-- mobile user sheet (MobileUserMenu.tsx) -->
+          <div class="rc-sheet-overlay" id="hdrUserSheetOverlay"></div>
+          <div class="rc-sheet-panel" id="hdrUserSheetPanel" role="dialog" aria-label="用戶選單">
+            <button type="button" class="rc-sheet-close" id="hdrUserSheetClose" aria-label="關閉用戶選單">
+              <svg width="26" height="26" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <button type="button" class="rc-sheet-user-profile">
+              <span class="avatar avatar-56" id="hdrSheetAvatar56">陳</span>
+              <span>
+                <span class="name" id="hdrSheetName" style="display:block">陳雅婷</span>
+                <span class="subtitle" id="hdrSheetSubtitle">資深後端工程師 at XYZ 新創</span>
+              </span>
+            </button>
+            <div class="rc-sheet-user-share"><button type="button" class="btn btn-outline" id="hdrSheetShareBtn">分享個人頁面</button></div>
+            <div class="dd-divider"></div>
+            <nav class="rc-sheet-user-nav">
+              <button type="button" class="role-label">我的導師頁面</button>
+              <button type="button">我的預約</button>
+            </nav>
+            <div class="rc-sheet-user-bottom"><button type="button">登出</button></div>
+          </div>
+
+          <!-- share profile dialog (ShareProfileDialog.tsx) — reuses this file's existing rc-portal-layer Dialog pattern -->
+          <div id="hdrSharePortal" class="rc-portal-layer">
+            <div class="rc-dialog-overlay"></div>
+            <div class="rc-dialog-content w-[calc(100%-32px)] max-w-[440px] rounded-[24px] border border-background-border bg-white shadow-lg">
+              <div class="p-6 pb-8">
+                <div class="relative mb-6 flex items-center justify-center">
+                  <div class="text-[28px] leading-none font-semibold text-text-primary">分享個人頁面</div>
+                  <button type="button" id="hdrShareClose" class="absolute right-0 top-1/2 -translate-y-1/2 text-2xl leading-none text-text-primary" aria-label="關閉">×</button>
+                </div>
+                <div class="mb-5 flex items-center gap-4 rounded-[20px] border border-background-border p-[18px_20px] shadow-sm">
+                  <span class="avatar avatar-64" id="hdrShareAvatar">陳</span>
+                  <div class="min-w-0">
+                    <div class="text-lg font-semibold text-text-primary" id="hdrShareName">陳雅婷</div>
+                    <div class="mt-1 text-sm font-medium text-text-primary" id="hdrShareSubtitle">資深後端工程師 at XYZ 新創</div>
+                  </div>
+                </div>
+                <div>
+                  <label class="mb-2 block text-sm font-medium text-text-primary">個人頁面連結</label>
+                  <div class="flex items-center gap-[10px] rounded-[14px] border border-background-border p-[10px_14px]">
+                    <input type="text" id="hdrShareLinkInput" readonly value="" class="min-w-0 flex-1 border-none bg-transparent text-sm text-text-primary outline-none" />
+                    <button type="button" id="hdrShareCopyBtn" class="btn btn-outline h-[38px] shrink-0 rounded-[10px] px-[14px] text-sm">複製</button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- portal layer: unsaved-changes dialog + delete confirm dialog + school popover, sibling of the frame's content (mirrors document.body portal target) -->
+          <div id="unsavedPortal" class="rc-portal-layer">
+            <div class="rc-dialog-overlay"></div>
+            <div class="rc-dialog-content w-[90vw] max-w-md rounded-lg border bg-white p-6 shadow-lg">
+              <p class="text-lg leading-none font-semibold tracking-tight">尚未儲存的變更</p>
+              <p class="mt-1.5 text-sm text-text-tertiary">你的更動會直接遺失，確定要離開嗎？</p>
+              <div class="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end sm:space-x-2">
+                <button id="unsavedCancel" class="rounded-md border border-background-border bg-white px-4 py-2 text-sm hover:bg-background-bottom">繼續編輯</button>
+                <button id="unsavedLeave" class="rounded-md bg-status-error-default px-4 py-2 text-sm text-white hover:bg-status-error-default/90">離開頁面</button>
+              </div>
+            </div>
+          </div>
+
+          <div id="deletePortal" class="rc-portal-layer">
+            <div class="rc-dialog-overlay"></div>
+            <div class="rc-dialog-content w-[90vw] max-w-md gap-0 rounded-2xl border-none bg-white p-6 shadow-lg">
+              <p class="text-center text-xl font-bold text-text-primary" id="deleteTitle">要刪除這段工作經驗嗎？</p>
+              <p class="mt-2 text-center text-text-secondary" id="deleteDesc">您確定要移除這個區塊嗎？</p>
+              <div class="mt-6 flex justify-center gap-4">
+                <button id="deleteCancel" class="rounded-md border border-background-border bg-white px-4 py-2 text-sm hover:bg-background-bottom">取消</button>
+                <button id="deleteConfirm" class="rounded-md bg-status-error-default px-4 py-2 text-sm text-white hover:bg-status-error-default/90">確認</button>
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+
+      <p class="mt-3 text-xs text-text-tertiary">
+        以容器查詢（container queries）模擬 sm(640) / md(768) / lg(1024) 中斷點，並非真實 viewport media query，因為此重現被嵌入在更大的頁面中。
+      </p>
+    </main>
+  </div>
+</div>
+
+<script>
+  const app = document.getElementById('app');
+  const frame = document.getElementById('frame');
+
+  // ---------- category multi-select (CategoryMultiSelect faithful mini-repro) ----------
+  const DEMO_CATEGORIES = [
+    { key: 'g1', label: '產品與策略', options: [ { value: 'pm', label: '產品管理' }, { value: 'strategy', label: '商業策略' }, { value: 'growth', label: '成長駭客' } ] },
+    { key: 'g2', label: '工程', options: [ { value: 'fe', label: '前端開發' }, { value: 'be', label: '後端開發' }, { value: 'data', label: '資料工程' }, { value: 'infra', label: '基礎架構' } ] },
+    { key: 'g3', label: '設計', options: [ { value: 'ux', label: 'UX 設計' }, { value: 'ui', label: 'UI 視覺設計' } ] },
+  ];
+
+  function buildCategorySelect(container, opts) {
+    const state = { query: '', open: {}, selected: new Set(opts.prefilled ? [DEMO_CATEGORIES[0].options[0].value, DEMO_CATEGORIES[1].options[1].value] : []) };
+    const maxSelected = 10;
+
+    function render() {
+      const q = state.query.trim().toLowerCase();
+      const filtered = q
+        ? DEMO_CATEGORIES.map((c) => ({ ...c, options: c.options.filter((o) => o.label.toLowerCase().includes(q) || c.label.toLowerCase().includes(q)) })).filter((c) => c.options.length > 0)
+        : DEMO_CATEGORIES;
+      const limitReached = state.selected.size >= maxSelected;
+
+      const groupsHtml = filtered.map((cat, idx) => {
+        const open = q ? true : !!state.open[cat.key];
+        const selectedCount = cat.options.reduce((a, o) => a + (state.selected.has(o.value) ? 1 : 0), 0);
+        const itemsHtml = cat.options.map((o) => {
+          const checked = state.selected.has(o.value);
+          const disabled = !checked && limitReached;
+          return `<li><label class="flex cursor-pointer items-center gap-3 px-4 py-2 pl-11 ${disabled ? 'cursor-not-allowed opacity-50' : 'hover:bg-background-bottom'}">
+            <span class="peer relative inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-brand-500 ${checked ? 'bg-brand-500' : ''}" data-toggle="${o.value}">
+              ${checked ? '<svg class="size-3.5 text-text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>' : ''}
+            </span>
+            <span class="text-base text-text-primary">${o.label}</span>
+          </label></li>`;
+        }).join('');
+        return `<div class="${idx !== 0 ? 'border-t border-background-border' : ''}">
+          <button type="button" data-toggle-cat="${cat.key}" class="flex w-full items-center justify-between px-4 py-3 text-left ${q ? '' : 'hover:bg-background-bottom'}" ${q ? 'disabled' : ''}>
+            <span class="flex items-center gap-2">
+              <svg class="size-4 text-text-secondary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">${open ? '<path d="M6 9l6 6 6-6"/>' : '<path d="M9 6l6 6-6 6"/>'}</svg>
+              <span class="text-base font-semibold text-text-primary">${cat.label}</span>
+            </span>
+            <span class="rounded-full px-2.5 py-0.5 text-sm tabular-nums ${selectedCount > 0 ? 'bg-brand-100 text-brand-700' : 'text-text-tertiary'}">${selectedCount} / ${cat.options.length}</span>
+          </button>
+          ${open ? `<ul class="pb-2">${itemsHtml}</ul>` : ''}
+        </div>`;
+      }).join('') || `<div class="px-4 py-6 text-center text-sm text-text-tertiary">沒有符合的選項</div>`;
+
+      const helper = state.selected.size >= maxSelected
+        ? `已選 ${state.selected.size} / ${maxSelected} — 取消其他項目以繼續選擇`
+        : `已選 ${state.selected.size} / ${maxSelected}`;
+
+      container.innerHTML = `
+        <div class="flex flex-col rounded-xl border border-background-border bg-white">
+          <div class="border-b border-background-border p-3">
+            <div class="relative">
+              <svg class="absolute top-1/2 left-3 size-4 -translate-y-1/2 text-text-tertiary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg>
+              <input data-query class="flex h-10 w-full rounded-md border-0 bg-white pl-9 py-2 text-sm placeholder:text-text-tertiary shadow-none focus-visible:ring-0 focus-visible:outline-none" placeholder="${opts.searchPlaceholder}" value="${state.query}" />
+            </div>
+          </div>
+          <div class="max-h-80 overflow-y-auto">${groupsHtml}</div>
+          <div class="border-t border-background-border px-4 py-2 text-sm tabular-nums ${state.selected.size >= maxSelected ? 'text-status-error-default' : 'text-text-tertiary'}">${helper}</div>
+        </div>
+        <p class="validation-msg mt-2 text-sm font-medium text-status-error-default">請至少選擇一項</p>
+      `;
+
+      container.querySelectorAll('[data-toggle-cat]').forEach((btn) => btn.addEventListener('click', () => {
+        const key = btn.getAttribute('data-toggle-cat');
+        state.open[key] = !state.open[key];
+        render();
+      }));
+      container.querySelectorAll('[data-toggle]').forEach((el) => el.addEventListener('click', () => {
+        const v = el.getAttribute('data-toggle');
+        if (state.selected.has(v)) state.selected.delete(v);
+        else if (state.selected.size < maxSelected) state.selected.add(v);
+        render();
+      }));
+      const queryInput = container.querySelector('[data-query]');
+      queryInput.addEventListener('input', (e) => { state.query = e.target.value; render(); queryInput.focus(); });
+    }
+    render();
+  }
+
+  document.querySelectorAll('[data-category-select]').forEach((el) => {
+    buildCategorySelect(el, { searchPlaceholder: el.getAttribute('data-search-placeholder'), prefilled: app.dataset.prefilled === 'true' });
+  });
+
+  // ---------- repeatable job / education cards ----------
+  const YEARS = Array.from({ length: 30 }, (_, i) => String(new Date().getFullYear() - i));
+
+  function yearOptions(selected) {
+    return `<option value="">請選擇年份</option>` + YEARS.map((y) => `<option value="${y}" ${y === selected ? 'selected' : ''}>${y}</option>`).join('');
+  }
+
+  function jobCardHtml(index, count, prefilled) {
+    const data = prefilled
+      ? [
+          { job: '資深產品經理', company: 'XChange 股份有限公司', start: '2022', end: '', industry: '軟體工程', loc: '台灣', desc: '負責導師媒合平台的產品策略與 0→1 開發。', primary: true },
+          { job: '產品經理', company: 'ACME Inc.', start: '2019', end: '2022', industry: '產品管理', loc: '台灣', desc: '', primary: false },
+        ][index] || { job: '', company: '', start: '', end: '', industry: '', loc: '', desc: '', primary: false }
+      : { job: '', company: '', start: '', end: '', industry: '', loc: '', desc: '', primary: index === 0 };
+
+    return `<div class="job-card mb-4 rounded-lg border border-background-border p-4" data-idx="${index}">
+      <div class="rc-reorder mb-4 flex justify-end gap-1 ${count > 1 ? '' : 'hidden'}">
+        <button type="button" class="rc-move-up flex size-10 items-center justify-center rounded-md hover:bg-background-bottom disabled:pointer-events-none disabled:opacity-50" ${index === 0 ? 'disabled' : ''}><svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 15l6-6 6 6"/></svg></button>
+        <button type="button" class="rc-move-down flex size-10 items-center justify-center rounded-md hover:bg-background-bottom disabled:pointer-events-none disabled:opacity-50" ${index === count - 1 ? 'disabled' : ''}><svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></button>
+      </div>
+
+      <div class="rc-md-flex mb-6">
+        <div class="mb-4 flex-1 rc-mb0-md">
+          <label class="text-sm font-medium">職稱</label>
+          <input class="validation-ring mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm" value="${data.job}" />
+        </div>
+        <div class="flex-1">
+          <label class="text-sm font-medium">公司名稱</label>
+          <input class="validation-ring mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm" value="${data.company}" />
+        </div>
+      </div>
+
+      <div class="rc-md-flex rc-gap-2 mb-2 items-end">
+        <div class="rc-basis-half mb-4 rc-mb0-md">
+          <label class="text-sm font-medium">開始年份</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">${yearOptions(data.start)}</select>
+        </div>
+        <p class="rc-tilde-md text-center">～</p>
+        <p class="rc-zhi-md text-center text-sm">至</p>
+        <div class="rc-basis-half">
+          <label class="rc-label-invisible-md text-sm font-medium">&nbsp;</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm"><option value="now" ${!data.end ? 'selected' : ''}>至今</option>${yearOptions(data.end)}</select>
+        </div>
+      </div>
+
+      <div class="rc-md-flex mb-6">
+        <div class="mb-4 flex-1 rc-mb0-md">
+          <label class="text-sm font-medium">產業</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm"><option value="">請選擇產業</option><option ${data.industry === '軟體工程' ? 'selected' : ''}>軟體工程</option><option ${data.industry === '產品管理' ? 'selected' : ''}>產品管理</option><option>設計</option></select>
+        </div>
+        <div class="flex-1">
+          <label class="text-sm font-medium">地點</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm"><option value="">請選擇地區</option><option ${data.loc === '台灣' ? 'selected' : ''}>台灣</option><option>日本</option><option>美國</option></select>
+        </div>
+      </div>
+
+      <div class="mb-6">
+        <label class="text-sm font-medium">描述</label>
+        <textarea class="mt-2 block h-24 w-full rounded-md border border-background-border bg-transparent px-3 py-2 text-sm">${data.desc}</textarea>
+      </div>
+
+      <label class="mb-6 flex items-center gap-2 text-sm">
+        <span class="rc-primary-toggle relative inline-flex size-4 shrink-0 items-center justify-center rounded-sm border border-brand-500 ${data.primary ? 'bg-brand-500' : ''}">${data.primary ? '<svg class="size-3.5 text-text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>' : ''}</span>
+        設為頁面顯示的職稱
+      </label>
+
+      <button type="button" class="rc-item-delete inline-flex h-10 items-center rounded-md bg-status-error-default px-4 text-sm font-medium text-white hover:bg-status-error-default/90 ${count > 1 ? '' : 'hidden'}">
+        <svg class="mr-2 size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0-1 14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2L4 6"/></svg>移除
+      </button>
+    </div>`;
+  }
+
+  function eduCardHtml(index, count, prefilled) {
+    const data = prefilled
+      ? [
+          { subject: '資訊工程學系', school: '國立臺灣大學', start: '2015', end: '2019' },
+          { subject: '企業管理碩士', school: '國立政治大學', start: '2019', end: '2021' },
+        ][index] || { subject: '', school: '', start: '', end: '' }
+      : { subject: '', school: '', start: '', end: '' };
+
+    return `<div class="edu-card mb-4 rounded-lg border border-background-border p-4" data-idx="${index}">
+      <div class="rc-reorder mb-4 flex justify-end gap-1 ${count > 1 ? '' : 'hidden'}">
+        <button type="button" class="rc-move-up flex size-10 items-center justify-center rounded-md hover:bg-background-bottom disabled:pointer-events-none disabled:opacity-50" ${index === 0 ? 'disabled' : ''}><svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 15l6-6 6 6"/></svg></button>
+        <button type="button" class="rc-move-down flex size-10 items-center justify-center rounded-md hover:bg-background-bottom disabled:pointer-events-none disabled:opacity-50" ${index === count - 1 ? 'disabled' : ''}><svg class="size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M6 9l6 6 6-6"/></svg></button>
+      </div>
+
+      <div class="rc-md-flex mb-6">
+        <div class="mb-4 flex-1 rc-mb0-md">
+          <label class="text-sm font-medium">主修</label>
+          <input class="validation-ring mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm" value="${data.subject}" />
+        </div>
+        <div class="flex-1 rc-school-combo">
+          <label class="text-sm font-medium">學校名稱</label>
+          <div class="rc-popover-open relative mt-2">
+            <button type="button" data-school-trigger class="flex h-10 w-full items-center justify-between rounded-md border border-background-border bg-white px-3 py-2 text-sm font-normal">
+              <span class="rc-school-value ${data.school ? 'text-text-primary' : 'text-text-tertiary'}">${data.school || '請選擇學校'}</span>
+              <svg class="ml-2 size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M8 9l4-4 4 4M8 15l4 4 4-4"/></svg>
+            </button>
+            <div class="rc-popover-content z-50 mt-1 w-full min-w-[260px] overflow-hidden rounded-md border bg-white text-text-primary shadow-md">
+              <div class="flex items-center border-b px-3"><svg class="mr-2 size-4 shrink-0 opacity-50" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="7"/><path d="M21 21l-4-4"/></svg><input class="flex h-11 w-full bg-transparent py-3 text-sm outline-none placeholder:text-text-tertiary" placeholder="搜尋學校..." /></div>
+              <ul class="max-h-[220px] overflow-y-auto p-1">
+                ${['國立臺灣大學', '國立政治大學', '國立清華大學', '國立交通大學', '國立成功大學', '輔仁大學', '東吳大學'].map((s) => `<li data-school="${s}" class="relative flex cursor-pointer items-center rounded-sm px-2 py-1.5 text-sm hover:bg-background-bottom">
+                  <svg class="mr-2 size-4 ${s === data.school ? 'opacity-100' : 'opacity-0'}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M20 6L9 17l-5-5"/></svg>${s}
+                </li>`).join('')}
+              </ul>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="rc-md-flex rc-gap-2 mb-2 items-end md:basis-1/2">
+        <div class="rc-basis-half mb-4 rc-mb0-md">
+          <label class="text-sm font-medium">開始年份</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">${yearOptions(data.start)}</select>
+        </div>
+        <p class="rc-tilde-md text-center">～</p>
+        <p class="rc-zhi-md text-center text-sm">至</p>
+        <div class="rc-basis-half">
+          <label class="rc-label-invisible-md text-sm font-medium">&nbsp;</label>
+          <select class="rc-native mt-2 flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm">${yearOptions(data.end)}</select>
+        </div>
+      </div>
+
+      <button type="button" class="rc-item-delete mt-4 inline-flex h-10 items-center rounded-md bg-status-error-default px-4 text-sm font-medium text-white hover:bg-status-error-default/90 ${count > 1 ? '' : 'hidden'}">
+        <svg class="mr-2 size-5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 6h18M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2m3 0-1 14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2L4 6"/></svg>移除
+      </button>
+    </div>`;
+  }
+
+  function renderJobs() {
+    const count = Number(app.dataset.jobs);
+    const list = document.getElementById('jobList');
+    const prefilled = app.dataset.prefilled === 'true';
+    let html = '';
+    for (let i = 0; i < count; i++) html += jobCardHtml(i, count, prefilled);
+    list.innerHTML = html;
+    wireCards(list, 'job', count, () => renderJobs());
+  }
+
+  function renderEdus() {
+    const count = Number(app.dataset.edus);
+    const list = document.getElementById('eduList');
+    const prefilled = app.dataset.prefilled === 'true';
+    let html = '';
+    for (let i = 0; i < count; i++) html += eduCardHtml(i, count, prefilled);
+    list.innerHTML = html;
+    wireCards(list, 'edu', count, () => renderEdus());
+    list.querySelectorAll('[data-school-trigger]').forEach((btn) => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        const wrap = btn.closest('.rc-popover-open');
+        const wasOpen = wrap.classList.contains('rc-popover-open-active');
+        document.querySelectorAll('.rc-popover-open-active').forEach((w) => w.classList.remove('rc-popover-open-active'));
+        if (!wasOpen) wrap.classList.add('rc-popover-open-active');
+      });
+    });
+    list.querySelectorAll('[data-school]').forEach((item) => {
+      item.addEventListener('click', () => {
+        const val = item.getAttribute('data-school');
+        const valueEl = item.closest('.rc-popover-open').querySelector('.rc-school-value');
+        valueEl.textContent = val;
+        valueEl.classList.remove('text-text-tertiary');
+        valueEl.classList.add('text-text-primary');
+        item.closest('.rc-popover-open').classList.remove('rc-popover-open-active');
+      });
+    });
+  }
+
+  document.addEventListener('click', () => document.querySelectorAll('.rc-popover-open-active').forEach((w) => w.classList.remove('rc-popover-open-active')));
+
+  const style2 = document.createElement('style');
+  style2.textContent = `.rc-popover-open .rc-popover-content{display:none}.rc-popover-open-active .rc-popover-content{display:block}`;
+  document.head.appendChild(style2);
+
+  function wireCards(list, kind, count, rerender) {
+    list.querySelectorAll('.rc-move-up').forEach((btn, i) => btn.addEventListener('click', () => moveCard(kind, i, i - 1)));
+    list.querySelectorAll('.rc-move-down').forEach((btn, i) => btn.addEventListener('click', () => moveCard(kind, i, i + 1)));
+    list.querySelectorAll('.rc-item-delete').forEach((btn, i) => btn.addEventListener('click', () => openDeleteConfirm(kind, i)));
+    if (kind === 'job') {
+      list.querySelectorAll('.rc-primary-toggle').forEach((el) => el.addEventListener('click', () => {
+        list.querySelectorAll('.rc-primary-toggle').forEach((s) => { s.classList.remove('bg-brand-500'); s.innerHTML = ''; });
+        el.classList.add('bg-brand-500');
+        el.innerHTML = '<svg class="size-3.5 text-text-primary" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="3"><path d="M20 6L9 17l-5-5"/></svg>';
+      }));
+    }
+  }
+
+  function moveCard() { /* order swap is a cosmetic no-op in the static reproduction — the count controls in the sidebar demonstrate the add/remove interaction */ }
+
+  let pendingDelete = null;
+  function openDeleteConfirm(kind, index) {
+    pendingDelete = { kind, index };
+    document.getElementById('deleteTitle').textContent = kind === 'job' ? '要刪除這段工作經驗嗎？' : '要刪除這筆學歷嗎？';
+    document.getElementById('deleteDesc').textContent = '您確定要移除這個區塊嗎？';
+    document.getElementById('deletePortal').classList.add('rc-open');
+  }
+  document.getElementById('deleteCancel').addEventListener('click', () => document.getElementById('deletePortal').classList.remove('rc-open'));
+  document.getElementById('deleteConfirm').addEventListener('click', () => {
+    if (pendingDelete) {
+      const key = pendingDelete.kind === 'job' ? 'jobs' : 'edus';
+      const next = Math.max(0, Number(app.dataset[key]) - 1);
+      app.dataset[key] = String(next);
+      syncCountButtons();
+      pendingDelete.kind === 'job' ? renderJobs() : renderEdus();
+    }
+    document.getElementById('deletePortal').classList.remove('rc-open');
+  });
+
+  document.getElementById('addJob').addEventListener('click', () => { app.dataset.jobs = String(Math.min(3, Number(app.dataset.jobs) + 1)); syncCountButtons(); renderJobs(); });
+  document.getElementById('addEdu').addEventListener('click', () => { app.dataset.edus = String(Math.min(3, Number(app.dataset.edus) + 1)); syncCountButtons(); renderEdus(); });
+
+  // ---------- links section ----------
+  const SOCIAL_LINKS = [
+    { label: 'LinkedIn', color: '#0A66C2', prefilled: 'https://linkedin.com/in/example' },
+    { label: 'Facebook', color: '#1877F2', prefilled: '' },
+    { label: 'Instagram', color: '#E4405F', prefilled: '' },
+    { label: 'X (formerly Twitter)', color: '#000000', prefilled: '' },
+    { label: 'YouTube', color: '#FF0000', prefilled: '' },
+    { label: '個人網站', color: '#76808F', prefilled: 'https://example.dev' },
+  ];
+  function renderLinks() {
+    const prefilled = app.dataset.prefilled === 'true';
+    document.getElementById('linksList').innerHTML = SOCIAL_LINKS.map((l) => `
+      <div class="mb-4">
+        <label class="text-sm font-medium">${l.label}</label>
+        <div class="mt-2 flex items-center">
+          <div class="mr-3 flex size-5 shrink-0 items-center justify-center rounded-full" style="background:${l.color}"></div>
+          <input class="!m-auto flex h-10 w-full rounded-md border border-background-border bg-white px-3 py-2 text-sm placeholder:text-text-tertiary" placeholder="請填入您的連結" value="${prefilled ? l.prefilled : ''}" />
+        </div>
+      </div>
+    `).join('');
+  }
+
+  // ---------- control panel wiring ----------
+  const ctl = {
+    loading: document.getElementById('ctlLoading'),
+    error: document.getElementById('ctlError'),
+    saving: document.getElementById('ctlSaving'),
+    role: document.getElementById('ctlRole'),
+    prefilled: document.getElementById('ctlPrefilled'),
+    errors: document.getElementById('ctlErrors'),
+    avatar: document.getElementById('ctlAvatar'),
+  };
+
+  function applyRequiredIndicators() {
+    const mentorRole = app.dataset.role !== 'mentee';
+    app.querySelectorAll('[data-req="__mentorReq"]').forEach((el) => { el.style.display = mentorRole ? 'inline' : 'none'; });
+    app.querySelectorAll('[data-req="__avatarReq"]').forEach((el) => { el.style.display = mentorRole ? 'inline' : 'none'; });
+  }
+
+  function updateHeaderTitle() {
+    document.querySelector('.header-title').textContent = app.dataset.role === 'onboarding' ? '完成個人資料' : '編輯個人頁面';
+  }
+
+  // ---------- site Header identity (kept in sync with the role/prefilled controls) ----------
+  function updateHeaderIdentity() {
+    const mentor = app.dataset.role !== 'mentee';
+    const prefilled = app.dataset.prefilled === 'true';
+    const name = prefilled ? '陳雅婷' : '使用者';
+    const subtitle = prefilled ? '資深後端工程師 at XYZ 新創' : '';
+    const initial = name.charAt(0);
+    document.querySelectorAll('.role-label').forEach((el) => { el.textContent = mentor ? '我的導師頁面' : '成為導師'; });
+    ['hdrAvatar32', 'hdrAvatar56', 'hdrMobileAvatar32', 'hdrSheetAvatar56'].forEach((id) => {
+      const el = document.getElementById(id);
+      if (el) el.textContent = initial;
+    });
+    const nameEl = document.getElementById('hdrName');
+    if (nameEl) nameEl.textContent = name;
+    const sheetNameEl = document.getElementById('hdrSheetName');
+    if (sheetNameEl) sheetNameEl.textContent = name;
+    const sheetSubEl = document.getElementById('hdrSheetSubtitle');
+    if (sheetSubEl) sheetSubEl.textContent = subtitle;
+  }
+
+  // ---------- desktop dropdown (UserDropdown.tsx) ----------
+  const hdrDropdownAnchor = document.getElementById('hdrDropdownAnchor');
+  const hdrDropdownTrigger = document.getElementById('hdrDropdownTrigger');
+  const hdrDropdownPanel = document.getElementById('hdrDropdownPanel');
+  let hdrDropdownOpen = false;
+  function openHdrDropdown() { hdrDropdownOpen = true; hdrDropdownPanel.classList.add('is-open'); hdrDropdownTrigger.setAttribute('aria-expanded', 'true'); }
+  function closeHdrDropdown() { hdrDropdownOpen = false; hdrDropdownPanel.classList.remove('is-open'); hdrDropdownTrigger.setAttribute('aria-expanded', 'false'); }
+  hdrDropdownTrigger.addEventListener('click', () => hdrDropdownOpen ? closeHdrDropdown() : openHdrDropdown());
+  hdrDropdownPanel.addEventListener('click', (e) => { if (e.target.closest('.dd-item, .dd-profile')) closeHdrDropdown(); });
+  document.addEventListener('click', (e) => { if (hdrDropdownOpen && !hdrDropdownAnchor.contains(e.target)) closeHdrDropdown(); });
+
+  // ---------- mobile sheets (HamburgerMenu.tsx / MobileUserMenu.tsx) ----------
+  const hdrNavOverlay = document.getElementById('hdrNavSheetOverlay');
+  const hdrNavPanel = document.getElementById('hdrNavSheetPanel');
+  const hdrUserOverlay = document.getElementById('hdrUserSheetOverlay');
+  const hdrUserPanel = document.getElementById('hdrUserSheetPanel');
+  let hdrSheet = null;
+  function openHdrSheet(which) {
+    closeHdrDropdown();
+    hdrSheet = which;
+    (which === 'nav' ? hdrNavOverlay : hdrUserOverlay).classList.add('is-open');
+    (which === 'nav' ? hdrNavPanel : hdrUserPanel).classList.add('is-open');
+  }
+  function closeHdrSheet(which) {
+    if (which && hdrSheet !== which) return;
+    const w = which || hdrSheet;
+    (w === 'nav' ? hdrNavOverlay : hdrUserOverlay).classList.remove('is-open');
+    (w === 'nav' ? hdrNavPanel : hdrUserPanel).classList.remove('is-open');
+    hdrSheet = null;
+  }
+  document.getElementById('hdrHamburgerTrigger').addEventListener('click', () => openHdrSheet('nav'));
+  document.getElementById('hdrMobileAvatarTrigger').addEventListener('click', () => openHdrSheet('user'));
+  document.getElementById('hdrNavSheetClose').addEventListener('click', () => closeHdrSheet('nav'));
+  document.getElementById('hdrUserSheetClose').addEventListener('click', () => closeHdrSheet('user'));
+  hdrNavOverlay.addEventListener('click', () => closeHdrSheet('nav'));
+  hdrUserOverlay.addEventListener('click', () => closeHdrSheet('user'));
+  hdrNavPanel.querySelectorAll('a').forEach((el) => el.addEventListener('click', () => closeHdrSheet('nav')));
+
+  // ---------- share profile dialog (ShareProfileDialog.tsx) ----------
+  const hdrSharePortal = document.getElementById('hdrSharePortal');
+  let hdrShareFromMobile = false;
+  function openHdrShare(fromMobile) {
+    hdrShareFromMobile = fromMobile;
+    const name = document.getElementById('hdrName').textContent;
+    const subtitle = document.getElementById('hdrSheetSubtitle').textContent;
+    document.getElementById('hdrShareAvatar').textContent = name.charAt(0);
+    document.getElementById('hdrShareName').textContent = name;
+    document.getElementById('hdrShareSubtitle').textContent = subtitle;
+    document.getElementById('hdrShareLinkInput').value = 'https://x-talent.example.com/profile/u_2290';
+    document.getElementById('hdrShareCopyBtn').textContent = '複製';
+    hdrSharePortal.classList.add('rc-open');
+  }
+  function closeHdrShare() {
+    hdrSharePortal.classList.remove('rc-open');
+    if (hdrShareFromMobile) closeHdrSheet('user');
+  }
+  document.getElementById('hdrShareBtn').addEventListener('click', () => { closeHdrDropdown(); setTimeout(() => openHdrShare(false), 60); });
+  document.getElementById('hdrSheetShareBtn').addEventListener('click', () => openHdrShare(true));
+  document.getElementById('hdrShareClose').addEventListener('click', closeHdrShare);
+  document.querySelector('#hdrSharePortal .rc-dialog-overlay').addEventListener('click', closeHdrShare);
+  document.getElementById('hdrShareCopyBtn').addEventListener('click', async () => {
+    const input = document.getElementById('hdrShareLinkInput');
+    try { await navigator.clipboard.writeText(input.value); } catch { input.select(); }
+    const btn = document.getElementById('hdrShareCopyBtn');
+    btn.textContent = '已複製';
+    setTimeout(() => { btn.textContent = '複製'; }, 1500);
+  });
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (hdrSharePortal.classList.contains('rc-open')) closeHdrShare();
+    else if (hdrSheet) closeHdrSheet();
+    else if (hdrDropdownOpen) closeHdrDropdown();
+  });
+
+  function refreshAll() {
+    app.dataset.role = ctl.role.value === 'mentee' ? 'mentee' : 'mentor';
+    app.dataset.loading = String(ctl.loading.checked);
+    app.dataset.error = String(ctl.error.checked);
+    app.dataset.saving = String(ctl.saving.checked);
+    app.dataset.prefilled = String(ctl.prefilled.checked);
+    app.dataset.errors = String(ctl.errors.checked);
+    app.dataset.avatar = ctl.avatar.value;
+    app.dataset.onboarding = String(ctl.role.value === 'onboarding');
+    applyRequiredIndicators();
+    updateHeaderIdentity();
+    updateHeaderTitle();
+    renderJobs();
+    renderEdus();
+    renderLinks();
+  }
+
+  Object.values(ctl).forEach((el) => el.addEventListener('change', refreshAll));
+
+  function syncCountButtons() {
+    document.querySelectorAll('#ctlJobs .rc-count-btn').forEach((b) => b.classList.toggle('bg-brand-500', b.dataset.v === app.dataset.jobs) && b.classList.toggle('text-white', b.dataset.v === app.dataset.jobs));
+    document.querySelectorAll('#ctlJobs .rc-count-btn').forEach((b) => {
+      const active = b.dataset.v === app.dataset.jobs;
+      b.className = 'rc-count-btn rounded-full border px-3 py-1 text-sm ' + (active ? 'border-brand-500 bg-brand-500 text-white' : 'border-background-border bg-white text-text-secondary hover:bg-background-bottom');
+    });
+    document.querySelectorAll('#ctlEdus .rc-count-btn').forEach((b) => {
+      const active = b.dataset.v === app.dataset.edus;
+      b.className = 'rc-count-btn rounded-full border px-3 py-1 text-sm ' + (active ? 'border-brand-500 bg-brand-500 text-white' : 'border-background-border bg-white text-text-secondary hover:bg-background-bottom');
+    });
+  }
+
+  document.querySelectorAll('#ctlJobs .rc-count-btn').forEach((btn) => btn.addEventListener('click', () => { app.dataset.jobs = btn.dataset.v; syncCountButtons(); renderJobs(); }));
+  document.querySelectorAll('#ctlEdus .rc-count-btn').forEach((btn) => btn.addEventListener('click', () => { app.dataset.edus = btn.dataset.v; syncCountButtons(); renderEdus(); }));
+
+  // ---------- unsaved-changes dialog ----------
+  document.getElementById('openUnsaved').addEventListener('click', () => document.getElementById('unsavedPortal').classList.add('rc-open'));
+  document.getElementById('unsavedCancel').addEventListener('click', () => document.getElementById('unsavedPortal').classList.remove('rc-open'));
+  document.getElementById('unsavedLeave').addEventListener('click', () => document.getElementById('unsavedPortal').classList.remove('rc-open'));
+
+  // ---------- submit-failure scroll demo (mirrors scrollToField in container.tsx) ----------
+  document.getElementById('scrollDemo').addEventListener('click', () => {
+    ctl.errors.checked = true;
+    refreshAll();
+    const target = document.getElementById('work_experiences');
+    frame.parentElement.scrollTo({ top: 0, behavior: 'smooth' });
+    target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    target.style.outline = '2px solid #EE3911';
+    target.style.outlineOffset = '4px';
+    setTimeout(() => { target.style.outline = ''; }, 1600);
+  });
+
+  // ---------- device frame width ----------
+  const widthSlider = document.getElementById('widthSlider');
+  const widthLabel = document.getElementById('widthLabel');
+  function setWidth(px) {
+    frame.style.width = px + 'px';
+    widthSlider.value = px;
+    widthLabel.textContent = px + 'px';
+  }
+  widthSlider.addEventListener('input', () => setWidth(widthSlider.value));
+  document.getElementById('presetSm').addEventListener('click', () => setWidth(375));
+  document.getElementById('presetMd').addEventListener('click', () => setWidth(820));
+  document.getElementById('presetLg').addEventListener('click', () => setWidth(1440));
+
+  // ---------- init ----------
+  syncCountButtons();
+  refreshAll();
+</script>

--- a/.lavish/profile-view.html
+++ b/.lavish/profile-view.html
@@ -1,0 +1,1822 @@
+<title>X-Talent 個人檔案（檢視頁）還原 — 載入／登入／導師／預約流程互動版</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&family=Open+Sans:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
+
+<style>
+  :root {
+    --color-text-primary: #1e2026;
+    --color-text-secondary: #474d57;
+    --color-text-tertiary: #76808f;
+    --color-text-disable: #aeb4bc;
+    --color-text-white: #ffffff;
+    --color-background-bottom: #f5f5f5;
+    --color-background-bottom-secondary: #fafafa;
+    --color-background-white: #ffffff;
+    --color-background-border: #e6e8ea;
+    --color-brand-50: #eafafa;
+    --color-brand-100: #d5f5f5;
+    --color-brand-300: #80e0e0;
+    --color-brand-500: #2ccbcb;
+    --color-brand-500-rgb: 44, 203, 203;
+    --color-brand-900: #092929;
+    --color-status-error-default: #ee3911;
+    --color-status-success-default: #00ba34;
+    --color-blue-active: #97eeff;
+    --color-pink-active: #ff9bbd;
+    --color-light: #ffffff;
+    --color-dark: #282828;
+    --radius: 8px;
+    --page-bg: #eef1f3;
+    --page-ink: #1e2026;
+    --page-muted: #6b7280;
+    --page-card: #ffffff;
+    --page-border: #e2e5e9;
+    --accent: #2ccbcb;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    margin: 0;
+    background: var(--page-bg);
+    color: var(--page-ink);
+    font-family: 'Noto Sans TC', 'Open Sans', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 1180px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+  }
+
+  /* ---------- intro ---------- */
+  .intro h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    letter-spacing: -0.01em;
+  }
+  .intro p {
+    margin: 0;
+    color: var(--page-muted);
+    font-size: 14.5px;
+    line-height: 1.7;
+    max-width: 860px;
+  }
+  .intro .source-note {
+    margin-top: 14px;
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 12.5px;
+    color: #2c7a7a;
+    background: #e9fbfb;
+    border: 1px solid #c9f1f1;
+    padding: 7px 12px;
+    border-radius: 999px;
+  }
+  .intro .source-note b {
+    font-weight: 700;
+  }
+  code.inline {
+    background: #f1f3f5;
+    padding: 1px 6px;
+    border-radius: 5px;
+    font-family: ui-monospace, 'SFMono-Regular', monospace;
+    font-size: 12px;
+  }
+
+  /* ---------- control panel ---------- */
+  .panel {
+    margin-top: 28px;
+    background: var(--page-card);
+    border: 1px solid var(--page-border);
+    border-radius: 16px;
+    padding: 18px 22px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 22px 32px;
+    align-items: flex-start;
+    box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  }
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .control-label {
+    font-size: 11.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #9aa1ac;
+  }
+  .segmented {
+    display: inline-flex;
+    background: var(--page-bg);
+    border: 1px solid var(--page-border);
+    border-radius: 999px;
+    padding: 3px;
+    gap: 2px;
+  }
+  .seg-btn {
+    border: 0;
+    background: transparent;
+    padding: 6px 13px;
+    border-radius: 999px;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--page-muted);
+    cursor: pointer;
+    font-family: inherit;
+    white-space: nowrap;
+  }
+  .seg-btn.active {
+    background: var(--page-card);
+    color: var(--page-ink);
+    box-shadow: 0 1px 3px rgba(16, 24, 40, 0.12);
+  }
+  .seg-btn:hover:not(.active) {
+    color: var(--page-ink);
+  }
+  .dialog-jump {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    max-width: 360px;
+  }
+  .dialog-jump button {
+    border: 1px solid var(--page-border);
+    background: var(--page-card);
+    padding: 5px 10px;
+    border-radius: 8px;
+    font-size: 12px;
+    font-family: inherit;
+    cursor: pointer;
+    color: var(--page-ink);
+  }
+  .dialog-jump button.active {
+    border-color: var(--accent);
+    background: #e9fbfb;
+    color: #14807f;
+    font-weight: 700;
+  }
+
+  /* ---------- device frame ---------- */
+  .frame-shell {
+    margin-top: 26px;
+    display: flex;
+    justify-content: center;
+  }
+  .frame-chrome {
+    background: #1c2027;
+    border-radius: 16px;
+    padding: 10px 10px 0;
+    box-shadow: 0 20px 45px -18px rgba(16, 24, 40, 0.35);
+    max-width: 100%;
+  }
+  .frame-chrome-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 6px 10px;
+  }
+  .frame-chrome-bar .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: #3a4150;
+  }
+  .frame-chrome-bar .url {
+    margin-left: 10px;
+    background: #2a303b;
+    color: #8b93a1;
+    font-size: 11.5px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-family: ui-monospace, monospace;
+  }
+
+  .width-controls {
+    margin-top: 20px;
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .width-slider-row {
+    position: relative;
+    padding-top: 18px;
+  }
+  .width-slider-row input[type='range'] {
+    width: 100%;
+  }
+  .bp-flag {
+    position: absolute;
+    top: 0;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    pointer-events: none;
+  }
+  .bp-flag .tag {
+    font-size: 10px;
+    font-weight: 700;
+    color: #9aa1ac;
+    white-space: nowrap;
+  }
+  .bp-flag .line {
+    width: 1px;
+    height: 26px;
+    background: #d7dbe0;
+    margin-top: 2px;
+  }
+  .width-readout {
+    font-size: 12.5px;
+    color: var(--page-muted);
+    display: flex;
+    align-items: center;
+    gap: 10px;
+  }
+  .width-readout .num {
+    font-weight: 700;
+    color: var(--page-ink);
+    font-family: ui-monospace, monospace;
+  }
+  .bp-pill {
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 9px;
+    border-radius: 999px;
+    background: #e9fbfb;
+    color: #1a7a7a;
+  }
+
+  .frame {
+    position: relative;
+    width: 1024px;
+    max-width: 100%;
+    height: 900px;
+    background: var(--color-background-bottom);
+    overflow: hidden;
+    border-radius: 8px 8px 0 0;
+    container-type: inline-size;
+    container-name: pv-demo;
+  }
+
+  .page-body {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    background: var(--color-background-white);
+  }
+
+  /* ---------- header (faithful reproduction of Header.tsx / HamburgerMenu.tsx / UserDropdown.tsx / MobileUserMenu.tsx / ShareProfileDialog.tsx) ----------
+     Real Header is `fixed`; here it is `sticky` inside this page's own scroll
+     container instead, since a true `position:fixed` would escape this
+     device-frame demo and pin to the browser viewport instead of the frame.
+     Visually identical while scrolling — this is a demo-frame adaptation, not
+     a design change. */
+  .xt-header {
+    position: sticky;
+    top: 0;
+    height: 70px;
+    background: var(--color-light);
+    z-index: 40;
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+  }
+  .xt-header-inner { width: 100%; height: 100%; display: flex; align-items: center; justify-content: space-between; }
+  .xt-left { display: flex; align-items: center; gap: 40px; min-width: 0; }
+  .xt-logo { display: flex; align-items: center; flex-shrink: 0; }
+  .xt-logo svg { display: block; height: 26px; width: auto; }
+  .xt-nav { display: none; align-items: center; gap: 28px; }
+  .xt-nav a { font-family: 'Open Sans', sans-serif; font-size: 16px; color: var(--color-text-primary); text-decoration: none; white-space: nowrap; }
+  .xt-nav a:hover { color: #14807f; }
+  .xt-right { display: flex; align-items: center; gap: 12px; }
+  .xt-right-desktop { display: none; align-items: center; gap: 12px; }
+  .xt-right-mobile { display: flex; align-items: center; gap: 12px; }
+  /* >=1024px mirrors the app's `lg:` breakpoint, scoped to this page's own container */
+  @container pv-demo (min-width: 1024px) {
+    .xt-nav { display: flex; }
+    .xt-right-desktop { display: flex; }
+    .xt-right-mobile { display: none; }
+    .xt-right { margin-right: 80px; }
+  }
+
+  /* Header's own buttons are namespaced `.hbtn*` (not `.btn*`) so they don't
+     collide with this page's own pill-shaped `.btn` (編輯個人資訊 / 成為導師). */
+  .hbtn { appearance: none; border: none; font: inherit; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; font-size: 14px; font-weight: 500; height: 40px; padding: 0 16px; border-radius: 6px; white-space: nowrap; }
+  .hbtn-primary { background: var(--color-brand-500); color: var(--color-text-primary); }
+  .hbtn-primary:hover { background: #24b6b6; }
+  .hbtn-outline { background: var(--color-background-white); color: var(--color-text-primary); border: 1px solid var(--color-background-border); }
+  .hbtn-outline:hover { background: var(--color-background-bottom); }
+  .hbtn-outline-brand { background: var(--color-background-white); color: var(--color-brand-500); border: 1px solid var(--color-brand-500); }
+  .hbtn-outline-brand:hover { background: #eafafa; }
+
+  .icon-btn { appearance: none; border: none; background: transparent; cursor: pointer; display: inline-flex; align-items: center; justify-content: center; width: 40px; height: 40px; border-radius: 6px; color: var(--color-text-primary); }
+  .icon-btn:hover { background: var(--color-background-bottom); }
+
+  .avatar { border-radius: 50%; display: inline-flex; align-items: center; justify-content: center; font-weight: 700; color: #06403f; background: linear-gradient(135deg, #9bf1ef, #4fdad6); flex-shrink: 0; }
+  .avatar-32 { width: 32px; height: 32px; font-size: 13px; }
+  .avatar-56 { width: 56px; height: 56px; font-size: 20px; }
+  .avatar-64 { width: 64px; height: 64px; font-size: 22px; }
+
+  .dropdown-trigger { appearance: none; border: none; background: transparent; cursor: pointer; display: inline-flex; align-items: center; gap: 6px; padding: 2px; }
+  .dropdown-trigger .chev { font-size: 19px; line-height: 1; color: var(--color-text-primary); transition: transform 0.15s ease; }
+  .dropdown-trigger[aria-expanded='true'] .chev { transform: rotate(180deg); }
+  .dropdown-anchor { position: relative; }
+  .dropdown-panel {
+    position: absolute; top: calc(100% + 4px); right: 0; width: 360px; max-height: 440px; overflow-y: auto;
+    background: var(--color-background-white); border: 1px solid var(--color-background-border); border-radius: 16px;
+    box-shadow: 0 12px 32px -8px rgba(16, 24, 40, 0.22); z-index: 95; transform-origin: top right;
+    opacity: 0; transform: scale(0.96); pointer-events: none; transition: opacity 0.12s ease, transform 0.12s ease;
+  }
+  .dropdown-panel.is-open { opacity: 1; transform: scale(1); pointer-events: auto; }
+  .dd-profile { width: 100%; display: flex; align-items: center; gap: 16px; padding: 24px 24px 16px; background: none; border: none; cursor: pointer; text-align: left; font: inherit; }
+  .dd-profile .name { font-size: 22px; font-weight: 600; color: var(--color-text-primary); overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .dd-share { padding: 0 24px 20px; }
+  .dd-share .hbtn { width: 100%; height: 56px; border-radius: 16px; font-size: 17px; font-weight: 600; }
+  .dd-divider { height: 1px; background: var(--color-background-bottom); }
+  .dd-items { padding: 12px 8px; display: flex; flex-direction: column; }
+  .dd-item { appearance: none; border: none; background: none; text-align: left; font: inherit; font-size: 17px; color: var(--color-text-primary); padding: 12px 16px; border-radius: 6px; cursor: pointer; }
+  .dd-item:hover { background: var(--color-background-bottom); }
+  .dd-item.is-danger { color: var(--color-status-error-default); }
+
+  .sheet-overlay { position: absolute; inset: 0; background: rgba(255, 255, 255, 0.8); backdrop-filter: blur(2px); z-index: 96; opacity: 0; pointer-events: none; transition: opacity 0.2s ease; }
+  .sheet-overlay.is-open { opacity: 1; pointer-events: auto; }
+  .sheet-panel {
+    position: absolute; inset: 0 0 0 auto; width: 100%; background: var(--color-background-white); z-index: 97;
+    padding: 24px; display: flex; flex-direction: column; transform: translateX(100%);
+    transition: transform 0.32s cubic-bezier(0.32, 0.72, 0, 1); box-shadow: -8px 0 24px -12px rgba(16, 24, 40, 0.2);
+  }
+  .sheet-panel.is-open { transform: translateX(0); }
+  .sheet-close { margin-left: auto; appearance: none; border: none; background: none; cursor: pointer; color: var(--color-brand-900); padding: 4px; display: inline-flex; }
+  .sheet-nav-links { flex: 1; min-height: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 32px; font-size: 22px; }
+  .sheet-nav-links a { color: var(--color-text-primary); text-decoration: none; }
+  .sheet-nav-bottom { margin-top: auto; display: flex; flex-direction: column; align-items: center; gap: 20px; padding-bottom: 8px; }
+  .sheet-nav-bottom .hbtn { width: 160px; }
+  .sheet-user-profile { display: flex; align-items: center; gap: 16px; padding: 16px 0 24px; text-align: left; background: none; border: none; cursor: pointer; font: inherit; }
+  .sheet-user-profile .name { font-size: 20px; font-weight: 600; color: var(--color-text-primary); }
+  .sheet-user-profile .subtitle { margin-top: 4px; font-size: 13px; color: var(--color-text-tertiary); }
+  .sheet-user-share { margin-bottom: 24px; }
+  .sheet-user-share .hbtn { width: 100%; height: 48px; border-radius: 16px; font-size: 15px; font-weight: 600; }
+  .sheet-user-nav { display: flex; flex-direction: column; padding: 8px 0; }
+  .sheet-user-nav button { appearance: none; border: none; background: none; text-align: left; font: inherit; padding: 14px 0; font-size: 17px; color: var(--color-text-primary); cursor: pointer; }
+  .sheet-user-bottom { display: flex; flex-direction: column; padding-bottom: 16px; }
+  .sheet-user-bottom button { appearance: none; border: none; background: none; text-align: left; font: inherit; padding: 14px 0; font-size: 17px; color: var(--color-text-primary); cursor: pointer; }
+  .sheet-user-bottom button.is-danger { color: var(--color-status-error-default); }
+
+  .share-overlay { position: absolute; inset: 0; background: rgba(40, 40, 40, 0.7); z-index: 98; opacity: 0; pointer-events: none; transition: opacity 0.2s ease; }
+  .share-overlay.is-open { opacity: 1; pointer-events: auto; }
+  .share-dialog {
+    position: absolute; top: 50%; left: 50%; width: calc(100% - 32px); max-width: 440px; z-index: 99;
+    border-radius: 24px; border: 1px solid var(--color-background-border); background: var(--color-light);
+    box-shadow: 0 25px 60px -15px rgba(16, 24, 40, 0.35); opacity: 0; pointer-events: none;
+    transform: translate(-50%, -48%) scale(0.97); transition: opacity 0.16s ease, transform 0.16s ease;
+  }
+  .share-dialog.is-open { opacity: 1; pointer-events: auto; transform: translate(-50%, -50%) scale(1); }
+  .share-dialog-inner { padding: 24px 24px 32px; }
+  .share-dialog-head { position: relative; margin-bottom: 24px; display: flex; align-items: center; justify-content: center; }
+  .share-dialog-title { font-size: 28px; font-weight: 600; color: var(--color-text-primary); line-height: 1; text-align: center; }
+  .share-dialog-close { position: absolute; right: 0; top: 50%; transform: translateY(-50%); font-size: 26px; line-height: 1; color: var(--color-text-primary); background: none; border: none; cursor: pointer; padding: 4px; }
+  .share-profile-card { margin-bottom: 20px; display: flex; align-items: center; gap: 16px; border-radius: 20px; border: 1px solid var(--color-background-border); background: var(--color-light); padding: 18px 20px; box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04); }
+  .share-profile-name { font-size: 18px; font-weight: 600; color: var(--color-text-primary); }
+  .share-profile-subtitle { margin-top: 4px; font-size: 13px; font-weight: 500; color: var(--color-text-primary); }
+  .share-link-label { display: block; margin-bottom: 8px; font-size: 13px; font-weight: 500; color: var(--color-text-primary); }
+  .share-link-row { display: flex; align-items: center; gap: 10px; border-radius: 14px; border: 1px solid var(--color-background-border); background: var(--color-light); padding: 10px 14px; }
+  .share-link-row input { flex: 1; min-width: 0; border: none; background: transparent; font: inherit; font-size: 13px; color: var(--color-text-primary); outline: none; }
+  .share-copy-btn { height: 38px; flex-shrink: 0; border-radius: 10px; padding: 0 14px; font-size: 13px; }
+
+  [hidden] { display: none !important; }
+
+  /* ---------- banner ---------- */
+  .banner {
+    position: relative;
+    height: 111px;
+    background: linear-gradient(to bottom right, var(--color-blue-active), var(--color-pink-active));
+  }
+  @container pv-demo (min-width: 640px) {
+    .banner {
+      height: 100px;
+    }
+  }
+
+  /* ---------- container ---------- */
+  .pv-container {
+    width: 100%;
+    margin: 0 auto;
+    padding: 0 2rem;
+    max-width: 1024px;
+    margin-bottom: 5rem;
+  }
+  @container pv-demo (min-width: 1536px) {
+    .pv-container {
+      max-width: 1280px;
+    }
+  }
+
+  /* ---------- animate-pulse skeleton ---------- */
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.5; }
+  }
+  .skel {
+    background: var(--color-background-bottom);
+    border-radius: var(--radius);
+    animation: pulse 1.6s cubic-bezier(0.4, 0, 0.6, 1) infinite;
+  }
+
+  /* ---------- profile head ---------- */
+  .profile-head {
+    display: flex;
+    flex-direction: column;
+    transform: translateY(-40px);
+  }
+  @container pv-demo (min-width: 640px) {
+    .profile-head {
+      flex-direction: row;
+      align-items: flex-start;
+    }
+  }
+  .avatar-wrap {
+    position: relative;
+    margin: 0 auto;
+    height: 160px;
+    width: 160px;
+    flex-shrink: 0;
+    overflow: hidden;
+    border-radius: 999px;
+    background: var(--color-background-white);
+    box-shadow: 0 0 0 4px var(--color-background-white);
+  }
+  @container pv-demo (min-width: 640px) {
+    .avatar-wrap { margin: 0; }
+  }
+  .avatar-wrap img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+  .avatar-skel {
+    height: 160px;
+    width: 160px;
+    border-radius: 999px;
+    flex-shrink: 0;
+    margin: 0 auto;
+  }
+  @container pv-demo (min-width: 640px) {
+    .avatar-skel { margin: 0; }
+  }
+
+  .info-col {
+    display: flex;
+    min-width: 0;
+    flex-direction: column;
+    align-items: center;
+  }
+  @container pv-demo (min-width: 640px) {
+    .info-col {
+      margin-top: 2.5rem;
+      margin-left: 1.5rem;
+      align-items: flex-start;
+    }
+  }
+  .name-row {
+    margin-bottom: 8px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 4px;
+  }
+  @container pv-demo (min-width: 640px) {
+    .name-row { flex-direction: row; flex-wrap: wrap; align-items: center; gap: 8px; }
+  }
+  .name-text {
+    font-size: 24px;
+    font-weight: 600;
+    word-break: break-word;
+    margin: 0;
+  }
+  .link-icons {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+  }
+  @container pv-demo (min-width: 640px) {
+    .link-icons { justify-content: flex-start; }
+  }
+  .link-icons a {
+    color: var(--color-text-secondary);
+    display: inline-flex;
+  }
+  .link-icons a:hover { color: var(--color-brand-500); }
+  .job-line {
+    font-size: 14px;
+    color: var(--color-text-primary);
+    margin: 0;
+  }
+  .job-line .at { color: var(--color-text-tertiary); }
+  .action-row {
+    margin-top: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+  }
+  @container pv-demo (min-width: 640px) {
+    .action-row { justify-content: flex-start; }
+  }
+
+  /* ---------- buttons (from Button CVA) ---------- */
+  .btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 500;
+    transition: colors 0.15s;
+    border-radius: 999px;
+    padding: 12px 24px;
+    cursor: pointer;
+    border: none;
+    font-family: inherit;
+  }
+  .btn-outline {
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    color: var(--color-text-primary);
+  }
+  .btn-outline:hover { background: var(--color-background-bottom); }
+  .btn-default {
+    background: var(--color-brand-500);
+    color: var(--color-text-primary);
+  }
+  .btn-default:hover { background: rgba(var(--color-brand-500-rgb), 0.9); }
+  .btn-default:disabled, .btn-default[disabled] {
+    background: var(--color-background-border);
+    color: var(--color-text-disable);
+    cursor: not-allowed;
+  }
+  .btn-ghost { background: transparent; color: var(--color-text-primary); }
+  .btn-ghost:hover { background: var(--color-background-bottom); }
+  .btn-icon { width: 40px; height: 40px; padding: 0; border-radius: 6px; }
+  .btn-full { width: 100%; }
+  .btn:disabled, .btn[disabled] { opacity: 0.5; pointer-events: none; }
+
+  /* ---------- content columns ---------- */
+  .content-cols {
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+  }
+  @container pv-demo (min-width: 1536px) {
+    .content-cols { flex-direction: row; gap: 48px; }
+  }
+  .left-col { width: 100%; }
+  @container pv-demo (min-width: 1536px) {
+    .left-col { width: 60%; }
+  }
+  .right-col { width: 100%; }
+  @container pv-demo (min-width: 1536px) {
+    .right-col { width: 40%; }
+  }
+
+  .section-title {
+    font-size: 20px;
+    font-weight: 700;
+    margin: 0 0 16px;
+  }
+  .about-text {
+    font-size: 14px;
+    color: var(--color-text-tertiary);
+    word-break: break-word;
+    margin: 0;
+  }
+  .badge-section { margin-top: 40px; }
+  .badge-row { display: flex; flex-wrap: wrap; gap: 12px; }
+  .badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: var(--radius);
+    border: 1px solid transparent;
+    background: var(--color-brand-500);
+    color: var(--color-text-primary);
+    padding: 2px 10px;
+    font-size: 12px;
+    font-weight: 600;
+  }
+
+  .exp-block { margin-top: 40px; }
+  .exp-item { margin-bottom: 24px; display: flex; flex-direction: column; gap: 12px; }
+  .exp-item .exp-top {
+    display: flex;
+    justify-content: space-between;
+    gap: 8px;
+    font-size: 14px;
+    color: var(--color-text-secondary);
+  }
+  .exp-item .exp-top .exp-dates { flex-shrink: 0; font-size: 12px; }
+  .exp-item h3 {
+    font-size: 16px;
+    font-weight: 700;
+    color: var(--color-text-secondary);
+    margin: 0 0 4px;
+    word-break: break-word;
+  }
+  .exp-item .exp-desc {
+    font-size: 14px;
+    color: var(--color-text-secondary);
+    margin: 0;
+    word-break: break-word;
+  }
+  .exp-divider {
+    height: 1px;
+    background: var(--color-background-border);
+    margin: 0 0 24px;
+  }
+
+  /* ---------- schedule card ---------- */
+  .right-col-inner { display: flex; flex-direction: column; gap: 16px; max-width: 335px; }
+  @container pv-demo (min-width: 768px) {
+    .right-col-inner { max-width: 695px; }
+  }
+  @container pv-demo (min-width: 1536px) {
+    .right-col-inner { max-width: 414px; }
+  }
+  .schedule-card {
+    width: 100%;
+    border-radius: 16px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    padding: 20px;
+    box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  }
+  .schedule-card-head {
+    margin-bottom: 12px;
+    border-bottom: 1px solid var(--color-background-border);
+    padding-bottom: 12px;
+  }
+  .schedule-card-head .label {
+    margin: 0 0 4px;
+    font-size: 12px;
+    font-weight: 500;
+    color: var(--color-text-tertiary);
+  }
+  .schedule-card-head h2 {
+    margin: 0;
+    font-size: 24px;
+    font-weight: 600;
+    letter-spacing: -0.01em;
+    color: var(--color-text-primary);
+  }
+
+  /* ---------- calendar reproduction (src/components/ui/calendar.tsx via ScheduleCalendar) ---------- */
+  .cal { width: 100%; background: var(--color-background-white); }
+  .cal-month { position: relative; display: flex; flex-direction: column; gap: 4px; }
+  .cal-caption-row { display: flex; align-items: center; justify-content: flex-start; gap: 2px; height: 32px; }
+  .cal-caption-row-default { justify-content: center; padding: 0 32px; }
+  .cal-dropdown {
+    display: inline-flex; align-items: center; gap: 2px; border-radius: 6px; padding: 2px 4px;
+    font-size: 14px; font-weight: 600; color: var(--color-text-secondary); cursor: pointer; background: transparent; border: none; font-family: inherit;
+  }
+  .cal-dropdown:hover { background: var(--color-background-bottom-secondary); }
+  .cal-dropdown svg { color: var(--color-text-tertiary); flex-shrink: 0; }
+  .cal-dropdown-boxed { border: 1px solid var(--color-background-border); border-radius: 6px; box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04); font-weight: 500; color: var(--color-text-primary); padding: 4px 8px; }
+  .cal-nav-profile { position: absolute; top: 0; right: 0; display: flex; align-items: center; justify-content: flex-end; gap: 4px; }
+  .cal-nav-default { position: absolute; inset: 0 0 auto 0; display: flex; width: 100%; align-items: center; justify-content: space-between; }
+  .cal-month .nav-btn { width: 32px; height: 32px; border-radius: 6px; border: none; background: transparent; cursor: pointer; display: flex; align-items: center; justify-content: center; color: var(--color-text-primary); flex-shrink: 0; }
+  .cal-month .nav-btn:hover { background: var(--color-background-bottom); }
+  .cal-weekdays, .cal-grid { display: grid; grid-template-columns: repeat(7, 1fr); gap: 4px; }
+  .cal-weekdays div { text-align: center; font-size: 13px; font-weight: 600; color: var(--color-text-primary); padding: 6px 0; }
+  .cal-grid { margin-top: 4px; }
+  .cal-day { position: relative; aspect-ratio: 1; display: flex; align-items: center; justify-content: center; border-radius: 999px; font-size: 14px; font-weight: 500; cursor: pointer; color: var(--color-text-primary); background: transparent; border: none; font-family: inherit; }
+  .cal-day.outside { color: var(--color-text-tertiary); font-weight: 400; }
+  .cal-day.available { background: rgba(var(--color-brand-500-rgb), 0.2); }
+  .cal-day.available:hover { background: rgba(var(--color-brand-500-rgb), 0.3); }
+  .cal-day.disabled { color: var(--color-text-tertiary); opacity: 0.5; cursor: not-allowed; font-weight: 400; }
+  .cal-day.selected { background: var(--color-brand-100); border: 1px solid var(--color-brand-300); }
+  .cal-day.selected-default { background: var(--color-brand-500); color: var(--color-text-primary); }
+  .cal-day.today-ring { border: 1px solid var(--color-brand-500); color: var(--color-brand-500); }
+  .cal-loading-overlay { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; background: rgba(255,255,255,0.4); }
+  .spinner {
+    width: 22px; height: 22px; border-radius: 999px;
+    border: 2.5px solid var(--color-background-border);
+    border-top-color: var(--color-text-tertiary);
+    animation: spin 0.8s linear infinite;
+  }
+  @keyframes spin { to { transform: rotate(360deg); } }
+
+  /* booking form */
+  .slot-list-label { margin: 0 0 16px; font-size: 14px; }
+  .slot-empty { min-height: 40px; display: flex; align-items: center; color: var(--color-text-disable); font-size: 14px; }
+  .slot-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 8px; }
+  .slot-btn {
+    height: 40px; border-radius: 8px; font-size: 14px; display: flex; align-items: center; justify-content: center;
+    border: 1px solid var(--color-background-border); background: var(--color-background-white); color: var(--color-text-primary);
+    cursor: pointer; font-family: inherit; font-weight: 500;
+  }
+  .slot-btn:hover { background: var(--color-background-bottom); }
+  .slot-btn.selected { background: var(--color-brand-500); color: var(--color-text-primary); border-color: var(--color-brand-500); }
+  .slot-btn.booked {
+    cursor: not-allowed; border-color: var(--color-background-border); background: var(--color-background-bottom); color: var(--color-text-disable);
+  }
+  .booking-textarea-wrap { display: flex; flex-direction: column; gap: 8px; margin-top: 16px; }
+  .booking-textarea-wrap label { font-size: 14px; font-weight: 600; }
+  .booking-textarea {
+    height: 156px; width: 100%; border-radius: 8px; border: 1px solid var(--color-background-border); background: transparent;
+    padding: 8px 12px; font-size: 14px; font-family: inherit; resize: vertical; color: var(--color-text-primary);
+  }
+  .booking-textarea::placeholder { color: var(--color-text-tertiary); }
+
+  /* generic skeleton pieces */
+  .skel-h4 { height: 16px; }
+  .skel-h5 { height: 20px; }
+  .skel-h6 { height: 24px; }
+  .skel-h7 { height: 28px; }
+  .skel-pill { border-radius: 999px; }
+  .skel-round { border-radius: 999px; }
+
+  /* ---------- MentorScheduleDialog overlays ---------- */
+  .msd-overlay, .msd-overlay-2 {
+    position: absolute;
+    inset: 0;
+    z-index: 50;
+    background: rgba(40, 40, 40, 0.8);
+    display: none;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 24px 12px;
+    overflow-y: auto;
+  }
+  .msd-overlay-2 { z-index: 60; }
+  .dialog-card {
+    width: 100%;
+    max-width: 440px;
+    background: var(--color-background-white);
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 20px 45px -18px rgba(16, 24, 40, 0.5);
+    position: relative;
+  }
+  .dialog-card h3 { margin: 0 0 4px; font-size: 18px; font-weight: 600; letter-spacing: -0.01em; }
+  .dialog-card .dialog-desc { margin: 0; font-size: 14px; color: var(--color-text-tertiary); }
+  .dialog-close {
+    position: absolute; top: 16px; right: 16px; background: transparent; border: none; cursor: pointer;
+    color: var(--color-text-tertiary); opacity: 0.7; display: flex;
+  }
+  .dialog-close:hover { opacity: 1; }
+  .dialog-footer { margin-top: 16px; display: flex; gap: 12px; justify-content: center; }
+  .msd-slot-row {
+    display: flex; flex-direction: column; gap: 8px; border-radius: 8px; border: 1px solid var(--color-background-border);
+    background: var(--color-background-white); padding: 12px; cursor: pointer;
+  }
+  .msd-slot-row:hover { background: rgba(245,245,245,0.5); }
+  .msd-slot-row.past { cursor: not-allowed; opacity: 0.5; }
+  .msd-slot-top { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+  .msd-slot-time { display: flex; align-items: center; gap: 8px; font-size: 16px; font-weight: 500; }
+  .msd-slot-dur { font-size: 13px; color: var(--color-text-tertiary); }
+  .field-label { font-size: 14px; font-weight: 500; margin: 0 0 8px; }
+  .time-pair { display: flex; align-items: center; gap: 12px; }
+  .time-select {
+    height: 48px; width: 96px; border-radius: 8px; border: 1px solid var(--color-background-border);
+    background: var(--color-background-white); font-size: 16px; padding: 0 12px; font-family: inherit;
+  }
+  .duration-radio { display: flex; gap: 8px; }
+  .duration-radio button {
+    flex: 1; border-radius: 8px; border: 1px solid var(--color-background-border); background: var(--color-background-white);
+    padding: 8px 16px; font-size: 16px; cursor: pointer; font-family: inherit;
+  }
+  .duration-radio button.active { border-color: var(--color-brand-500); background: rgba(var(--color-brand-500-rgb), 0.1); color: var(--color-brand-500); }
+  .weekly-check-row { display: flex; align-items: center; gap: 8px; font-size: 14px; cursor: pointer; }
+  .weekly-check-row input { width: 16px; height: 16px; accent-color: var(--color-brand-500); }
+
+  /* device frame breakpoint zone tint */
+  .zone-hint { display:none; }
+
+  footer.note {
+    max-width: 1180px;
+    margin: 22px auto 0;
+    padding: 0 24px;
+    font-size: 12.5px;
+    color: var(--page-muted);
+  }
+
+  /* ---------- site footer (src/components/layout/Footer/Footer.tsx) ---------- */
+  .pv-footer { display: flex; width: 100%; background: var(--color-dark); padding-bottom: 50px; }
+  .pv-footer-inner { display: flex; width: 100%; flex-direction: column; align-items: center; padding: 50px 20px 0; }
+  @container pv-demo (min-width: 768px) {
+    .pv-footer-inner { flex-direction: row; align-items: flex-start; justify-content: space-between; padding: 50px 70px 0; }
+  }
+  .pv-footer-logo {
+    display: flex; align-items: center; justify-content: center;
+    width: 146px; height: 39px; flex-shrink: 0;
+    font-family: 'Open Sans', sans-serif; font-weight: 700; font-size: 20px; color: var(--color-text-white);
+  }
+  @container pv-demo (min-width: 768px) { .pv-footer-logo { justify-content: flex-start; } }
+  .pv-footer-cols { margin-top: 32px; display: flex; flex-direction: column; align-items: center; gap: 32px; color: var(--color-text-white); }
+  @container pv-demo (min-width: 768px) { .pv-footer-cols { margin-top: 0; flex-direction: row; align-items: flex-start; gap: 64px; } }
+  .pv-footer-col { display: flex; flex-direction: column; align-items: center; }
+  @container pv-demo (min-width: 768px) { .pv-footer-col { align-items: flex-start; } }
+  .pv-footer-col p { margin: 0 0 20px; font-size: 20px; font-weight: 700; letter-spacing: 0.085em; }
+  .pv-footer-links { display: flex; flex-direction: column; align-items: center; gap: 12px; }
+  @container pv-demo (min-width: 768px) { .pv-footer-links { align-items: flex-start; } }
+  .pv-footer-links a { color: var(--color-text-white); text-decoration: none; font-weight: 400; }
+  .pv-footer-links a:hover { text-decoration: underline; }
+</style>
+
+<div class="wrap">
+  <div class="intro">
+    <h1>個人檔案頁（檢視）互動還原</h1>
+    <p>
+      對應
+      <code class="inline">src/app/profile/[pageUserId]/{page,ui,container,skeleton}.tsx</code>
+      與其子元件（ProfileBanner、ProfileBadgeSection、ExperienceSection、BookingForm →
+      MentorScheduleConfig／MenteeBookingForm、ScheduleCalendar、MentorScheduleDialog），也包含站台全域
+      <code class="inline">Header</code>（RWD／漢堡選單／帳號下拉／分享個人頁面對話框，還原自
+      <code class="inline">.lavish/header_rwd.html</code>）與 <code class="inline">Footer</code>。左側控制面板可切換載入、登入、身份與預約流程狀態；拖動下方滑桿模擬
+      sm(640) / md(768) / lg(1024，Header 導覽列切換點) / 2xl(1536) 響應式斷點（以 CSS container query 模擬，因為此還原被嵌入在較大的頁面中）。
+    </p>
+    <div class="source-note"><b>設計來源：</b>本 repo 自身的 design tokens（src/styles/tokens.css）與 src/components/ui/*（CVA variants）</div>
+  </div>
+
+  <div class="panel">
+    <div class="control-group">
+      <div class="control-label">資料載入</div>
+      <div class="segmented" data-group="loading">
+        <button class="seg-btn active" data-val="0">已載入</button>
+        <button class="seg-btn" data-val="1">載入中</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">登入狀態</div>
+      <div class="segmented" data-group="logged">
+        <button class="seg-btn active" data-val="1">已登入</button>
+        <button class="seg-btn" data-val="0">未登入</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">檢視對象（需已登入）</div>
+      <div class="segmented" data-group="own">
+        <button class="seg-btn" data-val="1">自己的檔案</button>
+        <button class="seg-btn active" data-val="0">他人的檔案</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">身份</div>
+      <div class="segmented" data-group="mentor">
+        <button class="seg-btn active" data-val="1">導師</button>
+        <button class="seg-btn" data-val="0">一般會員</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">排程資料</div>
+      <div class="segmented" data-group="sched">
+        <button class="seg-btn active" data-val="1">已載入</button>
+        <button class="seg-btn" data-val="0">載入中</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">月份切換</div>
+      <div class="segmented" data-group="month">
+        <button class="seg-btn active" data-val="0">穩定</button>
+        <button class="seg-btn" data-val="1">切換中</button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">MentorScheduleDialog（預約設定彈窗，需「自己的檔案」+「導師」）</div>
+      <div class="dialog-jump" data-group="dialog">
+        <button class="active" data-val="closed">關閉</button>
+        <button data-val="main">主列表</button>
+        <button data-val="add">新增時段</button>
+        <button data-val="edit">編輯時段</button>
+        <button data-val="booked">阻擋：已預約</button>
+        <button data-val="pending">阻擋：待確認</button>
+      </div>
+    </div>
+  </div>
+
+  <div class="width-controls">
+    <div class="width-slider-row">
+      <div class="bp-flag" style="left: 26.3%"><span class="tag">sm 640</span><span class="line"></span></div>
+      <div class="bp-flag" style="left: 36.8%"><span class="tag">md 768</span><span class="line"></span></div>
+      <div class="bp-flag" style="left: 57.9%"><span class="tag">lg 1024</span><span class="line"></span></div>
+      <div class="bp-flag" style="left: 100%"><span class="tag">2xl 1536</span><span class="line"></span></div>
+      <input type="range" id="width-slider" min="320" max="1536" value="1024" step="1" />
+    </div>
+    <div class="width-readout">
+      容器寬度 <span class="num" id="width-num">1024px</span>
+      <span class="bp-pill" id="bp-pill">md+ 版型</span>
+    </div>
+  </div>
+</div>
+
+<div class="frame-shell">
+  <div class="frame-chrome">
+    <div class="frame-chrome-bar">
+      <span class="dot" style="background: #ff6159"></span>
+      <span class="dot" style="background: #ffbd2e"></span>
+      <span class="dot" style="background: #28ca41"></span>
+      <span class="url">x-talent.example.com/profile/1024</span>
+    </div>
+    <div class="frame" id="frame">
+      <div class="page-body" id="page-body" data-loading="0" data-logged="1" data-own="0" data-mentor="1" data-sched="1" data-month="0" data-dialog="closed" data-show-schedule="1" data-own-mentor="0">
+        <header class="xt-header">
+          <div class="xt-header-inner">
+            <div class="xt-left">
+              <a href="#" class="xt-logo" aria-label="Go to homepage" onclick="return false;">
+                <svg width="110" height="22" viewBox="0 0 151 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M41.8876 16.4878C44.5017 16.4878 46.6209 14.4925 46.6209 12.0313C46.6209 9.56997 44.5017 7.57471 41.8876 7.57471C39.2735 7.57471 37.1543 9.56997 37.1543 12.0313C37.1543 14.4925 39.2735 16.4878 41.8876 16.4878Z" fill="#003C5A" />
+                  <path d="M41.9651 0C38.4686 0 35.2971 1.32445 32.9895 3.46929L32.7532 3.69177C31.7379 4.65122 31.7379 6.2051 32.7569 7.16454C33.7759 8.12399 35.43 8.12399 36.449 7.16107L36.6669 6.9525C38.1954 5.53766 40.2556 4.80765 42.4118 4.92584C46.2 5.13094 49.2792 8.02318 49.5081 11.5898C49.7739 15.7161 46.2849 19.1506 41.9614 19.1506C39.9676 19.1506 38.0883 18.4241 36.6632 17.1101L22.035 3.46929C19.7274 1.32445 16.5595 0 13.0594 0C5.81911 0 -0.0181448 5.66976 0.291994 12.5527C0.565212 18.6709 5.77481 23.6698 12.2656 24.0417C12.8563 24.0765 13.4397 24.0695 14.0083 24.0313C15.5626 23.9235 16.7035 22.6165 16.4414 21.1703C16.2125 19.9119 15.0125 19.0255 13.6944 19.1298C13.484 19.1472 13.2735 19.1541 13.0594 19.1541C8.7359 19.1541 5.24683 15.7161 5.51267 11.5933C5.74158 8.02666 8.82082 5.13789 12.6089 4.92932C14.7688 4.81113 16.8254 5.54114 18.3539 6.95597L32.9895 20.6002C35.3968 22.8389 38.7418 24.1808 42.4229 24.0626C49.1832 23.8401 54.6439 18.591 54.7435 12.2225C54.8506 5.48552 49.0872 0 41.9651 0Z" fill="#003C5A" />
+                  <path d="M27.514 21.0904C26.8826 21.0904 26.2845 21.2085 25.7344 21.4171L17.512 13.6755C17.7262 13.168 17.8443 12.6118 17.8443 12.0313C17.8443 9.57007 15.725 7.57471 13.111 7.57471C10.497 7.57471 8.37769 9.57007 8.37769 12.0313C8.37769 14.4924 10.497 16.4878 13.111 16.4878C13.7276 16.4878 14.3146 16.3766 14.8537 16.1749L23.0982 23.9374C22.8915 24.4345 22.7807 24.9768 22.7807 25.5434C22.7807 28.0046 24.9 30 27.514 30C30.128 30 32.2473 28.0046 32.2473 25.5434C32.2473 23.0857 30.128 21.0904 27.514 21.0904Z" fill="#003C5A" />
+                  <text x="63" y="21" font-family="Open Sans, sans-serif" font-size="17" font-weight="700" fill="#003C5A">X-Talent</text>
+                </svg>
+              </a>
+
+              <nav class="xt-nav">
+                <a href="#" onclick="return false;">尋找導師</a>
+                <a href="#" class="role-label" onclick="return false;">成為導師</a>
+                <a href="#" onclick="return false;">關於 X-Talent</a>
+                <a href="#" onclick="return false;">提供回饋</a>
+              </nav>
+            </div>
+
+            <div class="xt-right">
+              <div class="xt-right-desktop">
+                <div class="auth-guest-only" style="display: contents">
+                  <a href="#" onclick="return false;"><button class="hbtn hbtn-outline-brand">註冊</button></a>
+                  <a href="#" onclick="return false;"><button class="hbtn hbtn-primary">登入</button></a>
+                </div>
+                <div class="auth-loggedin-only dropdown-anchor" style="display: none" id="desktop-dropdown-anchor">
+                  <button type="button" class="dropdown-trigger" id="dropdown-trigger" aria-label="開啟用戶選單" aria-expanded="false">
+                    <span class="avatar avatar-32" id="dd-avatar-32">陳</span>
+                    <span class="chev" aria-hidden="true">▾</span>
+                  </button>
+                  <div class="dropdown-panel" id="dropdown-panel" role="menu">
+                    <button type="button" class="dd-profile">
+                      <span class="avatar avatar-56" id="dd-avatar-56">陳</span>
+                      <span class="name" id="dd-name">陳雅婷</span>
+                    </button>
+                    <div class="dd-share">
+                      <button type="button" class="hbtn hbtn-outline" id="dd-share-btn">分享個人頁面</button>
+                    </div>
+                    <div class="dd-divider"></div>
+                    <div class="dd-items">
+                      <button type="button" class="dd-item role-label" role="menuitem">成為導師</button>
+                      <button type="button" class="dd-item" role="menuitem">我的預約</button>
+                      <button type="button" class="dd-item" role="menuitem">登出</button>
+                      <button type="button" class="dd-item is-danger delete-account-item" role="menuitem" hidden>刪除帳號</button>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <div class="xt-right-mobile">
+                <button type="button" class="icon-btn auth-loggedin-only" style="display: none" id="mobile-avatar-trigger" aria-label="開啟用戶選單">
+                  <span class="avatar avatar-32" id="mobile-avatar-32">陳</span>
+                </button>
+                <button type="button" class="icon-btn" id="hamburger-trigger" aria-label="開啟導航選單">
+                  <svg width="22" height="22" viewBox="0 0 22 22" fill="none">
+                    <path d="M3 6H19M3 11H19M3 16H19" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" />
+                  </svg>
+                </button>
+              </div>
+            </div>
+          </div>
+        </header>
+
+        <!-- Sheets / share-dialog are portalled as siblings of the header's 70px box, not
+             nested inside it — matching Radix's real DOM behavior so their `inset:0`
+             resolves against the full frame instead of the header's own small box. -->
+        <div class="sheet-overlay" id="nav-sheet-overlay"></div>
+        <div class="sheet-panel" id="nav-sheet-panel" role="dialog" aria-label="導航選單">
+          <button type="button" class="sheet-close" id="nav-sheet-close" aria-label="關閉導航選單">
+            <svg width="26" height="26" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>
+          </button>
+          <div class="sheet-nav-links">
+            <a href="#" onclick="return false;">尋找導師</a>
+            <a href="#" class="role-label" onclick="return false;">成為導師</a>
+            <a href="#" onclick="return false;">關於 X-Talent</a>
+            <a href="#" onclick="return false;">提供回饋</a>
+          </div>
+          <div class="sheet-nav-bottom auth-guest-only" data-display-when-guest="flex">
+            <a href="#" onclick="return false;"><button class="hbtn hbtn-primary">登入</button></a>
+            <a href="#" onclick="return false;"><button class="hbtn hbtn-outline-brand">註冊</button></a>
+          </div>
+        </div>
+
+        <div class="sheet-overlay" id="user-sheet-overlay"></div>
+        <div class="sheet-panel" id="user-sheet-panel" role="dialog" aria-label="用戶選單">
+          <button type="button" class="sheet-close" id="user-sheet-close" aria-label="關閉用戶選單">
+            <svg width="26" height="26" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" /></svg>
+          </button>
+          <button type="button" class="sheet-user-profile">
+            <span class="avatar avatar-56" id="sheet-avatar-56">陳</span>
+            <span>
+              <span class="name" id="sheet-user-name" style="display: block">陳雅婷</span>
+              <span class="subtitle" id="sheet-user-subtitle">資深後端工程師 at 樂天國際商業股份有限公司</span>
+            </span>
+          </button>
+          <div class="sheet-user-share">
+            <button type="button" class="hbtn hbtn-outline" id="sheet-share-btn">分享個人頁面</button>
+          </div>
+          <div class="dd-divider"></div>
+          <nav class="sheet-user-nav">
+            <button type="button" class="role-label">成為導師</button>
+            <button type="button">我的預約</button>
+          </nav>
+          <div class="sheet-user-bottom">
+            <button type="button">登出</button>
+            <button type="button" class="is-danger delete-account-item" hidden>刪除帳號</button>
+          </div>
+        </div>
+
+        <!-- Share profile dialog (ShareProfileDialog.tsx) -->
+        <div class="share-overlay" id="share-overlay"></div>
+        <div class="share-dialog" id="share-dialog" role="dialog" aria-label="分享個人頁面">
+          <div class="share-dialog-inner">
+            <div class="share-dialog-head">
+              <div class="share-dialog-title">分享個人頁面</div>
+              <button type="button" class="share-dialog-close" id="share-dialog-close" aria-label="關閉">×</button>
+            </div>
+            <div class="share-profile-card">
+              <span class="avatar avatar-64" id="share-avatar">陳</span>
+              <div style="min-width: 0">
+                <div class="share-profile-name" id="share-name">陳雅婷</div>
+                <div class="share-profile-subtitle" id="share-subtitle">資深後端工程師 at 樂天國際商業股份有限公司</div>
+              </div>
+            </div>
+            <div>
+              <label class="share-link-label" for="share-link-input">個人頁面連結</label>
+              <div class="share-link-row">
+                <input type="text" id="share-link-input" readonly value="" />
+                <button type="button" class="hbtn hbtn-outline share-copy-btn" id="share-copy-btn">複製</button>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div class="banner"></div>
+
+        <div class="pv-container">
+          <!-- ============ profile head: skeleton ============ -->
+          <div class="profile-head loading-only">
+            <div class="skel avatar-skel"></div>
+            <div style="display:flex;flex-direction:column;gap:12px;margin-top:24px;">
+              <div class="skel skel-h7" style="width:192px;"></div>
+              <div class="skel skel-h4" style="width:128px;"></div>
+            </div>
+          </div>
+
+          <!-- ============ profile head: loaded ============ -->
+          <div class="profile-head loaded-only">
+            <div class="avatar-wrap">
+              <img src="https://images.unsplash.com/photo-1573497019940-1c28c88b4f3e?w=320&auto=format&fit=crop&q=80" alt="Avatar of 陳雅婷" />
+            </div>
+            <div class="info-col">
+              <div class="name-row">
+                <p class="name-text">陳雅婷 (Emma Chen)</p>
+                <div class="link-icons">
+                  <a href="#" onclick="return false;" title="LinkedIn">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="#0A66C2"><path d="M20.45 20.45h-3.55v-5.57c0-1.33-.02-3.04-1.85-3.04-1.86 0-2.14 1.45-2.14 2.94v5.67H9.36V9h3.41v1.56h.05c.48-.9 1.64-1.85 3.38-1.85 3.6 0 4.27 2.37 4.27 5.46v6.28zM5.34 7.43a2.06 2.06 0 1 1 0-4.12 2.06 2.06 0 0 1 0 4.12zM7.12 20.45H3.56V9h3.56v11.45z"/></svg>
+                  </a>
+                  <a href="#" onclick="return false;" title="個人網站">
+                    <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#474D57" stroke-width="1.6"><circle cx="12" cy="12" r="9"/><path d="M3 12h18M12 3a14 14 0 0 1 0 18a14 14 0 0 1 0-18z"/></svg>
+                  </a>
+                </div>
+              </div>
+              <p class="job-line"><span class="job-title">資深後端工程師</span><span class="at"> at </span><span class="company">樂天國際商業股份有限公司</span></p>
+              <div class="action-row">
+                <button class="btn btn-outline own-only" onclick="return false;">編輯個人資訊</button>
+                <button class="btn btn-default own-only become-mentor-btn" onclick="return false;">成為導師</button>
+              </div>
+            </div>
+          </div>
+
+          <div class="content-cols">
+            <div class="left-col">
+              <!-- content skeleton -->
+              <div class="loading-only" style="display:flex;flex-direction:column;gap:32px;">
+                <div style="display:flex;flex-direction:column;gap:12px;">
+                  <div class="skel skel-h6" style="width:64px;"></div>
+                  <div class="skel skel-h4" style="width:100%;"></div>
+                  <div class="skel skel-h4" style="width:100%;"></div>
+                  <div class="skel skel-h4" style="width:75%;"></div>
+                </div>
+                <div style="display:flex;flex-direction:column;gap:12px;">
+                  <div class="skel skel-h6" style="width:96px;"></div>
+                  <div style="display:flex;flex-wrap:wrap;gap:8px;">
+                    <div class="skel skel-h6 skel-pill" style="width:80px;"></div>
+                    <div class="skel skel-h6 skel-pill" style="width:80px;"></div>
+                    <div class="skel skel-h6 skel-pill" style="width:80px;"></div>
+                    <div class="skel skel-h6 skel-pill" style="width:80px;"></div>
+                    <div class="skel skel-h6 skel-pill" style="width:80px;"></div>
+                  </div>
+                </div>
+                <div style="display:flex;flex-direction:column;gap:12px;">
+                  <div class="skel skel-h6" style="width:80px;"></div>
+                  <div style="display:flex;flex-direction:column;gap:16px;">
+                    <div style="display:flex;flex-direction:column;gap:8px;">
+                      <div class="skel skel-h5" style="width:160px;"></div>
+                      <div class="skel skel-h4" style="width:112px;"></div>
+                      <div class="skel skel-h4" style="width:100%;"></div>
+                    </div>
+                    <div style="display:flex;flex-direction:column;gap:8px;">
+                      <div class="skel skel-h5" style="width:160px;"></div>
+                      <div class="skel skel-h4" style="width:112px;"></div>
+                      <div class="skel skel-h4" style="width:100%;"></div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- content loaded -->
+              <div class="loaded-only">
+                <div>
+                  <p class="section-title">關於我</p>
+                  <p class="about-text">熱衷於分散式系統與後端效能優化，過去五年在電商與金融科技產業累積豐富經驗，樂於分享職涯轉換與技術面試的實務心得。</p>
+                </div>
+
+                <div class="badge-section">
+                  <p class="section-title">經驗</p>
+                  <div class="badge-row"><span class="badge">5-10 年</span></div>
+                </div>
+
+                <div class="badge-section">
+                  <p class="section-title">產業</p>
+                  <div class="badge-row"><span class="badge">電子商務</span></div>
+                </div>
+
+                <div class="badge-section mentor-only">
+                  <p class="section-title">專業能力</p>
+                  <div class="badge-row">
+                    <span class="badge">後端架構設計</span>
+                    <span class="badge">系統效能調校</span>
+                    <span class="badge">技術面試準備</span>
+                  </div>
+                </div>
+
+                <div class="badge-section mentor-only">
+                  <p class="section-title">我能提供的服務</p>
+                  <div class="badge-row">
+                    <span class="badge">職涯諮詢</span>
+                    <span class="badge">履歷健檢</span>
+                    <span class="badge">模擬面試</span>
+                  </div>
+                </div>
+
+                <div class="badge-section">
+                  <p class="section-title">有興趣多了解的職位</p>
+                  <div class="badge-row">
+                    <span class="badge">技術主管</span>
+                    <span class="badge">解決方案架構師</span>
+                  </div>
+                </div>
+
+                <div class="badge-section">
+                  <p class="section-title">想多了解、加強的技能</p>
+                  <div class="badge-row">
+                    <span class="badge">團隊管理</span>
+                    <span class="badge">系統設計面談</span>
+                  </div>
+                </div>
+
+                <div class="badge-section">
+                  <p class="section-title">想多了解的主題</p>
+                  <div class="badge-row">
+                    <span class="badge">遠端團隊協作</span>
+                    <span class="badge">技術寫作</span>
+                  </div>
+                </div>
+
+                <div class="exp-block">
+                  <p class="section-title">工作經驗</p>
+                  <div class="exp-item">
+                    <div class="exp-top"><span>樂天國際商業股份有限公司</span><span class="exp-dates">2022/03 - 至今</span></div>
+                    <h3>資深後端工程師</h3>
+                    <p class="exp-desc">負責訂單系統與金流服務的架構設計，帶領 4 人小組完成微服務化改造，將尖峰時段延遲降低 40%。</p>
+                  </div>
+                  <div class="exp-divider"></div>
+                  <div class="exp-item">
+                    <div class="exp-top"><span>蝦皮購物</span><span class="exp-dates">2019/07 - 2022/02</span></div>
+                    <h3>後端工程師</h3>
+                    <p class="exp-desc">開發並維護商品推薦服務，導入快取層將 API 平均回應時間從 220ms 降至 60ms。</p>
+                  </div>
+                </div>
+
+                <div class="exp-block">
+                  <p class="section-title">教育</p>
+                  <div class="exp-item">
+                    <div class="exp-top"><span>國立台灣大學</span><span class="exp-dates">2015/09 - 2019/06</span></div>
+                    <h3>資訊工程學系</h3>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+            <div class="right-col schedule-region">
+              <div class="right-col-inner">
+                <!-- schedule skeleton -->
+                <div class="sched-loading-only" style="display:flex;flex-direction:column;gap:16px;">
+                  <div class="skel skel-h6" style="width:96px;"></div>
+                  <div class="skel" style="height:256px;width:100%;border-radius:16px;"></div>
+                  <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:8px;">
+                    <div class="skel" style="height:40px;border-radius:8px;"></div>
+                    <div class="skel" style="height:40px;border-radius:8px;"></div>
+                    <div class="skel" style="height:40px;border-radius:8px;"></div>
+                    <div class="skel" style="height:40px;border-radius:8px;"></div>
+                  </div>
+                  <div class="skel" style="height:40px;width:100%;border-radius:999px;"></div>
+                </div>
+
+                <!-- schedule loaded -->
+                <div class="sched-loaded-only" style="display:flex;flex-direction:column;gap:16px;">
+                  <div class="schedule-card">
+                    <div class="schedule-card-head">
+                      <p class="label">可預約日期</p>
+                      <h2 id="selected-date-label">8月12日 (三)</h2>
+                    </div>
+                    <div class="cal" style="position:relative;">
+                      <div class="cal-month">
+                        <div class="cal-caption-row">
+                          <button type="button" class="cal-dropdown" onclick="return false;">8月<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg></button>
+                          <button type="button" class="cal-dropdown" onclick="return false;">2026<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg></button>
+                        </div>
+                        <div class="cal-nav-profile">
+                          <button type="button" class="nav-btn" onclick="return false;" aria-label="上個月"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg></button>
+                          <button type="button" class="nav-btn" onclick="return false;" aria-label="下個月"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg></button>
+                        </div>
+                      </div>
+                      <div class="cal-weekdays" id="cal-weekdays-view"></div>
+                      <div class="cal-grid" id="cal-grid-view"></div>
+                      <div class="cal-loading-overlay month-loading-only"><div class="spinner"></div></div>
+                    </div>
+                  </div>
+
+                  <!-- BookingForm: loading (reuses top-level loading flag) -->
+                  <div class="loading-only" style="display:flex;flex-direction:column;gap:16px;">
+                    <div style="display:flex;flex-direction:column;gap:8px;">
+                      <div class="skel skel-h4" style="width:112px;"></div>
+                      <div style="display:grid;grid-template-columns:repeat(2,1fr);gap:8px;">
+                        <div class="skel" style="height:40px;border-radius:8px;"></div>
+                        <div class="skel" style="height:40px;border-radius:8px;"></div>
+                      </div>
+                    </div>
+                    <div style="display:flex;flex-direction:column;gap:8px;">
+                      <div class="skel skel-h4" style="width:128px;"></div>
+                      <div class="skel" style="height:160px;border-radius:8px;"></div>
+                    </div>
+                    <div class="skel" style="height:48px;border-radius:999px;"></div>
+                  </div>
+
+                  <!-- MentorScheduleConfig: own + mentor -->
+                  <div class="loaded-only own-mentor-only" style="display:flex;flex-direction:column;gap:16px;">
+                    <div class="slot-list-label">當日可預約時段</div>
+                    <div class="slot-grid">
+                      <div class="slot-btn">10:00 – 10:30</div>
+                      <div class="slot-btn booked">14:00 – 14:30</div>
+                      <div class="slot-btn">16:00 – 16:30</div>
+                    </div>
+                    <button class="btn btn-default btn-full" id="open-msd-btn">預約設定</button>
+                  </div>
+
+                  <!-- MenteeBookingForm: not own-mentor -->
+                  <form class="loaded-only not-own-mentor-only" style="display:flex;flex-direction:column;gap:16px;" onsubmit="return false;">
+                    <div class="slot-list-label">當日可預約時段</div>
+                    <div class="slot-grid">
+                      <button type="button" class="slot-btn" data-slotbtn>10:00 – 10:30</button>
+                      <button type="button" class="slot-btn booked" disabled>14:00 – 14:30</button>
+                      <button type="button" class="slot-btn" data-slotbtn>16:00 – 16:30</button>
+                    </div>
+                    <div class="booking-textarea-wrap">
+                      <label for="booking-q">你想問導師的問題</label>
+                      <textarea id="booking-q" class="booking-textarea" placeholder="請在此輸入你的問題..."></textarea>
+                    </div>
+                    <button type="submit" class="btn btn-default btn-full" id="mentee-submit-btn" disabled>預約時間</button>
+                  </form>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <footer class="pv-footer">
+          <div class="pv-footer-inner">
+            <div class="pv-footer-logo">X-Talent</div>
+            <div class="pv-footer-cols">
+              <div class="pv-footer-col">
+                <p>關於</p>
+                <div class="pv-footer-links">
+                  <a href="#" onclick="return false;">隱私權政策</a>
+                  <a href="#" onclick="return false;">服務條款</a>
+                </div>
+              </div>
+              <div class="pv-footer-col">
+                <p>相關連結</p>
+                <div class="pv-footer-links">
+                  <a href="#" onclick="return false;">XChange Website</a>
+                  <a href="#" onclick="return false;">X-IMPACT Podcast</a>
+                  <a href="#" onclick="return false;">XChange Medium</a>
+                </div>
+              </div>
+              <div class="pv-footer-col">
+                <p>XChange 社群連結</p>
+                <div class="pv-footer-links">
+                  <a href="#" onclick="return false;">Facebook 粉絲專頁</a>
+                  <a href="#" onclick="return false;">Instagram 商業檔案</a>
+                </div>
+              </div>
+            </div>
+          </div>
+        </footer>
+
+        <!-- ============ MentorScheduleDialog: main list ============ -->
+        <div class="msd-overlay" id="msd-main">
+          <div class="dialog-card" style="max-width:560px;">
+            <button class="dialog-close" onclick="setDialog('closed')" aria-label="關閉">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+            <h3>設定可預約時段</h3>
+            <div style="display:flex;flex-direction:column;gap:16px;padding:16px 0;">
+              <div class="cal">
+                <div class="cal-month">
+                  <div class="cal-nav-default">
+                    <button type="button" class="nav-btn" onclick="return false;" aria-label="上個月"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M15 18l-6-6 6-6"/></svg></button>
+                    <button type="button" class="nav-btn" onclick="return false;" aria-label="下個月"><svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M9 18l6-6-6-6"/></svg></button>
+                  </div>
+                  <div class="cal-caption-row cal-caption-row-default">
+                    <button type="button" class="cal-dropdown cal-dropdown-boxed" onclick="return false;">8月<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg></button>
+                    <button type="button" class="cal-dropdown cal-dropdown-boxed" onclick="return false;">2026<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><path d="M6 9l6 6 6-6"/></svg></button>
+                  </div>
+                </div>
+                <div class="cal-weekdays" id="cal-weekdays-msd"></div>
+                <div class="cal-grid" id="cal-grid-msd"></div>
+              </div>
+              <div>
+                <p style="font-weight:600;margin:0 0 12px;">可預約時段</p>
+                <div style="display:flex;flex-direction:column;gap:12px;">
+                  <div class="msd-slot-row" onclick="setDialog('edit')">
+                    <div class="msd-slot-top">
+                      <div class="msd-slot-time">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#76808F" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+                        10:00 – 10:30 <span class="msd-slot-dur">(30 分)</span>
+                      </div>
+                      <button class="btn btn-ghost btn-icon" onclick="event.stopPropagation(); return false;" aria-label="刪除">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+                      </button>
+                    </div>
+                  </div>
+                  <div class="msd-slot-row" onclick="setDialog('booked')">
+                    <div class="msd-slot-top">
+                      <div class="msd-slot-time">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#76808F" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+                        14:00 – 14:30 <span class="msd-slot-dur">(30 分)</span>
+                      </div>
+                    </div>
+                  </div>
+                  <div class="msd-slot-row" onclick="setDialog('pending')">
+                    <div class="msd-slot-top">
+                      <div class="msd-slot-time">
+                        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#76808F" stroke-width="2"><circle cx="12" cy="12" r="9"/><path d="M12 7v5l3 3"/></svg>
+                        16:00 – 16:30 <span class="msd-slot-dur">(30 分)</span>
+                      </div>
+                    </div>
+                  </div>
+                  <button class="btn btn-ghost" style="height:40px;width:100%;" onclick="setDialog('add')">
+                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 5v14M5 12h14"/></svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+            <div class="dialog-footer">
+              <button class="btn btn-outline" onclick="setDialog('closed')">取消</button>
+              <button class="btn btn-default" onclick="setDialog('closed')">儲存</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============ AddSlotModal ============ -->
+        <div class="msd-overlay-2" id="msd-add">
+          <div class="dialog-card">
+            <button class="dialog-close" onclick="setDialog('main')" aria-label="關閉">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+            <h3>新增可預約時段</h3>
+            <p class="dialog-desc">2026/08/12 (週三)</p>
+            <div style="display:flex;flex-direction:column;gap:20px;padding:8px 0;">
+              <div>
+                <p class="field-label">開始時間</p>
+                <div class="time-pair">
+                  <select class="time-select"><option>09</option></select>
+                  <span style="color:var(--color-text-tertiary);">:</span>
+                  <select class="time-select"><option>00</option></select>
+                </div>
+              </div>
+              <div>
+                <p class="field-label">會議長度</p>
+                <div class="duration-radio">
+                  <button class="active" onclick="return false;">15 分</button>
+                  <button onclick="return false;">30 分</button>
+                  <button onclick="return false;">60 分</button>
+                </div>
+              </div>
+              <label class="weekly-check-row"><input type="checkbox" /> 套用至本月剩餘的每週三</label>
+            </div>
+            <div class="dialog-footer">
+              <button class="btn btn-outline" onclick="setDialog('main')">取消</button>
+              <button class="btn btn-default" onclick="setDialog('main')">建立</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============ EditSlotModal ============ -->
+        <div class="msd-overlay-2" id="msd-edit">
+          <div class="dialog-card">
+            <button class="dialog-close" onclick="setDialog('main')" aria-label="關閉">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+            <h3>編輯時段</h3>
+            <div style="display:flex;flex-direction:column;gap:20px;padding:16px 0 8px;">
+              <div>
+                <p class="field-label">開始時間</p>
+                <div class="time-pair">
+                  <select class="time-select"><option>10</option></select>
+                  <span style="color:var(--color-text-tertiary);">:</span>
+                  <select class="time-select"><option>00</option></select>
+                </div>
+              </div>
+              <div>
+                <p class="field-label">會議長度</p>
+                <div class="duration-radio">
+                  <button onclick="return false;">15 分</button>
+                  <button class="active" onclick="return false;">30 分</button>
+                  <button onclick="return false;">60 分</button>
+                </div>
+              </div>
+            </div>
+            <div class="dialog-footer">
+              <button class="btn btn-outline" onclick="setDialog('main')">取消</button>
+              <button class="btn btn-default" onclick="setDialog('main')">完成</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============ prompt: booked ============ -->
+        <div class="msd-overlay-2" id="msd-booked">
+          <div class="dialog-card" style="max-width:400px;">
+            <button class="dialog-close" onclick="setDialog('main')" aria-label="關閉">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+            <h3>此時段已有預約</h3>
+            <p class="dialog-desc">此時段已有 mentee 預約成功，無法編輯或移除。如需取消，請至「預約管理」頁面處理。</p>
+            <div class="dialog-footer">
+              <button class="btn btn-outline" onclick="setDialog('main')">取消</button>
+              <button class="btn btn-default" onclick="setDialog('main')">前往預約管理</button>
+            </div>
+          </div>
+        </div>
+
+        <!-- ============ prompt: pending ============ -->
+        <div class="msd-overlay-2" id="msd-pending">
+          <div class="dialog-card" style="max-width:400px;">
+            <button class="dialog-close" onclick="setDialog('main')" aria-label="關閉">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18 6L6 18M6 6l12 12"/></svg>
+            </button>
+            <h3>此時段有未處理的預約申請</h3>
+            <p class="dialog-desc">請至「預約管理」頁面接受或拒絕該申請，僅在拒絕後此時段才會重新釋出。</p>
+            <div class="dialog-footer">
+              <button class="btn btn-outline" onclick="setDialog('main')">取消</button>
+              <button class="btn btn-default" onclick="setDialog('main')">前往預約管理</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+
+<footer class="note">
+  已知會刻意保留的「不尋常」排版：avatar 區塊以 <code class="inline">translateY(-40px)</code> 疊在 banner 上（來源 <code class="inline">-translate-y-10</code>），非本次還原引入的瑕疵。MentorScheduleDialog 的子彈窗（新增／編輯／阻擋提示）在真實元件中各自獨立 portal 到 document.body，此處以第二層 overlay 疊加在主列表 dialog 之上重現同樣的視覺堆疊，而非巢狀在頭像／banner 這類小尺寸定位祖先內。
+</footer>
+
+<script>
+  const pageBody = document.getElementById('page-body');
+  const state = {
+    loading: '0',
+    logged: '1',
+    own: '0',
+    mentor: '1',
+    sched: '1',
+    month: '0',
+    dialog: 'closed',
+  };
+
+  function applyDerived() {
+    const own = state.own === '1' && state.logged === '1';
+    const mentor = state.mentor === '1';
+    const showSchedule = state.loading === '1' || mentor;
+    const ownMentor = own && mentor;
+
+    pageBody.dataset.loading = state.loading;
+    pageBody.dataset.logged = state.logged;
+    pageBody.dataset.own = own ? '1' : '0';
+    pageBody.dataset.mentor = state.mentor;
+    pageBody.dataset.sched = state.sched;
+    pageBody.dataset.month = state.month;
+    pageBody.dataset.dialog = state.dialog;
+    pageBody.dataset.showSchedule = showSchedule ? '1' : '0';
+    pageBody.dataset.ownMentor = ownMentor ? '1' : '0';
+    updateHeaderAuthUI();
+  }
+
+  function bindSegmented(group) {
+    const wrap = document.querySelector(`.segmented[data-group="${group}"]`);
+    wrap.querySelectorAll('.seg-btn').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        state[group] = btn.dataset.val;
+        wrap.querySelectorAll('.seg-btn').forEach((b) => b.classList.remove('active'));
+        btn.classList.add('active');
+        if (group === 'logged' && state.logged === '0') {
+          state.own = '0';
+          const ownWrap = document.querySelector('.segmented[data-group="own"]');
+          ownWrap.querySelectorAll('.seg-btn').forEach((b) => b.classList.toggle('active', b.dataset.val === '0'));
+        }
+        applyDerived();
+      });
+    });
+  }
+  ['loading', 'logged', 'own', 'mentor', 'sched', 'month'].forEach(bindSegmented);
+
+  function setDialog(val) {
+    state.dialog = val;
+    document.querySelectorAll('.dialog-jump button').forEach((b) => b.classList.toggle('active', b.dataset.val === val));
+    applyDerived();
+  }
+  document.querySelectorAll('.dialog-jump button').forEach((btn) => {
+    btn.addEventListener('click', () => setDialog(btn.dataset.val));
+  });
+  document.getElementById('open-msd-btn').addEventListener('click', () => setDialog('main'));
+
+  document.querySelectorAll('[data-slotbtn]').forEach((btn) => {
+    btn.addEventListener('click', () => {
+      document.querySelectorAll('[data-slotbtn]').forEach((b) => b.classList.remove('selected'));
+      btn.classList.add('selected');
+      document.getElementById('mentee-submit-btn').disabled = false;
+    });
+  });
+
+  /* ---- calendar render ----
+     Two distinct instances, matching each call site's real props:
+     - profile calendar (ui.tsx): ScheduleCalendar size="profile" -> variant="profile",
+       showTodayStyle={false}, disableEmptyDates={true} (only dates with slots are
+       clickable), disablePastDates not set (false).
+     - MentorScheduleDialog calendar: ScheduleCalendar with no `size` prop, which
+       defaults to size="compact" -> variant="default" (NOT "profile"), and passes
+       showTodayStyle left at Calendar's own default (true), disableEmptyDates={false}
+       (any future date is clickable so a mentor can add new availability),
+       disablePastDates={true}, highlightAvailableDates={true}. */
+  function renderCalendar(weekdaysId, gridId, opts) {
+    const weekdaysEl = document.getElementById(weekdaysId);
+    const gridEl = document.getElementById(gridId);
+    if (!weekdaysEl || !gridEl) return;
+    const daysInMonth = 31; // Aug 2026
+    const startWeekday = 6; // Aug 1 2026 is a Saturday
+    const available = new Set([3, 5, 8, 10, 12, 14, 17, 19, 21, 24, 26, 28]);
+    const selected = 12;
+    const today = 10;
+
+    const weekdayLabels = opts.variant === 'profile'
+      ? ['日', '一', '二', '三', '四', '五', '六']
+      : ['週日', '週一', '週二', '週三', '週四', '週五', '週六'];
+    weekdaysEl.innerHTML = weekdayLabels.map((w) => `<div>${w}</div>`).join('');
+
+    let html = '';
+    for (let i = 0; i < startWeekday; i++) {
+      html += `<div class="cal-day outside">${31 - startWeekday + i + 1}</div>`;
+    }
+    for (let d = 1; d <= daysInMonth; d++) {
+      const isAvail = available.has(d);
+      const isSel = d === selected;
+      const isToday = d === today;
+      const isPast = opts.disablePast && d < today;
+      const isEmpty = opts.disableEmpty && !isAvail;
+      const isDisabled = isPast || isEmpty;
+      let cls = 'cal-day';
+      if (opts.highlightAvailable && isAvail && !isSel && !isDisabled) cls += ' available';
+      if (isSel) cls += opts.variant === 'profile' ? ' selected' : ' selected-default';
+      if (isDisabled && !isSel) cls += ' disabled';
+      if (isToday && opts.showToday && !isSel) cls += ' today-ring';
+      html += isDisabled
+        ? `<button type="button" class="${cls}" disabled>${d}</button>`
+        : `<button type="button" class="${cls}" onclick="return false;">${d}</button>`;
+    }
+    gridEl.innerHTML = html;
+  }
+  renderCalendar('cal-weekdays-view', 'cal-grid-view', { variant: 'profile', disablePast: false, disableEmpty: true, showToday: false, highlightAvailable: true });
+  renderCalendar('cal-weekdays-msd', 'cal-grid-msd', { variant: 'default', disablePast: true, disableEmpty: false, showToday: true, highlightAvailable: true });
+
+  /* ---- header (Header.tsx / HamburgerMenu.tsx / UserDropdown.tsx / MobileUserMenu.tsx / ShareProfileDialog.tsx) ----
+     Reuses this page's own state.logged / state.own / state.mentor instead of a
+     separate auth control, since the header's login identity and the profile
+     page's own "own profile" state must stay in sync. */
+  const HEADER_USER = { name: '陳雅婷', subtitle: '資深後端工程師 at 樂天國際商業股份有限公司', initial: '陳', id: 'u_2290' };
+
+  const dropdownAnchor = document.getElementById('desktop-dropdown-anchor');
+  const dropdownTrigger = document.getElementById('dropdown-trigger');
+  const dropdownPanel = document.getElementById('dropdown-panel');
+  const mobileAvatarTrigger = document.getElementById('mobile-avatar-trigger');
+  const hamburgerTrigger = document.getElementById('hamburger-trigger');
+  const navOverlay = document.getElementById('nav-sheet-overlay');
+  const navPanel = document.getElementById('nav-sheet-panel');
+  const userOverlay = document.getElementById('user-sheet-overlay');
+  const userPanel = document.getElementById('user-sheet-panel');
+
+  let dropdownOpen = false;
+  let openSheetName = null;
+
+  function updateHeaderAuthUI() {
+    const loggedIn = state.logged === '1';
+    document.querySelectorAll('.auth-guest-only').forEach((el) => {
+      el.style.display = loggedIn ? 'none' : (el.dataset.displayWhenGuest || 'contents');
+    });
+    document.querySelectorAll('.auth-loggedin-only').forEach((el) => {
+      const isDropdownAnchor = el === dropdownAnchor;
+      el.style.display = loggedIn ? (isDropdownAnchor ? 'block' : 'inline-flex') : 'none';
+    });
+    document.querySelectorAll('.role-label').forEach((el) => {
+      el.textContent = state.mentor === '1' ? '我的導師頁面' : '成為導師';
+    });
+    document.querySelectorAll('.delete-account-item').forEach((el) => { el.hidden = true; });
+    if (!loggedIn) {
+      closeDropdown();
+      closeSheet('user');
+      closeShareDialog();
+    }
+  }
+
+  function openDropdown() {
+    dropdownOpen = true;
+    dropdownPanel.classList.add('is-open');
+    dropdownTrigger.setAttribute('aria-expanded', 'true');
+  }
+  function closeDropdown() {
+    dropdownOpen = false;
+    dropdownPanel.classList.remove('is-open');
+    dropdownTrigger.setAttribute('aria-expanded', 'false');
+  }
+  dropdownTrigger.addEventListener('click', () => (dropdownOpen ? closeDropdown() : openDropdown()));
+  dropdownPanel.addEventListener('click', (e) => {
+    if (e.target.closest('.dd-item, .dd-profile')) closeDropdown();
+  });
+  document.addEventListener('click', (e) => {
+    if (dropdownOpen && !dropdownAnchor.contains(e.target)) closeDropdown();
+  });
+
+  function openSheet(which) {
+    closeDropdown();
+    openSheetName = which;
+    const overlay = which === 'nav' ? navOverlay : userOverlay;
+    const panel = which === 'nav' ? navPanel : userPanel;
+    overlay.classList.add('is-open');
+    panel.classList.add('is-open');
+  }
+  function closeSheet(which) {
+    if (which && openSheetName !== which) return;
+    const overlay = (which || openSheetName) === 'nav' ? navOverlay : userOverlay;
+    const panel = (which || openSheetName) === 'nav' ? navPanel : userPanel;
+    overlay.classList.remove('is-open');
+    panel.classList.remove('is-open');
+    openSheetName = null;
+  }
+  function closeAnySheet() {
+    closeSheet('nav');
+    closeSheet('user');
+  }
+  hamburgerTrigger.addEventListener('click', () => openSheet('nav'));
+  mobileAvatarTrigger.addEventListener('click', () => openSheet('user'));
+  document.getElementById('nav-sheet-close').addEventListener('click', () => closeSheet('nav'));
+  document.getElementById('user-sheet-close').addEventListener('click', () => closeSheet('user'));
+  navOverlay.addEventListener('click', () => closeSheet('nav'));
+  userOverlay.addEventListener('click', () => closeSheet('user'));
+  navPanel.querySelectorAll('a, button').forEach((el) => el.addEventListener('click', () => closeSheet('nav')));
+  userPanel.querySelectorAll('button').forEach((el) => {
+    if (el.closest('.sheet-user-share')) return;
+    el.addEventListener('click', () => closeSheet('user'));
+  });
+
+  const shareOverlay = document.getElementById('share-overlay');
+  const shareDialog = document.getElementById('share-dialog');
+  const shareLinkInput = document.getElementById('share-link-input');
+  const shareCopyBtn = document.getElementById('share-copy-btn');
+  let shareSource = null;
+  let shareCopyResetTimer = null;
+
+  function openShareDialog(source) {
+    if (state.logged !== '1') return;
+    shareLinkInput.value = `https://x-talent.example.com/profile/${HEADER_USER.id}`;
+    shareCopyBtn.textContent = '複製';
+    shareSource = source;
+    shareOverlay.classList.add('is-open');
+    shareDialog.classList.add('is-open');
+  }
+  function closeShareDialog() {
+    shareOverlay.classList.remove('is-open');
+    shareDialog.classList.remove('is-open');
+    if (shareSource === 'mobile') closeSheet('user');
+    shareSource = null;
+  }
+  document.getElementById('dd-share-btn').addEventListener('click', () => {
+    closeDropdown();
+    setTimeout(() => openShareDialog('desktop'), 60);
+  });
+  document.getElementById('sheet-share-btn').addEventListener('click', () => openShareDialog('mobile'));
+  shareCopyBtn.addEventListener('click', async () => {
+    try {
+      await navigator.clipboard.writeText(shareLinkInput.value);
+    } catch {
+      shareLinkInput.select();
+    }
+    shareCopyBtn.textContent = '已複製';
+    clearTimeout(shareCopyResetTimer);
+    shareCopyResetTimer = setTimeout(() => { shareCopyBtn.textContent = '複製'; }, 1500);
+  });
+  document.getElementById('share-dialog-close').addEventListener('click', closeShareDialog);
+  shareOverlay.addEventListener('click', closeShareDialog);
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (shareDialog.classList.contains('is-open')) closeShareDialog();
+    else if (openSheetName) closeAnySheet();
+    else if (dropdownOpen) closeDropdown();
+  });
+
+  /* ---- resizer ---- */
+  const frame = document.getElementById('frame');
+  const slider = document.getElementById('width-slider');
+  const widthNum = document.getElementById('width-num');
+  const bpPill = document.getElementById('bp-pill');
+  function updateWidth() {
+    const w = parseInt(slider.value, 10);
+    frame.style.width = w + 'px';
+    widthNum.textContent = w + 'px';
+    let label;
+    if (w >= 1536) label = '2xl+ 版型（雙欄並排 ／ Header 導覽列）';
+    else if (w >= 1024) label = 'lg+ 版型（Header 顯示導覽列＋帳號選單）';
+    else if (w >= 768) label = 'md+ 版型（Header 顯示漢堡選單）';
+    else if (w >= 640) label = 'sm+ 版型（頭像列改橫排，Header 顯示漢堡選單）';
+    else label = '< sm 版型（單欄堆疊，Header 顯示漢堡選單）';
+    bpPill.textContent = label;
+    if (w >= 1024) closeAnySheet();
+    else closeDropdown();
+  }
+  slider.addEventListener('input', updateWidth);
+  updateWidth();
+
+  applyDerived();
+</script>
+
+<style>
+  /* ---- state-driven visibility (kept at end so it wins the cascade) ---- */
+  #page-body[data-loading="1"] .loaded-only { display: none !important; }
+  #page-body[data-loading="0"] .loading-only { display: none !important; }
+
+  #page-body[data-logged="1"] .logged-out-only { display: none !important; }
+  #page-body[data-logged="0"] .logged-in-only { display: none !important; }
+
+  #page-body[data-own="0"] .own-only { display: none !important; }
+  #page-body[data-mentor="1"] .become-mentor-btn { display: none !important; }
+
+  #page-body[data-mentor="0"] .mentor-only { display: none !important; }
+
+  #page-body[data-show-schedule="0"] .schedule-region { display: none !important; }
+
+  #page-body[data-sched="1"] .sched-loading-only { display: none !important; }
+  #page-body[data-sched="0"] .sched-loaded-only { display: none !important; }
+
+  #page-body[data-month="0"] .month-loading-only { display: none !important; }
+
+  #page-body[data-own-mentor="1"] .not-own-mentor-only { display: none !important; }
+  #page-body[data-own-mentor="0"] .own-mentor-only { display: none !important; }
+
+  #page-body:not([data-dialog="closed"]) #msd-main { display: flex !important; }
+  #page-body[data-dialog="add"] #msd-add { display: flex !important; }
+  #page-body[data-dialog="edit"] #msd-edit { display: flex !important; }
+  #page-body[data-dialog="booked"] #msd-booked { display: flex !important; }
+  #page-body[data-dialog="pending"] #msd-pending { display: flex !important; }
+</style>


### PR DESCRIPTION
Adds interactive Lavish HTML reproductions of the profile view and
edit pages (src/app/profile/[pageUserId] and its /edit route), for
design/RWD review outside the running app.

**.lavish/profile-view.html**: reproduces ui.tsx/container.tsx incl.
ProfileBanner, ProfileBadgeSection, work/education experience,
BookingForm (mentor vs mentee), ScheduleCalendar, and
MentorScheduleDialog with its add/edit/conflict sub-dialogs. Uses the
real site Header/Footer (transplanted from header_rwd.html and
Footer.tsx) instead of placeholders, defaults to populated mock data
instead of a loading skeleton, and rebuilds the calendar to match
calendar.tsx's actual variant-specific rendering (profile vs default
variant differ in caption layout, selected-date fill, and
today-style).

**.lavish/profile-edit.html**: reproduces the edit form (avatar
upload, category multi-select, job/education repeatable sections,
social links, sticky header, unsaved-changes dialog) with the same
real Header/Footer transplant. Fixes an orphaned `.job-card,
.edu-card { display: none }` CSS rule that silently hid every
experience/education card regardless of count (add/remove looked
unresponsive even though the underlying state was updating
correctly). Also widens the reproduction's outer layout cap
(max-w-1400px -> max-w-1900px) so the device-frame can actually
render up to a genuine 1440px desktop width instead of being
clamped below the header's 1024px nav breakpoint by the sidebar's
own width.

## Screenshot

N/A - reproduction artifacts under .lavish/, not a change to shipped
application UI.
