### PR TITLE
fix(ui): keep desktop nav links visible when logged in (X-Tracker #554)

### DIFF
--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -180,7 +180,7 @@ describe('Header', () => {
     expect(avatarImgs[1]).toHaveAttribute('src', 'hint-avatar.png');
   });
 
-  it('keeps 尋找導師/關於 X-Talent/提供回饋/漢堡選單 mounted for logged-in users too, hiding them via CSS data-auth-state toggles instead of unmounting them (avoids a flash before authKnown settles)', () => {
+  it('keeps 尋找導師/關於 X-Talent/提供回饋/漢堡選單 mounted for logged-in users too, with navigation links always visible on desktop (avoids a flash before authKnown settles)', () => {
     mockUseSession.mockReturnValue({
       data: { ...mockSession, user: { ...mockSession.user, id: 'user-123' } },
       status: 'authenticated',
@@ -205,16 +205,18 @@ describe('Header', () => {
       name: '開啟導航選單',
     });
 
-    expect(findMentorLink).toHaveClass(
-      'group-data-[auth-state=mentee]:hidden',
+    expect(findMentorLink).not.toHaveClass(
+      'group-data-[auth-state=mentee]:hidden'
+    );
+    expect(findMentorLink).not.toHaveClass(
       'group-data-[auth-state=mentor]:hidden'
     );
-    expect(aboutLink).toHaveClass(
-      'group-data-[auth-state=mentee]:hidden',
-      'group-data-[auth-state=mentor]:hidden'
+    expect(aboutLink).not.toHaveClass('group-data-[auth-state=mentee]:hidden');
+    expect(aboutLink).not.toHaveClass('group-data-[auth-state=mentor]:hidden');
+    expect(feedbackLink).not.toHaveClass(
+      'group-data-[auth-state=mentee]:hidden'
     );
-    expect(feedbackLink).toHaveClass(
-      'group-data-[auth-state=mentee]:hidden',
+    expect(feedbackLink).not.toHaveClass(
       'group-data-[auth-state=mentor]:hidden'
     );
     expect(hamburgerTrigger.parentElement).toHaveClass(

--- a/src/components/layout/Header/Header.test.tsx
+++ b/src/components/layout/Header/Header.test.tsx
@@ -21,6 +21,11 @@ vi.mock('next/navigation', async () => {
   return navigationMockFactory();
 });
 
+const trackEvent = vi.fn();
+vi.mock('@/lib/analytics', () => ({
+  trackEvent: (...args: unknown[]) => trackEvent(...args),
+}));
+
 const mockUseAuthStatus = vi.fn();
 vi.mock('@/hooks/user/auth/useAuthStatus', () => ({
   useAuthStatus: () => mockUseAuthStatus(),
@@ -223,6 +228,28 @@ describe('Header', () => {
       'group-data-[auth-state=mentee]:hidden',
       'group-data-[auth-state=mentor]:hidden'
     );
+  });
+
+  it('tracks feedback_open when the desktop Header "提供回饋" link is clicked', () => {
+    trackEvent.mockClear();
+    mockUseSession.mockReturnValue({ data: null, status: 'unauthenticated' });
+    mockUseAuthStatus.mockReturnValue({
+      authKnown: true,
+      isLoggedIn: false,
+      isMentor: false,
+      userId: undefined,
+      hasFullUser: false,
+      isResolvingUser: false,
+    });
+
+    render(<Header />);
+
+    const feedbackLink = screen.getByRole('link', {
+      name: '提供回饋（另開新分頁）',
+    });
+    fireEvent.click(feedbackLink);
+
+    expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
   });
 
   it('renders pre-hydration avatar placeholder with CSS visibility toggles before auth is known', () => {

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -67,7 +67,7 @@ function HeaderComponent(): JSX.Element {
           <nav className="hidden items-center gap-7 lg:flex">
             <Link
               href={FIND_MENTOR_HREF}
-              className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+              className="font-['Open_Sans'] text-base text-text-primary"
             >
               尋找導師
             </Link>
@@ -102,7 +102,7 @@ function HeaderComponent(): JSX.Element {
 
             <Link
               href="/about"
-              className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+              className="font-['Open_Sans'] text-base text-text-primary"
             >
               關於 X-Talent
             </Link>
@@ -113,7 +113,7 @@ function HeaderComponent(): JSX.Element {
               rel="noopener noreferrer"
               aria-label="提供回饋（另開新分頁）"
               onClick={() => trackEvent({ name: 'feedback_open' })}
-              className="font-['Open_Sans'] text-base text-text-primary group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden"
+              className="font-['Open_Sans'] text-base text-text-primary"
             >
               提供回饋
             </a>

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -108,35 +108,19 @@ describe('UserDropdown share flow', () => {
     expect(shareButton).toBeDisabled();
   });
 
-  it('renders the merged header navigation links (尋找導師, 關於 X-Talent, 提供回饋) inside the dropdown menu', () => {
+  it('does not render the merged header navigation links (尋找導師, 關於 X-Talent, 提供回饋) inside the desktop dropdown menu', () => {
     render(<UserDropdown user={buildUser()} />);
 
     openMenu();
 
-    const findMentorLink = screen.getByRole('menuitem', { name: '尋找導師' });
-    const aboutLink = screen.getByRole('menuitem', { name: '關於 X-Talent' });
-    const feedbackLink = screen.getByRole('menuitem', { name: '提供回饋' });
-
-    expect(findMentorLink).toBeInTheDocument();
-    expect(findMentorLink).toHaveAttribute('href', '/mentor-pool');
-
-    expect(aboutLink).toBeInTheDocument();
-    expect(aboutLink).toHaveAttribute('href', '/about');
-
-    expect(feedbackLink).toBeInTheDocument();
-    expect(feedbackLink).toHaveAttribute(
-      'href',
-      'https://forms.gle/594hMVdTyoR3Pgtg9'
-    );
-  });
-
-  it('tracks feedback_open when 提供回饋 is clicked', () => {
-    trackEvent.mockClear();
-    render(<UserDropdown user={buildUser()} />);
-
-    openMenu();
-    fireEvent.click(screen.getByRole('menuitem', { name: '提供回饋' }));
-
-    expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
+    expect(
+      screen.queryByRole('menuitem', { name: '尋找導師' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: '關於 X-Talent' })
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('menuitem', { name: '提供回饋' })
+    ).not.toBeInTheDocument();
   });
 });

--- a/src/components/layout/Header/UserDropdown.test.tsx
+++ b/src/components/layout/Header/UserDropdown.test.tsx
@@ -108,19 +108,35 @@ describe('UserDropdown share flow', () => {
     expect(shareButton).toBeDisabled();
   });
 
-  it('does not render the merged header navigation links (尋找導師, 關於 X-Talent, 提供回饋) inside the desktop dropdown menu', () => {
+  it('renders the merged header navigation links (尋找導師, 關於 X-Talent, 提供回饋) inside the dropdown menu', () => {
     render(<UserDropdown user={buildUser()} />);
 
     openMenu();
 
-    expect(
-      screen.queryByRole('menuitem', { name: '尋找導師' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('menuitem', { name: '關於 X-Talent' })
-    ).not.toBeInTheDocument();
-    expect(
-      screen.queryByRole('menuitem', { name: '提供回饋' })
-    ).not.toBeInTheDocument();
+    const findMentorLink = screen.getByRole('menuitem', { name: '尋找導師' });
+    const aboutLink = screen.getByRole('menuitem', { name: '關於 X-Talent' });
+    const feedbackLink = screen.getByRole('menuitem', { name: '提供回饋' });
+
+    expect(findMentorLink).toBeInTheDocument();
+    expect(findMentorLink).toHaveAttribute('href', '/mentor-pool');
+
+    expect(aboutLink).toBeInTheDocument();
+    expect(aboutLink).toHaveAttribute('href', '/about');
+
+    expect(feedbackLink).toBeInTheDocument();
+    expect(feedbackLink).toHaveAttribute(
+      'href',
+      'https://forms.gle/594hMVdTyoR3Pgtg9'
+    );
+  });
+
+  it('tracks feedback_open when 提供回饋 is clicked', () => {
+    trackEvent.mockClear();
+    render(<UserDropdown user={buildUser()} />);
+
+    openMenu();
+    fireEvent.click(screen.getByRole('menuitem', { name: '提供回饋' }));
+
+    expect(trackEvent).toHaveBeenCalledWith({ name: 'feedback_open' });
   });
 });

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
 import * as React from 'react';
@@ -15,7 +16,9 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
+import { trackEvent } from '@/lib/analytics';
 
+import { FEEDBACK_FORM_URL, FIND_MENTOR_HREF } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
@@ -150,6 +153,34 @@ export const UserDropdown = React.memo(function UserDropdown({
               aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <Link href={FIND_MENTOR_HREF}>尋找導師</Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <Link href="/about">關於 X-Talent</Link>
+            </DropdownMenuItem>
+
+            <DropdownMenuItem
+              asChild
+              className="cursor-pointer px-4 py-3 text-2xl"
+            >
+              <a
+                href={FEEDBACK_FORM_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                onClick={() => trackEvent({ name: 'feedback_open' })}
+              >
+                提供回饋
+              </a>
             </DropdownMenuItem>
 
             <DropdownMenuItem

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
 import * as React from 'react';
@@ -16,9 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
-import { trackEvent } from '@/lib/analytics';
 
-import { FEEDBACK_FORM_URL, FIND_MENTOR_HREF } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
@@ -34,7 +31,6 @@ export const UserDropdown = React.memo(function UserDropdown({
   const closeMenu = React.useCallback(() => setMenuOpen(false), []);
   const {
     userId,
-    isMentor,
     canDeleteAccount,
     name,
     avatarSrc,
@@ -47,15 +43,12 @@ export const UserDropdown = React.memo(function UserDropdown({
     setDeleteDialogOpen,
     handleGoProfile,
     handleShareProfile,
-    handleAsMentor,
     handleMyReservation,
     handleDeleteAccount,
     handleLogout,
   } = useAccountMenu({ user, closeMenu });
 
   const isOnProfile = Boolean(userId) && pathname === profilePath;
-  const isOnMentorReservation =
-    pathname?.startsWith('/reservation/mentor') ?? false;
   const isOnMenteeReservation =
     pathname?.startsWith('/reservation/mentee') ?? false;
 
@@ -138,49 +131,10 @@ export const UserDropdown = React.memo(function UserDropdown({
           <div className="px-2 py-3">
             <DropdownMenuItem
               className="px-4 py-3 text-2xl"
-              onClick={handleAsMentor}
-              disabled={!userId}
-              aria-current={
-                isMentor && isOnMentorReservation ? 'page' : undefined
-              }
-            >
-              {isMentor ? '導師預約管理' : '成為導師'}
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              className="px-4 py-3 text-2xl"
               onClick={handleMyReservation}
               aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <Link href={FIND_MENTOR_HREF}>尋找導師</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <Link href="/about">關於 X-Talent</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <a
-                href={FEEDBACK_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent({ name: 'feedback_open' })}
-              >
-                提供回饋
-              </a>
             </DropdownMenuItem>
 
             <DropdownMenuItem

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import Image from 'next/image';
-import Link from 'next/link';
 import { usePathname } from 'next/navigation';
 import type { Session } from 'next-auth';
 import * as React from 'react';
@@ -16,9 +15,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useAccountMenu } from '@/hooks/layout/useAccountMenu';
-import { trackEvent } from '@/lib/analytics';
 
-import { FEEDBACK_FORM_URL, FIND_MENTOR_HREF } from './constants';
 import { ShareProfileDialog } from './ShareProfileDialog';
 
 export type UserDropdownProps = {
@@ -153,34 +150,6 @@ export const UserDropdown = React.memo(function UserDropdown({
               aria-current={isOnMenteeReservation ? 'page' : undefined}
             >
               我的預約
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <Link href={FIND_MENTOR_HREF}>尋找導師</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <Link href="/about">關於 X-Talent</Link>
-            </DropdownMenuItem>
-
-            <DropdownMenuItem
-              asChild
-              className="cursor-pointer px-4 py-3 text-2xl"
-            >
-              <a
-                href={FEEDBACK_FORM_URL}
-                target="_blank"
-                rel="noopener noreferrer"
-                onClick={() => trackEvent({ name: 'feedback_open' })}
-              >
-                提供回饋
-              </a>
             </DropdownMenuItem>
 
             <DropdownMenuItem

--- a/src/components/layout/Header/UserDropdown.tsx
+++ b/src/components/layout/Header/UserDropdown.tsx
@@ -30,6 +30,7 @@ export const UserDropdown = React.memo(function UserDropdown({
   const closeMenu = React.useCallback(() => setMenuOpen(false), []);
   const {
     userId,
+    isMentor,
     canDeleteAccount,
     name,
     avatarSrc,
@@ -42,12 +43,15 @@ export const UserDropdown = React.memo(function UserDropdown({
     setDeleteDialogOpen,
     handleGoProfile,
     handleShareProfile,
+    handleAsMentor,
     handleMyReservation,
     handleDeleteAccount,
     handleLogout,
   } = useAccountMenu({ user, closeMenu });
 
   const isOnProfile = Boolean(userId) && pathname === profilePath;
+  const isOnMentorReservation =
+    pathname?.startsWith('/reservation/mentor') ?? false;
   const isOnMenteeReservation =
     pathname?.startsWith('/reservation/mentee') ?? false;
 
@@ -124,6 +128,17 @@ export const UserDropdown = React.memo(function UserDropdown({
           <div className="h-px w-full bg-background-bottom" />
 
           <div className="px-2 py-3">
+            <DropdownMenuItem
+              className="px-4 py-3 text-2xl"
+              onClick={handleAsMentor}
+              disabled={!userId}
+              aria-current={
+                isMentor && isOnMentorReservation ? 'page' : undefined
+              }
+            >
+              {isMentor ? '導師預約管理' : '成為導師'}
+            </DropdownMenuItem>
+
             <DropdownMenuItem
               className="px-4 py-3 text-2xl"
               onClick={handleMyReservation}


### PR DESCRIPTION
## What Does This PR Do?

This PR fixes issue #554 where the desktop (≥1024px) Header navigation links (尋找導師, 成為導師, 關於 X-Talent, 提供回饋) were hidden when logged in, and instead merged into the user avatar dropdown menu.

- **Header.tsx**: Removed CSS toggle classes (`group-data-[auth-state=mentee]:hidden group-data-[auth-state=mentor]:hidden`) from '尋找導師', '關於 X-Talent', and '提供回饋' links to keep them always visible on desktop regardless of auth state.
- **UserDropdown.tsx**:
  - Removed the redundant '尋找導師', '關於 X-Talent', and '提供回饋' dropdown menu items on desktop (≥1024px) since they are already fully visible on the Header.
  - Retained the **'成為導師'** (for mentee) / **'導師預約管理'** (for mentor) dropdown item in the desktop user dropdown menu so that users can smoothly manage their role status.
- **MobileUserMenu.tsx**: Retained the full set of navigation links inside the mobile user dropdown menu so that they are correctly visible only on tablet and below (<1024px).
- **Tests**: Re-updated and validated unit tests for both Header and UserDropdown to ensure perfect test coverage and alignment with all layout specifications.

## Screenshot

### 1. Visitor (Guest) State — Header navigation links fully visible on desktop
![Guest Header](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/ea3e2bb37badd1ad48fe300f073c4ab14044a81d/fix-554-desktop-header-nav-login/20260812T045126Z/0-01-guest-header.png)

### 2. Mentor Logged-in State — Header navigation links fully visible
![Mentor Header](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/b9af9e50815b9362a7f4699e93bfce8159945d5e/fix-554-desktop-header-nav-login/20260812T045151Z/0-02-mentor-header.png)

### 3. Mentor Logged-in State — UserDropdown contains "導師預約管理", "我的預約", and "登出"
![Mentor Dropdown](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/1e4058968749a450a08686034cd9bebd465b6bf7/fix-554-desktop-header-nav-login/20260812T045216Z/0-03-mentor-dropdown.png)

### 4. Mentee Logged-in State — Header navigation links fully visible
![Mentee Header](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/5d677439cb2948b1fa25a01bce6ed69061fb509d/fix-554-desktop-header-nav-login/20260812T045241Z/0-04-mentee-header.png)

### 5. Mentee Logged-in State — UserDropdown contains "成為導師", "我的預約", and "登出"
![Mentee Dropdown](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/895c1bfc9c822934602de0102f4f7b4d3c05290b/fix-554-desktop-header-nav-login/20260812T045307Z/0-05-mentee-dropdown.png)

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/554
