### PR TITLE
chore(lavish): add interactive mentor-pool page reproduction preview

### DIFF
--- a/.lavish/mentor-pool.html
+++ b/.lavish/mentor-pool.html
@@ -1,0 +1,2817 @@
+<title>X-Talent 導師列表頁還原 — 搜尋／篩選／熱門職位／無限捲動</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link
+  href="https://fonts.googleapis.com/css2?family=Noto+Sans+TC:wght@400;500;600;700&family=Open+Sans:wght@400;500;600;700&display=swap"
+  rel="stylesheet"
+/>
+
+<style>
+  :root {
+    --color-text-primary: #1e2026;
+    --color-text-secondary: #474d57;
+    --color-text-tertiary: #76808f;
+    --color-text-disable: #aeb4bc;
+    --color-text-white: #ffffff;
+    --color-background-bottom: #f5f5f5;
+    --color-background-bottom-secondary: #fafafa;
+    --color-background-white: #ffffff;
+    --color-background-border: #e6e8ea;
+    --color-brand-500: #2ccbcb;
+    --color-brand-600: #23a2a2;
+    --color-status-error-default: #ee3911;
+    --color-dark: #282828;
+    --color-landing-purple-light: #f7f2fb;
+    --bg-mentor-hero: linear-gradient(
+      90deg,
+      #ffffef 0%,
+      #fff6ff 19%,
+      #f7f2fb 42%,
+      #e4ffff 100%
+    );
+    --radius: 8px;
+    --page-bg: #eef1f3;
+    --page-ink: #1e2026;
+    --page-muted: #6b7280;
+    --page-card: #ffffff;
+    --page-border: #e2e5e9;
+    --accent: #2ccbcb;
+  }
+
+  * {
+    box-sizing: border-box;
+  }
+
+  body {
+    margin: 0;
+    background: var(--page-bg);
+    color: var(--page-ink);
+    font-family: 'Noto Sans TC', 'Open Sans', system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+  }
+
+  .wrap {
+    max-width: 1560px;
+    margin: 0 auto;
+    padding: 40px 24px 80px;
+  }
+
+  /* ---------- intro ---------- */
+  .intro h1 {
+    font-size: 26px;
+    font-weight: 700;
+    margin: 0 0 8px;
+    letter-spacing: -0.01em;
+  }
+  .intro p {
+    margin: 0;
+    color: var(--page-muted);
+    font-size: 14.5px;
+    line-height: 1.7;
+    max-width: 860px;
+  }
+  .intro .source-note {
+    margin-top: 14px;
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+    font-size: 12.5px;
+    color: #2c7a7a;
+    background: #e9fbfb;
+    border: 1px solid #c9f1f1;
+    padding: 7px 12px;
+    border-radius: 999px;
+  }
+  .intro .source-note b {
+    font-weight: 700;
+  }
+  .intro .scope-note {
+    margin-top: 10px;
+    font-size: 12.5px;
+    color: #8a6d16;
+    background: #fff8e6;
+    border: 1px solid #f3e3b5;
+    padding: 7px 12px;
+    border-radius: 999px;
+    display: inline-flex;
+    gap: 8px;
+    align-items: center;
+  }
+  code.inline {
+    background: #f1f3f5;
+    padding: 1px 6px;
+    border-radius: 5px;
+    font-family: ui-monospace, 'SFMono-Regular', monospace;
+    font-size: 12px;
+  }
+
+  /* ---------- control panel ---------- */
+  .panel {
+    margin-top: 28px;
+    background: var(--page-card);
+    border: 1px solid var(--page-border);
+    border-radius: 16px;
+    padding: 18px 22px;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 22px 32px;
+    align-items: flex-start;
+    box-shadow: 0 1px 2px rgba(16, 24, 40, 0.04);
+  }
+  .control-group {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .control-label {
+    font-size: 11.5px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.06em;
+    color: #9aa1ac;
+  }
+  .segmented {
+    display: inline-flex;
+    background: #f1f3f5;
+    border-radius: 10px;
+    padding: 3px;
+    gap: 2px;
+    flex-wrap: wrap;
+  }
+  .segmented button {
+    appearance: none;
+    border: none;
+    background: transparent;
+    padding: 7px 14px;
+    font: inherit;
+    font-size: 13px;
+    font-weight: 600;
+    color: var(--page-muted);
+    border-radius: 8px;
+    cursor: pointer;
+    transition:
+      background 0.15s ease,
+      color 0.15s ease,
+      box-shadow 0.15s ease;
+    white-space: nowrap;
+  }
+  .segmented button[aria-pressed='true'] {
+    background: #fff;
+    color: var(--page-ink);
+    box-shadow: 0 1px 3px rgba(16, 24, 40, 0.12);
+  }
+
+  .width-controls {
+    flex: 1 1 320px;
+    min-width: 280px;
+  }
+  .preset-row {
+    display: flex;
+    gap: 6px;
+    margin-bottom: 10px;
+    flex-wrap: wrap;
+  }
+  .preset-row button {
+    appearance: none;
+    border: 1px solid var(--page-border);
+    background: #fff;
+    padding: 6px 11px;
+    font: inherit;
+    font-size: 12.5px;
+    font-weight: 600;
+    color: var(--page-muted);
+    border-radius: 8px;
+    cursor: pointer;
+    white-space: nowrap;
+  }
+  .preset-row button:hover {
+    border-color: var(--accent);
+    color: var(--page-ink);
+  }
+  .preset-row button[aria-pressed='true'] {
+    border-color: var(--accent);
+    background: #e9fbfb;
+    color: #12706f;
+  }
+  .slider-track {
+    position: relative;
+    padding-top: 14px;
+  }
+  .slider-track input[type='range'] {
+    width: 100%;
+    accent-color: var(--accent);
+  }
+  .bp-flag {
+    position: absolute;
+    top: -2px;
+    transform: translateX(-50%);
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    pointer-events: none;
+  }
+  .bp-flag .tag {
+    font-size: 10px;
+    font-weight: 700;
+    color: #9aa1ac;
+    background: #fff;
+    padding: 0 3px;
+  }
+  .bp-flag .line {
+    width: 1px;
+    height: 20px;
+    background: #d7dbe0;
+  }
+  .width-readout {
+    margin-top: 8px;
+    font-size: 12.5px;
+    color: var(--page-muted);
+    display: flex;
+    align-items: center;
+    gap: 8px;
+  }
+  .width-readout .num {
+    font-family: ui-monospace, monospace;
+    font-weight: 700;
+    color: var(--page-ink);
+  }
+  .bp-pill {
+    background: #eef1f3;
+    padding: 2px 8px;
+    border-radius: 999px;
+    font-size: 11px;
+    font-weight: 600;
+  }
+
+  /* ---------- frame shell ---------- */
+  .frame-shell {
+    margin-top: 24px;
+  }
+  .frame-chrome {
+    background: #1c212b;
+    border-radius: 12px 12px 0 0;
+    padding-top: 10px;
+  }
+  .frame-chrome-bar {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 0 6px 10px;
+  }
+  .frame-chrome-bar .dot {
+    width: 9px;
+    height: 9px;
+    border-radius: 50%;
+    background: #3a4150;
+  }
+  .frame-chrome-bar .url {
+    margin-left: 10px;
+    background: #2a303b;
+    color: #8b93a1;
+    font-size: 11.5px;
+    padding: 4px 10px;
+    border-radius: 6px;
+    font-family: ui-monospace, monospace;
+  }
+
+  .frame-shell {
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+  .frame {
+    position: relative;
+    width: 1280px;
+    max-width: none;
+    height: 800px;
+    background: var(--color-background-white);
+    overflow: hidden;
+    border-radius: 8px 8px 0 0;
+    container-type: inline-size;
+    container-name: mp-demo;
+  }
+  .page-body {
+    position: absolute;
+    inset: 0;
+    overflow-y: auto;
+    background: var(--color-background-white);
+  }
+
+  /* ---------- header replica (ported from .lavish/header_rwd.html — same
+     source component, so the two reproductions must not visually diverge) ---------- */
+  .xt-header {
+    position: absolute;
+    inset: 0 0 auto 0;
+    height: 70px;
+    background: var(--color-background-white);
+    z-index: 50;
+    padding: 0 20px;
+    display: flex;
+    align-items: center;
+  }
+  .xt-header-inner {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .xt-left {
+    display: flex;
+    align-items: center;
+    gap: 40px;
+    min-width: 0;
+  }
+  .xt-logo {
+    display: flex;
+    align-items: center;
+    flex-shrink: 0;
+  }
+  .xt-logo svg {
+    display: block;
+    height: 26px;
+    width: auto;
+  }
+  .xt-nav {
+    display: none;
+    align-items: center;
+    gap: 28px;
+  }
+  .xt-nav a {
+    font-family: 'Open Sans', sans-serif;
+    font-size: 16px;
+    color: var(--color-text-primary);
+    text-decoration: none;
+    white-space: nowrap;
+  }
+  .xt-nav a:hover {
+    color: #14807f;
+  }
+  .xt-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  .xt-right-desktop {
+    display: none;
+    align-items: center;
+    gap: 12px;
+  }
+  .xt-right-mobile {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+  @container mp-demo (min-width: 1024px) {
+    .xt-nav {
+      display: flex;
+    }
+    .xt-right-desktop {
+      display: flex;
+    }
+    .xt-right-mobile {
+      display: none;
+    }
+    .xt-right {
+      margin-right: 80px;
+    }
+  }
+
+  .btn {
+    appearance: none;
+    border: none;
+    font: inherit;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 14px;
+    font-weight: 500;
+    height: 40px;
+    padding: 0 16px;
+    border-radius: 6px;
+    white-space: nowrap;
+  }
+  .btn-primary {
+    background: var(--color-brand-500);
+    color: var(--color-text-primary);
+  }
+  .btn-primary:hover {
+    background: #24b6b6;
+  }
+  .btn-outline {
+    background: var(--color-background-white);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-background-border);
+  }
+  .btn-outline:hover {
+    background: var(--color-background-bottom);
+  }
+  /* Header.tsx overrides the shadcn outline variant with border-brand-500
+     text-brand-500 specifically on the 註冊 button — not a generic outline. */
+  .btn-outline-brand {
+    background: var(--color-background-white);
+    color: var(--color-brand-500);
+    border: 1px solid var(--color-brand-500);
+  }
+  .btn-outline-brand:hover {
+    background: #eafafa;
+  }
+
+  .icon-btn {
+    appearance: none;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 6px;
+    color: var(--color-text-primary);
+  }
+  .icon-btn:hover {
+    background: var(--color-background-bottom);
+  }
+
+  .avatar {
+    border-radius: 50%;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 700;
+    color: #06403f;
+    background: linear-gradient(135deg, #9bf1ef, #4fdad6);
+    flex-shrink: 0;
+  }
+  .avatar-32 {
+    width: 32px;
+    height: 32px;
+    font-size: 13px;
+  }
+  .avatar-56 {
+    width: 56px;
+    height: 56px;
+    font-size: 20px;
+  }
+  .avatar-64 {
+    width: 64px;
+    height: 64px;
+    font-size: 22px;
+  }
+
+  .dropdown-trigger {
+    appearance: none;
+    border: none;
+    background: transparent;
+    cursor: pointer;
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px;
+  }
+  .dropdown-trigger .chev {
+    font-size: 19px;
+    line-height: 1;
+    color: var(--color-text-primary);
+    transition: transform 0.15s ease;
+  }
+  .dropdown-trigger[aria-expanded='true'] .chev {
+    transform: rotate(180deg);
+  }
+  .dropdown-anchor {
+    position: relative;
+  }
+  .dropdown-panel {
+    position: absolute;
+    top: calc(100% + 4px);
+    right: 0;
+    width: 320px;
+    max-height: 440px;
+    overflow-y: auto;
+    background: var(--color-background-white);
+    border: 1px solid var(--color-background-border);
+    border-radius: 16px;
+    box-shadow: 0 12px 32px -8px rgba(16, 24, 40, 0.22);
+    z-index: 60;
+    transform-origin: top right;
+    opacity: 0;
+    transform: scale(0.96);
+    pointer-events: none;
+    transition:
+      opacity 0.12s ease,
+      transform 0.12s ease;
+  }
+  .dropdown-panel.is-open {
+    opacity: 1;
+    transform: scale(1);
+    pointer-events: auto;
+  }
+  .dd-profile {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 20px 20px 16px;
+    background: none;
+    border: none;
+    cursor: pointer;
+    text-align: left;
+    font: inherit;
+  }
+  .dd-profile .name {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .dd-share {
+    padding: 0 20px 16px;
+  }
+  .dd-share .btn {
+    width: 100%;
+    height: 48px;
+    border-radius: 14px;
+    font-size: 15px;
+    font-weight: 600;
+  }
+  .dd-divider {
+    height: 1px;
+    background: var(--color-background-bottom);
+  }
+  .dd-items {
+    padding: 8px;
+    display: flex;
+    flex-direction: column;
+  }
+  .dd-item {
+    appearance: none;
+    border: none;
+    background: none;
+    text-align: left;
+    font: inherit;
+    font-size: 15px;
+    color: var(--color-text-primary);
+    padding: 10px 12px;
+    border-radius: 6px;
+    cursor: pointer;
+  }
+  .dd-item:hover {
+    background: var(--color-background-bottom);
+  }
+
+  /* ---------- mobile sheets ---------- */
+  .sheet-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(255, 255, 255, 0.8);
+    backdrop-filter: blur(2px);
+    z-index: 70;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+  .sheet-overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .sheet-panel {
+    position: absolute;
+    inset: 0 0 0 auto;
+    width: 100%;
+    max-width: 360px;
+    background: var(--color-background-white);
+    z-index: 71;
+    padding: 24px;
+    display: flex;
+    flex-direction: column;
+    transform: translateX(100%);
+    transition: transform 0.32s cubic-bezier(0.32, 0.72, 0, 1);
+    box-shadow: -8px 0 24px -12px rgba(16, 24, 40, 0.2);
+  }
+  .sheet-panel.is-open {
+    transform: translateX(0);
+  }
+  .sheet-close {
+    margin-left: auto;
+    appearance: none;
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--color-brand-900, #092929);
+    padding: 4px;
+    display: inline-flex;
+  }
+  .sheet-nav-links {
+    flex: 1;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 28px;
+    font-size: 20px;
+  }
+  .sheet-nav-links a {
+    color: var(--color-text-primary);
+    text-decoration: none;
+  }
+  .sheet-nav-bottom {
+    margin-top: auto;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    padding-bottom: 8px;
+  }
+  .sheet-nav-bottom .btn {
+    width: 160px;
+  }
+  .sheet-user-profile {
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    padding: 16px 0 24px;
+    text-align: left;
+    background: none;
+    border: none;
+    cursor: pointer;
+    font: inherit;
+  }
+  .sheet-user-profile .name {
+    font-size: 18px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+  }
+  .sheet-user-share {
+    margin-bottom: 20px;
+  }
+  .sheet-user-share .btn {
+    width: 100%;
+    height: 46px;
+    border-radius: 14px;
+    font-size: 15px;
+    font-weight: 600;
+  }
+  .sheet-user-nav {
+    display: flex;
+    flex-direction: column;
+    padding: 8px 0;
+  }
+  .sheet-user-nav button,
+  .sheet-user-bottom button {
+    appearance: none;
+    border: none;
+    background: none;
+    text-align: left;
+    font: inherit;
+    padding: 12px 0;
+    font-size: 15px;
+    color: var(--color-text-primary);
+    cursor: pointer;
+  }
+  .sheet-user-bottom {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 16px;
+  }
+
+  /* ---------- share profile dialog (ShareProfileDialog.tsx) ---------- */
+  .share-overlay {
+    position: absolute;
+    inset: 0;
+    background: rgba(40, 40, 40, 0.7);
+    z-index: 90;
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease;
+  }
+  .share-overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+  .share-dialog {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: calc(100% - 32px);
+    max-width: 420px;
+    z-index: 91;
+    border-radius: 24px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    box-shadow: 0 25px 60px -15px rgba(16, 24, 40, 0.35);
+    opacity: 0;
+    pointer-events: none;
+    transform: translate(-50%, -48%) scale(0.97);
+    transition:
+      opacity 0.16s ease,
+      transform 0.16s ease;
+  }
+  .share-dialog.is-open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translate(-50%, -50%) scale(1);
+  }
+  .share-dialog-inner {
+    padding: 24px 24px 28px;
+  }
+  .share-dialog-head {
+    position: relative;
+    margin-bottom: 20px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .share-dialog-title {
+    font-size: 22px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+    line-height: 1;
+    text-align: center;
+  }
+  .share-dialog-close {
+    position: absolute;
+    right: 0;
+    top: 50%;
+    transform: translateY(-50%);
+    font-size: 24px;
+    line-height: 1;
+    color: var(--color-text-primary);
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 4px;
+  }
+  .share-profile-card {
+    margin-bottom: 18px;
+    display: flex;
+    align-items: center;
+    gap: 16px;
+    border-radius: 16px;
+    border: 1px solid var(--color-background-border);
+    padding: 16px 18px;
+  }
+  .share-profile-name {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+  }
+  .share-profile-subtitle {
+    margin-top: 4px;
+    font-size: 13px;
+    color: var(--color-text-tertiary);
+  }
+  .share-link-label {
+    display: block;
+    margin-bottom: 8px;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+  }
+  .share-link-row {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    border-radius: 12px;
+    border: 1px solid var(--color-background-border);
+    padding: 10px 14px;
+  }
+  .share-link-row input {
+    flex: 1;
+    min-width: 0;
+    border: none;
+    background: transparent;
+    font: inherit;
+    font-size: 13px;
+    color: var(--color-text-primary);
+    outline: none;
+  }
+  .share-copy-btn {
+    height: 36px;
+    flex-shrink: 0;
+    border-radius: 8px;
+    padding: 0 14px;
+    font-size: 13px;
+  }
+  [hidden] {
+    display: none !important;
+  }
+
+  /* ---------- hero ---------- */
+  .mp-hero-wrap {
+    position: relative;
+  }
+  .mp-hero {
+    display: flex;
+    height: 202px;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    background: var(--bg-mentor-hero);
+    padding: 0 20px;
+    text-align: center;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--color-text-primary);
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-hero {
+      font-size: 30px;
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-hero {
+      border-bottom-right-radius: 120px;
+    }
+  }
+
+  /* ---------- search bar (absolutely positioned over hero, per real component) ---------- */
+  .mp-searchbar-wrap {
+    position: absolute;
+    top: 172px;
+    left: calc(50% - 169px);
+    height: 80px;
+    width: 338px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-searchbar-wrap {
+      left: calc(50% - 344px);
+      width: 688px;
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-searchbar-wrap {
+      left: calc(50% - 423px);
+      width: 846px;
+    }
+  }
+  .mp-searchbar {
+    display: flex;
+    align-items: center;
+    width: 100%;
+    max-width: 846px;
+    border-radius: 16px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    padding: 6px 12px;
+    box-shadow: 0 8px 24px rgba(16, 24, 40, 0.08);
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-searchbar {
+      padding: 16px 24px;
+    }
+  }
+  .mp-search-icon {
+    margin-right: 8px;
+    flex-shrink: 0;
+    color: var(--color-text-tertiary);
+  }
+  .mp-search-input {
+    height: 20px;
+    min-width: 0;
+    flex: 1 1 auto;
+    border: none;
+    outline: none;
+    background: transparent;
+    font: inherit;
+    font-size: 16px;
+    color: var(--color-text-primary);
+  }
+  .mp-search-input::placeholder {
+    color: var(--color-text-tertiary);
+  }
+  .mp-search-input-mobile {
+    display: block;
+  }
+  .mp-search-input-tablet,
+  .mp-search-input-desktop {
+    display: none;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-search-input-mobile {
+      display: none;
+    }
+    .mp-search-input-tablet {
+      display: block;
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-search-input-tablet {
+      display: none;
+    }
+    .mp-search-input-desktop {
+      display: block;
+    }
+  }
+  .mp-search-btn {
+    margin-left: 8px;
+    flex-shrink: 0;
+    cursor: pointer;
+    border: none;
+    border-radius: 9999px;
+    background: var(--color-brand-500);
+    color: var(--color-text-primary);
+    width: 40px;
+    height: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: 500;
+    font-size: 14px;
+    padding: 0;
+  }
+  .mp-search-btn:hover {
+    background: #26b8b8;
+  }
+  .mp-search-btn:disabled {
+    opacity: 0.7;
+    cursor: default;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-search-btn {
+      width: auto;
+      height: auto;
+      border-radius: 24px;
+      padding: 10px 24px;
+    }
+  }
+  .mp-search-btn .btn-text {
+    display: none;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-search-btn .btn-icon {
+      display: none;
+    }
+    .mp-search-btn .btn-text {
+      display: inline;
+    }
+  }
+  .spin {
+    animation: mp-spin 0.8s linear infinite;
+  }
+  @keyframes mp-spin {
+    to {
+      transform: rotate(360deg);
+    }
+  }
+
+  /* ---------- content section ---------- */
+  .mp-content {
+    margin-top: 80px;
+    padding: 0 20px 40px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-content {
+      padding: 0 40px 40px;
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-content {
+      padding: 0 80px 40px;
+    }
+  }
+  .mp-content-inner {
+    max-width: 1280px;
+    margin: 0 auto;
+    width: 100%;
+  }
+
+  /* ---------- popular chips ---------- */
+  .mp-chips-wrap {
+    position: relative;
+    transition: opacity 0.15s;
+  }
+  .mp-chips-row {
+    display: flex;
+    gap: 8px;
+    overflow-x: auto;
+    scrollbar-width: none;
+    -ms-overflow-style: none;
+  }
+  .mp-chips-row::-webkit-scrollbar {
+    display: none;
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-chips-row {
+      overflow-x: visible;
+      justify-content: center;
+      width: 846px;
+      margin: 0 auto;
+    }
+  }
+  .mp-chip {
+    flex-shrink: 0;
+    border-radius: 9999px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    padding: 6px 16px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+    cursor: pointer;
+    white-space: nowrap;
+    font-family: inherit;
+  }
+  .mp-chip:hover {
+    background: var(--color-landing-purple-light);
+  }
+  .mp-chip:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-chip.mp-chip-overflow {
+      display: none;
+    }
+  }
+  .mp-chip-fade {
+    pointer-events: none;
+    position: absolute;
+    inset: 0 auto 0 0;
+    width: 40px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    background: linear-gradient(
+      to right,
+      var(--color-background-white),
+      rgba(255, 255, 255, 0)
+    );
+  }
+  .mp-chip-fade.right {
+    inset: 0 0 0 auto;
+    justify-content: flex-end;
+    background: linear-gradient(
+      to left,
+      var(--color-background-white),
+      rgba(255, 255, 255, 0)
+    );
+  }
+  .mp-chip-fade svg {
+    color: rgba(30, 32, 38, 0.6);
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-chip-fade {
+      display: none;
+    }
+  }
+
+  /* ---------- toolbar: count + filter ---------- */
+  .mp-toolbar {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 16px;
+    margin-top: 24px;
+    margin-bottom: 20px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-toolbar {
+      flex-direction: row;
+      align-items: center;
+      justify-content: space-between;
+      gap: 0;
+    }
+  }
+  .mp-count {
+    font-size: 16px;
+    color: var(--color-text-primary);
+    transition: opacity 0.15s;
+  }
+  .mp-count.is-replacing {
+    opacity: 0.5;
+  }
+  .mp-toolbar-actions {
+    width: 100%;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-toolbar-actions {
+      width: auto;
+    }
+  }
+
+  .mp-filter-anchor {
+    position: relative;
+  }
+  .mp-filter-trigger {
+    display: flex;
+    height: 40px;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    border-radius: 8px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    padding: 4px 16px;
+    font: inherit;
+    font-size: 14px;
+    color: var(--color-text-primary);
+    cursor: pointer;
+  }
+  .mp-filter-trigger:hover {
+    background: var(--color-background-bottom-secondary);
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-filter-trigger {
+      width: auto;
+    }
+  }
+  .mp-filter-panel {
+    display: none;
+    position: absolute;
+    top: calc(100% + 8px);
+    right: 0;
+    z-index: 55;
+    width: 320px;
+    max-height: 420px;
+    flex-direction: column;
+    border-radius: 8px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    box-shadow: 0 12px 32px rgba(16, 24, 40, 0.18);
+  }
+  .mp-filter-panel.open {
+    display: flex;
+  }
+  .mp-filter-body {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px 16px 8px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .mp-filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+  }
+  .mp-filter-field label {
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+  }
+  .mp-filter-field select {
+    height: 40px;
+    border-radius: 6px;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    padding: 0 12px;
+    font: inherit;
+    font-size: 14px;
+    color: var(--color-text-primary);
+  }
+  .mp-filter-footer {
+    display: flex;
+    gap: 8px;
+    border-top: 1px solid var(--color-background-border);
+    padding: 12px 16px 16px;
+  }
+
+  .mp-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    font: inherit;
+    font-size: 14px;
+    font-weight: 500;
+    border-radius: 6px;
+    height: 40px;
+    padding: 0 16px;
+    cursor: pointer;
+    border: none;
+    transition: background-color 0.15s;
+  }
+  .mp-btn.primary {
+    background: var(--color-brand-500);
+    color: var(--color-text-primary);
+    flex: 1;
+  }
+  .mp-btn.primary:hover {
+    background: #26b8b8;
+  }
+  .mp-btn.outline {
+    background: var(--color-background-white);
+    color: var(--color-text-primary);
+    border: 1px solid var(--color-background-border);
+    flex: 1;
+  }
+  .mp-btn.outline:hover {
+    background: var(--color-background-bottom);
+  }
+  .mp-btn.lg {
+    height: 44px;
+    padding: 0 32px;
+  }
+
+  /* ---------- filter badges ---------- */
+  .mp-badges {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 12px;
+    margin-bottom: 20px;
+  }
+  .mp-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 8px;
+    height: 32px;
+    border-radius: 8px;
+    border: 1px solid var(--color-background-border);
+    padding: 6px 8px 6px 12px;
+    font-size: 14px;
+    font-weight: 500;
+    color: var(--color-text-primary);
+  }
+  .mp-badge button {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    border: none;
+    background: transparent;
+    color: var(--color-text-primary);
+    padding: 0;
+    cursor: pointer;
+    border-radius: 4px;
+  }
+  .mp-badge button:hover {
+    opacity: 0.7;
+  }
+
+  /* ---------- grid & cards ---------- */
+  .mp-grid-outer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 24px;
+  }
+  .mp-grid {
+    display: grid;
+    min-width: max-content;
+    grid-template-columns: 334px;
+    gap: 20px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-grid {
+      grid-template-columns: repeat(2, 334px);
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-grid {
+      grid-template-columns: repeat(3, 413px);
+    }
+  }
+  .mp-grid-wrap {
+    position: relative;
+    margin-bottom: 24px;
+    width: 100%;
+  }
+
+  .mp-card {
+    position: relative;
+    width: 334px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    transition: box-shadow 0.15s;
+    text-decoration: none;
+    color: inherit;
+    display: block;
+  }
+  .mp-card:hover {
+    box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.1),
+      0 8px 10px -6px rgba(0, 0, 0, 0.1);
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-card {
+      width: 413px;
+      height: 480px;
+    }
+  }
+  .mp-card-figure {
+    margin: 0;
+    position: relative;
+    height: 348px;
+    width: 100%;
+    overflow: hidden;
+    background: var(--color-background-bottom);
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-card-figure {
+      height: 292px;
+    }
+  }
+  .mp-card-figure img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+  .mp-card-years {
+    position: absolute;
+    right: 30px;
+    bottom: 30px;
+    border-radius: 8px;
+    background: rgba(40, 40, 40, 0.3);
+    color: #fff;
+    padding: 4px 10px;
+    font-size: 13px;
+  }
+  .mp-card-body {
+    padding: 16px 16px 24px;
+    display: flex;
+    flex-direction: column;
+    gap: 16px;
+  }
+  .mp-card-name {
+    font-size: 16px;
+    line-height: 24px;
+    font-weight: 700;
+    letter-spacing: 0.5px;
+    margin: 0;
+  }
+  .mp-card-role {
+    display: flex;
+    gap: 6px;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.02em;
+  }
+  .mp-card-role .at {
+    color: var(--color-text-tertiary);
+  }
+  .mp-card-about {
+    margin: 0;
+    font-size: 14px;
+    line-height: 20px;
+    letter-spacing: 0.02em;
+    color: var(--color-text-tertiary);
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+  .mp-tag-container {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .mp-tag {
+    border-radius: 6px;
+    border: 1px solid var(--color-background-border);
+    padding: 6px 12px;
+    font-size: 14px;
+    line-height: 20px;
+    font-weight: 500;
+    letter-spacing: 0.02em;
+    white-space: nowrap;
+  }
+  .mp-tag-measure {
+    position: absolute;
+    top: 0;
+    left: 0;
+    visibility: hidden;
+    pointer-events: none;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+
+  /* ---------- skeleton ---------- */
+  .mp-skel-section {
+    margin-top: 132px;
+    padding: 0 20px 40px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .mp-skel-section {
+      padding: 0 40px 40px;
+    }
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-skel-section {
+      padding: 0 80px 40px;
+    }
+  }
+  .mp-skel-title {
+    margin-bottom: 20px;
+    height: 24px;
+    width: 128px;
+    border-radius: 6px;
+    background: var(--color-background-bottom);
+    animation: mp-pulse 1.4s ease-in-out infinite;
+  }
+  .mp-skel-card {
+    width: 334px;
+    border-radius: 8px;
+    overflow: hidden;
+    border: 1px solid var(--color-background-border);
+    background: var(--color-background-white);
+    animation: mp-pulse 1.4s ease-in-out infinite;
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-skel-card {
+      width: 413px;
+      height: 480px;
+    }
+  }
+  .mp-skel-figure {
+    height: 200px;
+    width: 100%;
+    background: var(--color-background-bottom);
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-skel-figure {
+      height: 260px;
+    }
+  }
+  .mp-skel-body {
+    padding: 16px 16px 24px;
+  }
+  .mp-skel-line {
+    border-radius: 4px;
+    background: var(--color-background-bottom);
+  }
+  @keyframes mp-pulse {
+    0%,
+    100% {
+      opacity: 1;
+    }
+    50% {
+      opacity: 0.5;
+    }
+  }
+
+  /* ---------- overlay / spinner / states ---------- */
+  .mp-overlay {
+    pointer-events: none;
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(255, 255, 255, 0.6);
+  }
+  .mp-spinner-icon {
+    color: var(--color-text-tertiary);
+  }
+  .mp-full-spinner {
+    display: flex;
+    width: 100%;
+    align-items: center;
+    justify-content: center;
+    padding: 80px 0;
+  }
+  .mp-state {
+    margin-top: 24px;
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 16px;
+    padding: 48px 0;
+    text-align: center;
+  }
+  .mp-state p {
+    margin: 0;
+    font-size: 20px;
+    color: var(--color-text-primary);
+  }
+  @container mp-demo (min-width: 1280px) {
+    .mp-state p {
+      font-size: 30px;
+    }
+  }
+  .mp-state svg {
+    color: var(--color-text-tertiary);
+  }
+  .mp-sentinel {
+    height: 1px;
+  }
+
+  /* ---------- footer (Footer.tsx) ---------- */
+  .xt-footer {
+    display: flex;
+    width: 100%;
+    background: var(--color-dark);
+    padding-bottom: 50px;
+  }
+  .xt-footer-inner {
+    display: flex;
+    width: 100%;
+    flex-direction: column;
+    align-items: center;
+    padding: 50px 20px 0;
+  }
+  @container mp-demo (min-width: 768px) {
+    .xt-footer-inner {
+      flex-direction: row;
+      align-items: flex-start;
+      justify-content: space-between;
+      padding: 50px 70px 0;
+    }
+  }
+  .xt-footer-logo {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  @container mp-demo (min-width: 768px) {
+    .xt-footer-logo {
+      align-items: flex-start;
+    }
+  }
+  .xt-footer-logo svg {
+    display: block;
+    height: 32px;
+    width: auto;
+  }
+  .xt-footer-cols {
+    margin-top: 32px;
+    display: flex;
+    flex-direction: column;
+    gap: 32px;
+    color: var(--color-text-white);
+  }
+  @container mp-demo (min-width: 768px) {
+    .xt-footer-cols {
+      margin-top: 0;
+      flex-direction: row;
+      gap: 64px;
+    }
+  }
+  .xt-footer-col {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+  @container mp-demo (min-width: 768px) {
+    .xt-footer-col {
+      align-items: flex-start;
+    }
+  }
+  .xt-footer-col h4 {
+    margin: 0 0 20px;
+    font-size: 20px;
+    font-weight: 700;
+    letter-spacing: 0.085em;
+  }
+  .xt-footer-links {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  @container mp-demo (min-width: 768px) {
+    .xt-footer-links {
+      align-items: flex-start;
+    }
+  }
+  .xt-footer-links a {
+    color: var(--color-text-white);
+    font-size: 14px;
+    text-decoration: none;
+  }
+  .xt-footer-links a:hover {
+    text-decoration: underline;
+  }
+
+  /* ---------- notes ---------- */
+  .notes {
+    margin-top: 20px;
+    background: var(--page-card);
+    border: 1px solid var(--page-border);
+    border-radius: 16px;
+    padding: 18px 22px;
+    font-size: 13px;
+    line-height: 1.8;
+    color: var(--page-muted);
+  }
+  .notes h2 {
+    font-size: 14px;
+    margin: 0 0 10px;
+    color: var(--page-ink);
+  }
+  .notes ul {
+    margin: 0;
+    padding-left: 18px;
+  }
+  .notes li {
+    margin-bottom: 4px;
+  }
+
+  .sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
+  }
+</style>
+
+<div class="wrap">
+  <div class="intro">
+    <h1>導師列表頁（/mentor-pool）還原</h1>
+    <p>
+      依照 <code class="inline">src/app/mentor-pool</code> 與
+      <code class="inline">src/components/mentor-pool</code>
+      現有原始碼重建：Hero、搜尋列、熱門職位橫向捲動列、篩選下拉、導師卡片格線（含標籤溢位計算）、骨架屏、無結果／載入失敗狀態，以及卡片底部無限捲動載入更多。左側控制面板可切換情境與模擬裝置寬度（以
+      CSS container query 取代真實 viewport media query）。
+    </p>
+    <div class="source-note">
+      🎨 <b>設計來源：</b>本專案（X-Talent-Frontend）既有的 Tailwind
+      設計權杖（<code class="inline">src/styles/tokens.css</code>）與
+      <code class="inline">src/components/ui/*</code> 元件樣式，非自創視覺。
+    </div>
+    <div class="scope-note">
+      ℹ️ Header／Footer 與 <code class="inline">.lavish/header_rwd.html</code>
+      共用同一份原始碼（<code class="inline">Header.tsx</code> /
+      <code class="inline">Footer.tsx</code>），標記、樣式與漢堡選單／使用者下拉選單互動皆自該還原檔移植，避免兩份還原互相分歧；個人頁面才有的「分享個人頁面」對話框與「刪除帳號」不在此頁範圍內，予以省略。
+    </div>
+  </div>
+
+  <div class="panel">
+    <div class="control-group">
+      <div class="control-label">列表情境</div>
+      <div class="segmented" id="scenario-row">
+        <button data-scenario="success" aria-pressed="true">✅ 有結果</button>
+        <button data-scenario="empty" aria-pressed="false">🔍 無結果</button>
+        <button data-scenario="error" aria-pressed="false">⚠️ 載入失敗</button>
+        <button data-scenario="skeleton" aria-pressed="false">
+          ⏳ 首次載入骨架
+        </button>
+      </div>
+    </div>
+
+    <div class="control-group">
+      <div class="control-label">Header 登入狀態</div>
+      <div class="segmented" id="auth-row">
+        <button data-auth="guest" aria-pressed="true">訪客</button>
+        <button data-auth="mentee" aria-pressed="false">已登入・Mentee</button>
+        <button data-auth="mentor" aria-pressed="false">已登入・Mentor</button>
+      </div>
+    </div>
+
+    <div class="width-controls">
+      <div class="control-label">裝置寬度（模擬 RWD 斷點）</div>
+      <div class="preset-row" id="preset-row">
+        <button data-w="1440" aria-pressed="false">🖥️ Desktop 1440</button>
+        <button data-w="1280" aria-pressed="true" title="1280–1438px 這段寬度的導師格線會溢出，疑似真實版面 bug，見下方說明">🖥️ Desktop 1280 ⚠️</button>
+        <button data-w="768" aria-pressed="false">💻 Tablet 768</button>
+        <button data-w="375" aria-pressed="false">📱 Mobile 375</button>
+      </div>
+      <div class="slider-track">
+        <div class="bp-flag" style="left: 41.3%">
+          <span class="tag">md 768</span><span class="line"></span>
+        </div>
+        <div class="bp-flag" style="left: 86%">
+          <span class="tag">xl 1280</span><span class="line"></span>
+        </div>
+        <input
+          type="range"
+          id="width-slider"
+          min="320"
+          max="1440"
+          value="1280"
+          step="1"
+        />
+      </div>
+      <div class="width-readout">
+        容器寬度 <span class="num" id="width-num">1280px</span>
+        <span class="bp-pill" id="bp-pill">xl 版型</span>
+      </div>
+    </div>
+  </div>
+
+  <div class="frame-shell">
+    <div class="frame-chrome">
+      <div class="frame-chrome-bar">
+        <span class="dot" style="background: #ff6159"></span>
+        <span class="dot" style="background: #ffbd2e"></span>
+        <span class="dot" style="background: #28ca41"></span>
+        <span class="url">x-talent.example.com/mentor-pool</span>
+      </div>
+      <div class="frame" id="frame">
+        <div class="page-body" id="page-body">
+          <!-- Header.tsx — markup/behavior ported 1:1 from .lavish/header_rwd.html
+               (the shared, already-vetted header reproduction) so this page doesn't
+               drift from that source of truth. Share-profile dialog and delete-account
+               are omitted: they're profile-page-only affordances, out of scope here. -->
+          <header class="xt-header">
+            <div class="xt-header-inner">
+              <div class="xt-left">
+                <a href="#" class="xt-logo" aria-label="Go to homepage" onclick="return false;">
+                  <svg width="151" height="30" viewBox="0 0 151 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                    <g clip-path="url(#mp-logo-clip)">
+                      <path d="M74.6777 23.754C74.3889 23.7619 74.1041 23.6915 73.8603 23.552C73.6165 23.4126 73.4249 23.2105 73.3104 22.972L69.8298 16.5585L66.4985 22.9272C66.3727 23.1849 66.1625 23.402 65.8961 23.5497C65.6296 23.6974 65.3194 23.7687 65.0067 23.754C64.7237 23.7426 64.4491 23.6635 64.2115 23.5248C63.9738 23.386 63.7818 23.1928 63.655 22.9649C63.5283 22.7371 63.4716 22.483 63.4907 22.2289C63.5098 21.9748 63.604 21.7298 63.7637 21.5194L67.7664 14.3686L64.3107 7.66469C64.1759 7.43812 64.1071 7.18454 64.111 6.92764C64.1149 6.67073 64.1912 6.4189 64.3327 6.19569C64.4743 5.97248 64.6766 5.78518 64.9205 5.65128C65.1645 5.51739 65.4422 5.44126 65.7278 5.43006C66.0489 5.40701 66.3692 5.483 66.6358 5.64549C66.9025 5.80797 67.0995 6.04724 67.1945 6.3239L70.0038 12.268L73.0121 6.39094C73.1192 6.10269 73.3271 5.85333 73.6049 5.68013C73.8828 5.50694 74.2156 5.41923 74.5535 5.43006C75.8214 5.43006 76.418 6.54738 75.7716 7.66469L72.1419 14.3686L76.0451 21.5418C76.1667 21.765 76.2265 22.0114 76.2194 22.2599C76.2123 22.5084 76.1384 22.7516 76.0041 22.9688C75.8698 23.1861 75.6791 23.371 75.4481 23.5077C75.2172 23.6444 74.9529 23.729 74.6777 23.754V23.754Z" fill="#003C5A"/>
+                      <path d="M78.4068 16.4022C78.4034 16.2663 78.4307 16.1313 78.4869 16.0052C78.5432 15.8791 78.6274 15.7646 78.7343 15.6685C78.8412 15.5724 78.9685 15.4968 79.1088 15.4463C79.2491 15.3957 79.3994 15.3711 79.5505 15.3742H83.4784C83.6445 15.3522 83.8138 15.3627 83.9749 15.4049C84.1361 15.447 84.2852 15.5198 84.4122 15.6184C84.5392 15.717 84.6412 15.8391 84.711 15.9763C84.7809 16.1134 84.8169 16.2625 84.8169 16.4133C84.8169 16.5642 84.7809 16.7132 84.711 16.8504C84.6412 16.9876 84.5392 17.1096 84.4122 17.2082C84.2852 17.3068 84.1361 17.3796 83.9749 17.4217C83.8138 17.4639 83.6445 17.4744 83.4784 17.4524H79.5007C79.2018 17.4408 78.9198 17.3243 78.7153 17.128C78.5108 16.9316 78.4 16.671 78.4068 16.4022V16.4022Z" fill="#003C5A"/>
+                      <path d="M92.4038 22.3241C92.3546 22.6812 92.162 23.0098 91.8621 23.248C91.5621 23.4863 91.1756 23.6178 90.7753 23.6178C90.375 23.6178 89.9886 23.4863 89.6887 23.248C89.3888 23.0098 89.1961 22.6812 89.147 22.3241V7.93306H85.7908C85.6103 7.9361 85.4309 7.9064 85.2635 7.84571C85.0961 7.78501 84.944 7.69455 84.8163 7.57981C84.6887 7.46507 84.5881 7.32842 84.5206 7.17793C84.453 7.02745 84.4199 6.86628 84.4233 6.70404C84.4198 6.54281 84.4529 6.3826 84.5207 6.23329C84.5885 6.08398 84.6897 5.94869 84.8177 5.83571C84.9457 5.72272 85.098 5.63441 85.2653 5.57622C85.4326 5.51803 85.6115 5.4912 85.7908 5.49732H95.7352C95.9124 5.49428 96.0884 5.5234 96.2528 5.58297C96.4172 5.64254 96.5666 5.73129 96.6919 5.84396C96.8173 5.95662 96.9161 6.0909 96.9824 6.23867C97.0486 6.38645 97.081 6.54474 97.0777 6.70404C97.0845 6.86519 97.0545 7.02589 96.9898 7.1763C96.9251 7.3267 96.8269 7.46358 96.7012 7.57865C96.5755 7.69373 96.425 7.78456 96.2589 7.8455C96.0928 7.90644 95.9146 7.93622 95.7352 7.93306H92.4038V22.3241Z" fill="#003C5A"/>
+                      <path d="M106.276 14.4583V22.4136C106.283 22.5894 106.25 22.7646 106.179 22.9286C106.108 23.0925 106 23.2418 105.863 23.3672C105.726 23.4926 105.562 23.5917 105.38 23.6583C105.199 23.7248 105.005 23.7575 104.809 23.7543C104.611 23.7606 104.414 23.7302 104.23 23.665C104.046 23.5998 103.879 23.5014 103.739 23.3756C103.599 23.2498 103.489 23.0994 103.417 22.934C103.344 22.7685 103.311 22.5914 103.318 22.4136C102.948 22.8971 102.449 23.2894 101.867 23.5549C101.285 23.8203 100.638 23.9504 99.9861 23.9332C97.5 23.9332 96.1576 22.4583 96.1576 19.8885C96.1576 17.3186 97.9475 15.6203 101.403 15.6203H103.168V14.1678C103.222 13.8809 103.202 13.5868 103.111 13.3077C103.02 13.0285 102.859 12.7717 102.641 12.5565C102.423 12.3414 102.154 12.1735 101.853 12.0655C101.553 11.9575 101.229 11.9122 100.906 11.9332C99.9906 12.0269 99.0847 12.1837 98.1962 12.4024C98.0451 12.4085 97.8942 12.3869 97.7527 12.3391C97.6111 12.2912 97.4819 12.2182 97.3727 12.1242C97.2635 12.0302 97.1766 11.9173 97.1173 11.7923C97.058 11.6673 97.0275 11.5327 97.0276 11.3968C97.0235 11.1541 97.1092 10.9171 97.2712 10.723C97.4332 10.5288 97.6623 10.3886 97.9226 10.3242C99.0755 9.96882 100.284 9.78025 101.503 9.76557C102.181 9.72452 102.86 9.82125 103.491 10.0486C104.122 10.276 104.688 10.6283 105.146 11.0791C105.605 11.5299 105.944 12.0678 106.14 12.6528C106.336 13.2378 106.382 13.855 106.276 14.4583ZM103.168 21.1622V17.3857H102C99.9613 17.3857 99.0912 18.0784 99.0912 19.7991C99.0912 21.5197 99.6879 22.0337 101.006 22.0337C101.424 22.0363 101.838 21.9508 102.214 21.7839C102.589 21.6171 102.916 21.3736 103.168 21.0728V21.1622Z" fill="#003C5A"/>
+                      <path d="M111.323 4.00025C111.528 3.99417 111.733 4.02568 111.924 4.09286C112.116 4.16005 112.29 4.26151 112.437 4.39108C112.583 4.52066 112.699 4.67565 112.777 4.84663C112.854 5.01761 112.893 5.20101 112.889 5.38572V22.369C112.889 22.7423 112.724 23.1005 112.43 23.3645C112.137 23.6285 111.738 23.7768 111.323 23.7768C110.907 23.7768 110.509 23.6285 110.215 23.3645C109.922 23.1005 109.757 22.7423 109.757 22.369V5.38572C109.753 5.20101 109.792 5.01761 109.869 4.84663C109.947 4.67565 110.063 4.52066 110.209 4.39108C110.356 4.26151 110.53 4.16005 110.721 4.09286C110.913 4.02568 111.117 3.99417 111.323 4.00025Z" fill="#003C5A"/>
+                      <path d="M126.041 22.2573C126.037 22.4629 125.969 22.6634 125.847 22.8369C125.724 23.0104 125.55 23.1501 125.345 23.2405C124.268 23.7815 123.047 24.0444 121.814 24.0003C118.085 24.0003 115.848 21.3857 115.848 16.8718C115.848 12.3578 118.011 9.81031 121.342 9.81031C124.673 9.81031 126.19 12.0449 126.19 16.0226C126.19 17.0058 125.668 17.5421 124.624 17.5421H118.93C118.93 20.4025 120.149 21.8997 122.212 21.8997C123.182 21.7847 124.133 21.5671 125.046 21.2516C125.188 21.2506 125.328 21.2769 125.458 21.3286C125.588 21.3804 125.703 21.4564 125.797 21.5516C125.892 21.6469 125.962 21.7591 126.004 21.8808C126.046 22.0025 126.058 22.1308 126.041 22.2573V22.2573ZM118.93 15.8662H123.555C123.555 13.0282 122.834 11.8885 121.441 11.8885C120.049 11.8885 118.98 13.2293 118.93 15.8662Z" fill="#003C5A"/>
+                      <path d="M139.739 14.1007V22.3688C139.743 22.5516 139.705 22.7331 139.629 22.9026C139.553 23.072 139.439 23.226 139.295 23.3553C139.151 23.4845 138.98 23.5864 138.792 23.655C138.603 23.7235 138.401 23.7573 138.198 23.7543C137.99 23.7602 137.783 23.729 137.589 23.6623C137.395 23.5956 137.217 23.4948 137.067 23.3659C136.917 23.2369 136.796 23.0823 136.713 22.9112C136.63 22.74 136.585 22.5556 136.582 22.3688V14.4582C136.582 12.827 135.911 11.9554 134.593 11.9554C134.109 11.9721 133.635 12.085 133.205 12.2859C132.775 12.4868 132.4 12.7708 132.107 13.1174V22.3688C132.107 22.7422 131.942 23.1003 131.648 23.3643C131.354 23.6283 130.956 23.7766 130.541 23.7766C130.125 23.7766 129.727 23.6283 129.433 23.3643C129.139 23.1003 128.975 22.7422 128.975 22.3688V11.1956C128.975 10.84 129.132 10.499 129.411 10.2476C129.691 9.99612 130.071 9.85482 130.466 9.85482C130.862 9.85482 131.241 9.99612 131.521 10.2476C131.801 10.499 131.958 10.84 131.958 11.1956V11.5532C132.442 11.0063 133.054 10.5609 133.749 10.2483C134.445 9.93568 135.208 9.76329 135.985 9.74312C138.272 9.81016 139.739 11.4191 139.739 14.1007Z" fill="#003C5A"/>
+                      <path d="M150.28 22.3686C150.274 22.6053 150.196 22.836 150.056 23.0365C149.916 23.237 149.719 23.4 149.485 23.5083C148.79 23.8227 148.025 23.9909 147.247 23.9999C146.756 24.0203 146.265 23.9434 145.811 23.7745C145.356 23.6057 144.948 23.3491 144.616 23.0229C144.284 22.6967 144.036 22.3089 143.889 21.8869C143.742 21.4649 143.7 21.0191 143.767 20.5809V12.0222H142.722C142.583 12.0194 142.446 11.9915 142.319 11.9403C142.192 11.889 142.077 11.8154 141.982 11.7238C141.887 11.6322 141.814 11.5244 141.766 11.4068C141.718 11.2892 141.697 11.1641 141.703 11.039C141.693 10.9132 141.712 10.7868 141.758 10.6678C141.805 10.5488 141.878 10.4397 141.974 10.3474C142.07 10.2551 142.186 10.1815 142.314 10.1314C142.443 10.0812 142.582 10.0555 142.722 10.0558H143.767V7.55295C143.767 7.17957 143.932 6.82151 144.225 6.55749C144.519 6.29348 144.917 6.14518 145.333 6.14518C145.748 6.14518 146.147 6.29348 146.44 6.55749C146.734 6.82151 146.899 7.17957 146.899 7.55295V10.1675H149.236C149.526 10.1675 149.804 10.2711 150.01 10.4555C150.215 10.6399 150.33 10.89 150.33 11.1507C150.33 11.4115 150.215 11.6616 150.01 11.846C149.804 12.0304 149.526 12.134 149.236 12.134H146.899V20.6926C146.899 21.5641 147.198 21.8993 147.894 21.8993C148.59 21.8993 148.888 21.5642 149.336 21.5642C149.578 21.5639 149.811 21.6471 149.987 21.7968C150.162 21.9466 150.267 22.1512 150.28 22.3686Z" fill="#003C5A"/>
+                    </g>
+                    <path d="M41.8876 16.4878C44.5017 16.4878 46.6209 14.4925 46.6209 12.0313C46.6209 9.56997 44.5017 7.57471 41.8876 7.57471C39.2735 7.57471 37.1543 9.56997 37.1543 12.0313C37.1543 14.4925 39.2735 16.4878 41.8876 16.4878Z" fill="#003C5A"/>
+                    <path d="M41.9651 0C38.4686 0 35.2971 1.32445 32.9895 3.46929L32.7532 3.69177C31.7379 4.65122 31.7379 6.2051 32.7569 7.16454C33.7759 8.12399 35.43 8.12399 36.449 7.16107L36.6669 6.9525C38.1954 5.53766 40.2556 4.80765 42.4118 4.92584C46.2 5.13094 49.2792 8.02318 49.5081 11.5898C49.7739 15.7161 46.2849 19.1506 41.9614 19.1506C39.9676 19.1506 38.0883 18.4241 36.6632 17.1101L22.035 3.46929C19.7274 1.32445 16.5595 0 13.0594 0C5.81911 0 -0.0181448 5.66976 0.291994 12.5527C0.565212 18.6709 5.77481 23.6698 12.2656 24.0417C12.8563 24.0765 13.4397 24.0695 14.0083 24.0313C15.5626 23.9235 16.7035 22.6165 16.4414 21.1703C16.2125 19.9119 15.0125 19.0255 13.6944 19.1298C13.484 19.1472 13.2735 19.1541 13.0594 19.1541C8.7359 19.1541 5.24683 15.7161 5.51267 11.5933C5.74158 8.02666 8.82082 5.13789 12.6089 4.92932C14.7688 4.81113 16.8254 5.54114 18.3539 6.95597L32.9895 20.6002C35.3968 22.8389 38.7418 24.1808 42.4229 24.0626C49.1832 23.8401 54.6439 18.591 54.7435 12.2225C54.8506 5.48552 49.0872 0 41.9651 0Z" fill="#003C5A"/>
+                    <path d="M27.514 21.0904C26.8826 21.0904 26.2845 21.2085 25.7344 21.4171L17.512 13.6755C17.7262 13.168 17.8443 12.6118 17.8443 12.0313C17.8443 9.57007 15.725 7.57471 13.111 7.57471C10.497 7.57471 8.37769 9.57007 8.37769 12.0313C8.37769 14.4924 10.497 16.4878 13.111 16.4878C13.7276 16.4878 14.3146 16.3766 14.8537 16.1749L23.0982 23.9374C22.8915 24.4345 22.7807 24.9768 22.7807 25.5434C22.7807 28.0046 24.9 30 27.514 30C30.128 30 32.2473 28.0046 32.2473 25.5434C32.2473 23.0857 30.128 21.0904 27.514 21.0904ZM28.9576 25.5469C28.9576 25.5504 28.9576 25.5504 28.9576 25.5539C28.9539 26.3012 28.3078 26.9061 27.514 26.9061C27.5103 26.9061 27.5103 26.9061 27.5066 26.9061C26.7128 26.9026 26.0704 26.2943 26.0704 25.5469C26.0704 25.4635 26.0815 25.3835 26.0962 25.307C26.0999 25.2862 26.1036 25.2653 26.111 25.2445C26.1295 25.1715 26.1516 25.0985 26.1811 25.0324C26.1885 25.015 26.1996 24.9977 26.207 24.9803C26.2218 24.949 26.2365 24.9177 26.255 24.8864C26.2587 24.8829 26.2624 24.8795 26.2661 24.8795C26.3879 24.6778 26.5651 24.5075 26.7756 24.3893C26.7756 24.3858 26.7793 24.3858 26.783 24.3824C26.8236 24.3615 26.8642 24.3406 26.9048 24.3233C26.9343 24.3094 26.9676 24.2989 26.9971 24.285C27.0562 24.2642 27.1189 24.2468 27.1817 24.2294C27.2076 24.2224 27.2297 24.219 27.2556 24.2155C27.3368 24.2016 27.4217 24.1912 27.5103 24.1912C28.3115 24.1877 28.9576 24.796 28.9576 25.5469Z" fill="#003C5A"/>
+                    <defs>
+                      <clipPath id="mp-logo-clip">
+                        <rect width="86.7403" height="20" fill="white" transform="translate(63.5399 4)"/>
+                      </clipPath>
+                    </defs>
+                  </svg>
+                </a>
+                <nav class="xt-nav">
+                  <a href="#" onclick="return false;">尋找導師</a>
+                  <a href="#" class="role-label" onclick="return false;">成為導師</a>
+                  <a href="#" onclick="return false;">關於 X-Talent</a>
+                  <a href="#" onclick="return false;">提供回饋</a>
+                </nav>
+              </div>
+
+              <div class="xt-right">
+                <div class="xt-right-desktop">
+                  <div class="auth-guest-only" style="display: contents">
+                    <a href="#" onclick="return false;"><button type="button" class="btn btn-outline-brand">註冊</button></a>
+                    <a href="#" onclick="return false;"><button type="button" class="btn btn-primary">登入</button></a>
+                  </div>
+                  <div class="auth-loggedin-only dropdown-anchor" style="display: none;" id="desktop-dropdown-anchor">
+                    <button type="button" class="dropdown-trigger" id="dropdown-trigger" aria-label="開啟用戶選單" aria-expanded="false">
+                      <span class="avatar avatar-32" id="dd-avatar-32">王</span>
+                      <span class="chev" aria-hidden="true">▾</span>
+                    </button>
+                    <div class="dropdown-panel" id="dropdown-panel" role="menu">
+                      <button type="button" class="dd-profile">
+                        <span class="avatar avatar-56" id="dd-avatar-56">王</span>
+                        <span class="name" id="dd-name">王小明</span>
+                      </button>
+                      <div class="dd-share">
+                        <button type="button" class="btn btn-outline" id="dd-share-btn">分享個人頁面</button>
+                      </div>
+                      <div class="dd-divider"></div>
+                      <div class="dd-items">
+                        <button type="button" class="dd-item role-label" role="menuitem">成為導師</button>
+                        <button type="button" class="dd-item" role="menuitem">我的預約</button>
+                        <button type="button" class="dd-item" role="menuitem">登出</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+                <div class="xt-right-mobile">
+                  <button type="button" class="icon-btn auth-loggedin-only" style="display: none;" id="mobile-avatar-trigger" aria-label="開啟用戶選單">
+                    <span class="avatar avatar-32" id="mobile-avatar-32">王</span>
+                  </button>
+                  <button type="button" class="icon-btn" id="hamburger-trigger" aria-label="開啟導航選單">
+                    <svg width="22" height="22" viewBox="0 0 22 22" fill="none"><path d="M3 6H19M3 11H19M3 16H19" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+                  </button>
+                </div>
+              </div>
+            </div>
+          </header>
+
+          <!-- Sheets are portalled as siblings of the header (Radix behavior), so
+               their inset:0 resolves against the full frame, not the 70px header box. -->
+          <div class="sheet-overlay" id="nav-sheet-overlay"></div>
+          <div class="sheet-panel" id="nav-sheet-panel" role="dialog" aria-label="導航選單">
+            <button type="button" class="sheet-close" id="nav-sheet-close" aria-label="關閉導航選單">
+              <svg width="24" height="24" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <div class="sheet-nav-links">
+              <a href="#" onclick="return false;">尋找導師</a>
+              <a href="#" class="role-label" onclick="return false;">成為導師</a>
+              <a href="#" onclick="return false;">關於 X-Talent</a>
+              <a href="#" onclick="return false;">提供回饋</a>
+            </div>
+            <div class="sheet-nav-bottom auth-guest-only" data-display-when-guest="flex">
+              <a href="#" onclick="return false;"><button type="button" class="btn btn-primary">登入</button></a>
+              <a href="#" onclick="return false;"><button type="button" class="btn btn-outline-brand">註冊</button></a>
+            </div>
+          </div>
+
+          <div class="sheet-overlay" id="user-sheet-overlay"></div>
+          <div class="sheet-panel" id="user-sheet-panel" role="dialog" aria-label="用戶選單">
+            <button type="button" class="sheet-close" id="user-sheet-close" aria-label="關閉用戶選單">
+              <svg width="24" height="24" viewBox="0 0 26 26" fill="none"><path d="M6 6L20 20M20 6L6 20" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <button type="button" class="sheet-user-profile">
+              <span class="avatar avatar-56" id="sheet-avatar-56">王</span>
+              <span class="name" id="sheet-user-name">王小明</span>
+            </button>
+            <div class="sheet-user-share">
+              <button type="button" class="btn btn-outline" id="sheet-share-btn">分享個人頁面</button>
+            </div>
+            <div class="dd-divider"></div>
+            <nav class="sheet-user-nav">
+              <button type="button" class="role-label">成為導師</button>
+              <button type="button">我的預約</button>
+            </nav>
+            <div class="sheet-user-bottom">
+              <button type="button">登出</button>
+            </div>
+          </div>
+
+          <!-- Share profile dialog (ShareProfileDialog.tsx) -->
+          <div class="share-overlay" id="share-overlay"></div>
+          <div class="share-dialog" id="share-dialog" role="dialog" aria-label="分享個人頁面">
+            <div class="share-dialog-inner">
+              <div class="share-dialog-head">
+                <div class="share-dialog-title">分享個人頁面</div>
+                <button type="button" class="share-dialog-close" id="share-dialog-close" aria-label="關閉">×</button>
+              </div>
+              <div class="share-profile-card">
+                <span class="avatar avatar-64" id="share-avatar">王</span>
+                <div style="min-width: 0;">
+                  <div class="share-profile-name" id="share-name">王小明</div>
+                  <div class="share-profile-subtitle" id="share-subtitle">成為導師</div>
+                </div>
+              </div>
+              <div>
+                <label class="share-link-label" for="share-link-input">個人頁面連結</label>
+                <div class="share-link-row">
+                  <input type="text" id="share-link-input" readonly value="" />
+                  <button type="button" class="btn btn-outline share-copy-btn" id="share-copy-btn">複製</button>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <!-- MentorPoolHero + MentorPoolSearchBar (page.tsx) -->
+          <div class="mp-hero-wrap">
+            <section class="mp-hero">和 Mentors 一起提升你的職涯經驗吧！</section>
+            <div class="mp-searchbar-wrap">
+              <div class="mp-searchbar">
+                <svg class="mp-search-icon" width="24" height="24" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="m20 20-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                <input class="mp-search-input mp-search-input-mobile" type="text" placeholder="搜尋職位、公司或領域" aria-label="搜尋" />
+                <input class="mp-search-input mp-search-input-tablet" type="text" placeholder="搜尋職位、公司或想精進的領域" aria-label="搜尋" />
+                <input class="mp-search-input mp-search-input-desktop" type="text" placeholder="搜尋職位、公司或想精進的領域" aria-label="搜尋" />
+                <button type="button" class="mp-search-btn" id="search-btn" aria-label="搜尋">
+                  <svg class="btn-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="m20 20-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                  <span class="btn-text">搜尋</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <!-- Suspense fallback: MentorGridSkeleton -->
+          <section class="mp-skel-section" id="skeleton-section" style="display:none;" aria-busy="true" aria-label="導師清單載入中">
+            <div class="mp-content-inner">
+              <div class="mp-skel-title"></div>
+              <div class="mp-grid-outer">
+                <div class="mp-grid" id="skeleton-grid"></div>
+              </div>
+            </div>
+          </section>
+
+          <!-- MentorPoolWithData -> container -> ui.tsx -->
+          <section class="mp-content" id="resolved-section">
+            <div class="mp-content-inner">
+              <!-- PopularPositionChips -->
+              <div class="mp-chips-wrap" id="chips-wrap">
+                <div class="mp-chips-row" id="chips-row" aria-label="熱門職位"></div>
+                <div class="mp-chip-fade left" id="chip-fade-left" style="display:none;">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M15 18l-6-6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </div>
+                <div class="mp-chip-fade right" id="chip-fade-right">
+                  <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M9 18l6-6-6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                </div>
+              </div>
+
+              <!-- count + MentorFilterDropdown -->
+              <div class="mp-toolbar">
+                <div class="mp-count" id="mp-count">找到 0 位導師</div>
+                <div class="mp-toolbar-actions">
+                  <div class="mp-filter-anchor">
+                    <button type="button" class="mp-filter-trigger" id="filter-trigger" aria-expanded="false">
+                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none"><path d="M4 5h16M7 12h10M10 19h4" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                      <span>篩選</span>
+                      <svg id="filter-chevron" width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="m6 9 6 6 6-6" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+                    </button>
+                    <div class="mp-filter-panel" id="filter-panel">
+                      <div class="mp-filter-body" id="filter-body"></div>
+                      <div class="mp-filter-footer">
+                        <button type="button" class="mp-btn primary" id="filter-apply">套用</button>
+                        <button type="button" class="mp-btn outline" id="filter-clear">清除全部</button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+
+              <!-- active filter badges -->
+              <div class="mp-badges" id="badges-row"></div>
+
+              <!-- grid / overlay -->
+              <div class="mp-grid-wrap" id="grid-wrap" style="display:none;">
+                <div class="mp-grid-outer">
+                  <div class="mp-grid" id="mentor-grid"></div>
+                  <div class="mp-sentinel" id="sentinel"></div>
+                </div>
+                <div class="mp-overlay" id="replacing-overlay" style="display:none;" aria-busy="true" aria-live="polite">
+                  <svg class="mp-spinner-icon spin" width="32" height="32" viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 1 1-9-9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+                </div>
+              </div>
+
+              <div class="mp-full-spinner" id="full-spinner" style="display:none;">
+                <svg class="mp-spinner-icon spin" width="32" height="32" viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 1 1-9-9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+              </div>
+
+              <div class="mp-full-spinner" id="loadmore-spinner" style="display:none;">
+                <svg class="mp-spinner-icon spin" width="32" height="32" viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 1 1-9-9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>
+              </div>
+
+              <div class="mp-state" id="empty-state" style="display:none;" role="status" aria-live="polite">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="m20 20-3.5-3.5M8 8l6 6M14 8l-6 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                <p>找不到符合的導師</p>
+                <button type="button" class="mp-btn outline lg" id="empty-clear-btn">清除所有條件</button>
+              </div>
+
+              <div class="mp-state" id="error-state" style="display:none;" role="status" aria-live="polite">
+                <svg width="48" height="48" viewBox="0 0 24 24" fill="none"><circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2"/><path d="M12 8v5M12 16h.01" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+                <p>載入失敗，請重試</p>
+                <button type="button" class="mp-btn outline lg" id="retry-btn">重新嘗試</button>
+              </div>
+            </div>
+          </section>
+
+          <!-- Footer.tsx -->
+          <footer class="xt-footer">
+            <div class="xt-footer-inner">
+              <div class="xt-footer-logo">
+                <svg width="146" height="30" viewBox="0 0 151 30" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M41.8876 16.4878C44.5017 16.4878 46.6209 14.4925 46.6209 12.0313C46.6209 9.56997 44.5017 7.57471 41.8876 7.57471C39.2735 7.57471 37.1543 9.56997 37.1543 12.0313C37.1543 14.4925 39.2735 16.4878 41.8876 16.4878Z" fill="#fff"/>
+                  <path d="M41.9651 0C38.4686 0 35.2971 1.32445 32.9895 3.46929L32.7532 3.69177C31.7379 4.65122 31.7379 6.2051 32.7569 7.16454C33.7759 8.12399 35.43 8.12399 36.449 7.16107L36.6669 6.9525C38.1954 5.53766 40.2556 4.80765 42.4118 4.92584C46.2 5.13094 49.2792 8.02318 49.5081 11.5898C49.7739 15.7161 46.2849 19.1506 41.9614 19.1506C39.9676 19.1506 38.0883 18.4241 36.6632 17.1101L22.035 3.46929C19.7274 1.32445 16.5595 0 13.0594 0C5.81911 0 -0.0181448 5.66976 0.291994 12.5527C0.565212 18.6709 5.77481 23.6698 12.2656 24.0417C12.8563 24.0765 13.4397 24.0695 14.0083 24.0313C15.5626 23.9235 16.7035 22.6165 16.4414 21.1703C16.2125 19.9119 15.0125 19.0255 13.6944 19.1298C13.484 19.1472 13.2735 19.1541 13.0594 19.1541C8.7359 19.1541 5.24683 15.7161 5.51267 11.5933C5.74158 8.02666 8.82082 5.13789 12.6089 4.92932C14.7688 4.81113 16.8254 5.54114 18.3539 6.95597L32.9895 20.6002C35.3968 22.8389 38.7418 24.1808 42.4229 24.0626C49.1832 23.8401 54.6439 18.591 54.7435 12.2225C54.8506 5.48552 49.0872 0 41.9651 0Z" fill="#fff"/>
+                  <path d="M27.514 21.0904C26.8826 21.0904 26.2845 21.2085 25.7344 21.4171L17.512 13.6755C17.7262 13.168 17.8443 12.6118 17.8443 12.0313C17.8443 9.57007 15.725 7.57471 13.111 7.57471C10.497 7.57471 8.37769 9.57007 8.37769 12.0313C8.37769 14.4924 10.497 16.4878 13.111 16.4878C13.7276 16.4878 14.3146 16.3766 14.8537 16.1749L23.0982 23.9374C22.8915 24.4345 22.7807 24.9768 22.7807 25.5434C22.7807 28.0046 24.9 30 27.514 30C30.128 30 32.2473 28.0046 32.2473 25.5434C32.2473 23.0857 30.128 21.0904 27.514 21.0904Z" fill="#fff"/>
+                  <text x="63" y="21" font-family="Open Sans, sans-serif" font-size="17" font-weight="700" fill="#fff">X-Talent</text>
+                </svg>
+              </div>
+              <div class="xt-footer-cols">
+                <div class="xt-footer-col">
+                  <h4>關於</h4>
+                  <div class="xt-footer-links">
+                    <a href="#" onclick="return false;">隱私權政策</a>
+                    <a href="#" onclick="return false;">服務條款</a>
+                  </div>
+                </div>
+                <div class="xt-footer-col">
+                  <h4>相關連結</h4>
+                  <div class="xt-footer-links">
+                    <a href="#" onclick="return false;">XChange Website</a>
+                    <a href="#" onclick="return false;">X-IMPACT Podcast</a>
+                    <a href="#" onclick="return false;">XChange Medium</a>
+                  </div>
+                </div>
+                <div class="xt-footer-col">
+                  <h4>XChange 社群連結</h4>
+                  <div class="xt-footer-links">
+                    <a href="#" onclick="return false;">Facebook 粉絲專頁</a>
+                    <a href="#" onclick="return false;">Instagram 商業檔案</a>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </footer>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="notes">
+    <h2>還原重點與已知怪癖（沿用 header/reservation 還原時踩過的坑）</h2>
+    <ul>
+      <li>
+        搜尋框在真實元件中是「同一份 state、三個依斷點顯示的 input」，此還原以單一
+        JS 變數同步三個 input 的 value，而非各自獨立狀態。
+      </li>
+      <li>
+        標籤（Tag）溢位邏輯完整重現 <code class="inline">Information.tsx</code> 的
+        <code class="inline">computeOverflowFit</code>：用隱藏量測列取得每個標籤實際寬度，再依卡片可用寬度換算可顯示數量並附上「+N」。熱門職位列在
+        xl
+        斷點也用同一演算法計算可顯示幾個（依 846px 桌機搜尋框寬度量測）。
+      </li>
+      <li>
+        「找到 N 位導師」與骨架屏（Suspense fallback）分屬不同狀態：初次載入骨架不含熱門職位／篩選列（因為
+        <code class="inline">MentorGridSkeleton</code> 在 Suspense 邊界內，取代整個
+        <code class="inline">MentorPoolWithData</code>），且骨架區塊的
+        <code class="inline">mt-[132px]</code> 與正式內容的
+        <code class="inline">mt-[80px]</code> 不同，刻意保留這個不對稱間距（讓骨架卡片視覺上對齊真正資料出現的位置）。
+      </li>
+      <li>
+        篩選套用時（搜尋、篩選 Apply、移除單一篩選 Badge、點擊熱門職位）沿用真實的
+        <code class="inline">isReplacing</code>
+        覆蓋層行為：若目前已有資料，舊卡片格線維持顯示並疊加半透明
+        spinner，等新結果回來才整批替換；若目前是空/錯誤狀態則改用置中的全版
+        spinner。篩選面板「清除全部」只清 pending 狀態，需按「套用」才會真正生效。
+      </li>
+      <li>
+        卡片底部以真實的 IntersectionObserver（threshold 0.5）觀察最後一張卡片，捲動到底才觸發載入下一頁（PAGE_LIMIT=9），第三頁資料不足
+        9 筆時 <code class="inline">hasMore</code> 轉為
+        false，之後捲到底不再觸發。
+      </li>
+      <li>
+        Header／Footer 的標記與樣式（含 logo SVG、真實 outline-brand
+        註冊鈕、桌機下拉選單、手機導航與使用者 sheet）直接沿用
+        <code class="inline">header_rwd.html</code> 已還原好的版本，避免同一顆
+        <code class="inline">Header.tsx</code> 在兩份還原之間走樣；只省略個人頁面才有的分享對話框／刪除帳號。
+      </li>
+      <li>
+        裝置寬度面板的框架容器（<code class="inline">.wrap</code>）與
+        <code class="inline">.frame-shell</code> 已放寬到可完整容納 1440px
+        寬的 frame（並在更窄的瀏覽器視窗下允許橫向捲動），拖曳寬度滑桿或按下「Desktop
+        1440」即可看到未被裁切的桌機版原始樣貌。
+      </li>
+      <li>
+        ⚠️ <b>疑似真實版面 bug（非本還原引入）：</b>viewport 寬度介於
+        <b>1280–1438px</b> 之間時，導師卡片格線會整排往右溢出被裁切——這不是還原誤差，是精確重算
+        <code class="inline">MentorPoolUI</code> 的實際 class
+        後得出的結果：<code class="inline">xl:grid-cols-3</code> 需要
+        3 × 413px 卡片 + 2 × 20px（<code class="inline">gap-5</code>）＝
+        1279px 才放得下，但外層
+        <code class="inline">max-w-screen-xl px-5 md:px-10 xl:px-20</code>
+        在 xl 斷點只提供「viewport − 160px 左右內距」的可用寬度，且格線又套用了
+        <code class="inline">min-w-max</code>（不會被壓縮），兩者只有在 viewport
+        ≥ 1439px 時才真正夠寬。也就是說常見的 1366×768、1280×800、1440×900（未滿
+        1439）等筆電解析度，實際網站上很可能都會出現一樣的溢出。此還原刻意如實重現這個現象（見「Desktop
+        1280 ⚠️」按鈕），沒有偷偷收窄卡片或加
+        <code class="inline">overflow-x</code> 把它蓋掉——如果這確實是待修的
+        production bug，建議另外開票處理，而不是在這份還原裡「校正」掉。
+      </li>
+    </ul>
+  </div>
+</div>
+
+<script>
+  (function () {
+    'use strict';
+
+    /* ================= mock data ================= */
+    var PHOTOS = [
+      'https://images.unsplash.com/photo-1534528741775-53994a69daeb?w=400&auto=format&fit=crop&q=80',
+      'https://images.unsplash.com/photo-1507003211169-0a1dd7228f2d?w=400&auto=format&fit=crop&q=80',
+      'https://images.unsplash.com/photo-1494790108377-be9c29b29330?w=400&auto=format&fit=crop&q=80',
+      'https://images.unsplash.com/photo-1500648767791-00dcc994a43e?w=400&auto=format&fit=crop&q=80',
+      'https://images.unsplash.com/photo-1544005313-94ddf0286df2?w=400&auto=format&fit=crop&q=80',
+      'https://images.unsplash.com/photo-1519085360753-af0119f7cbe7?w=400&auto=format&fit=crop&q=80',
+    ];
+
+    var YEARS_LABEL = {
+      BELOW_ONE_YEAR: '1 年以下',
+      ONE_TO_THREE: '1~3 年',
+      THREE_TO_FIVE: '3~5 年',
+      FIVE_TO_TEN: '5~10 年',
+      OVER_TEN_YEAR: '10 年以上',
+    };
+
+    var BASE_MENTORS = [
+      {
+        user_id: 1, name: '陳怡君 (Jane Chen)', avatar: PHOTOS[0],
+        job_title: 'Senior UI/UX Designer', company: 'Google', years_of_experience: 'THREE_TO_FIVE',
+        industry: 'Internet / Software',
+        about: '擁有 8 年以上數位產品設計經驗，曾主導多個跨國 B2B 與 B2C 產品的設計與優化。熱衷於使用者研究、資訊架構與互動設計。',
+        have_skill: ['Figma', 'Prototyping', 'User Interview', 'Wireframing'],
+        have_topic: ['UI/UX 設計', '使用者研究', '產品規劃', '職涯諮詢', '求職履歷優化'],
+      },
+      {
+        user_id: 2, name: '王小明 (John Wang)', avatar: PHOTOS[1],
+        job_title: 'Senior Frontend Engineer', company: 'TSMC', years_of_experience: 'FIVE_TO_TEN',
+        industry: 'Semiconductor',
+        about: '專注於 React/Next.js 前端開發、效能優化與前端架構設計。熱於分享技術與指導新人，協助將複雜需求轉化為高維護性的程式碼。',
+        have_skill: ['React', 'Next.js', 'TypeScript', 'TailwindCSS', 'Webpack', 'Vitest'],
+        have_topic: ['Frontend', 'React', 'TypeScript', 'Performance Optimization'],
+      },
+      {
+        user_id: 3, name: '林建宏 (Alex Lin)', avatar: PHOTOS[2],
+        job_title: 'Staff Product Manager', company: 'TSMC', years_of_experience: 'OVER_TEN_YEAR',
+        industry: 'Semiconductor',
+        about: '超過 12 年跨國科技大廠專案與產品管理實務，專精於敏捷開發導入、團隊流程重塑、大規模系統規劃與產品策略制定。',
+        have_skill: ['Agile', 'Scrum', 'Product Strategy', 'Roadmapping', 'Market Analysis'],
+        have_topic: ['Agile PM', 'Scrum', 'Product Strategy', 'System Architecture', 'Career Coaching'],
+      },
+      {
+        user_id: 4, name: '黃雅婷 (Emily Huang)', avatar: PHOTOS[3],
+        job_title: 'Data Science Lead', company: 'MediaTek', years_of_experience: 'FIVE_TO_TEN',
+        industry: 'IC Design',
+        about: '專精於機器學習、大數據分析與預測模型構建，帶領數據團隊解決多個核心演算法瓶頸，並曾於國際研討會發表多篇論文。',
+        have_skill: ['Python', 'PyTorch', 'SQL', 'Big Data', 'Machine Learning'],
+        have_topic: ['Data Science', 'Machine Learning', 'Big Data Analytics', 'AI Solutions'],
+      },
+      {
+        user_id: 5, name: '蔡明哲 (David Tsai)', avatar: PHOTOS[4],
+        job_title: 'Backend Tech Lead', company: 'Shopee', years_of_experience: 'FIVE_TO_TEN',
+        industry: 'E-commerce',
+        about: '主導蝦皮多個核心電商模組的架構重構與資料庫優化，具備豐富的微服務架構與系統維護經驗，熱衷於解決技術難題。',
+        have_skill: ['Go', 'Java', 'Microservices', 'Kubernetes', 'Redis', 'Kafka'],
+        have_topic: ['Backend Development', 'System Design', 'Microservices', 'Cloud Native'],
+      },
+      {
+        user_id: 6, name: '吳曼妮 (Sophie Wu)', avatar: PHOTOS[5],
+        job_title: 'Marketing Director', company: 'Line', years_of_experience: 'OVER_TEN_YEAR',
+        industry: 'Social Media / Internet',
+        about: '超過 11 年數位行銷與品牌建立經驗，擅長社群行銷策略、網紅異業合作、大型公關活動策劃及成長駭客模式運營。',
+        have_skill: ['Brand Strategy', 'Growth Hacking', 'Public Relations', 'SEO'],
+        have_topic: ['Marketing Strategy', 'Brand Building', 'Growth Marketing', 'PR Strategy'],
+      },
+    ];
+
+    // Extra placeholder mentors so the infinite-scroll demo (PAGE_LIMIT=9) has
+    // enough pages to show a real 2nd/3rd page + a "no more data" stop.
+    var EXTRA_TEMPLATES = [
+      ['張家豪 (Kevin Chang)', 'iOS Engineer', 'Cathay Financial', 'ONE_TO_THREE', 'Finance', ['Swift', 'SwiftUI', 'iOS'], ['iOS 開發', '行動架構']],
+      ['李佳穎 (Amy Lee)', 'Product Designer', 'Cake', 'THREE_TO_FIVE', 'Fintech', ['Figma', 'Design System'], ['產品設計', '設計系統']],
+      ['周思廷 (Tina Chou)', 'AI Engineer', 'Appier', 'THREE_TO_FIVE', 'AI / SaaS', ['Python', 'LLM', 'MLOps'], ['AI 工程', '模型部署']],
+      ['許承恩 (Eric Hsu)', 'DevOps Engineer', 'Chunghwa Telecom', 'FIVE_TO_TEN', 'Telecom', ['Kubernetes', 'Terraform', 'AWS'], ['雲端架構', 'SRE']],
+      ['潘怡蓁 (Grace Pan)', 'HR Business Partner', 'Delta Electronics', 'OVER_TEN_YEAR', 'Manufacturing', ['Talent Acquisition', 'OD'], ['人資策略', '組織發展']],
+      ['邱柏翰 (Ben Chiu)', 'Growth Product Manager', 'Cathay United Bank', 'THREE_TO_FIVE', 'Finance', ['A/B Testing', 'SQL'], ['成長駭客', '產品分析']],
+      ['謝欣妤 (Sherry Hsieh)', 'UX Researcher', 'HTC', 'ONE_TO_THREE', 'Hardware', ['User Research', 'Usability Testing'], ['使用者研究', '易用性測試']],
+      ['鄭宇軒 (Ray Cheng)', 'Full-Stack Engineer', 'PChome', 'FIVE_TO_TEN', 'E-commerce', ['Node.js', 'React', 'PostgreSQL'], ['全端開發', '系統設計']],
+      ['羅家瑜 (Nicole Lo)', 'Finance Manager', 'Fubon Financial', 'OVER_TEN_YEAR', 'Finance', ['Financial Modeling', 'FP&A'], ['財務規劃', '職涯轉換']],
+      ['孫立德 (Leo Sun)', 'Cloud Solutions Architect', 'Trend Micro', 'FIVE_TO_TEN', 'Cybersecurity', ['AWS', 'Security', 'Docker'], ['雲端安全', '系統架構']],
+      ['方雨薇 (Iris Fang)', 'Content Strategist', 'PressPlay', 'ONE_TO_THREE', 'Media', ['Content Strategy', 'SEO'], ['內容策略', '品牌敘事']],
+      ['温柏廷 (Oscar Wen)', 'QA Lead', 'Garmin', 'FIVE_TO_TEN', 'Hardware', ['Test Automation', 'CI/CD'], ['測試自動化', '品質流程']],
+      ['尤芷晴 (Fiona Yu)', 'Business Analyst', 'KPMG', 'THREE_TO_FIVE', 'Consulting', ['Data Analysis', 'Power BI'], ['商業分析', '顧問思維']],
+      ['盧俊傑 (Jason Lu)', 'Site Reliability Engineer', 'CTBC Bank', 'THREE_TO_FIVE', 'Finance', ['Prometheus', 'Kubernetes'], ['可靠性工程', '事件應變']],
+      ['江品萱 (Selina Chiang)', 'Talent Development Lead', 'ASUS', 'OVER_TEN_YEAR', 'Hardware', ['L&D', 'Coaching'], ['人才發展', '職涯教練']],
+      ['宋柏毅 (Sean Sung)', 'Backend Engineer', 'KKday', 'ONE_TO_THREE', 'Travel Tech', ['Java', 'Spring Boot'], ['後端開發', '求職準備']],
+      ['蕭婉如 (Wendy Hsiao)', 'Design Manager', 'Cathay Financial', 'FIVE_TO_TEN', 'Finance', ['Design Leadership', 'Design Ops'], ['設計管理', '團隊帶領']],
+      ['范植鈞 (Kyle Fan)', 'Machine Learning Engineer', 'Yahoo', 'THREE_TO_FIVE', 'Internet / Software', ['TensorFlow', 'MLOps'], ['機器學習', '模型上線']],
+    ];
+
+    var ALL_MENTORS = BASE_MENTORS.concat(
+      EXTRA_TEMPLATES.map(function (t, i) {
+        return {
+          user_id: 100 + i,
+          name: t[0],
+          avatar: PHOTOS[i % PHOTOS.length],
+          job_title: t[1],
+          company: t[2],
+          years_of_experience: t[3],
+          industry: t[4],
+          about: t[1] + ' @ ' + t[2] + '，樂於分享實戰經驗，協助你釐清下一步職涯方向與具體行動方案。',
+          have_skill: t[5],
+          have_topic: t[6],
+        };
+      })
+    );
+
+    var PAGE_LIMIT = 9;
+
+    var POPULAR_POSITIONS = [
+      '前端工程師', '後端工程師', '全端工程師', '產品經理',
+      'UIUX 設計師', '資料工程師', 'AI 工程師', 'iOS 工程師',
+    ];
+
+    function uniq(arr) {
+      var seen = {}, out = [];
+      arr.forEach(function (v) {
+        if (v && !seen[v]) { seen[v] = true; out.push(v); }
+      });
+      return out;
+    }
+
+    var FILTER_META = {
+      filter_skills: { name: '技能', options: uniq(ALL_MENTORS.reduce(function (a, m) { return a.concat(m.have_skill); }, [])) },
+      filter_topics: { name: '主題', options: uniq(ALL_MENTORS.reduce(function (a, m) { return a.concat(m.have_topic); }, [])) },
+      filter_industries: { name: '產業', options: uniq(ALL_MENTORS.map(function (m) { return m.industry; })) },
+    };
+    var FILTER_KEYS = ['filter_skills', 'filter_topics', 'filter_industries'];
+
+    /* ================= computeOverflowFit (mirrors src/lib/overflowFit.ts) ================= */
+    function computeOverflowFit(itemWidths, containerWidth, gapPx, reservePx, defaultVisibleCount) {
+      reservePx = reservePx || 0;
+      var isMeasuring = containerWidth == null || itemWidths.length === 0 || itemWidths.every(function (w) { return w === 0; });
+      if (isMeasuring) return { visibleCount: defaultVisibleCount != null ? defaultVisibleCount : itemWidths.length, isMeasuring: true };
+      var total = reservePx;
+      var lastIndex = itemWidths.length - 1;
+      for (var i = 0; i < itemWidths.length; i++) {
+        var gap = i > 0 ? gapPx : 0;
+        total += itemWidths[i] + gap;
+        if (total > containerWidth) { lastIndex = i - 1; break; }
+      }
+      var visibleCount = Math.max(0, Math.min(lastIndex + 1, itemWidths.length));
+      return { visibleCount: visibleCount, isMeasuring: false };
+    }
+
+    /* ================= state ================= */
+    var state = {
+      scenario: 'success',
+      auth: 'guest',
+      query: '',
+      committedFilters: {},   // { key: { name, value } }
+      pendingFilters: {},
+      mentors: [],
+      mentorCount: 0,
+      hasMore: true,
+      cursor: 0,
+      isReplacing: false,
+      isLoadMoreSpinning: false,
+    };
+
+    function matchesConditions(m, query, filters) {
+      if (query) {
+        var q = query.toLowerCase();
+        var hay = [m.name, m.job_title, m.company, m.about].concat(m.have_skill, m.have_topic).join(' ').toLowerCase();
+        if (hay.indexOf(q) === -1) return false;
+      }
+      if (filters.filter_skills && m.have_skill.indexOf(filters.filter_skills.value) === -1) return false;
+      if (filters.filter_topics && m.have_topic.indexOf(filters.filter_topics.value) === -1) return false;
+      if (filters.filter_industries && m.industry !== filters.filter_industries.value) return false;
+      return true;
+    }
+
+    function getFilteredPool() {
+      return ALL_MENTORS.filter(function (m) { return matchesConditions(m, state.query, state.committedFilters); });
+    }
+
+    /* ================= DOM refs ================= */
+    var $ = function (id) { return document.getElementById(id); };
+    var frame = $('frame');
+    var pageBody = $('page-body');
+    var skeletonSection = $('skeleton-section');
+    var resolvedSection = $('resolved-section');
+    var mpCount = $('mp-count');
+    var gridWrap = $('grid-wrap');
+    var mentorGrid = $('mentor-grid');
+    var replacingOverlay = $('replacing-overlay');
+    var fullSpinner = $('full-spinner');
+    var loadmoreSpinner = $('loadmore-spinner');
+    var emptyState = $('empty-state');
+    var errorState = $('error-state');
+    var badgesRow = $('badges-row');
+    var sentinel = $('sentinel');
+
+    /* ================= card rendering ================= */
+    function cardHtml(m) {
+      var yearsLabel = YEARS_LABEL[m.years_of_experience] || m.years_of_experience;
+      return (
+        '<a class="mp-card" href="#" onclick="return false;" aria-label="前往 ' + m.name + ' 的個人頁面" data-uid="' + m.user_id + '">' +
+          '<figure class="mp-card-figure">' +
+            '<img src="' + m.avatar + '" alt="' + m.name + ' 的頭像" loading="lazy" />' +
+            '<figcaption class="mp-card-years">' + yearsLabel + '工作經驗</figcaption>' +
+          '</figure>' +
+          '<div class="mp-card-body">' +
+            '<div>' +
+              '<h3 class="mp-card-name">' + m.name + '</h3>' +
+              '<div class="mp-card-role">' + m.job_title + (m.job_title && m.company ? '<span class="at">at</span>' : '') + m.company + '</div>' +
+            '</div>' +
+            '<p class="mp-card-about">' + m.about + '</p>' +
+            '<div class="mp-tag-slot" data-topics=\'' + JSON.stringify(m.have_topic) + '\'>' +
+              '<div class="mp-tag-measure"></div>' +
+              '<div class="mp-tag-container"></div>' +
+            '</div>' +
+          '</div>' +
+        '</a>'
+      );
+    }
+
+    function tagHtml(label) {
+      return '<div class="mp-tag">' + label + '</div>';
+    }
+
+    function layoutCardTags(cardEl) {
+      var slot = cardEl.querySelector('.mp-tag-slot');
+      if (!slot) return;
+      var topics = JSON.parse(slot.getAttribute('data-topics') || '[]');
+      var measure = slot.querySelector('.mp-tag-measure');
+      var display = slot.querySelector('.mp-tag-container');
+      measure.innerHTML = topics.map(tagHtml).join('');
+      var widths = Array.prototype.map.call(measure.children, function (el) { return el.getBoundingClientRect().width; });
+      var containerWidth = display.getBoundingClientRect().width;
+      var result = computeOverflowFit(widths, containerWidth, 8, 52, topics.length);
+      var visible = topics.slice(0, result.visibleCount);
+      var extra = topics.length - result.visibleCount;
+      var html = visible.map(tagHtml).join('');
+      if (extra > 0) html += tagHtml('+' + extra);
+      display.innerHTML = html;
+    }
+
+    function layoutAllCardTags() {
+      mentorGrid.querySelectorAll('.mp-card').forEach(layoutCardTags);
+    }
+
+    function renderMentorGrid(mentors, append) {
+      var html = mentors.map(cardHtml).join('');
+      if (append) mentorGrid.insertAdjacentHTML('beforeend', html);
+      else mentorGrid.innerHTML = html;
+      requestAnimationFrame(layoutAllCardTags);
+    }
+
+    /* ================= skeleton grid (static, matches MentorGridSkeleton) ================= */
+    (function renderSkeletonGrid() {
+      var skelGrid = $('skeleton-grid');
+      var one =
+        '<div class="mp-skel-card">' +
+          '<div class="mp-skel-figure"></div>' +
+          '<div class="mp-skel-body">' +
+            '<div class="mp-skel-line" style="height:20px;width:66%;margin-bottom:12px;"></div>' +
+            '<div class="mp-skel-line" style="height:16px;width:50%;margin-bottom:8px;"></div>' +
+            '<div class="mp-skel-line" style="height:12px;width:100%;margin-bottom:16px;"></div>' +
+            '<div style="display:flex;gap:8px;">' +
+              '<div class="mp-skel-line" style="height:24px;width:64px;border-radius:9999px;"></div>' +
+              '<div class="mp-skel-line" style="height:24px;width:80px;border-radius:9999px;"></div>' +
+              '<div class="mp-skel-line" style="height:24px;width:56px;border-radius:9999px;"></div>' +
+            '</div>' +
+          '</div>' +
+        '</div>';
+      skelGrid.innerHTML = new Array(9).fill(one).join('');
+    })();
+
+    /* ================= filter panel ================= */
+    (function renderFilterBody() {
+      var body = $('filter-body');
+      body.innerHTML = FILTER_KEYS.map(function (key) {
+        var meta = FILTER_META[key];
+        var opts = meta.options.map(function (o) { return '<option value="' + o + '">' + o + '</option>'; }).join('');
+        return (
+          '<div class="mp-filter-field">' +
+            '<label for="sel-' + key + '">' + meta.name + '</label>' +
+            '<select id="sel-' + key + '" data-key="' + key + '" data-name="' + meta.name + '">' +
+              '<option value="">請選擇' + meta.name + '</option>' + opts +
+            '</select>' +
+          '</div>'
+        );
+      }).join('');
+    })();
+
+    function syncPendingSelectsToDom() {
+      FILTER_KEYS.forEach(function (key) {
+        var el = $('sel-' + key);
+        el.value = state.pendingFilters[key] ? state.pendingFilters[key].value : '';
+      });
+    }
+
+    var filterTrigger = $('filter-trigger');
+    var filterPanel = $('filter-panel');
+    var filterChevron = $('filter-chevron');
+    function openFilterPanel() {
+      state.pendingFilters = JSON.parse(JSON.stringify(state.committedFilters));
+      syncPendingSelectsToDom();
+      filterPanel.classList.add('open');
+      filterTrigger.setAttribute('aria-expanded', 'true');
+      filterChevron.style.transform = 'rotate(180deg)';
+    }
+    function closeFilterPanel() {
+      filterPanel.classList.remove('open');
+      filterTrigger.setAttribute('aria-expanded', 'false');
+      filterChevron.style.transform = '';
+    }
+    filterTrigger.addEventListener('click', function (e) {
+      e.stopPropagation();
+      if (filterPanel.classList.contains('open')) closeFilterPanel();
+      else openFilterPanel();
+    });
+    filterPanel.addEventListener('click', function (e) { e.stopPropagation(); });
+    document.addEventListener('click', function () { closeFilterPanel(); });
+    $('filter-body').addEventListener('change', function (e) {
+      var sel = e.target.closest('select');
+      if (!sel) return;
+      var key = sel.getAttribute('data-key');
+      var name = sel.getAttribute('data-name');
+      if (sel.value) state.pendingFilters[key] = { name: name, value: sel.value };
+      else delete state.pendingFilters[key];
+    });
+    $('filter-clear').addEventListener('click', function () {
+      state.pendingFilters = {};
+      syncPendingSelectsToDom();
+    });
+    $('filter-apply').addEventListener('click', function () {
+      state.committedFilters = state.pendingFilters;
+      closeFilterPanel();
+      trackScenarioReset();
+      runFilterTransition();
+    });
+
+    /* ================= badges ================= */
+    function renderBadges() {
+      var keys = Object.keys(state.committedFilters);
+      badgesRow.innerHTML = keys.map(function (key) {
+        var f = state.committedFilters[key];
+        return (
+          '<span class="mp-badge" data-key="' + key + '">' +
+            '<span>' + f.name + '：' + f.value + '</span>' +
+            '<button type="button" aria-label="移除「' + f.name + '：' + f.value + '」篩選" data-remove="' + key + '">' +
+              '<svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M6 6l12 12M18 6 6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>' +
+            '</button>' +
+          '</span>'
+        );
+      }).join('');
+    }
+    badgesRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('button[data-remove]');
+      if (!btn) return;
+      var key = btn.getAttribute('data-remove');
+      delete state.committedFilters[key];
+      trackScenarioReset();
+      runFilterTransition();
+    });
+
+    /* ================= popular chips ================= */
+    var chipsRow = $('chips-row');
+    var DESKTOP_WIDTH = 846, GAP_PX = 8;
+    (function renderChips() {
+      chipsRow.innerHTML = POPULAR_POSITIONS.map(function (p, i) {
+        return '<button type="button" class="mp-chip" data-i="' + i + '" data-pos="' + p + '">' + p + '</button>';
+      }).join('');
+    })();
+    function measureChips() {
+      var buttons = Array.prototype.slice.call(chipsRow.querySelectorAll('.mp-chip'));
+      var widths = buttons.map(function (b) { return b.offsetWidth; });
+      var result = computeOverflowFit(widths, DESKTOP_WIDTH, GAP_PX, 0, POPULAR_POSITIONS.length);
+      buttons.forEach(function (b, i) {
+        b.classList.toggle('mp-chip-overflow', i >= result.visibleCount);
+      });
+    }
+    function updateChipScrollFades() {
+      var scrollLeft = chipsRow.scrollLeft;
+      var scrollWidth = chipsRow.scrollWidth;
+      var clientWidth = chipsRow.clientWidth;
+      $('chip-fade-left').style.display = scrollLeft > 0 ? 'flex' : 'none';
+      $('chip-fade-right').style.display = scrollLeft + clientWidth < scrollWidth - 1 ? 'flex' : 'none';
+    }
+    chipsRow.addEventListener('scroll', updateChipScrollFades, { passive: true });
+    chipsRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('.mp-chip');
+      if (!btn) return;
+      var pos = btn.getAttribute('data-pos');
+      state.query = pos;
+      syncSearchInputs();
+      trackScenarioReset();
+      runFilterTransition();
+    });
+
+    /* ================= search bar ================= */
+    var searchInputs = Array.prototype.slice.call(document.querySelectorAll('.mp-search-input'));
+    var searchBtn = $('search-btn');
+    function syncSearchInputs() {
+      searchInputs.forEach(function (el) { el.value = state.query; });
+    }
+    searchInputs.forEach(function (el) {
+      el.addEventListener('input', function () { state.query = el.value; syncSearchInputs(); });
+      el.addEventListener('keydown', function (e) { if (e.key === 'Enter') doSearch(); });
+    });
+    function doSearch() {
+      searchBtn.disabled = true;
+      searchBtn.querySelector('.btn-icon').outerHTML =
+        '<svg class="btn-icon spin" width="20" height="20" viewBox="0 0 24 24" fill="none"><path d="M21 12a9 9 0 1 1-9-9" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/></svg>';
+      window.setTimeout(function () {
+        searchBtn.disabled = false;
+        var icon = searchBtn.querySelector('.btn-icon');
+        icon.outerHTML = '<svg class="btn-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" aria-hidden="true"><circle cx="11" cy="11" r="7" stroke="currentColor" stroke-width="2"/><path d="m20 20-3.5-3.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>';
+        trackScenarioReset();
+        runFilterTransition();
+      }, 350);
+    }
+    searchBtn.addEventListener('click', doSearch);
+
+    /* ================= scenario / auth / width controls ================= */
+    function trackScenarioReset() {
+      // Interacting with search/filter/chips always represents the "success" family of
+      // states going forward, same as the real app leaving forced/error snapshots behind.
+      setScenarioPressed('success');
+      state.scenario = 'success';
+    }
+    function setScenarioPressed(name) {
+      document.querySelectorAll('#scenario-row button').forEach(function (b) {
+        b.setAttribute('aria-pressed', String(b.getAttribute('data-scenario') === name));
+      });
+    }
+    $('scenario-row').addEventListener('click', function (e) {
+      var btn = e.target.closest('button[data-scenario]');
+      if (!btn) return;
+      state.scenario = btn.getAttribute('data-scenario');
+      setScenarioPressed(state.scenario);
+      applyScenario();
+    });
+
+    $('auth-row').addEventListener('click', function (e) {
+      var btn = e.target.closest('button[data-auth]');
+      if (!btn) return;
+      state.auth = btn.getAttribute('data-auth');
+      document.querySelectorAll('#auth-row button').forEach(function (b) {
+        b.setAttribute('aria-pressed', String(b === btn));
+      });
+      renderHeaderAuth();
+    });
+
+    /* ---------- header auth / dropdown / mobile sheets (ported from header_rwd.html) ---------- */
+    var HDR_USERS = {
+      mentee: { name: '王小明', isMentor: false, initial: '王' },
+      mentor: { name: '陳雅婷', isMentor: true, initial: '陳' },
+    };
+    var dropdownAnchor = $('desktop-dropdown-anchor');
+    var dropdownTrigger = $('dropdown-trigger');
+    var dropdownPanel = $('dropdown-panel');
+    var mobileAvatarTrigger = $('mobile-avatar-trigger');
+    var hamburgerTrigger = $('hamburger-trigger');
+    var navOverlay = $('nav-sheet-overlay');
+    var navPanel = $('nav-sheet-panel');
+    var userOverlay = $('user-sheet-overlay');
+    var userPanel = $('user-sheet-panel');
+    var dropdownOpen = false;
+    var openSheetName = null;
+
+    function renderHeaderAuth() {
+      var loggedIn = state.auth !== 'guest';
+      var user = loggedIn ? HDR_USERS[state.auth] : null;
+      document.querySelectorAll('.auth-guest-only').forEach(function (el) {
+        el.style.display = loggedIn ? 'none' : (el.getAttribute('data-display-when-guest') || 'contents');
+      });
+      document.querySelectorAll('.auth-loggedin-only').forEach(function (el) {
+        el.style.display = loggedIn ? (el === dropdownAnchor ? 'block' : 'inline-flex') : 'none';
+      });
+      if (user) {
+        document.querySelectorAll('.role-label').forEach(function (el) {
+          el.textContent = user.isMentor ? '我的導師頁面' : '成為導師';
+        });
+        document.querySelectorAll('#dd-avatar-32, #dd-avatar-56, #mobile-avatar-32, #sheet-avatar-56').forEach(function (el) {
+          el.textContent = user.initial;
+        });
+        $('dd-name').textContent = user.name;
+        $('sheet-user-name').textContent = user.name;
+      }
+      if (!loggedIn) { closeDropdown(); closeSheet('user'); closeShareDialog(); }
+    }
+
+    function openDropdown() {
+      dropdownOpen = true;
+      dropdownPanel.classList.add('is-open');
+      dropdownTrigger.setAttribute('aria-expanded', 'true');
+    }
+    function closeDropdown() {
+      dropdownOpen = false;
+      dropdownPanel.classList.remove('is-open');
+      dropdownTrigger.setAttribute('aria-expanded', 'false');
+    }
+    dropdownTrigger.addEventListener('click', function () { dropdownOpen ? closeDropdown() : openDropdown(); });
+    dropdownPanel.addEventListener('click', function (e) {
+      if (e.target.closest('#dd-share-btn')) return;
+      if (e.target.closest('.dd-item, .dd-profile')) closeDropdown();
+    });
+    document.addEventListener('click', function (e) {
+      if (dropdownOpen && !dropdownAnchor.contains(e.target)) closeDropdown();
+    });
+
+    function openSheet(which) {
+      closeDropdown();
+      openSheetName = which;
+      var overlay = which === 'nav' ? navOverlay : userOverlay;
+      var panel = which === 'nav' ? navPanel : userPanel;
+      overlay.classList.add('is-open');
+      panel.classList.add('is-open');
+    }
+    function closeSheet(which) {
+      if (which && openSheetName !== which) return;
+      var target = which || openSheetName;
+      if (!target) return;
+      var overlay = target === 'nav' ? navOverlay : userOverlay;
+      var panel = target === 'nav' ? navPanel : userPanel;
+      overlay.classList.remove('is-open');
+      panel.classList.remove('is-open');
+      openSheetName = null;
+    }
+    hamburgerTrigger.addEventListener('click', function () { openSheet('nav'); });
+    mobileAvatarTrigger.addEventListener('click', function () { openSheet('user'); });
+    $('nav-sheet-close').addEventListener('click', function () { closeSheet('nav'); });
+    $('user-sheet-close').addEventListener('click', function () { closeSheet('user'); });
+    navOverlay.addEventListener('click', function () { closeSheet('nav'); });
+    userOverlay.addEventListener('click', function () { closeSheet('user'); });
+    navPanel.querySelectorAll('a, button').forEach(function (el) { el.addEventListener('click', function () { closeSheet('nav'); }); });
+    userPanel.querySelectorAll('button').forEach(function (el) {
+      // The share button is excluded: on mobile the dialog opens on top of this
+      // sheet and the sheet only closes once the dialog itself closes (mirrors
+      // MobileUserMenu's onOpenChange chaining in the real Header component).
+      if (el.closest('.sheet-user-share')) return;
+      el.addEventListener('click', function () { closeSheet('user'); });
+    });
+
+    /* ---------- share profile dialog ---------- */
+    var shareOverlay = $('share-overlay');
+    var shareDialog = $('share-dialog');
+    var shareAvatar = $('share-avatar');
+    var shareName = $('share-name');
+    var shareSubtitle = $('share-subtitle');
+    var shareLinkInput = $('share-link-input');
+    var shareCopyBtn = $('share-copy-btn');
+    var shareSource = null;
+    function openShareDialog(source) {
+      if (state.auth === 'guest') return;
+      var user = HDR_USERS[state.auth];
+      shareAvatar.textContent = user.initial;
+      shareName.textContent = user.name;
+      shareSubtitle.textContent = user.isMentor ? '我的導師頁面' : '成為導師';
+      shareLinkInput.value = 'https://x-talent.example.com/profile/' + (user.isMentor ? 'u_2290' : 'u_8841');
+      shareCopyBtn.textContent = '複製';
+      shareSource = source;
+      shareOverlay.classList.add('is-open');
+      shareDialog.classList.add('is-open');
+    }
+    function closeShareDialog() {
+      shareOverlay.classList.remove('is-open');
+      shareDialog.classList.remove('is-open');
+      if (shareSource === 'mobile') closeSheet('user');
+      shareSource = null;
+    }
+    $('dd-share-btn').addEventListener('click', function () {
+      closeDropdown();
+      window.setTimeout(function () { openShareDialog('desktop'); }, 60);
+    });
+    $('sheet-share-btn').addEventListener('click', function () { openShareDialog('mobile'); });
+    $('share-dialog-close').addEventListener('click', closeShareDialog);
+    shareOverlay.addEventListener('click', closeShareDialog);
+    shareCopyBtn.addEventListener('click', function () {
+      shareLinkInput.select();
+      if (navigator.clipboard && navigator.clipboard.writeText) {
+        navigator.clipboard.writeText(shareLinkInput.value).catch(function () {});
+      }
+      shareCopyBtn.textContent = '已複製';
+      window.setTimeout(function () { shareCopyBtn.textContent = '複製'; }, 1500);
+    });
+
+    /* width slider (container query driver) */
+    var slider = $('width-slider');
+    var widthNum = $('width-num');
+    var bpPill = $('bp-pill');
+    var presetRow = $('preset-row');
+    var MIN_W = 320, MAX_W = 1440;
+    function bpLabel(px) {
+      if (px >= 1280) return 'xl 版型';
+      if (px >= 768) return 'md 版型（768–1279px）';
+      return '手機版型（&lt;768px）';
+    }
+    function setWidth(px, syncPresets) {
+      px = Math.max(MIN_W, Math.min(MAX_W, px));
+      frame.style.width = px + 'px';
+      slider.value = px;
+      widthNum.textContent = px + 'px';
+      bpPill.innerHTML = bpLabel(px);
+      if (syncPresets !== false) {
+        presetRow.querySelectorAll('button').forEach(function (b) {
+          b.setAttribute('aria-pressed', String(Number(b.getAttribute('data-w')) === px));
+        });
+      }
+      closeFilterPanel();
+      closeDropdown();
+      closeSheet('nav');
+      closeSheet('user');
+      closeShareDialog();
+      window.setTimeout(function () { measureChips(); updateChipScrollFades(); }, 0);
+    }
+    slider.addEventListener('input', function () { setWidth(Number(slider.value)); });
+    presetRow.addEventListener('click', function (e) {
+      var btn = e.target.closest('button[data-w]');
+      if (!btn) return;
+      setWidth(Number(btn.getAttribute('data-w')));
+    });
+    window.addEventListener('resize', function () {
+      window.setTimeout(function () { measureChips(); updateChipScrollFades(); layoutAllCardTags(); }, 0);
+    });
+
+    /* ================= rendering the resolved states ================= */
+    function showOnly(idsToShow) {
+      ['grid-wrap', 'full-spinner', 'loadmore-spinner', 'empty-state', 'error-state'].forEach(function (id) {
+        $(id).style.display = idsToShow.indexOf(id) === -1 ? 'none' : '';
+      });
+    }
+
+    function renderResolvedFromPool(paged) {
+      var pool = getFilteredPool();
+      state.mentors = pool.slice(0, PAGE_LIMIT);
+      state.mentorCount = state.mentors.length;
+      state.cursor = state.mentors.length;
+      state.hasMore = state.mentors.length === PAGE_LIMIT;
+      commitRender();
+    }
+
+    function commitRender() {
+      renderBadges();
+      mpCount.textContent = '找到 ' + state.mentorCount + ' 位導師';
+      mpCount.classList.toggle('is-replacing', state.isReplacing);
+      if (state.mentors.length > 0) {
+        showOnly(['grid-wrap']);
+        renderMentorGrid(state.mentors, false);
+        replacingOverlay.style.display = state.isReplacing ? 'flex' : 'none';
+      } else if (state.hasError) {
+        showOnly(['error-state']);
+      } else {
+        showOnly(['empty-state']);
+      }
+    }
+
+    function applyScenario() {
+      closeFilterPanel();
+      if (state.scenario === 'skeleton') {
+        skeletonSection.style.display = '';
+        resolvedSection.style.display = 'none';
+        return;
+      }
+      skeletonSection.style.display = 'none';
+      resolvedSection.style.display = '';
+      requestAnimationFrame(function () { measureChips(); updateChipScrollFades(); });
+
+      if (state.scenario === 'error') {
+        state.hasError = true;
+        state.mentors = [];
+        state.mentorCount = 0;
+        state.isReplacing = false;
+        commitRender();
+        return;
+      }
+      state.hasError = false;
+      if (state.scenario === 'empty') {
+        state.query = '前端 UI 動畫 特效';
+        syncSearchInputs();
+        state.committedFilters = {};
+        state.mentors = [];
+        state.mentorCount = 0;
+        state.hasMore = false;
+        state.isReplacing = false;
+        commitRender();
+        return;
+      }
+      // success
+      state.query = '';
+      syncSearchInputs();
+      state.committedFilters = {};
+      state.isReplacing = false;
+      renderResolvedFromPool();
+    }
+
+    function runFilterTransition() {
+      var hadMentors = state.mentors.length > 0;
+      state.hasError = false;
+      if (hadMentors) {
+        state.isReplacing = true;
+        showOnly(['grid-wrap']);
+        replacingOverlay.style.display = 'flex';
+        mpCount.classList.add('is-replacing');
+      } else {
+        showOnly(['full-spinner']);
+      }
+      window.setTimeout(function () {
+        state.isReplacing = false;
+        renderResolvedFromPool();
+      }, 550);
+    }
+
+    /* ================= infinite scroll (real IntersectionObserver) ================= */
+    var io = new IntersectionObserver(
+      function (entries) {
+        if (!entries[0].isIntersecting) return;
+        if (!state.hasMore || state.isReplacing || state.isLoadMoreSpinning) return;
+        loadMore();
+      },
+      { root: pageBody, threshold: 0.5 }
+    );
+    io.observe(sentinel);
+
+    function loadMore() {
+      var pool = getFilteredPool();
+      var next = pool.slice(state.cursor, state.cursor + PAGE_LIMIT);
+      if (next.length === 0) { state.hasMore = false; return; }
+      state.isLoadMoreSpinning = true;
+      loadmoreSpinner.style.display = 'flex';
+      window.setTimeout(function () {
+        state.mentors = state.mentors.concat(next);
+        state.mentorCount = state.mentors.length;
+        state.cursor += next.length;
+        state.hasMore = next.length === PAGE_LIMIT;
+        state.isLoadMoreSpinning = false;
+        loadmoreSpinner.style.display = 'none';
+        mpCount.textContent = '找到 ' + state.mentorCount + ' 位導師';
+        renderMentorGrid(next, true);
+      }, 500);
+    }
+
+    /* ================= empty / error actions ================= */
+    $('empty-clear-btn').addEventListener('click', function () {
+      state.query = '';
+      syncSearchInputs();
+      state.committedFilters = {};
+      trackScenarioReset();
+      state.hasError = false;
+      renderResolvedFromPool();
+    });
+    $('retry-btn').addEventListener('click', function () {
+      showOnly(['full-spinner']);
+      window.setTimeout(function () {
+        trackScenarioReset();
+        state.hasError = false;
+        renderResolvedFromPool();
+      }, 500);
+    });
+
+    /* ================= init ================= */
+    renderHeaderAuth();
+    setWidth(1280);
+    applyScenario();
+  })();
+</script>


### PR DESCRIPTION
## What Does This PR Do?

- Adds a faithful, interactive HTML reproduction of the /mentor-pool page (src/app/mentor-pool, src/components/mentor-pool) for design/QA review, following the same pattern as header_rwd.html, home-page.html, and reservation-page.html
- Covers: hero + search bar, popular position chips (with real overflow-fit measurement), filter dropdown (skills/topics/industries), mentor card grid with tag overflow ("+N") logic matching Information.tsx, Suspense skeleton fallback, empty/error states, isReplacing overlay, and IntersectionObserver-driven infinite scroll (PAGE_LIMIT=9)
- Header/Footer markup, styling, and interactivity (dropdown, hamburger sheet, share dialog) are ported 1:1 from the existing header_rwd.html reproduction so the two artifacts don't diverge
- A control panel lets reviewers switch list state (success/empty/error/skeleton), header auth state, and simulate RWD breakpoints via CSS container queries on a resizable device frame
- Documents a likely real production layout bug (mentor card grid overflow for viewport widths 1280-1438px, derived from the component's actual Tailwind classes) rather than silently masking it

## Demo

Open .lavish/mentor-pool.html directly, or run `npx lavish-axi .lavish/mentor-pool.html`

## Screenshot

N/A

## Anything to Note?

Reviewed interactively via Lavish Editor; a real layout bug (xl grid overflow between 1280-1438px viewport width) was found during review and documented in the artifact's notes rather than fixed, since it appears to originate from the real component's Tailwind classes, not the reproduction.
