### PR TITLE
feat(ui): synchronize read states on dropdown open (X-Tracker #539)

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -310,16 +310,16 @@ describe('Header', () => {
       name: '開啟用戶選單',
     })[0];
 
-    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+    expect(screen.queryByText('您有新的預約')).not.toBeInTheDocument();
 
     fireEvent.click(bellButton);
-    expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+    expect(screen.getByText('您有新的預約')).toBeInTheDocument();
 
     // Radix Popover listens to low-level pointerDown and mouseDown on document to close on click-outside
     fireEvent.pointerDown(avatarButton, { bubbles: true });
     fireEvent.mouseDown(avatarButton, { bubbles: true });
     fireEvent.click(avatarButton);
 
-    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+    expect(screen.queryByText('您有新的預約')).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -345,17 +345,17 @@ describe('Header', () => {
       name: '開啟用戶選單',
     });
 
-    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+    expect(screen.queryByText('您有新的預約')).not.toBeInTheDocument();
 
     fireEvent.click(bellButton);
-    expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+    expect(screen.getByText('您有新的預約')).toBeInTheDocument();
 
     // Radix Popover listens to low-level pointerDown and mouseDown on document to close on click-outside
     fireEvent.pointerDown(avatarButton, { bubbles: true });
     fireEvent.mouseDown(avatarButton, { bubbles: true });
     fireEvent.click(avatarButton);
 
-    expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+    expect(screen.queryByText('您有新的預約')).not.toBeInTheDocument();
   });
 
   it('closes mobile NotificationBell popover when mobile MobileUserMenu avatar is clicked', () => {

--- a/src/components/layout/Header/NotificationBell.stories.tsx
+++ b/src/components/layout/Header/NotificationBell.stories.tsx
@@ -9,7 +9,7 @@ const meta: Meta<typeof NotificationBell> = {
   tags: ['autodocs'],
   decorators: [
     (Story) => (
-      <div className="flex h-[150px] items-center justify-center bg-background-bottom p-10">
+      <div className="flex h-[450px] items-start justify-center bg-background-bottom p-10">
         <Story />
       </div>
     ),
@@ -22,17 +22,34 @@ type Story = StoryObj<typeof NotificationBell>;
 export const Default: Story = {
   args: {
     unreadCount: 5,
+    initialStatus: 'success',
+  },
+};
+
+export const LoadingState: Story = {
+  args: {
+    unreadCount: 5,
+    initialStatus: 'loading',
+  },
+};
+
+export const ErrorState: Story = {
+  args: {
+    unreadCount: 5,
+    initialStatus: 'error',
+  },
+};
+
+export const EmptyState: Story = {
+  args: {
+    unreadCount: 0,
+    initialStatus: 'empty',
   },
 };
 
 export const Over99Notifications: Story = {
   args: {
     unreadCount: 120,
-  },
-};
-
-export const NoNotifications: Story = {
-  args: {
-    unreadCount: 0,
+    initialStatus: 'success',
   },
 };

--- a/src/components/layout/Header/NotificationBell.stories.tsx
+++ b/src/components/layout/Header/NotificationBell.stories.tsx
@@ -53,3 +53,19 @@ export const Over99Notifications: Story = {
     initialStatus: 'success',
   },
 };
+
+export const LongText: Story = {
+  args: {
+    unreadCount: 1,
+    initialStatus: 'success',
+    initialNotifications: [
+      {
+        id: 'long-1',
+        type: 'reservation_new',
+        menteeName: '超級長長長長長長長長長長長長長長長長長名字使用者',
+        createdAt: new Date().toISOString(),
+        unread: true,
+      },
+    ],
+  },
+};

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,11 +1,9 @@
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import {
-  getNotificationContent,
-  NotificationBell,
-  type NotificationItem,
-} from './NotificationBell';
+import { type NotificationItem } from '@/hooks/useNotificationBell';
+
+import { getNotificationContent, NotificationBell } from './NotificationBell';
 
 describe('NotificationBell', () => {
   it('renders the bell icon button with title and aria-label', () => {

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -141,26 +141,27 @@ describe('NotificationBell', () => {
       ).toBeInTheDocument();
     });
 
-    it('triggers onRetry callback and transitions to loading when clicking retry button', () => {
-      const onRetryMock = vi.fn();
-      render(
-        <NotificationBell
-          unreadCount={5}
-          initialStatus="error"
-          onRetry={onRetryMock}
-        />
-      );
+    it('transitions to loading and then success when clicking retry button', () => {
+      vi.useFakeTimers();
+      render(<NotificationBell unreadCount={5} initialStatus="error" />);
       const button = screen.getByRole('button', { name: '開啟通知選單' });
       fireEvent.click(button);
 
       const retryButton = screen.getByRole('button', { name: '重新嘗試' });
       fireEvent.click(retryButton);
 
-      // Verify that onRetry callback was called
-      expect(onRetryMock).toHaveBeenCalledTimes(1);
-
-      // Verify that UI transitions to loading state (error text disappears)
+      // Verify that UI immediately transitions to loading state (error text disappears)
       expect(screen.queryByText('載入失敗，請重試')).not.toBeInTheDocument();
+
+      // Fast-forward 1000ms inside act
+      act(() => {
+        vi.advanceTimersByTime(1000);
+      });
+
+      // Verify that UI transitions to success state (notifications appear)
+      expect(screen.getByText('您有新的預約')).toBeInTheDocument();
+
+      vi.useRealTimers();
     });
   });
 

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,8 +1,6 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { formatRelativeTime } from '@/lib/dateUtils';
-
 import {
   getNotificationContent,
   NotificationBell,
@@ -153,38 +151,6 @@ describe('NotificationBell', () => {
 
       // Verify that UI transitions to loading state (error text disappears)
       expect(screen.queryByText('載入失敗，請重試')).not.toBeInTheDocument();
-    });
-  });
-
-  describe('Time formatting logic', () => {
-    it('correctly calculates relative time', () => {
-      const now = new Date();
-
-      // 0 minutes ago (just happened)
-      expect(formatRelativeTime(now)).toBe('1 小時');
-
-      // 30 minutes ago (less than 1 hour)
-      const thirtyMinsAgo = new Date(now.getTime() - 30 * 60 * 1000);
-      expect(formatRelativeTime(thirtyMinsAgo)).toBe('1 小時');
-
-      // 1 hour ago
-      const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000);
-      expect(formatRelativeTime(oneHourAgo)).toBe('1 小時');
-
-      // 23 hours ago
-      const twentyThreeHoursAgo = new Date(now.getTime() - 23 * 60 * 60 * 1000);
-      expect(formatRelativeTime(twentyThreeHoursAgo)).toBe('23 小時');
-
-      // 24 hours ago (exactly 1 day)
-      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-      expect(formatRelativeTime(oneDayAgo)).toBe('1 天');
-
-      // 30 days ago
-      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-      expect(formatRelativeTime(thirtyDaysAgo)).toBe('30 天');
-
-      // Invalid date
-      expect(formatRelativeTime('invalid-date-string')).toBe('');
     });
   });
 

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -5,6 +5,7 @@ import {
   formatRelativeTime,
   getNotificationContent,
   NotificationBell,
+  type NotificationItem,
 } from './NotificationBell';
 
 describe('NotificationBell', () => {

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -211,5 +211,24 @@ describe('NotificationBell', () => {
       // Badge should reappear showing 6
       expect(screen.getByText('6')).toBeInTheDocument();
     });
+
+    it('does not reset hasBeenClicked and keeps the badge hidden when unreadCount decreases', () => {
+      const { rerender } = render(<NotificationBell unreadCount={5} />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+      // Badge is initially 5
+      expect(screen.getByText('5')).toBeInTheDocument();
+
+      // Click to open and clear badge
+      fireEvent.click(button);
+      expect(screen.queryByText('5')).not.toBeInTheDocument();
+
+      // Rerender with a smaller unreadCount (e.g. 3) representing some notifications read elsewhere
+      rerender(<NotificationBell unreadCount={3} />);
+
+      // Badge should remain hidden
+      expect(screen.queryByText('3')).not.toBeInTheDocument();
+      expect(screen.queryByText('5')).not.toBeInTheDocument();
+    });
   });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -136,6 +136,13 @@ describe('NotificationBell', () => {
     it('correctly calculates relative time', () => {
       const now = new Date();
 
+      // 0 minutes ago (just happened)
+      expect(formatRelativeTime(now)).toBe('1 小時');
+
+      // 30 minutes ago (less than 1 hour)
+      const thirtyMinsAgo = new Date(now.getTime() - 30 * 60 * 1000);
+      expect(formatRelativeTime(thirtyMinsAgo)).toBe('1 小時');
+
       // 1 hour ago
       const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000);
       expect(formatRelativeTime(oneHourAgo)).toBe('1 小時');
@@ -151,6 +158,9 @@ describe('NotificationBell', () => {
       // 30 days ago
       const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
       expect(formatRelativeTime(thirtyDaysAgo)).toBe('30 天');
+
+      // Invalid date
+      expect(formatRelativeTime('invalid-date-string')).toBe('');
     });
   });
 
@@ -158,7 +168,7 @@ describe('NotificationBell', () => {
     it('returns template content for unknown notification types as fallback', () => {
       const result = getNotificationContent({
         id: '99',
-        type: 'unknown_type' as any,
+        type: 'unknown_type' as unknown as NotificationItem['type'],
         createdAt: new Date().toISOString(),
       });
       expect(result.title).toBe('通知');

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -165,4 +165,24 @@ describe('NotificationBell', () => {
       expect(result.body).toBe('您有一則新通知');
     });
   });
+
+  describe('Notification Read Syncing behavior', () => {
+    it('marks all notifications as read and clears unread badge when the dropdown opens', () => {
+      render(<NotificationBell unreadCount={5} initialStatus="success" />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+      // Badge is initially visible
+      expect(screen.getByText('5')).toBeInTheDocument();
+
+      // Click the bell button to open the popover
+      fireEvent.click(button);
+
+      // Badge should be hidden now
+      expect(screen.queryByText('5')).not.toBeInTheDocument();
+
+      // Every notification item in the dropdown should have its unread red dot removed
+      const unreadDots = document.querySelectorAll('.bg-status-error-default');
+      expect(unreadDots.length).toBe(0);
+    });
+  });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -194,5 +194,23 @@ describe('NotificationBell', () => {
       const unreadDots = document.querySelectorAll('.bg-status-error-default');
       expect(unreadDots.length).toBe(0);
     });
+
+    it('resets hasBeenClicked and displays the unread badge again when unreadCount increases', () => {
+      const { rerender } = render(<NotificationBell unreadCount={5} />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+
+      // Badge is initially 5
+      expect(screen.getByText('5')).toBeInTheDocument();
+
+      // Click to open and clear badge
+      fireEvent.click(button);
+      expect(screen.queryByText('5')).not.toBeInTheDocument();
+
+      // Rerender with a larger unreadCount (e.g. 6) representing a new notification arriving
+      rerender(<NotificationBell unreadCount={6} />);
+
+      // Badge should reappear showing 6
+      expect(screen.getByText('6')).toBeInTheDocument();
+    });
   });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,7 +1,11 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it } from 'vitest';
 
-import { NotificationBell } from './NotificationBell';
+import {
+  formatRelativeTime,
+  getNotificationContent,
+  NotificationBell,
+} from './NotificationBell';
 
 describe('NotificationBell', () => {
   it('renders the bell icon button with title and aria-label', () => {
@@ -26,7 +30,8 @@ describe('NotificationBell', () => {
   });
 
   it('hides the unread count badge and opens the empty popover container on click', () => {
-    render(<NotificationBell unreadCount={5} />);
+    // Pass initialStatus="empty" to preserve original test expectation
+    render(<NotificationBell unreadCount={5} initialStatus="empty" />);
     const button = screen.getByRole('button', { name: '開啟通知選單' });
 
     // Badge is initially visible
@@ -62,5 +67,102 @@ describe('NotificationBell', () => {
     expect(bell).not.toBeNull();
     expect(bell).toHaveClass('group-data-[state=open]:fill-current');
     expect(bell).toHaveClass('group-data-[state=open]:text-text-white');
+  });
+
+  describe('Notification Dropdown Rendering states', () => {
+    it('renders all 5 types of notification card contents under success state', () => {
+      render(<NotificationBell unreadCount={5} initialStatus="success" />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+      fireEvent.click(button);
+
+      // Check header
+      expect(screen.getByText('通知')).toBeInTheDocument();
+
+      // a. 預約通知
+      expect(screen.getByText('您有新的預約')).toBeInTheDocument();
+      expect(
+        screen.getByText('小明 與您提出預約需求，請前往接受預約')
+      ).toBeInTheDocument();
+
+      // b. 預約成功通知
+      expect(screen.getByText('林導師 已接受您的預約')).toBeInTheDocument();
+      expect(screen.getByText('前往查看您的預約詳情')).toBeInTheDocument();
+
+      // c. 預約失敗通知
+      expect(
+        screen.getByText('您與 王導師 的預約已被拒絕')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('您的預約已被拒絕，歡迎重新預約')
+      ).toBeInTheDocument();
+
+      // d. 預約取消通知
+      expect(
+        screen.getByText('您與 陳導師 的預約已被取消')
+      ).toBeInTheDocument();
+
+      // e. 預約即將到來通知
+      expect(
+        screen.getByText('您與 張導師 的預約即將到來')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText('您 24 小時後有與 張導師 的會議，請準時上線')
+      ).toBeInTheDocument();
+    });
+
+    it('renders skeletons when in loading state', () => {
+      render(<NotificationBell unreadCount={5} initialStatus="loading" />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+      fireEvent.click(button);
+
+      // Ensure the text '尚無新通知' or mock notifications are NOT shown
+      expect(screen.queryByText('尚無新通知')).not.toBeInTheDocument();
+      expect(screen.queryByText('您有新的預約')).not.toBeInTheDocument();
+    });
+
+    it('renders error state and a retry button', () => {
+      render(<NotificationBell unreadCount={5} initialStatus="error" />);
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+      fireEvent.click(button);
+
+      expect(screen.getByText('載入失敗，請重試')).toBeInTheDocument();
+      expect(
+        screen.getByRole('button', { name: '重新嘗試' })
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe('Time formatting logic', () => {
+    it('correctly calculates relative time', () => {
+      const now = new Date();
+
+      // 1 hour ago
+      const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000);
+      expect(formatRelativeTime(oneHourAgo)).toBe('1 小時');
+
+      // 23 hours ago
+      const twentyThreeHoursAgo = new Date(now.getTime() - 23 * 60 * 60 * 1000);
+      expect(formatRelativeTime(twentyThreeHoursAgo)).toBe('23 小時');
+
+      // 24 hours ago (exactly 1 day)
+      const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      expect(formatRelativeTime(oneDayAgo)).toBe('1 天');
+
+      // 30 days ago
+      const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      expect(formatRelativeTime(thirtyDaysAgo)).toBe('30 天');
+    });
+  });
+
+  describe('Notification Content mappings', () => {
+    it('returns template content for unknown notification types as fallback', () => {
+      const result = getNotificationContent({
+        id: '99',
+        type: 'unknown_type' as any,
+        createdAt: new Date().toISOString(),
+      });
+      expect(result.title).toBe('通知');
+      expect(result.body).toBe('您有一則新通知');
+    });
   });
 });

--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen } from '@testing-library/react';
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+import { formatRelativeTime } from '@/lib/dateUtils';
 
 import {
-  formatRelativeTime,
   getNotificationContent,
   NotificationBell,
   type NotificationItem,
@@ -130,6 +131,28 @@ describe('NotificationBell', () => {
       expect(
         screen.getByRole('button', { name: '重新嘗試' })
       ).toBeInTheDocument();
+    });
+
+    it('triggers onRetry callback and transitions to loading when clicking retry button', () => {
+      const onRetryMock = vi.fn();
+      render(
+        <NotificationBell
+          unreadCount={5}
+          initialStatus="error"
+          onRetry={onRetryMock}
+        />
+      );
+      const button = screen.getByRole('button', { name: '開啟通知選單' });
+      fireEvent.click(button);
+
+      const retryButton = screen.getByRole('button', { name: '重新嘗試' });
+      fireEvent.click(retryButton);
+
+      // Verify that onRetry callback was called
+      expect(onRetryMock).toHaveBeenCalledTimes(1);
+
+      // Verify that UI transitions to loading state (error text disappears)
+      expect(screen.queryByText('載入失敗，請重試')).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -17,6 +17,7 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Skeleton } from '@/components/ui/skeleton';
+import { formatRelativeTime } from '@/lib/dateUtils';
 import { cn } from '@/lib/utils';
 
 export type NotificationItem = {
@@ -95,29 +96,6 @@ export const defaultMockNotifications: NotificationItem[] = [
     unread: false,
   },
 ];
-
-/**
- * Formats elapsed time relative to the current time.
- * - Under 24 hours: formats in hours (e.g., "1 小時", "23 小時")
- * - 24 hours or more: formats in days (e.g., "1 天", "30 天")
- */
-export function formatRelativeTime(dateInput: Date | string): string {
-  const date = new Date(dateInput);
-  if (isNaN(date.getTime())) {
-    return '';
-  }
-  const now = new Date();
-  const diffMs = Math.max(0, now.getTime() - date.getTime());
-  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
-
-  if (diffHours < 24) {
-    const hours = Math.max(1, diffHours);
-    return `${hours} 小時`;
-  } else {
-    const days = Math.floor(diffHours / 24);
-    return `${days} 天`;
-  }
-}
 
 /**
  * Returns content templates (title, body, styles, and icon) for notification items.
@@ -271,16 +249,8 @@ export const NotificationBell = React.memo(function NotificationBell({
           </div>
         )}
 
-        {status === 'empty' && (
-          <div className="flex flex-col items-center justify-center py-8 text-center">
-            <Bell className="mb-3 size-10 text-text-tertiary" />
-            <p className="text-sm font-medium text-text-secondary">
-              尚無新通知
-            </p>
-          </div>
-        )}
-
-        {status === 'success' && notifications.length === 0 && (
+        {(status === 'empty' ||
+          (status === 'success' && notifications.length === 0)) && (
           <div className="flex flex-col items-center justify-center py-8 text-center">
             <Bell className="mb-3 size-10 text-text-tertiary" />
             <p className="text-sm font-medium text-text-secondary">

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -165,17 +165,6 @@ export const NotificationBell = React.memo(function NotificationBell({
   );
   const [localUnreadCount, setLocalUnreadCount] = React.useState(unreadCount);
 
-  // Sync state if props change (solving uncontrolled-to-controlled locking issues)
-  React.useEffect(() => {
-    setStatus(initialStatus);
-  }, [initialStatus]);
-
-  React.useEffect(() => {
-    if (initialNotifications) {
-      setNotifications(initialNotifications);
-    }
-  }, [initialNotifications]);
-
   // Track unreadCount changes and reset hasBeenClicked if new notifications arrive (solving badge hidden bug)
   const prevUnreadCountRef = React.useRef(unreadCount);
   React.useEffect(() => {

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -1,6 +1,14 @@
 'use client';
 
-import { Bell } from 'lucide-react';
+import {
+  AlertCircle,
+  Bell,
+  CalendarCheck,
+  CalendarOff,
+  CalendarPlus,
+  CalendarX,
+  Clock,
+} from 'lucide-react';
 import * as React from 'react';
 
 import {
@@ -8,7 +16,22 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from '@/components/ui/popover';
+import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+
+export type NotificationItem = {
+  id: string;
+  type:
+    | 'reservation_new'
+    | 'reservation_success'
+    | 'reservation_failed'
+    | 'reservation_canceled'
+    | 'reservation_upcoming';
+  menteeName?: string;
+  mentorName?: string;
+  createdAt: string; // ISO string
+  unread?: boolean;
+};
 
 export type NotificationBellProps = {
   /**
@@ -20,19 +43,173 @@ export type NotificationBellProps = {
    * Optional custom classes for the trigger button (e.g. for responsive RWD displays).
    */
   className?: string;
+  /**
+   * Initial display status of the notification center dropdown.
+   * @default 'success'
+   */
+  initialStatus?: 'loading' | 'error' | 'empty' | 'success';
+  /**
+   * Initial list of notifications. If omitted, will default to mock notifications.
+   */
+  initialNotifications?: NotificationItem[];
+  /**
+   * Optional callback when the retry button is clicked.
+   */
+  onRetry?: () => void;
 };
+
+export const defaultMockNotifications: NotificationItem[] = [
+  {
+    id: '1',
+    type: 'reservation_new',
+    menteeName: '小明',
+    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(), // 1 小時前
+    unread: true,
+  },
+  {
+    id: '2',
+    type: 'reservation_success',
+    mentorName: '林導師',
+    createdAt: new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString(), // 23 小時前
+    unread: true,
+  },
+  {
+    id: '3',
+    type: 'reservation_failed',
+    mentorName: '王導師',
+    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 天前
+    unread: false,
+  },
+  {
+    id: '4',
+    type: 'reservation_canceled',
+    mentorName: '陳導師',
+    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 天前
+    unread: false,
+  },
+  {
+    id: '5',
+    type: 'reservation_upcoming',
+    mentorName: '張導師',
+    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 天前
+    unread: false,
+  },
+];
+
+/**
+ * Formats elapsed time relative to the current time.
+ * - Under 24 hours: formats in hours (e.g., "1 小時", "23 小時")
+ * - 24 hours or more: formats in days (e.g., "1 天", "30 天")
+ */
+export function formatRelativeTime(dateInput: Date | string): string {
+  const date = new Date(dateInput);
+  const now = new Date();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+
+  if (diffHours < 24) {
+    const hours = Math.max(1, diffHours);
+    return `${hours} 小時`;
+  } else {
+    const days = Math.floor(diffHours / 24);
+    return `${days} 天`;
+  }
+}
+
+/**
+ * Returns content templates (title, body, styles) for notification items.
+ */
+export function getNotificationContent(item: NotificationItem) {
+  switch (item.type) {
+    case 'reservation_new':
+      return {
+        title: '您有新的預約',
+        body: `${item.menteeName || 'Mentee'} 與您提出預約需求，請前往接受預約`,
+        iconBgClass: 'bg-brand-50 text-brand-600',
+      };
+    case 'reservation_success':
+      return {
+        title: `${item.mentorName || 'Mentor'} 已接受您的預約`,
+        body: '前往查看您的預約詳情',
+        iconBgClass: 'bg-status-success-default/10 text-status-success-default',
+      };
+    case 'reservation_failed':
+      return {
+        title: `您與 ${item.mentorName || 'Mentor'} 的預約已被拒絕`,
+        body: '您的預約已被拒絕，歡迎重新預約',
+        iconBgClass: 'bg-status-error-default/10 text-status-error-default',
+      };
+    case 'reservation_canceled': {
+      const name = item.mentorName || item.menteeName || '導師';
+      return {
+        title: `您與 ${name} 的預約已被取消`,
+        body: '您的預約已被取消，歡迎重新預約',
+        iconBgClass: 'bg-background-hover text-text-secondary',
+      };
+    }
+    case 'reservation_upcoming':
+      return {
+        title: `您與 ${item.mentorName || 'Mentor'} 的預約即將到來`,
+        body: `您 24 小時後有與 ${item.mentorName || 'Mentor'} 的會議，請準時上線`,
+        iconBgClass: 'bg-status-warning-default/10 text-status-warning-default',
+      };
+    default:
+      return {
+        title: '通知',
+        body: '您有一則新通知',
+        iconBgClass: 'bg-background-bottom text-text-primary',
+      };
+  }
+}
+
+function getNotificationIcon(type: string) {
+  switch (type) {
+    case 'reservation_new':
+      return <CalendarPlus className="size-5" />;
+    case 'reservation_success':
+      return <CalendarCheck className="size-5" />;
+    case 'reservation_failed':
+      return <CalendarX className="size-5" />;
+    case 'reservation_canceled':
+      return <CalendarOff className="size-5" />;
+    case 'reservation_upcoming':
+      return <Clock className="size-5" />;
+    default:
+      return <Bell className="size-5" />;
+  }
+}
 
 export const NotificationBell = React.memo(function NotificationBell({
   unreadCount = 5,
   className,
+  initialStatus = 'success',
+  initialNotifications,
+  onRetry,
 }: NotificationBellProps): JSX.Element {
   const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
+  const [status, setStatus] = React.useState(initialStatus);
+  const [notifications, setNotifications] = React.useState<NotificationItem[]>(
+    initialNotifications ?? defaultMockNotifications
+  );
 
   const handleOpenChange = React.useCallback((open: boolean) => {
     if (open) {
       setHasBeenClicked(true);
     }
   }, []);
+
+  const handleRetry = React.useCallback(() => {
+    setStatus('loading');
+    if (onRetry) {
+      onRetry();
+    } else {
+      // Simulating a clean reload back to mock success list
+      setTimeout(() => {
+        setNotifications(defaultMockNotifications);
+        setStatus('success');
+      }, 1000);
+    }
+  }, [onRetry]);
 
   const showBadge = !hasBeenClicked && unreadCount > 0;
   const formattedCount = unreadCount > 99 ? '99+' : String(unreadCount);
@@ -65,14 +242,97 @@ export const NotificationBell = React.memo(function NotificationBell({
       <PopoverContent
         align="end"
         sideOffset={8}
-        className="w-80 rounded-2xl border border-background-border bg-background-white p-6 shadow-xl outline-none"
+        className="w-[360px] rounded-2xl border border-background-border bg-background-white p-5 shadow-xl outline-none"
       >
-        <div className="flex flex-col items-center justify-center py-8 text-center">
-          <Bell className="mb-3 size-12 text-text-tertiary" />
-          <p className="text-base font-medium text-text-secondary">
-            尚無新通知
-          </p>
+        <div className="mb-3 flex items-center justify-between border-b border-background-border pb-3">
+          <span className="text-lg font-bold text-text-primary">通知</span>
         </div>
+
+        {status === 'loading' && (
+          <div className="flex flex-col gap-3 py-2">
+            {Array.from({ length: 3 }).map((_, i) => (
+              <div key={i} className="flex items-start gap-3 py-2">
+                <Skeleton className="size-10 shrink-0 rounded-full" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-4 w-3/4 rounded" />
+                  <Skeleton className="h-3 w-5/6 rounded" />
+                  <Skeleton className="h-3 w-12 rounded" />
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {status === 'error' && (
+          <div className="flex flex-col items-center justify-center py-6 text-center">
+            <AlertCircle className="mb-2 size-8 text-status-error-default" />
+            <p className="mb-3 text-sm font-medium text-text-secondary">
+              載入失敗，請重試
+            </p>
+            <button
+              type="button"
+              onClick={handleRetry}
+              className="inline-flex h-8 items-center justify-center rounded-lg border border-background-border px-3 text-xs font-medium text-text-primary transition-all hover:bg-background-hover"
+            >
+              重新嘗試
+            </button>
+          </div>
+        )}
+
+        {status === 'empty' && (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Bell className="mb-3 size-10 text-text-tertiary" />
+            <p className="text-sm font-medium text-text-secondary">
+              尚無新通知
+            </p>
+          </div>
+        )}
+
+        {status === 'success' && notifications.length === 0 && (
+          <div className="flex flex-col items-center justify-center py-8 text-center">
+            <Bell className="mb-3 size-10 text-text-tertiary" />
+            <p className="text-sm font-medium text-text-secondary">
+              尚無新通知
+            </p>
+          </div>
+        )}
+
+        {status === 'success' && notifications.length > 0 && (
+          <div className="flex max-h-[360px] flex-col gap-1 overflow-y-auto pr-1">
+            {notifications.map((item) => {
+              const { title, body, iconBgClass } = getNotificationContent(item);
+              return (
+                <div
+                  key={item.id}
+                  className="group/item relative flex items-start gap-3 rounded-xl p-3 transition-all duration-200 hover:bg-background-hover"
+                >
+                  <div
+                    className={cn(
+                      'flex size-10 shrink-0 items-center justify-center rounded-full',
+                      iconBgClass
+                    )}
+                  >
+                    {getNotificationIcon(item.type)}
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="mb-1 text-sm leading-tight font-semibold break-words text-text-primary">
+                      {title}
+                    </p>
+                    <p className="mb-1.5 text-xs leading-normal break-words text-text-secondary">
+                      {body}
+                    </p>
+                    <span className="text-11 leading-none text-text-tertiary">
+                      {formatRelativeTime(item.createdAt)}
+                    </span>
+                  </div>
+                  {item.unread && (
+                    <span className="absolute top-4 right-3 size-2 rounded-full bg-status-error-default" />
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
       </PopoverContent>
     </Popover>
   );

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -53,10 +53,6 @@ export type NotificationBellProps = {
    * Initial list of notifications. If omitted, will default to mock notifications.
    */
   initialNotifications?: NotificationItem[];
-  /**
-   * Optional callback when the retry button is clicked.
-   */
-  onRetry?: () => void;
 };
 
 export const defaultMockNotifications: NotificationItem[] = [
@@ -151,13 +147,17 @@ export function getNotificationContent(item: NotificationItem) {
   }
 }
 
-export const NotificationBell = React.memo(function NotificationBell({
-  unreadCount = 5,
-  className,
-  initialStatus = 'success',
+export type UseNotificationBellProps = {
+  unreadCount: number;
+  initialStatus: 'loading' | 'error' | 'empty' | 'success';
+  initialNotifications?: NotificationItem[];
+};
+
+export function useNotificationBell({
+  unreadCount,
+  initialStatus,
   initialNotifications,
-  onRetry,
-}: NotificationBellProps): JSX.Element {
+}: UseNotificationBellProps) {
   const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
   const [status, setStatus] = React.useState(initialStatus);
   const [notifications, setNotifications] = React.useState<NotificationItem[]>(
@@ -187,20 +187,47 @@ export const NotificationBell = React.memo(function NotificationBell({
 
   const handleRetry = React.useCallback(() => {
     setStatus('loading');
-    if (onRetry) {
-      onRetry();
-    } else {
-      // Simulating a clean reload back to mock success list
-      setTimeout(() => {
-        setNotifications(defaultMockNotifications);
-        setStatus('success');
-      }, 1000);
-    }
-  }, [onRetry]);
+    // Simulating a clean reload back to mock success list
+    setTimeout(() => {
+      setNotifications(defaultMockNotifications);
+      setStatus('success');
+    }, 1000);
+  }, []);
 
   const showBadge = !hasBeenClicked && localUnreadCount > 0;
   const formattedCount =
     localUnreadCount > 99 ? '99+' : String(localUnreadCount);
+
+  return {
+    status,
+    notifications,
+    localUnreadCount,
+    showBadge,
+    formattedCount,
+    handleOpenChange,
+    handleRetry,
+  };
+}
+
+export const NotificationBell = React.memo(function NotificationBell({
+  unreadCount = 5,
+  className,
+  initialStatus = 'success',
+  initialNotifications,
+}: NotificationBellProps): JSX.Element {
+  const {
+    status,
+    notifications,
+    localUnreadCount,
+    showBadge,
+    formattedCount,
+    handleOpenChange,
+    handleRetry,
+  } = useNotificationBell({
+    unreadCount,
+    initialStatus,
+    initialNotifications,
+  });
 
   return (
     <Popover onOpenChange={handleOpenChange}>

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -103,6 +103,9 @@ export const defaultMockNotifications: NotificationItem[] = [
  */
 export function formatRelativeTime(dateInput: Date | string): string {
   const date = new Date(dateInput);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
   const now = new Date();
   const diffMs = Math.max(0, now.getTime() - date.getTime());
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
@@ -117,7 +120,7 @@ export function formatRelativeTime(dateInput: Date | string): string {
 }
 
 /**
- * Returns content templates (title, body, styles) for notification items.
+ * Returns content templates (title, body, styles, and icon) for notification items.
  */
 export function getNotificationContent(item: NotificationItem) {
   switch (item.type) {
@@ -126,18 +129,21 @@ export function getNotificationContent(item: NotificationItem) {
         title: '您有新的預約',
         body: `${item.menteeName || 'Mentee'} 與您提出預約需求，請前往接受預約`,
         iconBgClass: 'bg-brand-50 text-brand-600',
+        icon: <CalendarPlus className="size-5" />,
       };
     case 'reservation_success':
       return {
         title: `${item.mentorName || 'Mentor'} 已接受您的預約`,
         body: '前往查看您的預約詳情',
         iconBgClass: 'bg-status-success-default/10 text-status-success-default',
+        icon: <CalendarCheck className="size-5" />,
       };
     case 'reservation_failed':
       return {
         title: `您與 ${item.mentorName || 'Mentor'} 的預約已被拒絕`,
         body: '您的預約已被拒絕，歡迎重新預約',
         iconBgClass: 'bg-status-error-default/10 text-status-error-default',
+        icon: <CalendarX className="size-5" />,
       };
     case 'reservation_canceled': {
       const name = item.mentorName || item.menteeName || '導師';
@@ -145,6 +151,7 @@ export function getNotificationContent(item: NotificationItem) {
         title: `您與 ${name} 的預約已被取消`,
         body: '您的預約已被取消，歡迎重新預約',
         iconBgClass: 'bg-background-hover text-text-secondary',
+        icon: <CalendarOff className="size-5" />,
       };
     }
     case 'reservation_upcoming':
@@ -152,30 +159,15 @@ export function getNotificationContent(item: NotificationItem) {
         title: `您與 ${item.mentorName || 'Mentor'} 的預約即將到來`,
         body: `您 24 小時後有與 ${item.mentorName || 'Mentor'} 的會議，請準時上線`,
         iconBgClass: 'bg-status-warning-default/10 text-status-warning-default',
+        icon: <Clock className="size-5" />,
       };
     default:
       return {
         title: '通知',
         body: '您有一則新通知',
         iconBgClass: 'bg-background-bottom text-text-primary',
+        icon: <Bell className="size-5" />,
       };
-  }
-}
-
-function getNotificationIcon(type: string) {
-  switch (type) {
-    case 'reservation_new':
-      return <CalendarPlus className="size-5" />;
-    case 'reservation_success':
-      return <CalendarCheck className="size-5" />;
-    case 'reservation_failed':
-      return <CalendarX className="size-5" />;
-    case 'reservation_canceled':
-      return <CalendarOff className="size-5" />;
-    case 'reservation_upcoming':
-      return <Clock className="size-5" />;
-    default:
-      return <Bell className="size-5" />;
   }
 }
 
@@ -300,7 +292,8 @@ export const NotificationBell = React.memo(function NotificationBell({
         {status === 'success' && notifications.length > 0 && (
           <div className="flex max-h-[360px] flex-col gap-1 overflow-y-auto pr-1">
             {notifications.map((item) => {
-              const { title, body, iconBgClass } = getNotificationContent(item);
+              const { title, body, iconBgClass, icon } =
+                getNotificationContent(item);
               return (
                 <div
                   key={item.id}
@@ -312,7 +305,7 @@ export const NotificationBell = React.memo(function NotificationBell({
                       iconBgClass
                     )}
                   >
-                    {getNotificationIcon(item.type)}
+                    {icon}
                   </div>
                   <div className="min-w-0 flex-1">
                     <p className="mb-1 text-sm leading-tight font-semibold break-words text-text-primary">

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -163,6 +163,7 @@ export const NotificationBell = React.memo(function NotificationBell({
   const [notifications, setNotifications] = React.useState<NotificationItem[]>(
     initialNotifications ?? defaultMockNotifications
   );
+  const [localUnreadCount, setLocalUnreadCount] = React.useState(unreadCount);
 
   // Sync state if props change (solving uncontrolled-to-controlled locking issues)
   React.useEffect(() => {
@@ -181,12 +182,17 @@ export const NotificationBell = React.memo(function NotificationBell({
     if (unreadCount > prevUnreadCountRef.current) {
       setHasBeenClicked(false);
     }
+    setLocalUnreadCount(unreadCount);
     prevUnreadCountRef.current = unreadCount;
   }, [unreadCount]);
 
   const handleOpenChange = React.useCallback((open: boolean) => {
     if (open) {
       setHasBeenClicked(true);
+      setLocalUnreadCount(0);
+      setNotifications((prev) =>
+        prev.map((item) => ({ ...item, unread: false }))
+      );
     }
   }, []);
 
@@ -203,8 +209,9 @@ export const NotificationBell = React.memo(function NotificationBell({
     }
   }, [onRetry]);
 
-  const showBadge = !hasBeenClicked && unreadCount > 0;
-  const formattedCount = unreadCount > 99 ? '99+' : String(unreadCount);
+  const showBadge = !hasBeenClicked && localUnreadCount > 0;
+  const formattedCount =
+    localUnreadCount > 99 ? '99+' : String(localUnreadCount);
 
   return (
     <Popover onOpenChange={handleOpenChange}>
@@ -223,7 +230,7 @@ export const NotificationBell = React.memo(function NotificationBell({
           {showBadge && (
             <span
               className="absolute -right-0.5 -bottom-0.5 flex h-4 min-w-[16px] items-center justify-center rounded-full border border-background-white bg-status-error-default px-1 text-11 leading-none font-bold text-text-white select-none"
-              aria-label={`有 ${unreadCount} 則未讀通知`}
+              aria-label={`有 ${localUnreadCount} 則未讀通知`}
             >
               {formattedCount}
             </span>

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -17,22 +17,12 @@ import {
   PopoverTrigger,
 } from '@/components/ui/popover';
 import { Skeleton } from '@/components/ui/skeleton';
+import {
+  type NotificationItem,
+  useNotificationBell,
+} from '@/hooks/useNotificationBell';
 import { formatRelativeTime } from '@/lib/dateUtils';
 import { cn } from '@/lib/utils';
-
-export type NotificationItem = {
-  id: string;
-  type:
-    | 'reservation_new'
-    | 'reservation_success'
-    | 'reservation_failed'
-    | 'reservation_canceled'
-    | 'reservation_upcoming';
-  menteeName?: string;
-  mentorName?: string;
-  createdAt: string; // ISO string
-  unread?: boolean;
-};
 
 export type NotificationBellProps = {
   /**
@@ -54,44 +44,6 @@ export type NotificationBellProps = {
    */
   initialNotifications?: NotificationItem[];
 };
-
-export const defaultMockNotifications: NotificationItem[] = [
-  {
-    id: '1',
-    type: 'reservation_new',
-    menteeName: '小明',
-    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(), // 1 小時前
-    unread: true,
-  },
-  {
-    id: '2',
-    type: 'reservation_success',
-    mentorName: '林導師',
-    createdAt: new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString(), // 23 小時前
-    unread: true,
-  },
-  {
-    id: '3',
-    type: 'reservation_failed',
-    mentorName: '王導師',
-    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 天前
-    unread: false,
-  },
-  {
-    id: '4',
-    type: 'reservation_canceled',
-    mentorName: '陳導師',
-    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 天前
-    unread: false,
-  },
-  {
-    id: '5',
-    type: 'reservation_upcoming',
-    mentorName: '張導師',
-    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 天前
-    unread: false,
-  },
-];
 
 /**
  * Returns content templates (title, body, styles, and icon) for notification items.
@@ -145,68 +97,6 @@ export function getNotificationContent(item: NotificationItem) {
         icon: <Bell className="size-5" />,
       };
   }
-}
-
-export type UseNotificationBellProps = {
-  unreadCount: number;
-  initialStatus: 'loading' | 'error' | 'empty' | 'success';
-  initialNotifications?: NotificationItem[];
-};
-
-export function useNotificationBell({
-  unreadCount,
-  initialStatus,
-  initialNotifications,
-}: UseNotificationBellProps) {
-  const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
-  const [status, setStatus] = React.useState(initialStatus);
-  const [notifications, setNotifications] = React.useState<NotificationItem[]>(
-    initialNotifications ?? defaultMockNotifications
-  );
-  const [localUnreadCount, setLocalUnreadCount] = React.useState(unreadCount);
-
-  // Track unreadCount changes and reset hasBeenClicked if new notifications arrive (solving badge hidden bug)
-  const prevUnreadCountRef = React.useRef(unreadCount);
-  React.useEffect(() => {
-    if (unreadCount > prevUnreadCountRef.current) {
-      setHasBeenClicked(false);
-    }
-    setLocalUnreadCount(unreadCount);
-    prevUnreadCountRef.current = unreadCount;
-  }, [unreadCount]);
-
-  const handleOpenChange = React.useCallback((open: boolean) => {
-    if (open) {
-      setHasBeenClicked(true);
-      setLocalUnreadCount(0);
-      setNotifications((prev) =>
-        prev.map((item) => ({ ...item, unread: false }))
-      );
-    }
-  }, []);
-
-  const handleRetry = React.useCallback(() => {
-    setStatus('loading');
-    // Simulating a clean reload back to mock success list
-    setTimeout(() => {
-      setNotifications(defaultMockNotifications);
-      setStatus('success');
-    }, 1000);
-  }, []);
-
-  const showBadge = !hasBeenClicked && localUnreadCount > 0;
-  const formattedCount =
-    localUnreadCount > 99 ? '99+' : String(localUnreadCount);
-
-  return {
-    status,
-    notifications,
-    localUnreadCount,
-    showBadge,
-    formattedCount,
-    handleOpenChange,
-    handleRetry,
-  };
 }
 
 export const NotificationBell = React.memo(function NotificationBell({

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -132,13 +132,15 @@ export function getNotificationContent(item: NotificationItem) {
         icon: <CalendarOff className="size-5" />,
       };
     }
-    case 'reservation_upcoming':
+    case 'reservation_upcoming': {
+      const name = item.mentorName || item.menteeName || '導師';
       return {
-        title: `您與 ${item.mentorName || 'Mentor'} 的預約即將到來`,
-        body: `您 24 小時後有與 ${item.mentorName || 'Mentor'} 的會議，請準時上線`,
+        title: `您與 ${name} 的預約即將到來`,
+        body: `您 24 小時後有與 ${name} 的會議，請準時上線`,
         iconBgClass: 'bg-status-warning-default/10 text-status-warning-default',
         icon: <Clock className="size-5" />,
       };
+    }
     default:
       return {
         title: '通知',
@@ -161,6 +163,26 @@ export const NotificationBell = React.memo(function NotificationBell({
   const [notifications, setNotifications] = React.useState<NotificationItem[]>(
     initialNotifications ?? defaultMockNotifications
   );
+
+  // Sync state if props change (solving uncontrolled-to-controlled locking issues)
+  React.useEffect(() => {
+    setStatus(initialStatus);
+  }, [initialStatus]);
+
+  React.useEffect(() => {
+    if (initialNotifications) {
+      setNotifications(initialNotifications);
+    }
+  }, [initialNotifications]);
+
+  // Track unreadCount changes and reset hasBeenClicked if new notifications arrive (solving badge hidden bug)
+  const prevUnreadCountRef = React.useRef(unreadCount);
+  React.useEffect(() => {
+    if (unreadCount > prevUnreadCountRef.current) {
+      setHasBeenClicked(false);
+    }
+    prevUnreadCountRef.current = unreadCount;
+  }, [unreadCount]);
 
   const handleOpenChange = React.useCallback((open: boolean) => {
     if (open) {

--- a/src/hooks/useNotificationBell.ts
+++ b/src/hooks/useNotificationBell.ts
@@ -68,17 +68,17 @@ export function useNotificationBell({
   const [notifications, setNotifications] = React.useState<NotificationItem[]>(
     initialNotifications ?? defaultMockNotifications
   );
+
+  const [prevUnreadCount, setPrevUnreadCount] = React.useState(unreadCount);
   const [localUnreadCount, setLocalUnreadCount] = React.useState(unreadCount);
 
-  // Track unreadCount changes and reset hasBeenClicked if new notifications arrive (solving badge hidden bug)
-  const prevUnreadCountRef = React.useRef(unreadCount);
-  React.useEffect(() => {
-    if (unreadCount > prevUnreadCountRef.current) {
+  if (unreadCount !== prevUnreadCount) {
+    setPrevUnreadCount(unreadCount);
+    setLocalUnreadCount(unreadCount);
+    if (unreadCount > prevUnreadCount) {
       setHasBeenClicked(false);
     }
-    setLocalUnreadCount(unreadCount);
-    prevUnreadCountRef.current = unreadCount;
-  }, [unreadCount]);
+  }
 
   const handleOpenChange = React.useCallback((open: boolean) => {
     if (open) {

--- a/src/hooks/useNotificationBell.ts
+++ b/src/hooks/useNotificationBell.ts
@@ -1,0 +1,115 @@
+import * as React from 'react';
+
+export type NotificationItem = {
+  id: string;
+  type:
+    | 'reservation_new'
+    | 'reservation_success'
+    | 'reservation_failed'
+    | 'reservation_canceled'
+    | 'reservation_upcoming';
+  menteeName?: string;
+  mentorName?: string;
+  createdAt: string; // ISO string
+  unread?: boolean;
+};
+
+export const defaultMockNotifications: NotificationItem[] = [
+  {
+    id: '1',
+    type: 'reservation_new',
+    menteeName: '小明',
+    createdAt: new Date(Date.now() - 1 * 60 * 60 * 1000).toISOString(), // 1 小時前
+    unread: true,
+  },
+  {
+    id: '2',
+    type: 'reservation_success',
+    mentorName: '林導師',
+    createdAt: new Date(Date.now() - 23 * 60 * 60 * 1000).toISOString(), // 23 小時前
+    unread: true,
+  },
+  {
+    id: '3',
+    type: 'reservation_failed',
+    mentorName: '王導師',
+    createdAt: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(), // 1 天前
+    unread: false,
+  },
+  {
+    id: '4',
+    type: 'reservation_canceled',
+    mentorName: '陳導師',
+    createdAt: new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString(), // 5 天前
+    unread: false,
+  },
+  {
+    id: '5',
+    type: 'reservation_upcoming',
+    mentorName: '張導師',
+    createdAt: new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString(), // 30 天前
+    unread: false,
+  },
+];
+
+export type UseNotificationBellProps = {
+  unreadCount: number;
+  initialStatus: 'loading' | 'error' | 'empty' | 'success';
+  initialNotifications?: NotificationItem[];
+};
+
+export function useNotificationBell({
+  unreadCount,
+  initialStatus,
+  initialNotifications,
+}: UseNotificationBellProps) {
+  const [hasBeenClicked, setHasBeenClicked] = React.useState(false);
+  const [status, setStatus] = React.useState(initialStatus);
+  const [notifications, setNotifications] = React.useState<NotificationItem[]>(
+    initialNotifications ?? defaultMockNotifications
+  );
+  const [localUnreadCount, setLocalUnreadCount] = React.useState(unreadCount);
+
+  // Track unreadCount changes and reset hasBeenClicked if new notifications arrive (solving badge hidden bug)
+  const prevUnreadCountRef = React.useRef(unreadCount);
+  React.useEffect(() => {
+    if (unreadCount > prevUnreadCountRef.current) {
+      setHasBeenClicked(false);
+    }
+    setLocalUnreadCount(unreadCount);
+    prevUnreadCountRef.current = unreadCount;
+  }, [unreadCount]);
+
+  const handleOpenChange = React.useCallback((open: boolean) => {
+    if (open) {
+      setHasBeenClicked(true);
+      setLocalUnreadCount(0);
+      setNotifications((prev) =>
+        prev.map((item) => ({ ...item, unread: false }))
+      );
+    }
+  }, []);
+
+  const handleRetry = React.useCallback(() => {
+    setStatus('loading');
+    // Simulating a clean reload back to mock success list
+    setTimeout(() => {
+      setNotifications(defaultMockNotifications);
+      setStatus('success');
+    }, 1000);
+  }, []);
+
+  const showBadge = !hasBeenClicked && localUnreadCount > 0;
+  const formattedCount =
+    localUnreadCount > 99 ? '99+' : String(localUnreadCount);
+
+  return {
+    status,
+    notifications,
+    localUnreadCount,
+    showBadge,
+    formattedCount,
+    handleOpenChange,
+    handleRetry,
+  };
+}

--- a/src/hooks/useNotificationBell.ts
+++ b/src/hooks/useNotificationBell.ts
@@ -92,12 +92,12 @@ export function useNotificationBell({
 
   const handleRetry = React.useCallback(() => {
     setStatus('loading');
-    // Simulating a clean reload back to mock success list
+    // Simulating a clean reload back to initial or default success list
     setTimeout(() => {
-      setNotifications(defaultMockNotifications);
+      setNotifications(initialNotifications ?? defaultMockNotifications);
       setStatus('success');
     }, 1000);
-  }, []);
+  }, [initialNotifications]);
 
   const showBadge = !hasBeenClicked && localUnreadCount > 0;
   const formattedCount =

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { formatRelativeTime } from './dateUtils';
+
+describe('formatRelativeTime', () => {
+  it('correctly calculates relative time', () => {
+    const now = new Date();
+
+    // 0 minutes ago (just happened)
+    expect(formatRelativeTime(now)).toBe('1 小時');
+
+    // 30 minutes ago (less than 1 hour)
+    const thirtyMinsAgo = new Date(now.getTime() - 30 * 60 * 1000);
+    expect(formatRelativeTime(thirtyMinsAgo)).toBe('1 小時');
+
+    // 1 hour ago
+    const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000);
+    expect(formatRelativeTime(oneHourAgo)).toBe('1 小時');
+
+    // 23 hours ago
+    const twentyThreeHoursAgo = new Date(now.getTime() - 23 * 60 * 60 * 1000);
+    expect(formatRelativeTime(twentyThreeHoursAgo)).toBe('23 小時');
+
+    // 24 hours ago (exactly 1 day)
+    const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(oneDayAgo)).toBe('1 天');
+
+    // 30 days ago
+    const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+    expect(formatRelativeTime(thirtyDaysAgo)).toBe('30 天');
+
+    // Invalid date
+    expect(formatRelativeTime('invalid-date-string')).toBe('');
+  });
+});

--- a/src/lib/dateUtils.test.ts
+++ b/src/lib/dateUtils.test.ts
@@ -4,32 +4,33 @@ import { formatRelativeTime } from './dateUtils';
 
 describe('formatRelativeTime', () => {
   it('correctly calculates relative time', () => {
-    const now = new Date();
+    // Fixed reference time for deterministic testing
+    const now = new Date('2026-08-11T12:00:00.000Z');
 
     // 0 minutes ago (just happened)
-    expect(formatRelativeTime(now)).toBe('1 小時');
+    expect(formatRelativeTime(now, now)).toBe('1 小時');
 
     // 30 minutes ago (less than 1 hour)
     const thirtyMinsAgo = new Date(now.getTime() - 30 * 60 * 1000);
-    expect(formatRelativeTime(thirtyMinsAgo)).toBe('1 小時');
+    expect(formatRelativeTime(thirtyMinsAgo, now)).toBe('1 小時');
 
     // 1 hour ago
     const oneHourAgo = new Date(now.getTime() - 1 * 60 * 60 * 1000);
-    expect(formatRelativeTime(oneHourAgo)).toBe('1 小時');
+    expect(formatRelativeTime(oneHourAgo, now)).toBe('1 小時');
 
     // 23 hours ago
     const twentyThreeHoursAgo = new Date(now.getTime() - 23 * 60 * 60 * 1000);
-    expect(formatRelativeTime(twentyThreeHoursAgo)).toBe('23 小時');
+    expect(formatRelativeTime(twentyThreeHoursAgo, now)).toBe('23 小時');
 
     // 24 hours ago (exactly 1 day)
     const oneDayAgo = new Date(now.getTime() - 24 * 60 * 60 * 1000);
-    expect(formatRelativeTime(oneDayAgo)).toBe('1 天');
+    expect(formatRelativeTime(oneDayAgo, now)).toBe('1 天');
 
     // 30 days ago
     const thirtyDaysAgo = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
-    expect(formatRelativeTime(thirtyDaysAgo)).toBe('30 天');
+    expect(formatRelativeTime(thirtyDaysAgo, now)).toBe('30 天');
 
     // Invalid date
-    expect(formatRelativeTime('invalid-date-string')).toBe('');
+    expect(formatRelativeTime('invalid-date-string', now)).toBe('');
   });
 });

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -1,0 +1,22 @@
+/**
+ * Formats elapsed time relative to the current time.
+ * - Under 24 hours: formats in hours (e.g., "1 小時", "23 小時")
+ * - 24 hours or more: formats in days (e.g., "1 天", "30 天")
+ */
+export function formatRelativeTime(dateInput: Date | string): string {
+  const date = new Date(dateInput);
+  if (isNaN(date.getTime())) {
+    return '';
+  }
+  const now = new Date();
+  const diffMs = Math.max(0, now.getTime() - date.getTime());
+  const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
+
+  if (diffHours < 24) {
+    const hours = Math.max(1, diffHours);
+    return `${hours} 小時`;
+  } else {
+    const days = Math.floor(diffHours / 24);
+    return `${days} 天`;
+  }
+}

--- a/src/lib/dateUtils.ts
+++ b/src/lib/dateUtils.ts
@@ -3,12 +3,14 @@
  * - Under 24 hours: formats in hours (e.g., "1 小時", "23 小時")
  * - 24 hours or more: formats in days (e.g., "1 天", "30 天")
  */
-export function formatRelativeTime(dateInput: Date | string): string {
+export function formatRelativeTime(
+  dateInput: Date | string,
+  now: Date = new Date()
+): string {
   const date = new Date(dateInput);
   if (isNaN(date.getTime())) {
     return '';
   }
-  const now = new Date();
   const diffMs = Math.max(0, now.getTime() - date.getTime());
   const diffHours = Math.floor(diffMs / (1000 * 60 * 60));
 


### PR DESCRIPTION
## Description

This PR implements the local/mock notification read state synchronization when the dropdown popover is opened.

### What Does This PR Do?

- **`src/components/layout/Header/NotificationBell.tsx`**:
  - Automatically mark all notifications as read inside the list when the dropdown popover is opened.
  - Clear and hide the unread count badge on open.
  - Sync unread badge count with `unreadCount` prop updates, allowing the badge to reappear when new notifications arrive.
- **`src/components/layout/Header/NotificationBell.test.tsx`**:
  - Added comprehensive unit tests in `NotificationBell.test.tsx` to verify read state synchronization.

### Screenshots

#### 1. Before Opening Dropdown (Unread Badge Visible)
![Before Click](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/75bda06a85cfdb472cadddb1c9a14ce51383dab3/feat-539-notification-read-sync/20260812T012632Z/0-1-before-click.png)

#### 2. After Opening Dropdown (Badge Cleared & Notification Red Dots Removed)
![After Click](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/663e8fc38ddd1d74042c1ee19c52d554a4b0e27c/feat-539-notification-read-sync/20260812T012700Z/0-2-after-click.png)

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/539
