### PR TITLE
[Bug] 通知中心：已讀/未讀通知在標題文字上無視覺區別 (X-Tracker #555)

### DIFF
--- a/src/components/layout/Header/NotificationBell.test.tsx
+++ b/src/components/layout/Header/NotificationBell.test.tsx
@@ -2,6 +2,7 @@ import { act, fireEvent, render, screen } from '@testing-library/react';
 import { fromAny } from '@total-typescript/shoehorn';
 import { describe, expect, it, vi } from 'vitest';
 
+import * as useNotificationBellModule from '@/hooks/useNotificationBell';
 import { type NotificationItem } from '@/hooks/useNotificationBell';
 
 import { getNotificationContent, NotificationBell } from './NotificationBell';
@@ -127,6 +128,54 @@ describe('NotificationBell', () => {
       fireEvent.click(button);
 
       expect(screen.getByText('尚無新通知')).toBeInTheDocument();
+    });
+
+    it('applies unread and read classes appropriately to notification titles based on unread status', () => {
+      const spy = vi
+        .spyOn(useNotificationBellModule, 'useNotificationBell')
+        .mockReturnValue({
+          open: true,
+          closePopover: vi.fn(),
+          status: 'success',
+          notifications: [
+            {
+              id: '1',
+              type: 'reservation_new',
+              createdAt: new Date().toISOString(),
+              unread: true,
+            },
+            {
+              id: '2',
+              type: 'reservation_success',
+              createdAt: new Date().toISOString(),
+              unread: false,
+            },
+          ],
+          showBadge: false,
+          formattedCount: '1',
+          handleOpenChange: vi.fn(),
+          handleRetry: vi.fn(),
+          handleNotificationClick: vi.fn(),
+        });
+
+      render(<NotificationBell unreadCount={1} initialStatus="success" />);
+
+      // Since open is mocked to true, the popover is already open and notifications are rendered
+      // Check an unread notification
+      const unreadTitle = screen.getByText('您有新的預約');
+      expect(unreadTitle).toHaveClass('font-bold');
+      expect(unreadTitle).toHaveClass('text-text-primary');
+      expect(unreadTitle).not.toHaveClass('font-normal');
+      expect(unreadTitle).not.toHaveClass('text-text-secondary');
+
+      // Check a read notification
+      const readTitle = screen.getByText('Mentor 已接受您的預約');
+      expect(readTitle).toHaveClass('font-normal');
+      expect(readTitle).toHaveClass('text-text-secondary');
+      expect(readTitle).not.toHaveClass('font-bold');
+      expect(readTitle).not.toHaveClass('text-text-primary');
+
+      spy.mockRestore();
     });
 
     it('renders skeletons when in loading state', () => {

--- a/src/components/layout/Header/NotificationBell.tsx
+++ b/src/components/layout/Header/NotificationBell.tsx
@@ -212,7 +212,14 @@ export const NotificationBell = React.memo(function NotificationBell({
                       )}
                     </span>
                     <div className="min-w-0 flex-1">
-                      <p className="mb-1 text-sm leading-tight font-semibold break-words text-text-primary">
+                      <p
+                        className={cn(
+                          'mb-1 text-sm leading-tight break-words',
+                          item.unread
+                            ? 'font-bold text-text-primary'
+                            : 'font-normal text-text-secondary'
+                        )}
+                      >
                         {title}
                       </p>
                       <p className="mb-1.5 text-xs leading-normal break-words text-text-secondary">


### PR DESCRIPTION
## 說明 (Description)
解決 X-Tracker #555：通知下拉選單（Notification dropdown）中，已讀與未讀通知標題樣式無視覺區別的問題。

## 變更項目 (What Does This PR Do?)
- **UI 樣式動態化**：在 `src/components/layout/Header/NotificationBell.tsx` 中使用 `cn` 函式動態切換通知項目標題類別：
  - **未讀通知**：保留 teal 圓點 + 標題文字套用為深色／粗體（`font-bold text-text-primary`）
  - **已讀通知**：隱藏圓點 + 標題文字套用為較淺色／一般字重（`font-normal text-text-secondary`）
- **類別排序標準化**：使用 Prettier 自動整理並排序 `NotificationBell.tsx` 中的 Tailwind 類別。
- **完善單元測試**：在 `src/components/layout/Header/NotificationBell.test.tsx` 中加入 `applies unread and read classes appropriately to notification titles based on unread status` 測試案例，透過 `vi.spyOn` 乾淨模擬 `useNotificationBell` 的回傳狀態，完整測試雙向樣式切換且避免 popover 開關 side-effect 的干擾。

## 測試與驗證結果 (Verification & Tests)
- `pnpm test` (vitest)：115 個測試檔案、965 個測試案例全數通過！
- `pnpm type-check` (tsc)：完全無型別錯誤。
- `pnpm lint`：程式風格合規。

## 截圖 (Screenshots)
![通知已讀與未讀視覺區分](https://raw.githubusercontent.com/Xchange-Taiwan/X-Talent-Frontend/ed5b44f8b5d6ba1cec74870fafcacd23bb5e8e93/fix-555-notification-read-unread-style/20260812T151605Z/0-notification-bell-fixed.png)

Ref: https://github.com/Xchange-Taiwan/X-Talent-Tracker/issues/555
