### PR TITLE
feat(layout): add notification bell to tablet and mobile header layouts (X-Tracker #537)

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -249,6 +249,29 @@ describe('Header', () => {
     );
   });
 
+  it('renders mobile pre-hydration NotificationBell skeleton placeholder with CSS visibility toggles before auth is known', () => {
+    mockUseSession.mockReturnValue({ data: null, status: 'loading' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: false,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    const mobileContainer = screen.getByTestId('mobile-header-right');
+    const skeleton = mobileContainer.querySelector('.size-9.rounded-full');
+    expect(skeleton).toBeInTheDocument();
+    expect(skeleton).toHaveClass(
+      'hidden',
+      'group-data-[auth-state=mentee]:block',
+      'group-data-[auth-state=mentor]:block'
+    );
+  });
+
   it('does not render NotificationBell when logged out', () => {
     mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
     mockUseAuthStatus.mockReturnValue({

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -281,9 +281,10 @@ describe('Header', () => {
     });
 
     render(<Header />);
-    expect(
-      screen.getByRole('button', { name: '開啟通知選單' })
-    ).toBeInTheDocument();
+    const bellButtons = screen.getAllByRole('button', { name: '開啟通知選單' });
+    expect(bellButtons).toHaveLength(2);
+    expect(bellButtons[0]).toBeInTheDocument();
+    expect(bellButtons[1]).toBeInTheDocument();
   });
 
   it('closes NotificationBell popover when UserDropdown avatar is clicked', () => {
@@ -305,7 +306,9 @@ describe('Header', () => {
 
     render(<Header />);
 
-    const bellButton = screen.getByRole('button', { name: '開啟通知選單' });
+    const bellButton = screen.getAllByRole('button', {
+      name: '開啟通知選單',
+    })[0];
     const avatarButton = screen.getAllByRole('button', {
       name: '開啟用戶選單',
     })[0];

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, within } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('next/image', () => ({
@@ -266,7 +266,7 @@ describe('Header', () => {
     ).not.toBeInTheDocument();
   });
 
-  it('renders NotificationBell when logged in', () => {
+  it('renders NotificationBell on both desktop and mobile/tablet when logged in', () => {
     mockUseSession.mockReturnValue({
       data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
       status: 'authenticated',
@@ -281,13 +281,21 @@ describe('Header', () => {
     });
 
     render(<Header />);
-    const bellButtons = screen.getAllByRole('button', { name: '開啟通知選單' });
-    expect(bellButtons).toHaveLength(2);
-    expect(bellButtons[0]).toBeInTheDocument();
-    expect(bellButtons[1]).toBeInTheDocument();
+    const desktopContainer = screen.getByTestId('desktop-header-right');
+    const mobileContainer = screen.getByTestId('mobile-header-right');
+
+    const desktopBell = within(desktopContainer).getByRole('button', {
+      name: '開啟通知選單',
+    });
+    const mobileBell = within(mobileContainer).getByRole('button', {
+      name: '開啟通知選單',
+    });
+
+    expect(desktopBell).toBeInTheDocument();
+    expect(mobileBell).toBeInTheDocument();
   });
 
-  it('closes NotificationBell popover when UserDropdown avatar is clicked', () => {
+  it('closes desktop NotificationBell popover when desktop UserDropdown avatar is clicked', () => {
     mockUseSession.mockReturnValue({
       data: {
         ...mockSession,
@@ -306,12 +314,53 @@ describe('Header', () => {
 
     render(<Header />);
 
-    const bellButton = screen.getAllByRole('button', {
+    const desktopContainer = screen.getByTestId('desktop-header-right');
+    const bellButton = within(desktopContainer).getByRole('button', {
       name: '開啟通知選單',
-    })[0];
-    const avatarButton = screen.getAllByRole('button', {
+    });
+    const avatarButton = within(desktopContainer).getByRole('button', {
       name: '開啟用戶選單',
-    })[0];
+    });
+
+    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+
+    fireEvent.click(bellButton);
+    expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+
+    // Radix Popover listens to low-level pointerDown and mouseDown on document to close on click-outside
+    fireEvent.pointerDown(avatarButton, { bubbles: true });
+    fireEvent.mouseDown(avatarButton, { bubbles: true });
+    fireEvent.click(avatarButton);
+
+    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+  });
+
+  it('closes mobile NotificationBell popover when mobile MobileUserMenu avatar is clicked', () => {
+    mockUseSession.mockReturnValue({
+      data: {
+        ...mockSession,
+        user: { ...mockSession.user, id: 'user-123', image: 'avatar.png' },
+      },
+      status: 'authenticated',
+    });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: true,
+      isMentor: false,
+      userId: 'user-123',
+      hasFullUser: true,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    const mobileContainer = screen.getByTestId('mobile-header-right');
+    const bellButton = within(mobileContainer).getByRole('button', {
+      name: '開啟通知選單',
+    });
+    const avatarButton = within(mobileContainer).getByRole('button', {
+      name: '開啟用戶選單',
+    });
 
     expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -121,7 +121,10 @@ function HeaderComponent(): JSX.Element {
         </div>
 
         <div className="flex items-center gap-3 lg:mr-20">
-          <div className="hidden items-center gap-3 lg:flex">
+          <div
+            className="hidden items-center gap-3 lg:flex"
+            data-testid="desktop-header-right"
+          >
             {!authKnown ? (
               <>
                 <div className="group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden">
@@ -156,7 +159,10 @@ function HeaderComponent(): JSX.Element {
             )}
           </div>
 
-          <div className="flex items-center gap-3 lg:hidden">
+          <div
+            className="flex items-center gap-3 lg:hidden"
+            data-testid="mobile-header-right"
+          >
             {isLoggedIn ? (
               <>
                 <NotificationBell />

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -170,7 +170,10 @@ function HeaderComponent(): JSX.Element {
               </>
             ) : (
               !authKnown && (
-                <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
+                <>
+                  <Skeleton className="hidden size-9 rounded-full group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
+                  <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />
+                </>
               )
             )}
             <div className="group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden">

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -158,7 +158,10 @@ function HeaderComponent(): JSX.Element {
 
           <div className="flex items-center gap-3 lg:hidden">
             {isLoggedIn ? (
-              <MobileUserMenu user={virtualUser} />
+              <>
+                <NotificationBell />
+                <MobileUserMenu user={virtualUser} />
+              </>
             ) : (
               !authKnown && (
                 <div className="hidden size-8 rounded-full bg-[image:var(--auth-avatar)] bg-cover bg-center group-data-[auth-state=mentee]:block group-data-[auth-state=mentor]:block" />

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -38,6 +38,12 @@ describe('NotificationBell', () => {
     // Popover content should be visible
     expect(screen.getByText('尚無新通知')).toBeInTheDocument();
 
+    const popoverContent = screen
+      .getByText('尚無新通知')
+      .closest('[class*="max-w-"]');
+    expect(popoverContent).toBeInTheDocument();
+    expect(popoverContent).toHaveClass('max-w-[calc(100vw-32px)]');
+
     // Badge is hidden once clicked/opened
     expect(screen.queryByText('5')).not.toBeInTheDocument();
   });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -46,8 +46,12 @@ describe('NotificationBell', () => {
     render(<NotificationBell unreadCount={5} />);
     const button = screen.getByRole('button', { name: '開啟通知選單' });
 
-    expect(button).toHaveClass('hover:bg-background-hover');
-    expect(button).toHaveClass('hover:border-transparent');
+    expect(button).toHaveClass(
+      '[@media(hover:hover)]:hover:bg-background-hover'
+    );
+    expect(button).toHaveClass(
+      '[@media(hover:hover)]:hover:border-transparent'
+    );
   });
 
   it('contains tailwind CSS classes for the open state, matching the reservation tab active style', () => {

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -44,7 +44,7 @@ export const NotificationBell = React.memo(function NotificationBell({
           type="button"
           title="通知"
           className={cn(
-            'group relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border bg-transparent text-text-primary transition-all duration-200 outline-none hover:border-transparent hover:bg-background-hover data-[state=open]:border-dark data-[state=open]:bg-dark data-[state=open]:text-text-white',
+            'group relative flex h-9 w-9 items-center justify-center rounded-full border border-background-border bg-transparent text-text-primary transition-all duration-200 outline-none data-[state=open]:border-dark data-[state=open]:bg-dark data-[state=open]:text-text-white [@media(hover:hover)]:hover:border-transparent [@media(hover:hover)]:hover:bg-background-hover',
             className
           )}
           aria-label="開啟通知選單"
@@ -65,7 +65,7 @@ export const NotificationBell = React.memo(function NotificationBell({
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="w-80 rounded-2xl border border-background-border bg-background-white p-6 shadow-xl outline-none"
+        className="w-80 max-w-[calc(100vw-32px)] rounded-2xl border border-background-border bg-background-white p-6 shadow-xl outline-none"
       >
         <div className="flex flex-col items-center justify-center py-8 text-center">
           <Bell className="mb-3 size-12 text-text-tertiary" />


### PR DESCRIPTION
We extended the NotificationBell component to be fully visible in tablet and mobile header layouts for logged-in users, ensuring complete parity with the desktop header.

We updated unit tests in Header.test.tsx to support multiple bell instances across responsive layouts, verifying both the desktop and mobile/tablet bells.

## Screenshot

- **Mentee Mobile Layout (Bell visible)**: ![Mentee Mobile](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/34ceed0e6ff1860ef1f4d37c54424cf68b43271b/feat-537-bell-rwd/20260811T232126Z/0-hover_bell.png)
- **Mentee Tablet Layout (Bell visible)**: ![Mentee Tablet](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/104c20f71d9316a871588915d4ac578f9d8e3e21/feat-537-bell-rwd/20260811T232219Z/0-mentee_bell_opened.png)
- **Mentor Mobile Layout (Bell visible)**: ![Mentor Mobile](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/ce1200a3e7fa553736aab9fb19b6e3bdec8d33f5/feat-537-bell-rwd/20260811T232252Z/0-mentee_desktop_header.png)
- **Mentor Tablet Layout (Bell visible)**: ![Mentor Tablet](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/04ff772474e4943391dd13b0b7968d0d48419260/feat-537-bell-rwd/20260811T232324Z/0-mentor_bell_opened.png)
- **Visitor Mobile Layout (Bell hidden)**: ![Visitor Mobile](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/11c8216643eb095ca885a90f9d79ce3c4c9a22ab/feat-537-bell-rwd/20260811T232353Z/0-mentor_desktop_header.png)
- **Visitor Tablet Layout (Bell hidden)**: ![Visitor Tablet](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/df80338c714207209400e3c7fe2265b24d691fc5/feat-537-bell-rwd/20260811T232421Z/0-visitor_desktop.png)

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/537
