### PR TITLE
feat(layout): add desktop notification bell icon next to user avatar (X-Tracker #536)

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -248,4 +248,78 @@ describe('Header', () => {
       'hidden group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block'
     );
   });
+
+  it('does not render NotificationBell when logged out', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+    expect(
+      screen.queryByRole('button', { name: '開啟通知選單' })
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders NotificationBell when logged in', () => {
+    mockUseSession.mockReturnValue({
+      data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
+      status: 'authenticated',
+    });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: 'user-123',
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+    expect(
+      screen.getByRole('button', { name: '開啟通知選單' })
+    ).toBeInTheDocument();
+  });
+
+  it('closes NotificationBell popover when UserDropdown avatar is clicked', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        ...mockSession,
+        user: { ...mockSession.user, id: 'user-123', image: 'avatar.png' },
+      },
+      status: 'authenticated',
+    });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: 'user-123',
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    const bellButton = screen.getByRole('button', { name: '開啟通知選單' });
+    const avatarButton = screen.getAllByRole('button', {
+      name: '開啟用戶選單',
+    })[0];
+
+    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+
+    fireEvent.click(bellButton);
+    expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+
+    // Radix Popover listens to low-level pointerDown and mouseDown on document to close on click-outside
+    fireEvent.pointerDown(avatarButton, { bubbles: true });
+    fireEvent.mouseDown(avatarButton, { bubbles: true });
+    fireEvent.click(avatarButton);
+
+    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+  });
 });

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -148,7 +148,7 @@ function HeaderComponent(): JSX.Element {
               </>
             ) : isLoggedIn ? (
               <>
-                <NotificationBell />
+                <NotificationBell className="hidden lg:flex" />
                 <UserDropdown user={virtualUser} />
               </>
             ) : (

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -18,6 +18,7 @@ import { DisabledAwareLink } from './DisabledAwareLink';
 import { HamburgerMenu } from './HamburgerMenu';
 import { MobileUserMenu } from './MobileUserMenu';
 import { getBecomeMentorHref, getProfileHref } from './navHrefs';
+import { NotificationBell } from './NotificationBell';
 import { UserDropdown } from './UserDropdown';
 
 function HeaderComponent(): JSX.Element {
@@ -146,7 +147,10 @@ function HeaderComponent(): JSX.Element {
                 </Link>
               </>
             ) : isLoggedIn ? (
-              <UserDropdown user={virtualUser} />
+              <>
+                <NotificationBell />
+                <UserDropdown user={virtualUser} />
+              </>
             ) : (
               <Skeleton className="size-9 rounded-full" />
             )}

--- a/src/components/layout/Header/NotificationBell.stories.tsx
+++ b/src/components/layout/Header/NotificationBell.stories.tsx
@@ -1,0 +1,38 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import React from 'react';
+
+import { NotificationBell } from './NotificationBell';
+
+const meta: Meta<typeof NotificationBell> = {
+  title: '佈局元件/Header/NotificationBell',
+  component: NotificationBell,
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className="flex h-[150px] items-center justify-center bg-background-bottom p-10">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof NotificationBell>;
+
+export const Default: Story = {
+  args: {
+    unreadCount: 5,
+  },
+};
+
+export const Over99Notifications: Story = {
+  args: {
+    unreadCount: 120,
+  },
+};
+
+export const NoNotifications: Story = {
+  args: {
+    unreadCount: 0,
+  },
+};

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,0 +1,44 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { NotificationBell } from './NotificationBell';
+
+describe('NotificationBell', () => {
+  it('renders the bell icon button with title and aria-label', () => {
+    render(<NotificationBell unreadCount={5} />);
+    const button = screen.getByRole('button', { name: '開啟通知選單' });
+    expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute('title', '通知');
+  });
+
+  it('renders the unread count badge with correct count', () => {
+    render(<NotificationBell unreadCount={5} />);
+    const badge = screen.getByText('5');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('aria-label', '有 5 則未讀通知');
+  });
+
+  it('shows "99+" for unread count over 99', () => {
+    render(<NotificationBell unreadCount={120} />);
+    const badge = screen.getByText('99+');
+    expect(badge).toBeInTheDocument();
+    expect(badge).toHaveAttribute('aria-label', '有 120 則未讀通知');
+  });
+
+  it('hides the unread count badge and opens the empty popover container on click', () => {
+    render(<NotificationBell unreadCount={5} />);
+    const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+    // Badge is initially visible
+    expect(screen.getByText('5')).toBeInTheDocument();
+
+    // Click the bell button to open the popover
+    fireEvent.click(button);
+
+    // Popover content should be visible
+    expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+
+    // Badge is hidden once clicked/opened
+    expect(screen.queryByText('5')).not.toBeInTheDocument();
+  });
+});

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -41,4 +41,19 @@ describe('NotificationBell', () => {
     // Badge is hidden once clicked/opened
     expect(screen.queryByText('5')).not.toBeInTheDocument();
   });
+
+  it('contains tailwind CSS classes for hover and open states to avoid JS state overhead', () => {
+    render(<NotificationBell unreadCount={5} />);
+    const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+    expect(button).toHaveClass('hover:bg-background-hover');
+    expect(button).toHaveClass('hover:border-transparent');
+    expect(button).toHaveClass('data-[state=open]:bg-background-hover');
+    expect(button).toHaveClass('data-[state=open]:border-transparent');
+
+    const bell = button.querySelector('svg');
+    expect(bell).not.toBeNull();
+    expect(bell).toHaveClass('group-hover:fill-current');
+    expect(bell).toHaveClass('group-data-[state=open]:fill-current');
+  });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -50,10 +50,5 @@ describe('NotificationBell', () => {
     expect(button).toHaveClass('hover:border-transparent');
     expect(button).toHaveClass('data-[state=open]:bg-background-hover');
     expect(button).toHaveClass('data-[state=open]:border-transparent');
-
-    const bell = button.querySelector('svg');
-    expect(bell).not.toBeNull();
-    expect(bell).toHaveClass('group-hover:fill-current');
-    expect(bell).toHaveClass('group-data-[state=open]:fill-current');
   });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -42,13 +42,25 @@ describe('NotificationBell', () => {
     expect(screen.queryByText('5')).not.toBeInTheDocument();
   });
 
-  it('contains tailwind CSS classes for hover and open states to avoid JS state overhead', () => {
+  it('contains tailwind CSS classes for the hover state to avoid JS state overhead', () => {
     render(<NotificationBell unreadCount={5} />);
     const button = screen.getByRole('button', { name: '開啟通知選單' });
 
     expect(button).toHaveClass('hover:bg-background-hover');
     expect(button).toHaveClass('hover:border-transparent');
-    expect(button).toHaveClass('data-[state=open]:bg-background-hover');
-    expect(button).toHaveClass('data-[state=open]:border-transparent');
+  });
+
+  it('contains tailwind CSS classes for the open state, matching the reservation tab active style', () => {
+    render(<NotificationBell unreadCount={5} />);
+    const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+    expect(button).toHaveClass('data-[state=open]:bg-dark');
+    expect(button).toHaveClass('data-[state=open]:border-dark');
+    expect(button).toHaveClass('data-[state=open]:text-text-white');
+
+    const bell = button.querySelector('svg');
+    expect(bell).not.toBeNull();
+    expect(bell).toHaveClass('group-data-[state=open]:fill-current');
+    expect(bell).toHaveClass('group-data-[state=open]:text-text-white');
   });
 });

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -57,7 +57,7 @@ export const NotificationBell = React.memo(function NotificationBell({
 
           {showBadge && (
             <span
-              className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-light bg-status-error-default px-1 text-11 leading-none font-bold text-text-white select-none"
+              className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-background-white bg-status-error-default px-1 text-11 leading-none font-bold text-text-white select-none"
               aria-label={`有 ${unreadCount} 則未讀通知`}
             >
               {formattedCount}

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -16,47 +16,42 @@ export type NotificationBellProps = {
    * @default 5
    */
   unreadCount?: number;
+  /**
+   * Optional custom classes for the trigger button (e.g. for responsive RWD displays).
+   */
+  className?: string;
 };
 
 export const NotificationBell = React.memo(function NotificationBell({
   unreadCount = 5,
+  className,
 }: NotificationBellProps): JSX.Element {
-  const [isOpen, setIsOpen] = React.useState(false);
-  const [isHovered, setIsHovered] = React.useState(false);
   const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
 
   const handleOpenChange = React.useCallback((open: boolean) => {
-    setIsOpen(open);
     if (open) {
       setHasBeenClicked(true);
     }
   }, []);
 
-  const showBadge = !isOpen && !hasBeenClicked && unreadCount > 0;
+  const showBadge = !hasBeenClicked && unreadCount > 0;
   const formattedCount = unreadCount > 99 ? '99+' : String(unreadCount);
-  const isFilled = isOpen || isHovered;
 
   return (
-    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+    <Popover onOpenChange={handleOpenChange}>
       <PopoverTrigger asChild>
         <button
           type="button"
           title="通知"
-          onMouseEnter={() => setIsHovered(true)}
-          onMouseLeave={() => setIsHovered(false)}
-          style={{
-            backgroundColor: isFilled ? '#f2f6f9' : 'transparent',
-            borderColor: isFilled ? 'transparent' : undefined,
-          }}
           className={cn(
-            'relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border text-text-primary transition-all duration-200 outline-none'
+            'group relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border bg-transparent text-text-primary transition-all duration-200 outline-none hover:border-transparent hover:bg-background-hover data-[state=open]:border-transparent data-[state=open]:bg-background-hover',
+            className
           )}
           aria-label="開啟通知選單"
         >
           <Bell
             className={cn(
-              'size-5 text-text-primary transition-all',
-              isFilled && 'fill-current'
+              'size-5 text-text-primary transition-all group-hover:fill-current group-data-[state=open]:fill-current'
             )}
           />
 

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -44,12 +44,12 @@ export const NotificationBell = React.memo(function NotificationBell({
           type="button"
           title="通知"
           className={cn(
-            'group relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border bg-transparent text-text-primary transition-all duration-200 outline-none hover:border-transparent hover:bg-background-hover data-[state=open]:border-transparent data-[state=open]:bg-background-hover',
+            'group relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border bg-transparent text-text-primary transition-all duration-200 outline-none hover:border-transparent hover:bg-background-hover data-[state=open]:border-dark data-[state=open]:bg-dark data-[state=open]:text-text-white',
             className
           )}
           aria-label="開啟通知選單"
         >
-          <Bell className="size-5 text-text-primary" />
+          <Bell className="size-5 text-text-primary transition-all group-data-[state=open]:fill-current group-data-[state=open]:text-text-white" />
 
           {showBadge && (
             <span

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -57,8 +57,7 @@ export const NotificationBell = React.memo(function NotificationBell({
 
           {showBadge && (
             <span
-              style={{ fontSize: '9px' }}
-              className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-light bg-status-error-default px-1 leading-none font-bold text-text-white select-none"
+              className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-light bg-status-error-default px-1 text-11 leading-none font-bold text-text-white select-none"
               aria-label={`有 ${unreadCount} 則未讀通知`}
             >
               {formattedCount}

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -49,11 +49,7 @@ export const NotificationBell = React.memo(function NotificationBell({
           )}
           aria-label="開啟通知選單"
         >
-          <Bell
-            className={cn(
-              'size-5 text-text-primary transition-all group-hover:fill-current group-data-[state=open]:fill-current'
-            )}
-          />
+          <Bell className="size-5 text-text-primary" />
 
           {showBadge && (
             <span

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { Bell } from 'lucide-react';
+import * as React from 'react';
+
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from '@/components/ui/popover';
+import { cn } from '@/lib/utils';
+
+export type NotificationBellProps = {
+  /**
+   * The mock count of unread notifications.
+   * @default 5
+   */
+  unreadCount?: number;
+};
+
+export const NotificationBell = React.memo(function NotificationBell({
+  unreadCount = 5,
+}: NotificationBellProps): JSX.Element {
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [isHovered, setIsHovered] = React.useState(false);
+  const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
+
+  const handleOpenChange = React.useCallback((open: boolean) => {
+    setIsOpen(open);
+    if (open) {
+      setHasBeenClicked(true);
+    }
+  }, []);
+
+  const showBadge = !isOpen && !hasBeenClicked && unreadCount > 0;
+  const formattedCount = unreadCount > 99 ? '99+' : String(unreadCount);
+  const isFilled = isOpen || isHovered;
+
+  return (
+    <Popover open={isOpen} onOpenChange={handleOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="通知"
+          onMouseEnter={() => setIsHovered(true)}
+          onMouseLeave={() => setIsHovered(false)}
+          style={{
+            backgroundColor: isFilled ? '#f2f6f9' : 'transparent',
+            borderColor: isFilled ? 'transparent' : undefined,
+          }}
+          className={cn(
+            'relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border text-text-primary transition-all duration-200 outline-none'
+          )}
+          aria-label="開啟通知選單"
+        >
+          <Bell
+            className={cn(
+              'size-5 text-text-primary transition-all',
+              isFilled && 'fill-current'
+            )}
+          />
+
+          {showBadge && (
+            <span
+              style={{ fontSize: '9px' }}
+              className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-light bg-status-error-default px-1 leading-none font-bold text-text-white select-none"
+              aria-label={`有 ${unreadCount} 則未讀通知`}
+            >
+              {formattedCount}
+            </span>
+          )}
+        </button>
+      </PopoverTrigger>
+
+      <PopoverContent
+        align="end"
+        sideOffset={8}
+        className="w-80 rounded-2xl border border-background-border bg-background-white p-6 shadow-xl outline-none"
+      >
+        <div className="flex flex-col items-center justify-center py-8 text-center">
+          <Bell className="mb-3 size-12 text-text-tertiary" />
+          <p className="text-base font-medium text-text-secondary">
+            尚無新通知
+          </p>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+});

--- a/src/design/tokens/color-values.ts
+++ b/src/design/tokens/color-values.ts
@@ -13,6 +13,7 @@ export const rawColors = {
   'background-bottom-secondary': '0 0% 98%', // #FAFAFA
   'background-white': '0 0% 100%', // #FFFFFF
   'background-border': '210 9% 91%', // #E6E8EA
+  'background-hover': '206 31% 96%', // #F2F6F9
   'brand-50': '180 62% 95%', // #EAFAFA
   'brand-100': '180 62% 90%', // #D5F5F5
   'brand-200': '180 60% 79%', // #ABEAEA

--- a/src/design/tokens/color.ts
+++ b/src/design/tokens/color.ts
@@ -15,6 +15,7 @@ module.exports = {
       'hsl(var(--color-background-bottom-secondary) / <alpha-value>)',
     white: 'hsl(var(--color-background-white) / <alpha-value>)',
     border: 'hsl(var(--color-background-border) / <alpha-value>)',
+    hover: 'hsl(var(--color-background-hover) / <alpha-value>)',
   },
   brand: {
     50: 'hsl(var(--color-brand-50) / <alpha-value>)',

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -10,6 +10,7 @@
   --color-background-bottom-secondary: 0 0% 98%; /* #FAFAFA */
   --color-background-white: 0 0% 100%; /* #FFFFFF */
   --color-background-border: 210 9% 91%; /* #E6E8EA */
+  --color-background-hover: 206 31% 96%; /* #F2F6F9 */
   --color-brand-50: 180 62% 95%; /* #EAFAFA */
   --color-brand-100: 180 62% 90%; /* #D5F5F5 */
   --color-brand-200: 180 60% 79%; /* #ABEAEA */


### PR DESCRIPTION
在已登入使用者的 header（desktop 版位）顯示通知鈴鐺 icon，位置在大頭貼正左邊。
未登入或未註冊使用者不顯示、也不會呼叫任何 API。
靜態（未點選）狀態僅顯示邊框，hover 或點擊開啟選單時，鈴鐺圖示會塗滿且背景改為淺灰色 #f2f6f9，並有原生「通知」字樣 tooltip 提示。
未開啟下拉選單時，右下角顯示紅色的 mock 未讀通知數量，若大於 99 則會呈現「99+」。
點選開啟空的 Radix Popover 下拉容器（顯示為「尚無新通知」）後會隱藏未讀 count 標誌。

## Screenshot

### 1. 訪客狀態 (Visitor - Bell Hidden)
![visitor](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b6d2b9d7cfd9f0689466e856e9c3e14aa1701773/feat-536-notification-bell-desktop/20260811T212903Z/0-visitor_desktop.png)

### 2. Mentee 狀態 (Mentee - Bell Visible with Unread Count)
![mentee_static](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b6d2b9d7cfd9f0689466e856e9c3e14aa1701773/feat-536-notification-bell-desktop/20260811T212903Z/1-mentee_desktop_header.png)

### 3. Mentee 點選狀態 (Mentee - Popover Opened & Badge Hidden)
![mentee_opened](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b6d2b9d7cfd9f0689466e856e9c3e14aa1701773/feat-536-notification-bell-desktop/20260811T212903Z/2-mentee_bell_opened.png)

### 4. Mentor 狀態 (Mentor - Bell Visible with Unread Count)
![mentor_static](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b6d2b9d7cfd9f0689466e856e9c3e14aa1701773/feat-536-notification-bell-desktop/20260811T212903Z/3-mentor_desktop_header.png)

### 5. Mentor 點選狀態 (Mentor - Popover Opened & Badge Hidden)
![mentor_opened](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b6d2b9d7cfd9f0689466e856e9c3e14aa1701773/feat-536-notification-bell-desktop/20260811T212903Z/4-mentor_bell_opened.png)

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/536
